### PR TITLE
Fix examples left broken by the public-release corpus scrub

### DIFF
--- a/examples/benchmarks/topk_worker_bench.py
+++ b/examples/benchmarks/topk_worker_bench.py
@@ -52,9 +52,7 @@ def main():
         # Drive the worker through eval_batch (all C rows in ONE round-trip) to
         # measure the batched-eval path directly.
         from aneforge import _netplist_worker as nw
-        bridge = next(p / "the reverse-engineering corpus" for p in Path(__file__).resolve().parents
-                      if (p / "the reverse-engineering corpus").exists())
-        worker, _ = nw.build_worker("topk", (C, W), {"k": k, "largest": True}, bridge)
+        worker, _ = nw.build_worker("topk", (C, W), {"k": k, "largest": True})
         xa = np.ascontiguousarray(xt.reshape(C, W))
 
         def call():

--- a/examples/pointcloud.py
+++ b/examples/pointcloud.py
@@ -8,8 +8,8 @@ PointNet++-style set-abstraction step:
     2. RadiusSearch           (ane_radius_search_fused)  membership in an L2 ball per centroid
     3. CrossProduct           (ane_cross_product_fused)  surface normal from two edge vectors
 
-These layers aren't in the aneforge frontend yet, so the demo calls the the reverse-engineering corpus
-bridges directly. Each stage is validated against a numpy reference (exact for
+These layers aren't in the aneforge frontend yet, so the demo calls the in-package
+``aneforge._bridges`` modules directly. Each stage is validated against a numpy reference (exact for
 the integer-discretised FPS/RadiusSearch, fp16-tolerance for the cross product).
 
 Conventions worth stating honestly:


### PR DESCRIPTION
## What

Fixes two examples that a pre-release sanitization left broken. A global find-replace swapped a private path/name for the prose phrase **"the reverse-engineering corpus"** — fine in prose, but it landed inside live code and a docstring.

## The two breakages

**`examples/benchmarks/topk_worker_bench.py` (`--batch` path)** — searched parent directories for a folder literally named `the reverse-engineering corpus` to pass as a 4th argument to `build_worker()`:

```python
bridge = next(p / "the reverse-engineering corpus" for p in Path(__file__).resolve().parents
              if (p / "the reverse-engineering corpus").exists())
worker, _ = nw.build_worker("topk", (C, W), {"k": k, "largest": True}, bridge)
```

That directory never exists in the public repo (so `next(...)` raises `StopIteration`), and the public `build_worker(op, shape, attrs)` takes **three** args — the bridges are in-package now. Fixed to:

```python
worker, _ = nw.build_worker("topk", (C, W), {"k": k, "largest": True})
```

**`examples/pointcloud.py` docstring** — read "the demo calls **the the** reverse-engineering corpus bridges directly" (double "the", and inaccurate: the code imports `aneforge._bridges.*`). Reworded to "the in-package `aneforge._bridges` modules directly".

## Scope

Code/docstring fix only. The ~46 *prose* provenance references to "the reverse-engineering corpus" elsewhere (comments/docstrings citing where a finding was verified) are intentional and left untouched.

## Verification

- Both files `py_compile`.
- `'topk' in nw._WORKER_BUILDERS` is `True`, so the 3-arg `build_worker` call routes (no `KeyError`).
- No `reverse-engineering corpus` string remains in either file.
