### PR TITLE
Set KMP_DUPLICATE_LIB_OK on import; stop documenting it as a manual step

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ git config core.hooksPath .githooks   # off-hardware pre-commit checks
 The corpus is the gate and must pass before a change lands:
 
 ```sh
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/run_corpus.py
+PYTHONPATH=. python3 tests/run_corpus.py
 ```
 
 Most tests need a real ANE, so CI runs only the off-hardware checks. Run the

--- a/README.md
+++ b/README.md
@@ -168,8 +168,8 @@ The correctness corpus compiles and runs every op and kernel on the ANE, and is
 the project's reproducibility gate:
 
 ```sh
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/run_corpus.py
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/ -q
+PYTHONPATH=. python3 tests/run_corpus.py
+PYTHONPATH=. python3 -m pytest tests/ -q
 ```
 
 ## Documentation

--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -73,6 +73,13 @@ state round-trip remains). See examples/train_mnist_mlp.py.
 Layout: graph.py (Tensor + ops), _compile.py (per-op emit registry + compile),
 _blob.py (weight packing), autograd.py (on-ANE autograd), models.py (pretrained loaders).
 """
+# Tolerate a duplicate OpenMP runtime in one process: numpy/MKL and the ANE
+# runtime dylib each bring their own libomp, and without this the second to load
+# aborts the process. Set before any import that pulls in numpy so OpenMP sees it
+# at initialization; setdefault keeps it user-overridable.
+import os as _os
+_os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
 try:
     from ._version import __version__            # written by hatch-vcs at build time
 except ImportError:                              # raw source checkout, not yet built

--- a/aneforge/_bridges/ane_cost_volume_fused.py
+++ b/aneforge/_bridges/ane_cost_volume_fused.py
@@ -7,10 +7,6 @@ the L1 matching cost for each disparity `d in [0, R]` and position `x in [0, Wa)
     `cost[d, x] = | aux[x] - ref[x + d] |`
 
 returning `(R+1)` disparity planes each of width `Wa`.
-
-Run:
-    PYTHONPATH=the reverse-engineering corpus python3 \
-        aneforge/_bridges/ane_cost_volume_fused.py
 """
 
 from __future__ import annotations

--- a/aneforge/_bridges/ane_cost_volume_fused.py
+++ b/aneforge/_bridges/ane_cost_volume_fused.py
@@ -9,7 +9,7 @@ the L1 matching cost for each disparity `d in [0, R]` and position `x in [0, Wa)
 returning `(R+1)` disparity planes each of width `Wa`.
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=the reverse-engineering corpus python3 \
+    PYTHONPATH=the reverse-engineering corpus python3 \
         aneforge/_bridges/ane_cost_volume_fused.py
 """
 

--- a/aneforge/_bridges/ane_fps_fused.py
+++ b/aneforge/_bridges/ane_fps_fused.py
@@ -13,10 +13,6 @@ Schema (accepted unit dictionary)::
      "OutputChannels": 3,
      "OutputType": "Float16",
      "Params": {"CentroidCount": k, "DistanceMetric": "L1" | "L2"}}
-
-Run::
-
-    python3 -m aneforge._bridges.ane_fps_fused
 """
 
 from __future__ import annotations

--- a/aneforge/_bridges/ane_radius_search_fused.py
+++ b/aneforge/_bridges/ane_radius_search_fused.py
@@ -14,10 +14,6 @@ Schema (accepted unit dictionary)::
      "OutputChannels": 1,
      "OutputType": "Float16",
      "Params": {"Radius": r}}
-
-Run::
-
-    python3 -m aneforge._bridges.ane_radius_search_fused
 """
 
 from __future__ import annotations

--- a/aneforge/_bridges/lrn_fused.py
+++ b/aneforge/_bridges/lrn_fused.py
@@ -16,10 +16,6 @@ Non-obvious conventions:
        are identity-copied.  Use KernelChannel = C for full-tensor LRN; C must
        exceed KernelChannel-as-window only spatially - empirically C ==
        KernelChannel gives full coverage (C=5/KC=5).
-
-Run:
-    PYTHONPATH=the reverse-engineering corpus \
-        python3 -m aneforge._bridges.lrn_fused
 """
 
 from __future__ import annotations

--- a/aneforge/_bridges/lrn_fused.py
+++ b/aneforge/_bridges/lrn_fused.py
@@ -18,7 +18,7 @@ Non-obvious conventions:
        KernelChannel gives full coverage (C=5/KC=5).
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=the reverse-engineering corpus \
+    PYTHONPATH=the reverse-engineering corpus \
         python3 -m aneforge._bridges.lrn_fused
 """
 

--- a/aneforge/_bridges/minmax_norm_fused.py
+++ b/aneforge/_bridges/minmax_norm_fused.py
@@ -13,7 +13,7 @@ Epsilon convention: `Params.Epsilon` is a fp16 bit pattern, NOT a float
 real.  Pass `fp16_bits(desired_eps)`.
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=the reverse-engineering corpus \
+    PYTHONPATH=the reverse-engineering corpus \
         python3 -m aneforge._bridges.minmax_norm_fused
 """
 

--- a/aneforge/_bridges/minmax_norm_fused.py
+++ b/aneforge/_bridges/minmax_norm_fused.py
@@ -11,10 +11,6 @@ Supported reduction axes:
 
 Epsilon convention: `Params.Epsilon` is a fp16 bit pattern, NOT a float
 real.  Pass `fp16_bits(desired_eps)`.
-
-Run:
-    PYTHONPATH=the reverse-engineering corpus \
-        python3 -m aneforge._bridges.minmax_norm_fused
 """
 
 from __future__ import annotations

--- a/aneforge/_bridges/scaled_elementwise_fused.py
+++ b/aneforge/_bridges/scaled_elementwise_fused.py
@@ -4,10 +4,6 @@
 scalar scale factor:   y = scale * (x OP z).  `Params.Type` selects the
 elementwise op (Add / Mult / Sub / ...) and `Params.Scale` is a fp16 bit
 pattern (use `fp16_bits`).
-
-Run:
-    PYTHONPATH=the reverse-engineering corpus \
-        python3 -m aneforge._bridges.scaled_elementwise_fused
 """
 
 from __future__ import annotations

--- a/aneforge/_bridges/scaled_elementwise_fused.py
+++ b/aneforge/_bridges/scaled_elementwise_fused.py
@@ -6,7 +6,7 @@ elementwise op (Add / Mult / Sub / ...) and `Params.Scale` is a fp16 bit
 pattern (use `fp16_bits`).
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=the reverse-engineering corpus \
+    PYTHONPATH=the reverse-engineering corpus \
         python3 -m aneforge._bridges.scaled_elementwise_fused
 """
 

--- a/aneforge/dsp.py
+++ b/aneforge/dsp.py
@@ -37,7 +37,7 @@ CONVENTIONS (inherited):
   * Everything is fp16 on-device; the matmul accumulator is wide (>=fp32), so the
     error floor is fp16 INPUT/twiddle rounding (~few e-4), flat in length.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 aneforge/dsp.py
+    PYTHONPATH=. python3 aneforge/dsp.py
 """
 from __future__ import annotations
 

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -43,7 +43,7 @@ matmul/reduce decomposition. These raise `EinsumUnsupported`. Ellipsis (`...`)
 is also not implemented (v1).
 
 Run the self-test (validates a battery vs `numpy.einsum` on the ANE):
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 aneforge/einsum.py
+    PYTHONPATH=. python3 aneforge/einsum.py
 """
 from __future__ import annotations
 

--- a/aneforge/fft.py
+++ b/aneforge/fft.py
@@ -64,7 +64,7 @@ Each returns numpy arrays; under the hood it builds an aneforge graph, compiles 
 ONE fused e5rt program, and runs it on the ANE. A `Plan` object (fft_plan / rfft_plan)
 compiles once and runs many times.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 aneforge/fft.py
+    PYTHONPATH=. python3 aneforge/fft.py
 """
 from __future__ import annotations
 

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -64,7 +64,7 @@ API (importable as `from aneforge.linalg import conjugate_gradient, qr, eigh, ..
     pca(X, k, ...)                            - randomized_svd of centered data
 
 Run the self-test:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 aneforge/linalg.py
+    PYTHONPATH=. python3 aneforge/linalg.py
 """
 from __future__ import annotations
 

--- a/bench/below_ridge_fusion.py
+++ b/bench/below_ridge_fusion.py
@@ -28,7 +28,7 @@ This is the AI-lever demonstration the roofline predicts, complementary to the
 amortization demonstration (the conv stack) the paper already has.
 
 Run from repo root:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/below_ridge_fusion.py
+    PYTHONPATH=. python3 bench/below_ridge_fusion.py
 optionally with --window for the power pass. Writes results/below_ridge_fusion.json.
 """
 from __future__ import annotations

--- a/bench/decode_int8_accuracy.py
+++ b/bench/decode_int8_accuracy.py
@@ -20,7 +20,7 @@ predicted token relative to fp16/fp32 on identical weights. A single forward (no
 sustained loop) keeps it fast and avoids the decode-loop's session-state issues.
 
 Run from repo root:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/decode_int8_accuracy.py
+    PYTHONPATH=. python3 bench/decode_int8_accuracy.py
 Writes bench/results/decode_int8_accuracy.json.
 """
 from __future__ import annotations

--- a/bench/decode_measurement.py
+++ b/bench/decode_measurement.py
@@ -54,7 +54,7 @@ CONFIG (default, TinyLlama/GPT-small class):
 
 Run from repo root (energy needs passwordless sudo for powermetrics):
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/decode_measurement.py
+    PYTHONPATH=. python3 bench/decode_measurement.py
 
 Writes bench/results/decode_measurement_results.json. --quick shrinks the model
 (d=1024,L=4) and the power window for a smoke test. Devices run SEQUENTIALLY.

--- a/bench/device_bandwidth_roofline.py
+++ b/bench/device_bandwidth_roofline.py
@@ -44,7 +44,7 @@ silently omit an op. Emitted as a table to the JSON + printed.
 
 Run from repo root (energy needs passwordless sudo for powermetrics):
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/device_bandwidth_roofline.py
+    PYTHONPATH=. python3 bench/device_bandwidth_roofline.py
 
 --quick runs a reduced window + a coarser size sweep for a smoke test.
 Writes bench/results/device_bandwidth_roofline_results.json alongside the tables.

--- a/bench/device_compare_wattcomplete.py
+++ b/bench/device_compare_wattcomplete.py
@@ -50,7 +50,7 @@ IS fair and is included as the attention class.
 
 Run from repo root (energy needs passwordless sudo for powermetrics):
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/device_compare_wattcomplete.py
+    PYTHONPATH=. python3 bench/device_compare_wattcomplete.py
 
 Writes bench/results/device_compare_wattcomplete_results.json alongside the printed
 tables. --quick runs a reduced rep/window for a smoke test.

--- a/bench/device_saturation_sweep.py
+++ b/bench/device_saturation_sweep.py
@@ -32,7 +32,7 @@ NOT the same product as the fp16 peaks and is labeled as such everywhere.
 
 Run from repo root (energy needs passwordless sudo for powermetrics):
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/device_saturation_sweep.py
+    PYTHONPATH=. python3 bench/device_saturation_sweep.py
 
 Writes bench/results/device_saturation_sweep_results.json alongside the printed
 tables. --quick trims the largest (multi-second) sizes and shortens the power window

--- a/bench/device_serving_sweep.py
+++ b/bench/device_serving_sweep.py
@@ -49,7 +49,7 @@ ANE's watt advantage persists past its throughput advantage). Printed explicitly
 
 Run from repo root (energy needs passwordless sudo for powermetrics)::
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/device_serving_sweep.py
+    PYTHONPATH=. python3 bench/device_serving_sweep.py
 
 Writes bench/results/device_serving_sweep_results.json. --quick = short window;
 --batches "1,4,16" overrides the sweep; --window N overrides the per-loop seconds.

--- a/bench/fused_gpu_baseline.py
+++ b/bench/fused_gpu_baseline.py
@@ -23,7 +23,7 @@ the GPU close the perf/watt gap, or flip any ANE win? We report it plainly eithe
 
 Run from repo root (energy needs passwordless sudo):
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/fused_gpu_baseline.py
+    PYTHONPATH=. python3 bench/fused_gpu_baseline.py
 
 Writes bench/results/fused_gpu_baseline_results.json. --quick reduces the window.
 """

--- a/bench/gemv_bandwidth_sweep.py
+++ b/bench/gemv_bandwidth_sweep.py
@@ -25,7 +25,7 @@ device_compare_wattcomplete.
 
 Run from repo root (energy needs passwordless sudo for powermetrics):
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/gemv_bandwidth_sweep.py
+    PYTHONPATH=. python3 bench/gemv_bandwidth_sweep.py
 
 Writes bench/results/gemv_bandwidth_sweep_results.json. --quick caps sizes.
 """

--- a/bench/real_models_fp16.py
+++ b/bench/real_models_fp16.py
@@ -10,7 +10,7 @@ the fp16-vs-fp16 GPU/ANE energy ratio can be reported. It reuses the exact model
 builders from device_compare_wattcomplete.py.
 
 Run from repo root (energy needs passwordless sudo):
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/real_models_fp16.py --window 6
+    PYTHONPATH=. python3 bench/real_models_fp16.py --window 6
 Writes bench/results/real_models_fp16_results.json.
 """
 from __future__ import annotations

--- a/bench/roofline_analysis.py
+++ b/bench/roofline_analysis.py
@@ -28,7 +28,7 @@ conv block achieved GFLOP/s on the ANE, a GEMV decode point). GEMM/conv/bandwidt
 are READ from the existing JSONs.
 
 Run from repo root:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 bench/roofline_analysis.py
+    PYTHONPATH=. python3 bench/roofline_analysis.py
     # --no-measure  : skip the gap measurements (uses analytic AIxBW placeholders, labeled)
 """
 from __future__ import annotations

--- a/docs/development.md
+++ b/docs/development.md
@@ -55,9 +55,9 @@ graphs compiled and run on the ANE and compared against numpy references at
 fp16. It must be green before a release.
 
 ```sh
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. .venv/bin/python tests/run_corpus.py   # the corpus gate
-PYTHONPATH=. .venv/bin/python tests/op_smoketest.py                          # per-op smoke test
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. .venv/bin/python -m pytest tests/ -q   # full suite
+PYTHONPATH=. .venv/bin/python tests/run_corpus.py   # the corpus gate
+PYTHONPATH=. .venv/bin/python tests/op_smoketest.py # per-op smoke test
+PYTHONPATH=. .venv/bin/python -m pytest tests/ -q   # full suite
 ```
 
 The pytest suite runs each test in its own forked subprocess. Every `compile`

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,6 +1,7 @@
 """Shared example scaffolding - environment setup plus the few helpers every demo
-repeated verbatim. Import this FIRST in an example (before aneforge): importing it
-sets KMP_DUPLICATE_LIB_OK and puts the repo root on sys.path.
+repeated verbatim. Import this FIRST in an example: it puts the repo root on
+sys.path and imports aneforge, which sets the OpenMP duplicate-runtime guard
+before numpy loads.
 
 Deliberately minimal: error metrics, conditioned random test matrices, and the
 one-line pass/fail report. Demo logic stays in the demos so each file remains a
@@ -11,8 +12,8 @@ import sys
 import warnings
 from pathlib import Path
 
-os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))   # repo root -> import aneforge
+import aneforge  # noqa: F401  (importing the package sets KMP_DUPLICATE_LIB_OK before numpy loads OpenMP)
 
 import numpy as np
 

--- a/examples/benchmarks/README.md
+++ b/examples/benchmarks/README.md
@@ -3,7 +3,7 @@
 Throughput / dispatch benchmarks, not how-to demos. Run from the repo root, e.g.
 
 ```sh
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 examples/benchmarks/bench_encoder_batched.py
+PYTHONPATH=. python3 examples/benchmarks/bench_encoder_batched.py
 ```
 
 - `bench_encoder_batched.py` - batched encoder serving throughput on the ANE.

--- a/examples/benchmarks/bench_encoder_batched.py
+++ b/examples/benchmarks/bench_encoder_batched.py
@@ -9,7 +9,7 @@ Reuses the weights loaded by af.Encoder; builds a batched [B,S,D] encoder graph 
 fuses it into one program per (B,S). Correctness is checked against the
 transformers fp32 reference; throughput is reported vs B.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. \\
+    PYTHONPATH=. \\
         python3 examples/benchmarks/bench_encoder_batched.py
 """
 import os, sys, time

--- a/examples/benchmarks/bench_encoder_gpu.py
+++ b/examples/benchmarks/bench_encoder_gpu.py
@@ -6,7 +6,7 @@ S, measuring embeds/sec + power, so encoder serving can be compared ANE-vs-GPU o
 both throughput and efficiency (the LLM-decode question, asked for the workload the
 ANE should actually win).
 
-    KMP_DUPLICATE_LIB_OK=TRUE python3 examples/benchmarks/bench_encoder_gpu.py
+    python3 examples/benchmarks/bench_encoder_gpu.py
 """
 import os, re, subprocess, sys, time
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")

--- a/examples/benchmarks/rank_worker_bench.py
+++ b/examples/benchmarks/rank_worker_bench.py
@@ -12,7 +12,7 @@ A2 = persistent Path-A worker (aneforge/_netplist_worker.py +
 We measure per-call wall latency under each, single-call (cold) and over a
 32-call steady-state loop, and assert A2 produces BIT-IDENTICAL outputs.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 examples/benchmarks/rank_worker_bench.py
+    PYTHONPATH=. python3 examples/benchmarks/rank_worker_bench.py
 """
 import os
 import sys

--- a/examples/benchmarks/sdpa_worker_bench.py
+++ b/examples/benchmarks/sdpa_worker_bench.py
@@ -12,7 +12,7 @@ We measure per-call wall latency under each, single-call and over a 32-call loop
 to show A2's amortization. A2 is selected by default; A1 is forced with
 ANEFORGE_NETPLIST_WORKER=0.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 examples/benchmarks/sdpa_worker_bench.py
+    PYTHONPATH=. python3 examples/benchmarks/sdpa_worker_bench.py
 """
 import os
 import sys

--- a/examples/benchmarks/topk_worker_bench.py
+++ b/examples/benchmarks/topk_worker_bench.py
@@ -15,7 +15,7 @@ keeps the per-call eval() dispatch. To see the batched path's effect directly:
 
     --batch   route topk through eval_batch (one round-trip) instead of per-call
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 examples/benchmarks/topk_worker_bench.py
+    PYTHONPATH=. python3 examples/benchmarks/topk_worker_bench.py
 """
 import sys
 import time

--- a/examples/pointcloud.py
+++ b/examples/pointcloud.py
@@ -18,7 +18,7 @@ Conventions worth stating honestly:
     * RadiusSearch returns a [points x centroids] uint8 membership matrix
       (1 = inside the L2 ball); we transpose to [centroids x points] for grouping.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. \\
+    PYTHONPATH=. \\
         python3 examples/pointcloud.py
 """
 import sys

--- a/scripts/reproduce.sh
+++ b/scripts/reproduce.sh
@@ -32,9 +32,9 @@ cd "$REPO" || exit 1
 # real exit code (for CI); the default runs the full paper-artifact reproduction.
 MODE="${1:-all}"
 
-# Most tools want the repo root importable and OpenMP duplicate-lib tolerated.
+# Most tools want the repo root importable (aneforge tolerates the duplicate
+# OpenMP runtime itself, on import).
 export PYTHONPATH="$REPO"
-export KMP_DUPLICATE_LIB_OK=TRUE
 
 PASS=0; FAIL=0
 section() { printf '\n\033[1m========== %s ==========\033[0m\n' "$1"; }
@@ -79,19 +79,19 @@ section "§ Single-stream device map — ANE vs GPU vs CPU [needs sudo + MLX]"
 # CLAIM (Table 'device map', Fig 1): latency, fp16 relerr, idle-subtracted
 #        per-rail watts, perf/watt across the workload classes.
 run "Device map (wattcomplete; powermetrics per-rail)" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/device_compare_wattcomplete.py --window 6"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/device_compare_wattcomplete.py --window 6"
 
 # -----------------------------------------------------------------------------
 section "§ Compute / bandwidth / serving sweeps [needs sudo + MLX]"
 # CLAIM (Fig 2, compute peaks): saturation ceilings + large-square-GEMM falloff.
 run "Saturation sweep" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/device_saturation_sweep.py"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/device_saturation_sweep.py"
 # CLAIM (Fig 3, bandwidth ceiling): the two effective bandwidths + roofline.
 run "Bandwidth roofline sweep" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/device_bandwidth_roofline.py --window 6"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/device_bandwidth_roofline.py --window 6"
 # CLAIM (Fig 5, crossover): batched-serving throughput + throughput/watt.
 run "Serving sweep (batched multi-stream)" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/device_serving_sweep.py --window 5"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/device_serving_sweep.py --window 5"
 
 # -----------------------------------------------------------------------------
 section "§ Roofline synthesis (reads the saturation + bandwidth JSONs above)"
@@ -102,11 +102,11 @@ run "Roofline analysis" \
 # -----------------------------------------------------------------------------
 section "§ Appendix claims: fused-GPU baseline, weight stream, decode [needs sudo]"
 run "Fused-GPU baseline" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/fused_gpu_baseline.py"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/fused_gpu_baseline.py"
 run "Weight-stream (GEMV-K) sweep" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/gemv_bandwidth_sweep.py"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/gemv_bandwidth_sweep.py"
 run "End-to-end LLM decode sweep" \
-  "sudo -E env PYTHONPATH=$REPO KMP_DUPLICATE_LIB_OK=TRUE python3 bench/decode_measurement.py"
+  "sudo -E env PYTHONPATH=$REPO python3 bench/decode_measurement.py"
 
 # -----------------------------------------------------------------------------
 section "§ Compressed-weight streaming (latency only, no sudo) [needs MLX]"

--- a/tests/run_corpus.py
+++ b/tests/run_corpus.py
@@ -5,13 +5,13 @@ rewrite; the pass-rate and per-case relerr must not regress. Each case builds a
 graph, compiles it (``af.compile``), runs it on the M-series ANE, and asserts the
 output against a numpy golden reference within a per-category tolerance.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/run_corpus.py
+    PYTHONPATH=. python3 tests/run_corpus.py
 
 Optimizer-diff reuse: import ALL_CASES and tests._corpus.run_case to run the same
 builds with optimization on/off and diff the two ANE outputs directly.
 
 Also pytest-compatible (the default suite skips it, so name the file):
-KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. pytest tests/run_corpus.py
+PYTHONPATH=. pytest tests/run_corpus.py
 """
 from __future__ import annotations
 
@@ -20,6 +20,8 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))          # tests/  -> _corpus
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))      # repo root -> aneforge
+
+import aneforge  # noqa: F401,E402  (importing the package sets KMP_DUPLICATE_LIB_OK before numpy loads)
 
 from _corpus import run_corpus, eval_case  # noqa: E402
 import test_nn_blocks  # noqa: E402

--- a/tests/test_blas.py
+++ b/tests/test_blas.py
@@ -19,7 +19,7 @@ The point of this corpus is twofold:
 
 Run::
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/test_blas.py
+    PYTHONPATH=. python3 tests/test_blas.py
 
 The shared harness (tests/_corpus.py) does build->compile->run->compare. We reuse
 its ``Case`` record, ``eval_case`` and the gate accounting, and add a BLAS-specific

--- a/tests/test_builder_guards.py
+++ b/tests/test_builder_guards.py
@@ -7,7 +7,7 @@ tiling limit (kW <= 15).
 
 These are pure graph-construction tests (no ANE): nothing is compiled or run.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_builder_guards.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_builder_guards.py -q
 """
 import numpy as np
 import pytest

--- a/tests/test_compile_breaker.py
+++ b/tests/test_compile_breaker.py
@@ -8,7 +8,7 @@ failures; no failure-count cap is needed.
 These are pure unit tests (no ANE): a fake clock replaces _monotonic/_sleep so no
 real time passes.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_compile_breaker.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_compile_breaker.py -q
 """
 import warnings
 

--- a/tests/test_compile_targets.py
+++ b/tests/test_compile_targets.py
@@ -8,7 +8,7 @@ On the M5 dev host (family 5) everything is native, so target=None is a no-op fa
 and existing compiles are byte-identical. The decompose path IS verifiable here, because
 the rewritten graph (sin -> mul/exp polynomial) is all-native and runs on the M5.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_compile_targets.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_compile_targets.py -q
 """
 import numpy as np
 import pytest

--- a/tests/test_cost_model_analytic.py
+++ b/tests/test_cost_model_analytic.py
@@ -9,7 +9,7 @@ for all 28 chips from one extraction. Two anchors, both measured/fit on M1:
 Cross-chip throughput scales by ``cores * eff_freq(0.8*fmax)`` relative to M1:
   M5 (H17s) ~5.5x, H17d (Ultra) ~22x, M11 ~0.1x.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_cost_model_analytic.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_cost_model_analytic.py -q
 """
 import numpy as np
 

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -10,7 +10,7 @@ real silicon; this is compile-level validation.)
 These tests reproduce the measured op-floor ladder through aneforge's own dylib:
 relu needs H13+ (the MIL hard floor); native sin/cos need A15+.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_cross_compile.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_cross_compile.py -q
 """
 import pytest
 import aneforge as af

--- a/tests/test_cross_compile_matrix.py
+++ b/tests/test_cross_compile_matrix.py
@@ -13,7 +13,7 @@ Compile-level only (cross-target programs can't execute on this host); numeric
 correctness still needs the real silicon. Bridge/segmented cases are skipped (the
 cross-target checker is fused-route only).
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=.:tests python3 -m pytest tests/test_cross_compile_matrix.py -q
+Run: PYTHONPATH=.:tests python3 -m pytest tests/test_cross_compile_matrix.py -q
 """
 import sys
 import warnings

--- a/tests/test_fft2.py
+++ b/tests/test_fft2.py
@@ -4,7 +4,7 @@ The 2-D DFT of an [M,N] complex field is F_M @ X @ F_N^T - a handful of real GEM
 so it fuses into a single e5rt program instead of host-looping the 1-D plan over
 M rows + N columns (M+N dispatches).
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. .venv/bin/python -m pytest tests/test_fft2.py -q
+Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_fft2.py -q
 """
 from __future__ import annotations
 import os

--- a/tests/test_fp16_cross_chip.py
+++ b/tests/test_fp16_cross_chip.py
@@ -9,7 +9,7 @@ cross_compile_check compiles on this M5 host for another family's TargetArchitec
 these touch the dylib. The Trainer guard is host-static but the construction does
 compile tiny programs.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_fp16_cross_chip.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_fp16_cross_chip.py -q
 """
 import warnings
 

--- a/tests/test_group_norm_tiling.py
+++ b/tests/test_group_norm_tiling.py
@@ -6,7 +6,7 @@ the ANE per-axis cap. This lets SD-1.5's 640ch@64 and 512ch@128 maps compile + r
 the flattened extent (81920 / 262144) overflowed. These tests pin small-shape correctness,
 big-shape correctness vs fp32, and the relaxed construction guard.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_group_norm_tiling.py -q
+    PYTHONPATH=. python3 -m pytest tests/test_group_norm_tiling.py -q
 """
 from __future__ import annotations
 

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -4,7 +4,7 @@ Camera/decoded-video bytes feed the model directly; the uint8->fp16 cast + the
 ``scale*x + bias`` normalisation run as in-graph ANE ops. Each test compiles+runs a
 real graph fed a uint8 array and checks it against a host-fp16 reference.
 
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_image_input.py -q
+    PYTHONPATH=. python3 -m pytest tests/test_image_input.py -q
 """
 from __future__ import annotations
 

--- a/tests/test_lapack.py
+++ b/tests/test_lapack.py
@@ -11,7 +11,7 @@ records the conditioning envelope. The families whose only method is a pivoted/r
 DIRECT factorization (full spectrum, pivoted LU/QR) are the documented walls - listed,
 not run. Accumulation is via matmul (the ANE's wide >=fp32 accumulator).
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/test_lapack.py
+Run: PYTHONPATH=. python3 tests/test_lapack.py
 """
 from __future__ import annotations
 import os

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -7,7 +7,7 @@ SHAPES (tall / wide / square) for the SVD/QR/LU family - the wide case is what h
 ``svd`` Gram-matrix bug (it only ever formed A^T A, fine for tall A, a huge graph for wide
 A). Sizes are kept small: several kernels compile a deep unrolled graph.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. .venv/bin/python -m pytest tests/test_linalg.py -q
+Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_linalg.py -q
 """
 from __future__ import annotations
 import os

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -25,7 +25,7 @@ feasibility tags are kept in a side table keyed by case name and printed by our
 own runner, so we don't touch _corpus.py.
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/test_numerical.py
+    PYTHONPATH=. python3 tests/test_numerical.py
 """
 from __future__ import annotations
 

--- a/tests/test_pde_ode.py
+++ b/tests/test_pde_ode.py
@@ -43,7 +43,7 @@ time) and indexed with a one-hot ``@`` select - exactly the pattern test_numeric
 uses for Horner coefficients. The reference applies the identical constants.
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/test_pde_ode.py
+    PYTHONPATH=. python3 tests/test_pde_ode.py
 """
 from __future__ import annotations
 

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -15,7 +15,7 @@ drift: the route registry (``_capabilities.route_registry``), the executable bui
 (``_optimize._route_ids``).
 
 Run standalone:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/test_routes.py
+    PYTHONPATH=. python3 tests/test_routes.py
 """
 import sys
 from pathlib import Path

--- a/tests/test_special_trig.py
+++ b/tests/test_special_trig.py
@@ -9,7 +9,7 @@ Two things this guards:
    function in special.py). The decomposition uses only mul/sub/exp - native on M1 - so
    it is validated here on the M5 against numpy; the same graph runs on M1.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_special_trig.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_special_trig.py -q
 """
 import numpy as np
 

--- a/tests/test_spectral_sci.py
+++ b/tests/test_spectral_sci.py
@@ -38,7 +38,7 @@ We reuse the shared harness (Case, eval_case) verbatim and keep the tag side-tab
 spectral verdict block in our own runner, so we don't touch _corpus.py.
 
 Run:
-    KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 tests/test_spectral_sci.py
+    PYTHONPATH=. python3 tests/test_spectral_sci.py
 """
 from __future__ import annotations
 

--- a/tests/test_tune_guards.py
+++ b/tests/test_tune_guards.py
@@ -16,7 +16,7 @@ style as test_compile_breaker.py):
      RuntimeError naming the file (a broken installation), not a KeyError blaming
      the arch name.
 
-Run: KMP_DUPLICATE_LIB_OK=TRUE PYTHONPATH=. python3 -m pytest tests/test_tune_guards.py -q
+Run: PYTHONPATH=. python3 -m pytest tests/test_tune_guards.py -q
 """
 import warnings
 


### PR DESCRIPTION
## What

Set `KMP_DUPLICATE_LIB_OK=TRUE` once, on `import aneforge`, instead of expecting users (and every script) to set it manually.

## Why

NumPy/MKL and the ANE runtime dylib each bring their own OpenMP runtime. When both load into one process, the second to initialize aborts with `OMP: Error #15` unless `KMP_DUPLICATE_LIB_OK` is set. Until now it was:

- set ad hoc in `examples/_common.py`, so it only protected the bundled examples, and
- prefixed onto every documented run command, pushing the workaround onto users.

A plain `pip install aneforge` followed by `import aneforge` in a user script got **no** guard.

## How

`aneforge/__init__.py` now does, before any numpy-importing submodule loads:

```python
import os as _os
_os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
```

`setdefault` keeps it overridable (export `KMP_DUPLICATE_LIB_OK=FALSE` to get the real abort back for debugging). `import os as _os` keeps it out of the public namespace.

This cannot be done at pip-install time: install steps run in a throwaway process and cannot set a runtime env var. Import-time is the right hook; the only timing caveat is the usual one (import `aneforge` before `numpy`/`torch`).

## Changes

- `aneforge/__init__.py` — the guard.
- `examples/_common.py`, `tests/run_corpus.py` — import `aneforge` before `numpy` and drop their own env handling.
- `README.md`, `CONTRIBUTING.md`, `docs/development.md`, `examples/benchmarks/README.md` — run commands no longer prefixed with `KMP_DUPLICATE_LIB_OK=TRUE`.

Defensive `setdefault` guards are intentionally kept in the standalone `bench/` and `tests/` entry points, which may import numpy before aneforge.

## Verification

```
$ PYTHONPATH=. python3 -c "import aneforge, os, numpy; print(os.environ['KMP_DUPLICATE_LIB_OK'])"
TRUE
```

`import aneforge` + `numpy` succeeds with no prefix and no `OMP: Error #15`; `_common` imports clean; no `aneforge.os` leak.
