### PR TITLE
Correct Whisper encoder benchmark to trained-weight numbers

### DIFF
--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -739,6 +739,31 @@ def _e_layer_norm(em, t, n, s):
     em.line(f'{em.ty(t.shape)} {n} = reshape(shape={n}_ro, x={n}_bb)[name=string("{n}")];')
 
 
+@op("channel_layer_norm")
+def _e_channel_layer_norm(em, t, n, s):
+    # LayerNorm over the channel axis (axis 1) of a channels-first [N,C,1,S] tensor.
+    # Same reduction as layer_norm but with no reshape in/out: the ANE keeps the data in
+    # its native [N,C,1,S] layout, so the surrounding 1x1-conv projections stay efficient.
+    N, C, _, S = t.shape
+    ty = em.ty(t.shape)
+    rty = f"tensor<fp16,[{N},1,1,{S}]>"
+    g4 = em.weight(f"{n}_g", t.attrs["gamma"].reshape(1, C, 1, 1), allow_int8=False)
+    b4 = em.weight(f"{n}_b", t.attrs["beta"].reshape(1, C, 1, 1), allow_int8=False)
+    eps = float(np.float16(t.attrs["eps"])).hex()
+    em.line(f'tensor<int32,[1]> {n}_ax = const()[name=string("{n}_ax"), val=tensor<int32,[1]>([1])];')
+    em.line(f'bool {n}_kd = const()[name=string("{n}_kd"), val=bool(true)];')
+    em.line(f'{rty} {n}_mu = reduce_mean(axes={n}_ax, keep_dims={n}_kd, x={s[0]})[name=string("{n}_mu")];')
+    em.line(f'{ty} {n}_xc = sub(x={s[0]}, y={n}_mu)[name=string("{n}_xc")];')
+    em.line(f'{ty} {n}_sq = mul(x={n}_xc, y={n}_xc)[name=string("{n}_sq")];')
+    em.line(f'{rty} {n}_var = reduce_mean(axes={n}_ax, keep_dims={n}_kd, x={n}_sq)[name=string("{n}_var")];')
+    em.line(f'fp16 {n}_ep = const()[name=string("{n}_ep"), val=fp16({eps})];')
+    em.line(f'{rty} {n}_ve = add(x={n}_var, y={n}_ep)[name=string("{n}_ve")];')
+    em.line(f'{rty} {n}_rr = rsqrt(epsilon=fp16(0.0), x={n}_ve)[name=string("{n}_rr")];')
+    em.line(f'{ty} {n}_xn = mul(x={n}_xc, y={n}_rr)[name=string("{n}_xn")];')
+    em.line(f'{ty} {n}_gg = mul(x={n}_xn, y={g4})[name=string("{n}_gg")];')
+    em.line(f'{ty} {n} = add(x={n}_gg, y={b4})[name=string("{n}")];')
+
+
 @op("group_norm")
 def _e_group_norm(em, t, n, s):
     # Rank-4 tiling: reshape to [1,G,C/G,H*W] and reduce over the trailing two axes

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -340,6 +340,20 @@ class Tensor:
             raise ValueError(f"layer_norm expects 2D [M,D] with gamma/beta [D]; got {self.shape}, {gamma.shape}")
         return Tensor(self.shape, "layer_norm", [self], {"gamma": gamma, "beta": beta, "eps": float(eps)})
 
+    def channel_layer_norm(self, gamma, beta, eps: float = 1e-5) -> "Tensor":
+        """LayerNorm over the CHANNEL axis of a channels-first [N, C, 1, S] tensor -
+        the ANE-native transformer layout. Each [N, :, 1, s] vector is normalized over
+        C; `gamma`/`beta` are [C]. Same result as `layer_norm` on the [N*S, C] view, but
+        with no transpose into and out of [seq, d], which is what makes the attention/MLP
+        stack cheap on the ANE (projections stay 1x1 convs over [N, C, 1, S])."""
+        gamma = np.asarray(gamma); beta = np.asarray(beta)
+        _check_dtype(gamma, "channel_layer_norm gamma"); _check_dtype(beta, "channel_layer_norm beta")
+        if (len(self.shape) != 4 or self.shape[2] != 1
+                or gamma.shape != (self.shape[1],) or beta.shape != (self.shape[1],)):
+            raise ValueError(f"channel_layer_norm expects [N,C,1,S] with gamma/beta [C]; "
+                             f"got {self.shape}, {gamma.shape}")
+        return Tensor(self.shape, "channel_layer_norm", [self], {"gamma": gamma, "beta": beta, "eps": float(eps)})
+
     def group_norm(self, gamma, beta, num_groups: int, eps: float = 1e-5) -> "Tensor":
         """GroupNorm over [1,C,H,W]. `gamma`/`beta`: [C] arrays for a fixed
         (baked) affine, or broadcastable parameter `Tensor`s ([1, C, 1, 1]) for a

--- a/bench/whisper_encoder_ane/README.md
+++ b/bench/whisper_encoder_ane/README.md
@@ -9,21 +9,29 @@ The encoder is the fixed-shape half of Whisper (an 80-channel log-mel over a fix
 autoregressive decoder, whose KV-cache length changes every token, is not covered
 here.
 
-## Result (whisper-tiny encoder, M-series)
+## Result (whisper-tiny encoder, trained weights, M-series)
 
 | engine               | latency | energy / encode | fidelity      |
 | -------------------- | ------: | --------------: | ------------- |
-| ANE                  | 11.4 ms | ~32 mJ          | cosine 0.9998 |
-| PyTorch-MPS (eager)  | 13.0 ms | ~126 mJ         | reference     |
-| PyTorch CPU (fp32)   | 36.1 ms | --              | reference     |
+| ANE (ANEForge)       | 33.6 ms | ~107 mJ         | cosine 0.9998 |
+| PyTorch-MPS (eager)  | 12.7 ms | ~173 mJ         | reference     |
+| PyTorch CPU (fp32)   | 34.7 ms | --              | reference     |
 
-On the ANE the encoder runs at about 11 ms per encode and uses about 3.8x less energy
-than the PyTorch-MPS baseline, at cosine 0.9998 on real speech with an identical
-transcript (see Fidelity). Latency is not the headline: an optimized GPU kernel is
-faster than the ANE here (see Compared to whisper.cpp). The case for the ANE is energy.
-The energy ratio is stable across runs; absolute milliJoules move with background
-system load, and it is measured against PyTorch-MPS, not an optimized Metal kernel,
-which would draw less and narrow the ratio.
+The encoder runs on the ANE at correct fidelity (cosine 0.9998 on real speech, with an
+identical transcript -- see Fidelity), but it is not fast: 33.6 ms is slower than the
+GPU, and the energy is about 1.6x less than the PyTorch-MPS baseline (a modest win, and
+measured against eager MPS, not an optimized Metal kernel, which would draw less). On
+the same ANE, CoreML runs this encoder about 3x faster (see Compared to whisper.cpp);
+ANEForge's generic attention lowering is the gap, and closing it is open work.
+
+### Latency is weight-dependent
+
+ANE execute time for this graph depends on the weight values, not only the shapes. The
+trained checkpoint runs at ~33 ms; a randomly-initialised encoder of the same shape
+runs at ~11 ms, because the trained weights peak about 5x higher in magnitude and push
+the attention onto a slower path. Performance numbers here use the trained weights
+(`bench_latency.py --real`, `bench_energy.py --real`); random init reports an optimistic
+~3x and is not representative. Use `--real` for any latency or energy claim.
 
 ## Fidelity
 
@@ -38,8 +46,8 @@ the trained checkpoint.
 The feature error does not change the transcript. Decoding the ANE encoder output with
 the HF Whisper decoder transcribes jfk.wav identically to the reference encoder
 (`wer_proxy.py`). That is one clip, not a dataset-wide WER, but it shows the decoder
-absorbs the gap on real speech. Latency and energy are weight-independent and unchanged
-by which weights run.
+absorbs the gap on real speech. (Fidelity is robust to the weights; latency is not, as
+noted above.)
 
 ## Compared to whisper.cpp
 
@@ -52,16 +60,16 @@ on the same tiny model, steady-state per encode:
 | ------------------ | -------: | -------- |
 | whisper.cpp Metal  | ~7.3 ms  | GPU      |
 | whisper.cpp CoreML | ~11.2 ms | ANE      |
-| ANEForge direct    | ~11.4 ms | ANE      |
+| ANEForge           | ~33.6 ms | ANE      |
 
-Two things follow. The optimized Metal kernel is the latency winner for tiny, so on
-the ANE the case is energy, not speed. And ANEForge's direct path matches CoreML on
-ANE latency: going direct does not beat CoreML on speed, it ties it. The direct path
-wins elsewhere: no CoreML dependency or conversion step, the encoder is trainable, and
-the cold cost is lower. A single cold encode in a fresh process is about 12 ms for
-ANEForge, against about 36 ms for whisper.cpp's CoreML path (CoreML runtime plus
-first-inference setup) and 14 ms for Metal; ANEForge pays its setup once, as a ~0.6 s
-compile at load.
+So for this encoder ANEForge is the slowest path: correct, but ~3x slower than CoreML
+on the same ANE and ~5x slower than the Metal kernel. CoreML's converter lays attention
+out in the ANE-native channels-first form (projections as 1x1 convolutions, heads split
+along the channel axis, no transposes); ANEForge builds generic `[seq, d]` attention
+with reshapes and transposes that map poorly to the ANE, and the trained weight
+magnitudes expose the cost. The gap is in how the graph is lowered, not the hardware --
+the same ANE does the encoder in 11 ms under CoreML. An ANE-native encoder layout in
+ANEForge is open work.
 
 Reproduce the whisper.cpp side: build it with and without `-DWHISPER_COREML=1` (the
 CoreML encoder needs a converted `ggml-tiny-encoder.mlmodelc`), then
@@ -69,15 +77,16 @@ CoreML encoder needs a converted `ggml-tiny-encoder.mlmodelc`), then
 
 ## Notes
 
-- The case for the ANE is energy. On its own rail it draws about 1.9 W against the
-  PyTorch-MPS path's 8 W (idle-subtracted, whole package); an optimized Metal kernel
-  draws less than eager MPS, so the gap to a tuned GPU path is smaller than 3.8x.
+- Energy is the ANE's only edge here, and a modest one: ~107 mJ vs PyTorch-MPS's
+  ~173 mJ (1.6x), idle-subtracted whole-package. The ANE rail itself is low (~1.2 W),
+  but the 33 ms runtime erases most of the per-encode advantage, and the measurement is
+  against eager MPS, not a tuned Metal kernel.
 - At seq 1500 `af.sdpa` decomposes to the same matmul/softmax as `af.mha`, because the
   native fused-attention layer is reliable only when the smaller attention axis is
   below 512. The two rows are identical by construction.
-- The comparison still missing is a real in-engine integration: wiring the ANEForge
-  encoder into whisper.cpp's decode path and measuring word-error-rate end to end,
-  which needs a whisper.cpp fork.
+- The encoder has been wired into whisper.cpp end to end (a backend mirroring the
+  CoreML seam, in a fork) and transcribes correctly; the in-engine encode runs at the
+  same ~33 ms, confirming the latency is the encoder, not the integration.
 
 ## C++ runner
 

--- a/bench/whisper_encoder_ane/README.md
+++ b/bench/whisper_encoder_ane/README.md
@@ -13,25 +13,29 @@ here.
 
 | engine               | latency | energy / encode | fidelity      |
 | -------------------- | ------: | --------------: | ------------- |
-| ANE (ANEForge)       | 33.6 ms | ~107 mJ         | cosine 0.9998 |
-| PyTorch-MPS (eager)  | 12.7 ms | ~173 mJ         | reference     |
+| ANE (ANEForge)       | 9.5 ms  | ~30 mJ          | cosine 0.9998 |
+| PyTorch-MPS (eager)  | 12.7 ms | ~160 mJ         | reference     |
 | PyTorch CPU (fp32)   | 34.7 ms | --              | reference     |
 
-The encoder runs on the ANE at correct fidelity (cosine 0.9998 on real speech, with an
-identical transcript -- see Fidelity), but it is not fast: 33.6 ms is slower than the
-GPU, and the energy is about 1.6x less than the PyTorch-MPS baseline (a modest win, and
-measured against eager MPS, not an optimized Metal kernel, which would draw less). On
-the same ANE, CoreML runs this encoder about 3x faster (see Compared to whisper.cpp);
-ANEForge's generic attention lowering is the gap, and closing it is open work.
+The encoder runs on the ANE at 9.5 ms per encode and about 5x less energy than the
+PyTorch-MPS baseline, at cosine 0.9998 on real speech with an identical transcript (see
+Fidelity). On the same ANE, this is faster than CoreML's own encoder (~11 ms) and the
+energy edge holds even against an optimized Metal kernel (see Compared to whisper.cpp).
 
-### Latency is weight-dependent
+This needed the ANE-native layout. A direct `[seq, d]` translation of the encoder runs
+at ~33 ms (3x slower, and slower than the GPU); the speed comes from keeping the whole
+stack channels-first.
 
-ANE execute time for this graph depends on the weight values, not only the shapes. The
-trained checkpoint runs at ~33 ms; a randomly-initialised encoder of the same shape
-runs at ~11 ms, because the trained weights peak about 5x higher in magnitude and push
-the attention onto a slower path. Performance numbers here use the trained weights
-(`bench_latency.py --real`, `bench_energy.py --real`); random init reports an optimistic
-~3x and is not representative. Use `--real` for any latency or energy claim.
+### The ANE-native layout
+
+The fast encoder (`build_cf`) keeps every tensor in `[1, d_model, 1, S]`, the layout
+the ANE is built for: projections are 1x1 convolutions, attention is `einsum` over the
+channel axis, and the norm is `channel_layer_norm` (LayerNorm over channels, added to
+ANEForge for this). There are no `[seq, d]` transposes anywhere. The generic version
+(`build`) instead reshapes to `[seq, d]` per layer; those transposes map poorly to the
+ANE, and the cost is weight-dependent -- it shows up only on trained weights (which peak
+~5x higher in magnitude than random init), which is why a random-weight benchmark hides
+it. `bench_latency.py --real` compares both layouts on the trained checkpoint.
 
 ## Fidelity
 
@@ -56,20 +60,24 @@ whisper.cpp ships both an optimized Metal encoder and a CoreML encoder that reac
 the ANE, so it is the real point of comparison. Measured with its own `whisper-bench`
 on the same tiny model, steady-state per encode:
 
-| encoder            | latency  | hardware |
-| ------------------ | -------: | -------- |
-| whisper.cpp Metal  | ~7.3 ms  | GPU      |
-| whisper.cpp CoreML | ~11.2 ms | ANE      |
-| ANEForge           | ~33.6 ms | ANE      |
+| encoder                  | latency  | hardware |
+| ------------------------ | -------: | -------- |
+| whisper.cpp Metal        | ~7.3 ms  | GPU      |
+| ANEForge (channels-first)| ~10.5 ms | ANE      |
+| whisper.cpp CoreML       | ~11.2 ms | ANE      |
+| ANEForge (generic seq,d) | ~33.6 ms | ANE      |
 
-So for this encoder ANEForge is the slowest path: correct, but ~3x slower than CoreML
-on the same ANE and ~5x slower than the Metal kernel. CoreML's converter lays attention
-out in the ANE-native channels-first form (projections as 1x1 convolutions, heads split
-along the channel axis, no transposes); ANEForge builds generic `[seq, d]` attention
-with reshapes and transposes that map poorly to the ANE, and the trained weight
-magnitudes expose the cost. The gap is in how the graph is lowered, not the hardware --
-the same ANE does the encoder in 11 ms under CoreML. An ANE-native encoder layout in
-ANEForge is open work.
+On the ANE, the channels-first ANEForge encoder is faster than CoreML's own encoder
+(~10.5 vs ~11.2 ms in-engine), which is the result that matters: CoreML is the only
+other way to reach the ANE, and going direct through ANEForge now beats it, with no
+CoreML dependency or conversion step and a trainable graph. The optimized Metal kernel
+is still faster for tiny (~7.3 ms), so on latency alone the GPU wins; the ANE's case is
+energy (~5x less than MPS). The generic `[seq, d]` ANEForge encoder is included to show
+what the ANE-native layout buys (~3x).
+
+These ANEForge numbers are also measured end to end inside whisper.cpp: the encoder is
+wired in as a backend (mirroring the CoreML seam, in a fork), transcribes jfk.wav
+correctly, and runs at the same ~10.5 ms in `whisper-bench`.
 
 Reproduce the whisper.cpp side: build it with and without `-DWHISPER_COREML=1` (the
 CoreML encoder needs a converted `ggml-tiny-encoder.mlmodelc`), then
@@ -77,16 +85,14 @@ CoreML encoder needs a converted `ggml-tiny-encoder.mlmodelc`), then
 
 ## Notes
 
-- Energy is the ANE's only edge here, and a modest one: ~107 mJ vs PyTorch-MPS's
-  ~173 mJ (1.6x), idle-subtracted whole-package. The ANE rail itself is low (~1.2 W),
-  but the 33 ms runtime erases most of the per-encode advantage, and the measurement is
-  against eager MPS, not a tuned Metal kernel.
+- Energy is the ANE's strongest result: ~30 mJ vs PyTorch-MPS's ~160 mJ (about 5x),
+  idle-subtracted whole-package, with the fast encoder. Measured against eager MPS, not
+  a tuned Metal kernel, but the ANE rail is low (~2.6 W active over a 9.5 ms encode).
 - At seq 1500 `af.sdpa` decomposes to the same matmul/softmax as `af.mha`, because the
   native fused-attention layer is reliable only when the smaller attention axis is
-  below 512. The two rows are identical by construction.
-- The encoder has been wired into whisper.cpp end to end (a backend mirroring the
-  CoreML seam, in a fork) and transcribes correctly; the in-engine encode runs at the
-  same ~33 ms, confirming the latency is the encoder, not the integration.
+  below 512. The channels-first encoder uses `einsum` attention, not `af.sdpa`.
+- The fast encoder is wired into whisper.cpp end to end (a backend mirroring the CoreML
+  seam, in a fork) and transcribes correctly, at the same ~10.5 ms in-engine.
 
 ## C++ runner
 

--- a/bench/whisper_encoder_ane/bench_energy.py
+++ b/bench/whisper_encoder_ane/bench_energy.py
@@ -68,9 +68,9 @@ def main():
     enc, sd = E.real_encoder() if args.real else E.make_encoder()
     print(f"weights: {'trained whisper-tiny' if args.real else 'random init'}")
     mel = E.mel_input()
-    net = E.build(sd, attn="mha")
+    net = E.build_cf(sd)                              # the channels-first (fast) encoder
     mel4 = mel[:, :, None, :].astype("float16")
-    pos = sd["embed_positions.weight"].astype("float16")
+    pos = sd["embed_positions.weight"].T.reshape(1, E.D, 1, E.CTX).astype("float16")
     ane_call = lambda: net(mel4, pos)
 
     enc_mps = enc.to("mps").half()

--- a/bench/whisper_encoder_ane/bench_energy.py
+++ b/bench/whisper_encoder_ane/bench_energy.py
@@ -58,12 +58,15 @@ def pkg(means):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--window", type=float, default=8.0, help="seconds per workload sample")
+    ap.add_argument("--real", action="store_true",
+                    help="trained whisper-tiny weights (downloads; the representative number)")
     args = ap.parse_args()
 
     if subprocess.run(["sudo", "-n", "true"], capture_output=True).returncode != 0:
         sys.exit("powermetrics needs sudo: run `sudo -v` first (passwordless sudo).")
 
-    enc, sd = E.make_encoder()
+    enc, sd = E.real_encoder() if args.real else E.make_encoder()
+    print(f"weights: {'trained whisper-tiny' if args.real else 'random init'}")
     mel = E.mel_input()
     net = E.build(sd, attn="mha")
     mel4 = mel[:, :, None, :].astype("float16")

--- a/bench/whisper_encoder_ane/bench_latency.py
+++ b/bench/whisper_encoder_ane/bench_latency.py
@@ -47,11 +47,13 @@ def main():
     mel = E.mel_input()
     ref = E.torch_reference(enc, mel)
 
-    print(f"{'engine':18s} {'ms/call':>8} {'cosine':>9}")
-    for tag in ("mha", "sdpa"):
-        net = E.build(sd, attn=tag)
-        ms, out = time_call(lambda: E.run(net, sd, mel), args.reps)
-        print(f"ANE [{tag:4s}]        {ms:8.2f} {E.cosine(out, ref):9.6f}")
+    print(f"{'engine':22s} {'ms/call':>8} {'cosine':>9}")
+    net_cf = E.build_cf(sd)
+    ms, out = time_call(lambda: E.run_cf(net_cf, sd, mel), args.reps)
+    print(f"{'ANE channels-first':22s} {ms:8.2f} {E.cosine(out, ref):9.6f}")
+    net_sd = E.build(sd, attn="mha")
+    ms, out = time_call(lambda: E.run(net_sd, sd, mel), args.reps)
+    print(f"{'ANE [seq,d] (old)':22s} {ms:8.2f} {E.cosine(out, ref):9.6f}")
 
     mt = torch.from_numpy(mel)
 

--- a/bench/whisper_encoder_ane/bench_latency.py
+++ b/bench/whisper_encoder_ane/bench_latency.py
@@ -38,9 +38,12 @@ def time_call(call, reps):
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--reps", type=int, default=30)
+    ap.add_argument("--real", action="store_true",
+                    help="trained whisper-tiny weights (downloads; the representative number)")
     args = ap.parse_args()
 
-    enc, sd = E.make_encoder()
+    enc, sd = E.real_encoder() if args.real else E.make_encoder()
+    print(f"weights: {'trained whisper-tiny' if args.real else 'random init'}")
     mel = E.mel_input()
     ref = E.torch_reference(enc, mel)
 

--- a/bench/whisper_encoder_ane/encoder.py
+++ b/bench/whisper_encoder_ane/encoder.py
@@ -111,10 +111,61 @@ def build(sd, attn: str = "mha", build_dir: str | None = None):
     return af.compile(h, build_dir=build_dir)
 
 
+def _conv1x1(x, W, b):
+    """A Linear [out, in] as a 1x1 conv over channels-first [N, in, 1, S]."""
+    return af.conv(x, W.reshape(W.shape[0], W.shape[1], 1, 1), bias=b)
+
+
+def build_cf(sd, build_dir: str | None = None):
+    """The whisper-tiny encoder in the ANE-native channels-first layout: the whole
+    transformer stack stays [1, d_model, 1, S], projections are 1x1 convolutions, the
+    norm is `channel_layer_norm`, and attention is einsum, so there are no [seq, d]
+    transposes. About 3x faster than `build` on the trained checkpoint (it avoids the
+    layout the ANE handles poorly), at the same fidelity.
+
+    Inputs are (mel [1, 80, 1, 3000], positional-embedding [1, 384, 1, 1500]); feed with
+    `run_cf`. Output is [1500, 384] to match the reference and whisper.cpp's decoder.
+    """
+    mel = af.input((1, MELS, 1, FRAMES))
+    pos = af.input((1, D, 1, CTX))                    # positional embedding, channels-first
+    h = _pad_time(mel, 1)
+    h = af.conv(h, sd["conv1.weight"].reshape(D, MELS, 1, 3), stride=1, pad=0, bias=sd["conv1.bias"]).gelu()
+    h = _pad_time(h, 1)
+    h = af.conv(h, sd["conv2.weight"].reshape(D, D, 1, 3), stride=2, pad=0, bias=sd["conv2.bias"]).gelu()
+    h = h + pos                                       # already [1, 384, 1, 1500], no transpose
+    scale = (D // HEADS) ** -0.5
+    for i in range(LAYERS):
+        p = f"layers.{i}."
+        xn = h.channel_layer_norm(sd[p + "self_attn_layer_norm.weight"], sd[p + "self_attn_layer_norm.bias"])
+        q = _conv1x1(xn, sd[p + "self_attn.q_proj.weight"], sd[p + "self_attn.q_proj.bias"])
+        k = _conv1x1(xn, sd[p + "self_attn.k_proj.weight"], None)
+        v = _conv1x1(xn, sd[p + "self_attn.v_proj.weight"], sd[p + "self_attn.v_proj.bias"])
+        qh, kh, vh = af.split(q, HEADS, 1), af.split(k, HEADS, 1), af.split(v, HEADS, 1)
+        heads = []
+        for j in range(HEADS):
+            w = (af.einsum("bchq,bchk->bkhq", qh[j], kh[j]) * scale).softmax(1)
+            heads.append(af.einsum("bkhq,bchk->bchq", w, vh[j]))
+        a = _conv1x1(af.concat(heads, axis=1), sd[p + "self_attn.out_proj.weight"], sd[p + "self_attn.out_proj.bias"])
+        h = h + a
+        fn = h.channel_layer_norm(sd[p + "final_layer_norm.weight"], sd[p + "final_layer_norm.bias"])
+        f = _conv1x1(_conv1x1(fn, sd[p + "fc1.weight"], sd[p + "fc1.bias"]).gelu(),
+                     sd[p + "fc2.weight"], sd[p + "fc2.bias"])
+        h = h + f
+    h = h.channel_layer_norm(sd["layer_norm.weight"], sd["layer_norm.bias"])
+    return af.compile(h.reshape(D, CTX).transpose([1, 0]), build_dir=build_dir)
+
+
 def run(net, sd, mel: np.ndarray) -> np.ndarray:
     """Feed (mel, positional-embedding) in creation order; returns fp32 [1500, 384]."""
     mel4 = mel[:, :, None, :].astype(np.float16)
     pos = sd["embed_positions.weight"].astype(np.float16)
+    return net(mel4, pos)
+
+
+def run_cf(net, sd, mel: np.ndarray) -> np.ndarray:
+    """Feed the channels-first encoder (mel, positional-embedding transposed)."""
+    mel4 = mel[:, :, None, :].astype(np.float16)
+    pos = sd["embed_positions.weight"].T.reshape(1, D, 1, CTX).astype(np.float16)
     return net(mel4, pos)
 
 

--- a/bench/whisper_encoder_ane/encoder.py
+++ b/bench/whisper_encoder_ane/encoder.py
@@ -41,6 +41,16 @@ def make_encoder(seed: int = 0):
     return enc, sd
 
 
+def real_encoder():
+    """The trained whisper-tiny encoder and its numpy state dict (downloads the
+    checkpoint). Use this for performance numbers: ANE latency is weight-dependent,
+    and the trained weights run materially slower than random init."""
+    from transformers import WhisperForConditionalGeneration
+    enc = WhisperForConditionalGeneration.from_pretrained("openai/whisper-tiny").eval().model.encoder
+    sd = {k: v.detach().numpy().astype(np.float32) for k, v in enc.state_dict().items()}
+    return enc, sd
+
+
 def torch_reference(enc, mel: np.ndarray) -> np.ndarray:
     """The HF encoder output for `mel` ([1, 80, 3000] fp32); returns [1500, 384]."""
     import torch


### PR DESCRIPTION
The benchmark used a randomly-initialised encoder, and ANE execute time for this graph turns out to be weight-dependent: the trained checkpoint runs ~3x slower than random init (real weights peak ~5x higher in magnitude, pushing attention onto a slower path).

Real-weights numbers:
- latency ~33.6 ms (was reported 11.4)
- energy ~107 mJ, 1.6x less than PyTorch-MPS (was reported 3.8x)
- on the same ANE, whisper.cpp's CoreML encoder runs ~11.2 ms, so ANEForge is ~3x slower than CoreML and the slowest path for this encoder

The gap is ANEForge's generic [seq, d] attention lowering vs CoreML's ANE-native channels-first layout, not the hardware. Adds `--real` to bench_latency.py / bench_energy.py and makes trained weights the headline; fidelity (cosine 0.9998, identical transcript) is unchanged.

Holding this open: an ANE-native encoder layout to close the latency gap is in progress and will land before merge.