### PR TITLE
Correct Whisper encoder latency framing, add CoreML comparison

### DIFF
--- a/bench/whisper_encoder_ane/README.md
+++ b/bench/whisper_encoder_ane/README.md
@@ -1,8 +1,8 @@
 # Whisper encoder on the Apple Neural Engine
 
 The Whisper audio encoder, compiled with ANEForge into one program and run on the
-Apple Neural Engine (no CoreML), benchmarked against the same encoder in PyTorch on
-the CPU and the Metal GPU (MPS).
+Apple Neural Engine (no CoreML), benchmarked against the same encoder in PyTorch (CPU
+and Metal/MPS) and against whisper.cpp's own Metal and CoreML encoders.
 
 The encoder is the fixed-shape half of Whisper (an 80-channel log-mel over a fixed
 1500-frame context), so it compiles once and dispatches many times. The
@@ -11,19 +11,19 @@ here.
 
 ## Result (whisper-tiny encoder, M-series)
 
-| engine          | latency | energy / encode | fidelity      |
-| --------------- | ------: | --------------: | ------------- |
-| ANE             | 11.4 ms | ~32 mJ          | cosine 0.9998 |
-| Metal GPU (MPS) | 13.0 ms | ~126 mJ         | reference     |
-| CPU (fp32)      | 36.1 ms | --              | reference     |
+| engine               | latency | energy / encode | fidelity      |
+| -------------------- | ------: | --------------: | ------------- |
+| ANE                  | 11.4 ms | ~32 mJ          | cosine 0.9998 |
+| PyTorch-MPS (eager)  | 13.0 ms | ~126 mJ         | reference     |
+| PyTorch CPU (fp32)   | 36.1 ms | --              | reference     |
 
-The ANE matches the GPU on latency and uses about 3.8x less energy per encode, at
-cosine 0.9998 on real speech against the PyTorch reference, with an identical
-transcript (see Fidelity below). For reference, whisper.cpp's own Metal encoder runs
-the same tiny model at about 14.3 ms on this machine, so the ANE encoder is faster
-than the engine it would replace, not only the PyTorch baseline. The latency and the
-energy ratio are stable across runs; absolute milliJoules move with background system
-load.
+On the ANE the encoder runs at about 11 ms per encode and uses about 3.8x less energy
+than the PyTorch-MPS baseline, at cosine 0.9998 on real speech with an identical
+transcript (see Fidelity). Latency is not the headline: an optimized GPU kernel is
+faster than the ANE here (see Compared to whisper.cpp). The case for the ANE is energy.
+The energy ratio is stable across runs; absolute milliJoules move with background
+system load, and it is measured against PyTorch-MPS, not an optimized Metal kernel,
+which would draw less and narrow the ratio.
 
 ## Fidelity
 
@@ -41,19 +41,43 @@ the HF Whisper decoder transcribes jfk.wav identically to the reference encoder
 absorbs the gap on real speech. Latency and energy are weight-independent and unchanged
 by which weights run.
 
+## Compared to whisper.cpp
+
+The PyTorch-MPS baseline above is an eager GPU path, not an optimized kernel.
+whisper.cpp ships both an optimized Metal encoder and a CoreML encoder that reaches
+the ANE, so it is the real point of comparison. Measured with its own `whisper-bench`
+on the same tiny model, steady-state per encode:
+
+| encoder            | latency  | hardware |
+| ------------------ | -------: | -------- |
+| whisper.cpp Metal  | ~7.3 ms  | GPU      |
+| whisper.cpp CoreML | ~11.2 ms | ANE      |
+| ANEForge direct    | ~11.4 ms | ANE      |
+
+Two things follow. The optimized Metal kernel is the latency winner for tiny, so on
+the ANE the case is energy, not speed. And ANEForge's direct path matches CoreML on
+ANE latency: going direct does not beat CoreML on speed, it ties it. The direct path
+wins elsewhere: no CoreML dependency or conversion step, the encoder is trainable, and
+the cold cost is lower. A single cold encode in a fresh process is about 12 ms for
+ANEForge, against about 36 ms for whisper.cpp's CoreML path (CoreML runtime plus
+first-inference setup) and 14 ms for Metal; ANEForge pays its setup once, as a ~0.6 s
+compile at load.
+
+Reproduce the whisper.cpp side: build it with and without `-DWHISPER_COREML=1` (the
+CoreML encoder needs a converted `ggml-tiny-encoder.mlmodelc`), then
+`whisper-bench -m models/ggml-tiny.bin`.
+
 ## Notes
 
-- The advantage is energy, not latency. Latency is close; the ANE draws about 1.9 W
-  on its own rail against the GPU's 8 W (idle-subtracted, whole package).
+- The case for the ANE is energy. On its own rail it draws about 1.9 W against the
+  PyTorch-MPS path's 8 W (idle-subtracted, whole package); an optimized Metal kernel
+  draws less than eager MPS, so the gap to a tuned GPU path is smaller than 3.8x.
 - At seq 1500 `af.sdpa` decomposes to the same matmul/softmax as `af.mha`, because the
   native fused-attention layer is reliable only when the smaller attention axis is
   below 512. The two rows are identical by construction.
-- The main table's GPU baseline is PyTorch-eager MPS, the same baseline the top-level
-  benchmarks use. whisper.cpp's own Metal encoder, measured separately on the same
-  tiny model and clip, runs at about 14.3 ms, also slower than the ANE here. The
-  comparison still missing is whisper.cpp's CoreML path, which can already reach the
-  ANE for the encoder; measuring against it, and a real in-engine integration, need a
-  whisper.cpp fork.
+- The comparison still missing is a real in-engine integration: wiring the ANEForge
+  encoder into whisper.cpp's decode path and measuring word-error-rate end to end,
+  which needs a whisper.cpp fork.
 
 ## C++ runner
 


### PR DESCRIPTION
Corrects a misleading comparison and adds the CoreML-ANE measurement.

The previous README compared the ANE's warm per-encode latency against whisper.cpp's cold single-encode and concluded the ANE was faster than Metal. That was warm-vs-cold. Measured with whisper.cpp's own `whisper-bench` at steady state on the same tiny model:

| encoder            | latency  | hardware |
| ------------------ | -------: | -------- |
| whisper.cpp Metal  | ~7.3 ms  | GPU      |
| whisper.cpp CoreML | ~11.2 ms | ANE      |
| ANEForge direct    | ~11.4 ms | ANE      |

So the optimized Metal kernel is the latency winner for tiny, and ANEForge's direct path ties CoreML on ANE latency rather than beating it. The ANE case is energy, not speed. ANEForge's edge over CoreML is dependency (none), conversion (none), trainability, and cold cost: a single cold encode is ~12 ms for ANEForge vs ~36 ms for whisper.cpp's CoreML path. Also flags that the energy ratio is measured against PyTorch-MPS, not a tuned Metal kernel, which would narrow it.