### PR TITLE
Fix forked test-suite segfaults (OpenMP after fork)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,8 +16,17 @@ aneforge):
     this is set.
   - KMP_DUPLICATE_LIB_OK: tolerate the duplicate OpenMP runtime that numpy/the dylib
     can both pull in.
+  - OMP/MKL/OPENBLAS/VECLIB thread counts = 1: --forked calls os.fork() in a process
+    where numpy/torch may have started an OpenMP worker-thread pool. fork() does not
+    copy those worker threads, so the child inherits a broken pool, and the next
+    OpenMP op (e.g. torch CPU autograd in the grad-vs-torch CIFAR tests) faults inside
+    libomp (__kmp_fork_barrier) - a SIGSEGV that surfaced only late in the forked
+    suite. One OpenMP thread means there is no pool to break, so the fork is safe.
 """
 import os
 
 os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+for _thread_var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS",
+                    "OPENBLAS_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
+    os.environ.setdefault(_thread_var, "1")


### PR DESCRIPTION
## Problem

The two grad-vs-torch CIFAR tests (`test_conv2d_pad_grad_matches_torch`, `test_group_norm_train_grad_matches_torch`) crashed with **SIGSEGV** only *late* in the full `pytest tests/` run, yet passed in isolation — so it looked environmental.

## Root cause

The macOS crash report pinned the faulting thread **entirely in `libomp.dylib`** — not the ANE/Espresso/Metal stack:

```
libomp.dylib  __kmp_suspend_initialize_thread
libomp.dylib  __kmp_fork_barrier(int, int)
libomp.dylib  __kmp_launch_worker(void*)
EXC_BAD_ACCESS (SIGSEGV) KERN_INVALID_ADDRESS at 0x580
```

This is the classic **OpenMP-thread-pool-after-`fork()`** failure:
1. numpy/torch start an OpenMP worker-thread pool in the parent pytest process.
2. `pytest-forked` calls `os.fork()`; `fork()` does **not** copy the worker threads, so the child inherits a pool with dead thread descriptors.
3. The child's next OpenMP op — torch CPU autograd in these tests — calls into `libomp` (`__kmp_fork_barrier`), dereferences a dead descriptor, and segfaults.

That explains both symptoms: it only triggers once enough preceding tests have initialized the pool in the parent, and it's about threads, not test size (the tests are tiny).

## Fix

Force OpenMP/BLAS single-threaded in `tests/conftest.py`, before any test imports numpy/torch:

```python
for _thread_var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS",
                    "OPENBLAS_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
    os.environ.setdefault(_thread_var, "1")
```

With one OpenMP thread there is no worker pool to break across `fork()`, so the child is fork-safe. `setdefault` lets a caller override. These tiny test ops gain nothing from OpenMP parallelism, so there's no meaningful slowdown.

## Verification

- The 9-file subset that reliably reproduced the crash: **224 passed, 0 segfaults**.
- **Full forked suite: `527 passed in 497.78s`, 0 crashes / 0 failures** (was 2 SIGSEGV), with the env set only by `conftest.py`.

Independent of the cleanup in #3.