### PR TITLE
Add Whisper encoder ANE benchmark

### DIFF
--- a/bench/whisper_encoder_ane/README.md
+++ b/bench/whisper_encoder_ane/README.md
@@ -1,81 +1,77 @@
 # Whisper encoder on the Apple Neural Engine
 
-Whisper's audio encoder, compiled with ANEForge into one program and run **directly
-on the Apple Neural Engine** (no CoreML), then compared against the same encoder in
-PyTorch on the CPU and the Metal GPU (MPS).
+The Whisper audio encoder, compiled with ANEForge into one program and run on the
+Apple Neural Engine (no CoreML), benchmarked against the same encoder in PyTorch on
+the CPU and the Metal GPU (MPS).
 
-The encoder is the heavy, fixed-shape half of Whisper (an 80-channel log-mel spans a
-fixed 1500-frame context), which makes it a clean ahead-of-time target: compile once,
-dispatch many times. The autoregressive decoder is a separate problem (its KV-cache
-length changes every token) and is not addressed here.
+The encoder is the fixed-shape half of Whisper (an 80-channel log-mel over a fixed
+1500-frame context), so it compiles once and dispatches many times. The
+autoregressive decoder, whose KV-cache length changes every token, is not covered
+here.
 
 ## Result (whisper-tiny encoder, M-series)
 
-| engine            | latency   | energy / encode | fidelity     |
-| ----------------- | --------: | --------------: | ------------ |
-| **ANE**           | 11.4 ms   | ~32 mJ          | cosine 1.0000 |
-| Metal GPU (MPS)   | 13.0 ms   | ~126 mJ         | reference    |
-| CPU (fp32)        | 36.1 ms   | --              | reference    |
+| engine          | latency | energy / encode | fidelity      |
+| --------------- | ------: | --------------: | ------------- |
+| ANE             | 11.4 ms | ~32 mJ          | cosine 0.9999 |
+| Metal GPU (MPS) | 13.0 ms | ~126 mJ         | reference     |
+| CPU (fp32)      | 36.1 ms | --              | reference     |
 
-The ANE is slightly faster than the GPU and uses about **3.8x less energy per
-encode**, at cosine 0.999987 against the PyTorch reference. Latency and the energy
-ratio are stable across runs; the absolute milliJoule figures move with background
-system load (the ratio does not).
+At cosine 0.999987 against the PyTorch reference, the ANE matches the GPU on latency
+and uses about 3.8x less energy per encode. The latency and the energy ratio are
+stable across runs; absolute milliJoules move with background system load.
 
-## What this shows, and what it does not
+## Notes
 
-- **Fidelity is exact for practical purposes.** cosine 0.999987 over the full stack,
-  including the gelu LUT the ANE uses, on a randomly-initialised encoder. Latency and
-  energy are weight-independent, so the numbers carry to the published checkpoint.
-- **The win is energy, not raw speed.** Latency is close (the GPU is fast on this
-  workload); the ANE's advantage is drawing ~1.9 W on its own rail versus the GPU's
-  ~8 W (idle-subtracted, whole package).
-- **The native fused-attention layer does not apply here.** At seq 1500, `af.sdpa`
-  decomposes to the same matmul/softmax as `af.mha` (the native layer is reliable only
-  when the smaller attention axis is < 512). The `mha` and `sdpa` rows are identical
-  by construction.
-- **The baseline is PyTorch-eager MPS, not whisper.cpp's hand-tuned Metal kernel**, and
-  not whisper.cpp's existing CoreML path (which can already reach the ANE for the
-  encoder). A true head-to-head needs a whisper.cpp fork; this measures the ANEForge
-  path against a standard PyTorch GPU baseline, the same baseline the project's
+- Fidelity is cosine 0.999987 over the full stack, including the gelu LUT the ANE
+  uses, on a randomly-initialised encoder. Latency and energy are weight-independent,
+  so the numbers hold for the published checkpoint.
+- The advantage is energy, not latency. Latency is close; the ANE draws about 1.9 W
+  on its own rail against the GPU's 8 W (idle-subtracted, whole package).
+- At seq 1500 `af.sdpa` decomposes to the same matmul/softmax as `af.mha`, because the
+  native fused-attention layer is reliable only when the smaller attention axis is
+  below 512. The two rows are identical by construction.
+- The baseline is PyTorch-eager MPS, not whisper.cpp's Metal kernel or its CoreML path
+  (which can already reach the ANE for the encoder). A direct comparison needs a
+  whisper.cpp fork; this measures ANEForge against the same PyTorch GPU baseline the
   top-level benchmarks use.
 
-## Integration shape (the C++ runner)
+## C++ runner
 
 `whisper_ane_run.cpp` loads the compiled encoder and dispatches it on the ANE from
-plain C++ with no Python, which is what a whisper.cpp backend would do at model load.
+C++ with no Python, as a whisper.cpp backend would at model load.
 
-The compiled on-device program is keyed to the OS build and is not a shippable binary
-artifact, and the cached bundle is not cold-loadable by a fresh process
-(`program_library_create` succeeds, but creating the precompiled operation fails with
-"Must re-compile the E5 bundle"). So the supported reuse path is **compile-with-cache**:
-ship the portable `model.mil` + `weights.bin`, and compile once per process at model
-load (about 0.6 s, cached thereafter). The runner uses the existing
-`ane_e5rt_program_compile` entry point; no changes to ANEForge are needed.
+The compiled on-device program is keyed to the OS build and is not a shippable binary,
+and the cached bundle is not cold-loadable by a fresh process:
+`program_library_create` succeeds, but creating the precompiled operation fails with
+"Must re-compile the E5 bundle". The reuse path is therefore compile-with-cache: ship
+the portable `model.mil` and `weights.bin`, and compile once per process at model load
+(about 0.6 s, cached after). The runner uses the existing `ane_e5rt_program_compile`
+entry point, so ANEForge is unchanged.
 
 ## Files
 
-| file                 | what it does                                                        |
-| -------------------- | ------------------------------------------------------------------- |
-| `encoder.py`         | the whisper-tiny encoder built two ways (HF reference + ANEForge)   |
-| `fidelity.py`        | cosine / relative error vs the PyTorch reference                    |
-| `bench_latency.py`   | ANE (mha, sdpa) vs CPU vs MPS latency                               |
-| `bench_energy.py`    | ANE vs MPS energy via powermetrics (idle-subtracted, whole-package) |
-| `export_bundle.py`   | compile + persist the program, dump fp16 vectors + a port manifest  |
-| `whisper_ane_run.cpp`| standalone C++ ANE runner (links the dispatch dylib)                |
-| `run_cpp.sh`         | export, build, and run the C++ runner end to end                    |
+| file                  | what it does                                                        |
+| --------------------- | ------------------------------------------------------------------ |
+| `encoder.py`          | the whisper-tiny encoder built two ways (HF reference + ANEForge)  |
+| `fidelity.py`         | cosine and relative error vs the PyTorch reference                 |
+| `bench_latency.py`    | ANE (mha, sdpa) vs CPU vs MPS latency                              |
+| `bench_energy.py`     | ANE vs MPS energy via powermetrics (idle-subtracted, whole-package)|
+| `export_bundle.py`    | compile and persist the program, dump fp16 vectors and a manifest  |
+| `whisper_ane_run.cpp` | standalone C++ ANE runner (links the dispatch dylib)               |
+| `run_cpp.sh`          | export, build, and run the C++ runner end to end                   |
 
 ## Run
 
 From the repo root:
 
 ```sh
-PYTHONPATH=. python3 bench/whisper_encoder_ane/fidelity.py        # cosine 0.999987
-PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_latency.py   # ANE vs CPU vs MPS
+PYTHONPATH=. python3 bench/whisper_encoder_ane/fidelity.py
+PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_latency.py
 PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_energy.py    # needs passwordless sudo
-sh bench/whisper_encoder_ane/run_cpp.sh                           # C++, on the ANE, no Python
+sh bench/whisper_encoder_ane/run_cpp.sh
 ```
 
-The encoder is randomly initialised (fixed seed) so nothing is downloaded. To
-reproduce against the real checkpoint, load whisper-tiny's encoder weights into the
-state dict in `encoder.py` (the key names already match HF's `WhisperEncoder`).
+The encoder is randomly initialised (fixed seed), so nothing is downloaded. To run the
+real checkpoint, load whisper-tiny's encoder weights into the state dict in
+`encoder.py`; the key names already match HF's `WhisperEncoder`.

--- a/bench/whisper_encoder_ane/README.md
+++ b/bench/whisper_encoder_ane/README.md
@@ -1,0 +1,81 @@
+# Whisper encoder on the Apple Neural Engine
+
+Whisper's audio encoder, compiled with ANEForge into one program and run **directly
+on the Apple Neural Engine** (no CoreML), then compared against the same encoder in
+PyTorch on the CPU and the Metal GPU (MPS).
+
+The encoder is the heavy, fixed-shape half of Whisper (an 80-channel log-mel spans a
+fixed 1500-frame context), which makes it a clean ahead-of-time target: compile once,
+dispatch many times. The autoregressive decoder is a separate problem (its KV-cache
+length changes every token) and is not addressed here.
+
+## Result (whisper-tiny encoder, M-series)
+
+| engine            | latency   | energy / encode | fidelity     |
+| ----------------- | --------: | --------------: | ------------ |
+| **ANE**           | 11.4 ms   | ~32 mJ          | cosine 1.0000 |
+| Metal GPU (MPS)   | 13.0 ms   | ~126 mJ         | reference    |
+| CPU (fp32)        | 36.1 ms   | --              | reference    |
+
+The ANE is slightly faster than the GPU and uses about **3.8x less energy per
+encode**, at cosine 0.999987 against the PyTorch reference. Latency and the energy
+ratio are stable across runs; the absolute milliJoule figures move with background
+system load (the ratio does not).
+
+## What this shows, and what it does not
+
+- **Fidelity is exact for practical purposes.** cosine 0.999987 over the full stack,
+  including the gelu LUT the ANE uses, on a randomly-initialised encoder. Latency and
+  energy are weight-independent, so the numbers carry to the published checkpoint.
+- **The win is energy, not raw speed.** Latency is close (the GPU is fast on this
+  workload); the ANE's advantage is drawing ~1.9 W on its own rail versus the GPU's
+  ~8 W (idle-subtracted, whole package).
+- **The native fused-attention layer does not apply here.** At seq 1500, `af.sdpa`
+  decomposes to the same matmul/softmax as `af.mha` (the native layer is reliable only
+  when the smaller attention axis is < 512). The `mha` and `sdpa` rows are identical
+  by construction.
+- **The baseline is PyTorch-eager MPS, not whisper.cpp's hand-tuned Metal kernel**, and
+  not whisper.cpp's existing CoreML path (which can already reach the ANE for the
+  encoder). A true head-to-head needs a whisper.cpp fork; this measures the ANEForge
+  path against a standard PyTorch GPU baseline, the same baseline the project's
+  top-level benchmarks use.
+
+## Integration shape (the C++ runner)
+
+`whisper_ane_run.cpp` loads the compiled encoder and dispatches it on the ANE from
+plain C++ with no Python, which is what a whisper.cpp backend would do at model load.
+
+The compiled on-device program is keyed to the OS build and is not a shippable binary
+artifact, and the cached bundle is not cold-loadable by a fresh process
+(`program_library_create` succeeds, but creating the precompiled operation fails with
+"Must re-compile the E5 bundle"). So the supported reuse path is **compile-with-cache**:
+ship the portable `model.mil` + `weights.bin`, and compile once per process at model
+load (about 0.6 s, cached thereafter). The runner uses the existing
+`ane_e5rt_program_compile` entry point; no changes to ANEForge are needed.
+
+## Files
+
+| file                 | what it does                                                        |
+| -------------------- | ------------------------------------------------------------------- |
+| `encoder.py`         | the whisper-tiny encoder built two ways (HF reference + ANEForge)   |
+| `fidelity.py`        | cosine / relative error vs the PyTorch reference                    |
+| `bench_latency.py`   | ANE (mha, sdpa) vs CPU vs MPS latency                               |
+| `bench_energy.py`    | ANE vs MPS energy via powermetrics (idle-subtracted, whole-package) |
+| `export_bundle.py`   | compile + persist the program, dump fp16 vectors + a port manifest  |
+| `whisper_ane_run.cpp`| standalone C++ ANE runner (links the dispatch dylib)                |
+| `run_cpp.sh`         | export, build, and run the C++ runner end to end                    |
+
+## Run
+
+From the repo root:
+
+```sh
+PYTHONPATH=. python3 bench/whisper_encoder_ane/fidelity.py        # cosine 0.999987
+PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_latency.py   # ANE vs CPU vs MPS
+PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_energy.py    # needs passwordless sudo
+sh bench/whisper_encoder_ane/run_cpp.sh                           # C++, on the ANE, no Python
+```
+
+The encoder is randomly initialised (fixed seed) so nothing is downloaded. To
+reproduce against the real checkpoint, load whisper-tiny's encoder weights into the
+state dict in `encoder.py` (the key names already match HF's `WhisperEncoder`).

--- a/bench/whisper_encoder_ane/bench_energy.py
+++ b/bench/whisper_encoder_ane/bench_energy.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Energy: the whisper-tiny encoder on the ANE vs the Metal GPU (MPS), whole-package,
+idle-subtracted, via powermetrics. Same methodology as the project's headline numbers
+(bench/device_compare_wattcomplete.py): sample CPU+GPU+ANE rails at 500 ms, subtract a
+per-rail idle baseline, report milliJoules per encode.
+
+Needs passwordless sudo for powermetrics. Run from repo root:
+    PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_energy.py [--window 8]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import torch  # noqa: E402
+import encoder as E  # noqa: E402
+
+RAILS = ("CPU", "GPU", "ANE")
+
+
+def sample(workload, seconds):
+    """Spin `workload` in a loop for ~`seconds` while powermetrics samples the rails.
+    Returns (throughput inf/s, {rail: mean mW})."""
+    n = int(seconds * 1000 / 500) + 2
+    proc = subprocess.Popen(
+        ["sudo", "-n", "powermetrics", "--samplers", "cpu_power,gpu_power,ane_power",
+         "-i", "500", "-n", str(n)],
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+    t0 = time.perf_counter()
+    iters = 0
+    while time.perf_counter() - t0 < seconds:
+        workload()
+        iters += 1
+    elapsed = time.perf_counter() - t0
+    out, _ = proc.communicate(timeout=60)
+    means = {}
+    for r in RAILS:
+        vals = [float(v) for v in re.findall(rf"{r} Power:\s*([\d.]+)\s*mW", out)]
+        means[r] = sum(vals) / len(vals) if vals else 0.0
+    return (iters / elapsed if elapsed else 0.0), means
+
+
+def pkg(means):
+    return sum(means[r] for r in RAILS)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--window", type=float, default=8.0, help="seconds per workload sample")
+    args = ap.parse_args()
+
+    if subprocess.run(["sudo", "-n", "true"], capture_output=True).returncode != 0:
+        sys.exit("powermetrics needs sudo: run `sudo -v` first (passwordless sudo).")
+
+    enc, sd = E.make_encoder()
+    mel = E.mel_input()
+    net = E.build(sd, attn="mha")
+    mel4 = mel[:, :, None, :].astype("float16")
+    pos = sd["embed_positions.weight"].astype("float16")
+    ane_call = lambda: net(mel4, pos)
+
+    enc_mps = enc.to("mps").half()
+    x_mps = torch.from_numpy(mel).to("mps").half()
+    def mps_call():
+        with torch.no_grad():
+            enc_mps(x_mps)
+        torch.mps.synchronize()
+
+    print("sampling idle baseline...")
+    _, idle = sample(lambda: time.sleep(0.01), 5)
+    print(f"  idle  CPU {idle['CPU']:.0f}  GPU {idle['GPU']:.0f}  ANE {idle['ANE']:.0f} mW  (pkg {pkg(idle):.0f})")
+
+    rows = []
+    for name, call in (("ANE", ane_call), ("MPS (Metal GPU)", mps_call)):
+        print(f"sampling {name}...")
+        thru, m = sample(call, args.window)
+        active_w = max(0.0, pkg(m) - pkg(idle)) / 1000.0
+        mj = active_w / thru * 1000.0 if thru else 0.0
+        rows.append((name, thru, m, mj))
+
+    print("\n=== whisper-tiny encoder, idle-subtracted whole-package energy ===")
+    print(f"{'engine':16s} {'enc/s':>7} {'ms/enc':>7} {'CPU mW':>7} {'GPU mW':>7} {'ANE mW':>7} {'mJ/enc':>8}")
+    for name, thru, m, mj in rows:
+        ms = 1000 / thru if thru else 0
+        print(f"{name:16s} {thru:7.1f} {ms:7.2f} {m['CPU']:7.0f} {m['GPU']:7.0f} {m['ANE']:7.0f} {mj:8.1f}")
+    if len(rows) == 2 and rows[0][3] and rows[1][3]:
+        print(f"\nANE uses {rows[1][3] / rows[0][3]:.1f}x less energy per encode than MPS.")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/whisper_encoder_ane/bench_latency.py
+++ b/bench/whisper_encoder_ane/bench_latency.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Latency: the whisper-tiny encoder on the ANE (decomposed mha, and af.sdpa) vs the
+same encoder in PyTorch on the CPU (fp32) and the Metal GPU (MPS, fp16).
+
+The ANE 'mha' and 'sdpa' rows are expected to match: at seq=1500 af.sdpa decomposes
+to the same matmul/softmax (the native fused-attention layer needs the smaller
+attention axis < 512). All four run identical weights.
+
+Run from repo root:
+    PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_latency.py [--reps 30]
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+from pathlib import Path
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import torch  # noqa: E402
+import encoder as E  # noqa: E402
+
+
+def time_call(call, reps):
+    out = call()                      # warmup (also the returned sample)
+    t = time.perf_counter()
+    for _ in range(reps):
+        out = call()
+    return (time.perf_counter() - t) / reps * 1e3, out
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--reps", type=int, default=30)
+    args = ap.parse_args()
+
+    enc, sd = E.make_encoder()
+    mel = E.mel_input()
+    ref = E.torch_reference(enc, mel)
+
+    print(f"{'engine':18s} {'ms/call':>8} {'cosine':>9}")
+    for tag in ("mha", "sdpa"):
+        net = E.build(sd, attn=tag)
+        ms, out = time_call(lambda: E.run(net, sd, mel), args.reps)
+        print(f"ANE [{tag:4s}]        {ms:8.2f} {E.cosine(out, ref):9.6f}")
+
+    mt = torch.from_numpy(mel)
+
+    def torch_call(dev, half):
+        m = enc.to(dev)
+        x = mt.to(dev)
+        if half:
+            m = m.half(); x = x.half()
+        def call():
+            with torch.no_grad():
+                m(x)
+            if dev == "mps":
+                torch.mps.synchronize()
+        return call
+
+    ms, _ = time_call(torch_call("cpu", False), args.reps)
+    print(f"{'CPU [fp32]':18s} {ms:8.2f}")
+    enc.to("cpu").float()
+    if torch.backends.mps.is_available():
+        ms, _ = time_call(torch_call("mps", True), args.reps)
+        print(f"{'MPS [fp16]':18s} {ms:8.2f}   (Metal GPU)")
+        enc.to("cpu").float()
+    else:
+        print("MPS not available")
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/whisper_encoder_ane/encoder.py
+++ b/bench/whisper_encoder_ane/encoder.py
@@ -1,10 +1,10 @@
 """A whisper-tiny encoder built two ways from one state dict: the HuggingFace
 reference, and the equivalent ANEForge graph that runs on the Apple Neural Engine.
 
-The weights are randomly initialised (fixed seed) on purpose. Latency and energy
-are weight-independent, and fidelity only needs the two graphs to share weights, so
-nothing is downloaded. Pass real whisper-tiny weights (same key names) to reproduce
-against the published checkpoint.
+Weights are randomly initialised (fixed seed), so nothing is downloaded: latency and
+energy are weight-independent, and fidelity only needs the two graphs to share
+weights. Pass real whisper-tiny weights (same key names) to run the published
+checkpoint.
 
 Mapping notes:
   - The whole transformer stack runs as 2-D [seq, d_model] (batch 1), which is what

--- a/bench/whisper_encoder_ane/encoder.py
+++ b/bench/whisper_encoder_ane/encoder.py
@@ -1,0 +1,114 @@
+"""A whisper-tiny encoder built two ways from one state dict: the HuggingFace
+reference, and the equivalent ANEForge graph that runs on the Apple Neural Engine.
+
+The weights are randomly initialised (fixed seed) on purpose. Latency and energy
+are weight-independent, and fidelity only needs the two graphs to share weights, so
+nothing is downloaded. Pass real whisper-tiny weights (same key names) to reproduce
+against the published checkpoint.
+
+Mapping notes:
+  - The whole transformer stack runs as 2-D [seq, d_model] (batch 1), which is what
+    af.mha / af.layer_norm expect.
+  - Whisper's conv1d stem maps to af.conv (2-D) with a singleton height axis. af.conv
+    pads symmetrically, so the time axis is zero-padded explicitly (_pad_time) and the
+    conv runs with pad=0, leaving the singleton axis alone.
+  - Whisper's k_proj has no bias (passed as None); attention scale is 1/sqrt(d_head),
+    which is af.mha's default.
+"""
+from __future__ import annotations
+
+import numpy as np
+import aneforge as af
+
+# whisper-tiny encoder dimensions.
+D, LAYERS, HEADS, FFN, MELS, CTX, FRAMES = 384, 4, 6, 1536, 80, 1500, 3000
+
+
+def make_encoder(seed: int = 0):
+    """A randomly-initialised HF WhisperEncoder (tiny) and its numpy state dict."""
+    import torch
+    from transformers import WhisperConfig
+    from transformers.models.whisper.modeling_whisper import WhisperEncoder
+    torch.manual_seed(seed)
+    cfg = WhisperConfig(num_mel_bins=MELS, d_model=D, encoder_layers=LAYERS,
+                        encoder_attention_heads=HEADS, encoder_ffn_dim=FFN,
+                        decoder_layers=LAYERS, decoder_attention_heads=HEADS, decoder_ffn_dim=FFN,
+                        max_source_positions=CTX, max_target_positions=448,
+                        activation_function="gelu", dropout=0.0, attention_dropout=0.0,
+                        scale_embedding=False)
+    enc = WhisperEncoder(cfg).eval()
+    sd = {k: v.detach().numpy().astype(np.float32) for k, v in enc.state_dict().items()}
+    return enc, sd
+
+
+def torch_reference(enc, mel: np.ndarray) -> np.ndarray:
+    """The HF encoder output for `mel` ([1, 80, 3000] fp32); returns [1500, 384]."""
+    import torch
+    with torch.no_grad():
+        return enc(torch.from_numpy(mel)).last_hidden_state.numpy()[0]
+
+
+def mel_input(seed: int = 0) -> np.ndarray:
+    """A deterministic random log-mel batch, [1, 80, 3000] fp32."""
+    return np.random.default_rng(seed).standard_normal((1, MELS, FRAMES)).astype(np.float32) * 0.5
+
+
+def _pad_time(x, p: int):
+    """Zero-pad the time (width) axis by `p` each side; the singleton height axis is
+    left untouched. (af.conv pads symmetrically, which a 1-D conv must avoid; the zeros
+    are a width-`p` slice of `x` multiplied by zero, concatenated on either side.)"""
+    w = x.shape[3]
+    z = af.crop(x, 0, 0, 0, w - p) * 0.0
+    return af.concat([z, x, z], axis=3)
+
+
+def _attention(x, sd, p: str, kind: str):
+    wq, bq = sd[p + "self_attn.q_proj.weight"], sd[p + "self_attn.q_proj.bias"]
+    wk = sd[p + "self_attn.k_proj.weight"]                       # whisper k_proj: no bias
+    wv, bv = sd[p + "self_attn.v_proj.weight"], sd[p + "self_attn.v_proj.bias"]
+    wo, bo = sd[p + "self_attn.out_proj.weight"], sd[p + "self_attn.out_proj.bias"]
+    if kind == "mha":
+        return af.mha(x, wq, bq, wk, None, wv, bv, wo, bo, HEADS)
+    s, dh = x.shape[0], D // HEADS
+    def bhsd(t):
+        return t.reshape(s, HEADS, dh).transpose([1, 0, 2]).reshape(1, HEADS, s, dh)
+    o = af.sdpa(bhsd(x.linear(wq, bq)), bhsd(x.linear(wk, None)), bhsd(x.linear(wv, bv)))
+    return o.reshape(HEADS, s, dh).transpose([1, 0, 2]).reshape(s, D).linear(wo, bo)
+
+
+def build(sd, attn: str = "mha", build_dir: str | None = None):
+    """The whisper-tiny encoder as one ANEForge graph; returns the compiled model.
+
+    attn="mha" uses the decomposed multi-head attention. attn="sdpa" routes through
+    af.sdpa, which at seq=1500 also decomposes: the native fused-attention layer is
+    reliable only when the smaller attention axis is < 512, so it does not apply here.
+    Pass `build_dir` to persist model.mil + weights.bin + the compiled bundle there.
+    """
+    mel = af.input((1, MELS, 1, FRAMES))              # log-mel, created first -> fed first
+    pos = af.input((CTX, D))                          # positional embedding, fed as a constant
+    h = _pad_time(mel, 1)
+    h = af.conv(h, sd["conv1.weight"].reshape(D, MELS, 1, 3), stride=1, pad=0, bias=sd["conv1.bias"]).gelu()
+    h = _pad_time(h, 1)
+    h = af.conv(h, sd["conv2.weight"].reshape(D, D, 1, 3), stride=2, pad=0, bias=sd["conv2.bias"]).gelu()
+    h = h.reshape(D, CTX).transpose([1, 0]) + pos     # [1, 384, 1, 1500] -> [1500, 384] + pos
+    for i in range(LAYERS):
+        p = f"layers.{i}."
+        xn = h.layer_norm(sd[p + "self_attn_layer_norm.weight"], sd[p + "self_attn_layer_norm.bias"])
+        h = h + _attention(xn, sd, p, attn)
+        fn = h.layer_norm(sd[p + "final_layer_norm.weight"], sd[p + "final_layer_norm.bias"])
+        h = h + fn.linear(sd[p + "fc1.weight"], sd[p + "fc1.bias"]).gelu().linear(sd[p + "fc2.weight"], sd[p + "fc2.bias"])
+    h = h.layer_norm(sd["layer_norm.weight"], sd["layer_norm.bias"])
+    return af.compile(h, build_dir=build_dir)
+
+
+def run(net, sd, mel: np.ndarray) -> np.ndarray:
+    """Feed (mel, positional-embedding) in creation order; returns fp32 [1500, 384]."""
+    mel4 = mel[:, :, None, :].astype(np.float16)
+    pos = sd["embed_positions.weight"].astype(np.float16)
+    return net(mel4, pos)
+
+
+def cosine(a, b) -> float:
+    a = np.asarray(a, np.float64).ravel()
+    b = np.asarray(b, np.float64).ravel()
+    return float(a @ b / (np.linalg.norm(a) * np.linalg.norm(b)))

--- a/bench/whisper_encoder_ane/export_bundle.py
+++ b/bench/whisper_encoder_ane/export_bundle.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Compile the whisper-tiny encoder, persist its program (model.mil + weights.bin +
+the compiled bundle), and dump everything the standalone C++ runner needs: the exact
+fp16 input vectors, the port manifest (names + element counts), and the PyTorch
+reference output to score against.
+
+Run from repo root:
+    PYTHONPATH=. python3 bench/whisper_encoder_ane/export_bundle.py [--out DIR]
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np  # noqa: E402
+import encoder as E  # noqa: E402
+
+
+def find_composite_bundle(build_dir: Path):
+    """The composite '*.bundle' dir under the cache (it holds the per-hardware
+    H17*.bundle / universal.bundle variants); that is what e5rt_program_library_create
+    loads. Identify it as a '*.bundle' that itself contains '*.bundle' children."""
+    for d in build_dir.glob("cache/**/*.bundle"):
+        if any(d.glob("*.bundle")):
+            return d
+    return None
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--out", default="/tmp/whisper_enc_bundle", help="bundle + I/O output dir")
+    args = ap.parse_args()
+    build_dir = Path(args.out)
+    io_dir = build_dir / "io"
+    io_dir.mkdir(parents=True, exist_ok=True)
+
+    enc, sd = E.make_encoder()
+    mel = E.mel_input()
+    ref = E.torch_reference(enc, mel)
+
+    net = E.build(sd, attn="mha", build_dir=str(build_dir))
+    out = E.run(net, sd, mel)
+
+    feed = {(1, E.MELS, 1, E.FRAMES): mel[:, :, None, :].astype(np.float16),
+            (E.CTX, E.D): sd["embed_positions.weight"].astype(np.float16)}
+    for name, shape in net._inputs:
+        feed[tuple(shape)].tofile(io_dir / f"{name}.f16")
+    ref.astype(np.float32).tofile(io_dir / "ref.f32")
+    out.astype(np.float32).tofile(io_dir / "out_python.f32")
+
+    composite = find_composite_bundle(build_dir)
+    manifest = {
+        "build_dir": str(build_dir),
+        "bundle": str(composite) if composite else None,
+        "inputs": [[name, int(np.prod(shape))] for name, shape in net._inputs],
+        "output": [net._out_name, int(np.prod(out.shape))],
+        "out_shape": list(out.shape),
+    }
+    (io_dir / "manifest.json").write_text(json.dumps(manifest, indent=2))
+    print(f"cosine (python ANE vs torch): {E.cosine(out, ref):.6f}")
+    print(f"wrote {build_dir}/model.mil, weights.bin, cache/, and io/ (vectors + manifest)")
+    print(json.dumps(manifest, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/bench/whisper_encoder_ane/fidelity.py
+++ b/bench/whisper_encoder_ane/fidelity.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python3
+"""Fidelity gate: the ANEForge whisper-tiny encoder vs the PyTorch reference, same
+weights. Prints cosine similarity and relative error of the encoder output computed
+on the Apple Neural Engine.
+
+Run from repo root:
+    PYTHONPATH=. python3 bench/whisper_encoder_ane/fidelity.py
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import numpy as np  # noqa: E402
+import encoder as E  # noqa: E402
+
+enc, sd = E.make_encoder()
+mel = E.mel_input()
+ref = E.torch_reference(enc, mel)
+out = E.run(E.build(sd, attn="mha"), sd, mel)
+
+rel = float(np.linalg.norm(out.ravel().astype(np.float64) - ref.ravel().astype(np.float64))
+            / np.linalg.norm(ref.ravel().astype(np.float64)))
+print(f"whisper-tiny encoder  shape {tuple(out.shape)}")
+print(f"  cosine vs torch : {E.cosine(out, ref):.6f}")
+print(f"  relative error  : {rel:.4f}")

--- a/bench/whisper_encoder_ane/run_cpp.sh
+++ b/bench/whisper_encoder_ane/run_cpp.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+# End-to-end C++ demo: export the encoder bundle from Python, build the standalone
+# runner against the dispatch dylib, and run it on the ANE (no Python at run time).
+# Run from the repo root:  sh bench/whisper_encoder_ane/run_cpp.sh
+set -e
+here="$(cd "$(dirname "$0")" && pwd)"
+repo="$(cd "$here/../.." && pwd)"
+dylib="$repo/aneforge/_lib/libane_e5rt_dispatch.dylib"
+out="/tmp/whisper_enc_bundle"
+
+[ -f "$dylib" ] || sh "$repo/aneforge/_lib/build.sh"
+
+echo "== exporting bundle + test vectors (Python) =="
+PYTHONPATH="$repo" python3 "$here/export_bundle.py" --out "$out" >/dev/null
+echo "   done -> $out"
+
+echo "== building C++ runner =="
+xcrun clang++ -O2 -std=c++17 "$here/whisper_ane_run.cpp" "$dylib" -o /tmp/whisper_ane_run
+
+echo "== running on the ANE (no Python) =="
+python3 - "$out" <<'PY'
+import json, subprocess, sys
+io = sys.argv[1] + "/io"
+m = json.load(open(io + "/manifest.json"))
+(i0, n0), (i1, n1) = m["inputs"]
+on, onn = m["output"]
+subprocess.run(["/tmp/whisper_ane_run", m["build_dir"],
+                i0, str(n0), f"{io}/{i0}.f16", i1, str(n1), f"{io}/{i1}.f16",
+                on, str(onn), f"{io}/ref.f32"], check=True)
+PY

--- a/bench/whisper_encoder_ane/whisper_ane_run.cpp
+++ b/bench/whisper_encoder_ane/whisper_ane_run.cpp
@@ -1,7 +1,7 @@
 // Standalone Apple Neural Engine runner for the whisper-tiny encoder: loads the
 // program ANEForge produced (model.mil + weights.bin) and dispatches it on the ANE,
-// with no Python. This is the shape of the call a C inference engine (e.g. a
-// whisper.cpp backend) would make at model-load time.
+// with no Python, as a C inference engine (e.g. a whisper.cpp backend) would at
+// model load.
 //
 //   whisper_ane_run BUILD_DIR  IN0 N0 F0  IN1 N1 F1  OUT NOUT  REF.f32
 //

--- a/bench/whisper_encoder_ane/whisper_ane_run.cpp
+++ b/bench/whisper_encoder_ane/whisper_ane_run.cpp
@@ -1,0 +1,111 @@
+// Standalone Apple Neural Engine runner for the whisper-tiny encoder: loads the
+// program ANEForge produced (model.mil + weights.bin) and dispatches it on the ANE,
+// with no Python. This is the shape of the call a C inference engine (e.g. a
+// whisper.cpp backend) would make at model-load time.
+//
+//   whisper_ane_run BUILD_DIR  IN0 N0 F0  IN1 N1 F1  OUT NOUT  REF.f32
+//
+// IN*/N*/F*: input port name, element count, raw-fp16 file (from export_bundle.py).
+// OUT/NOUT: output port name and element count. REF.f32: fp32 reference to score.
+//
+// It links libane_e5rt_dispatch.dylib and calls ane_e5rt_program_compile. Note: the
+// cached on-device ANEF macho is NOT cold-loadable by a fresh process
+// (program_library_create succeeds but creating the precompiled operation fails with
+// "Must re-compile the E5 bundle"). So the supported reuse path is compile-with-cache:
+// ship model.mil + weights.bin, compile once per process at model load (cached after).
+#include <cstdio>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <cmath>
+#include <vector>
+#include <chrono>
+
+typedef struct ane_e5rt_program ane_e5rt_program_t;
+extern "C" {
+ane_e5rt_program_t *ane_e5rt_program_compile(
+    const char *mil_path, const char *cache_dir, uint64_t device_mask,
+    const char *const *input_names, const size_t *input_sizes, size_t n_inputs,
+    const char *const *output_names, const size_t *output_sizes, size_t n_outputs);
+int  ane_e5rt_program_set_input_fp16(ane_e5rt_program_t *, const char *, const uint16_t *, size_t);
+int  ane_e5rt_program_get_output_fp16(ane_e5rt_program_t *, const char *, uint16_t *, size_t);
+int  ane_e5rt_program_execute(ane_e5rt_program_t *);
+void ane_e5rt_program_release(ane_e5rt_program_t *);
+}
+
+static float half2float(uint16_t h) {
+  uint32_t s = (h >> 15) & 1, e = (h >> 10) & 0x1f, m = h & 0x3ff, out;
+  if (e == 0)         out = m ? ((s << 31) | (0x38800000u + (m << 13))) : (s << 31);
+  else if (e == 0x1f) out = (s << 31) | 0x7f800000u | (m << 13);
+  else                out = (s << 31) | ((e + 112) << 23) | (m << 13);
+  float f; memcpy(&f, &out, 4); return f;
+}
+
+static std::vector<uint16_t> read_f16(const char *path, size_t n) {
+  std::vector<uint16_t> v(n);
+  FILE *f = fopen(path, "rb");
+  if (!f) { fprintf(stderr, "open %s failed\n", path); exit(2); }
+  if (fread(v.data(), 2, n, f) != n) { fprintf(stderr, "short read %s\n", path); exit(2); }
+  fclose(f);
+  return v;
+}
+
+int main(int argc, char **argv) {
+  if (argc != 11) {
+    fprintf(stderr, "usage: %s BUILD_DIR IN0 N0 F0 IN1 N1 F1 OUT NOUT REF.f32\n", argv[0]);
+    return 1;
+  }
+  char mil_path[2048], cache_dir[2048];
+  snprintf(mil_path, sizeof(mil_path), "%s/model.mil", argv[1]);
+  snprintf(cache_dir, sizeof(cache_dir), "%s/cache", argv[1]);
+  const char *in_names[2] = {argv[2], argv[5]};
+  size_t in_nelems[2] = {(size_t)atoll(argv[3]), (size_t)atoll(argv[6])};
+  const char *in_files[2] = {argv[4], argv[7]};
+  const char *out_name = argv[8];
+  size_t out_nelems = (size_t)atoll(argv[9]);
+  size_t in_bytes[2] = {in_nelems[0] * 2, in_nelems[1] * 2};
+  size_t out_bytes = out_nelems * 2;
+
+  auto t0 = std::chrono::high_resolution_clock::now();
+  ane_e5rt_program_t *prog = ane_e5rt_program_compile(
+      mil_path, cache_dir, 0x4 /*ANE*/, in_names, in_bytes, 2, &out_name, &out_bytes, 1);
+  if (!prog) { fprintf(stderr, "ane_e5rt_program_compile failed\n"); return 3; }
+  auto t1 = std::chrono::high_resolution_clock::now();
+  printf("compiled+loaded encoder in %.0f ms (one-time, per process)\n",
+         std::chrono::duration<double, std::milli>(t1 - t0).count());
+
+  for (int i = 0; i < 2; i++) {
+    auto v = read_f16(in_files[i], in_nelems[i]);
+    if (ane_e5rt_program_set_input_fp16(prog, in_names[i], v.data(), in_nelems[i]) != 0) {
+      fprintf(stderr, "set_input %s failed\n", in_names[i]);
+      return 4;
+    }
+  }
+
+  if (ane_e5rt_program_execute(prog) != 0) { fprintf(stderr, "execute failed\n"); return 5; }
+  const int REP = 20;
+  auto e0 = std::chrono::high_resolution_clock::now();
+  for (int i = 0; i < REP; i++) ane_e5rt_program_execute(prog);
+  auto e1 = std::chrono::high_resolution_clock::now();
+  double ms = std::chrono::duration<double, std::milli>(e1 - e0).count() / REP;
+
+  std::vector<uint16_t> out16(out_nelems);
+  if (ane_e5rt_program_get_output_fp16(prog, out_name, out16.data(), out_nelems) != 0) {
+    fprintf(stderr, "get_output failed\n");
+    return 6;
+  }
+
+  std::vector<float> ref(out_nelems);
+  FILE *rf = fopen(argv[10], "rb");
+  if (!rf || fread(ref.data(), 4, out_nelems, rf) != out_nelems) { fprintf(stderr, "ref read failed\n"); return 7; }
+  fclose(rf);
+  double dot = 0, na = 0, nb = 0;
+  for (size_t i = 0; i < out_nelems; i++) {
+    double a = half2float(out16[i]), b = ref[i];
+    dot += a * b; na += a * a; nb += b * b;
+  }
+  printf("ANE encode latency: %.3f ms/call (avg of %d)\n", ms, REP);
+  printf("cosine vs torch reference: %.6f\n", dot / (sqrt(na) * sqrt(nb)));
+  ane_e5rt_program_release(prog);
+  return 0;
+}


### PR DESCRIPTION
Runs the whisper-tiny encoder on the Neural Engine via ANEForge and compares it against PyTorch on CPU and the Metal GPU (MPS), with a standalone C++ runner that dispatches the compiled encoder on the ANE with no Python.

Results (whisper-tiny encoder): cosine 0.999987 vs the PyTorch reference, ~11.4 ms/encode (vs 13.0 ms MPS, 36.1 ms CPU), and about 3.8x less energy per encode than the GPU. The win is energy, not raw speed.

Self-contained under `bench/whisper_encoder_ane/`; ANEForge itself is unchanged. The README is upfront about the limits: the baseline is PyTorch-MPS rather than whisper.cpp's own Metal/CoreML path, the native fused-attention layer does not apply at seq 1500 (af.sdpa decomposes), and the compiled bundle is not cold-loadable so the integration path is compile-with-cache.