### PR TITLE
Make channel_layer_norm a first-class op

### DIFF
--- a/aneforge/_capabilities.py
+++ b/aneforge/_capabilities.py
@@ -89,6 +89,7 @@ _FRONTEND_SPELLING: dict[str, str] = {
     "reduce_mean": "x.mean(axes)", "reduce_sum": "x.sum(axes)", "reduce_max": "x.amax(axes)",
     "reduce_min": "x.amin(axes)", "softmax": "x.softmax(axis)", "l2_norm": "x.l2_norm(axis,eps)",
     "rms_norm": "x.rms_norm(g,eps)", "layer_norm": "x.layer_norm(g,b,eps)",
+    "channel_layer_norm": "x.channel_layer_norm(g,b,eps)",
     "group_norm": "x.group_norm(g,b,groups,eps)", "batch_norm": "af.batch_norm(...)",
     # bridge ops
     "sdpa": "af.sdpa(q,k,v)", "argmax": "x.argmax(axis)", "topk": "af.topk(x,k)",

--- a/aneforge/_op_catalog.py
+++ b/aneforge/_op_catalog.py
@@ -9,8 +9,8 @@ Each device cell is one of: 'native' (runs on-engine), 'bridge' (needs a netplis
 or host/graph decomposition), 'walled' (no path - decompose on host).
 
 This is the NATIVE MIL op vocabulary the ANE emits. aneforge's higher-level ops
-(rms_norm, group_norm, mha, sdpa, einsum, the fft/linalg/special submodules) are
-COMPOSITES that lower to these - query their constituent ops here.
+(rms_norm, group_norm, channel_layer_norm, mha, sdpa, einsum, the fft/linalg/special
+submodules) are COMPOSITES that lower to these - query their constituent ops here.
 
 This dict is the single source of truth. The deeper per-op argument, shape, dtype,
 and per-chip capability write-ups live in the project's companion reference guide.

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -290,6 +290,20 @@ def _vjp_layer_norm(t, g):
     return [grad * rstd]
 
 
+@vjp("channel_layer_norm")
+def _vjp_channel_layer_norm(t, g):
+    x = t.srcs[0]; ax = (1,)                                     # LayerNorm over the channel axis
+    eps = float(t.attrs["eps"]); C = x.shape[1]
+    gamma = np.asarray(t.attrs["gamma"], np.float32)            # per-channel gamma as [1,C,1,1]
+    gt = graph.input((1, C, 1, 1)); gt.attrs["value"] = gamma.reshape(1, C, 1, 1)
+    gn = g * gt                                                  # g * gamma (beta drops out)
+    xc = x - x.mean(ax)                                          # x - channel mean
+    rstd = xc.square().mean(ax).adds(eps).rsqrt()              # 1/std  [N,1,1,S]
+    n = xc * rstd                                                # normalized
+    grad = gn - gn.mean(ax) - n * (gn * n).mean(ax)            # same LayerNorm backward, over C
+    return [grad * rstd]
+
+
 # --------------------------------------------------------------------------- #
 # unary math / activation vjps - surfaced by the gradient audit (each forward   #
 # op already runs natively; these make them trainable). Closed-form derivatives  #

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -255,6 +255,21 @@ def test_layer_norm_grad():
     assert _cos(gx, ref) > 0.99, (_cos(gx, ref),)
 
 
+def test_channel_layer_norm_grad():
+    rng = np.random.default_rng(63); C = 16
+    xv = rng.standard_normal((1, C, 1, 4)).astype(np.float32)
+    wv = rng.standard_normal((1, C, 1, 4)).astype(np.float32)
+    gam = rng.standard_normal(C).astype(np.float32)
+    x = agrad.parameter(xv); w = agrad.parameter(wv)
+    loss = (x.channel_layer_norm(gam, np.zeros(C, np.float32)) * w).sum((0, 1, 2, 3))
+    (gx,) = _ane_grad_shaped(loss, [x])
+    def cln(z):
+        mu = z.mean(1, keepdims=True); v = ((z - mu)**2).mean(1, keepdims=True)
+        return (z - mu) / np.sqrt(v + 1e-5) * gam.reshape(1, C, 1, 1)
+    ref = _fd_grad(cln, xv, wv)
+    assert _cos(gx, ref) > 0.99, (_cos(gx, ref),)
+
+
 def test_conv_grad_wrt_input():
     # native conv node: grad wrt input = conv_transpose(g, W). stride=1, pad in {0,1}.
     rng = np.random.default_rng(54)

--- a/tests/test_op_coverage.py
+++ b/tests/test_op_coverage.py
@@ -106,6 +106,8 @@ CASES = [
     # norms
     ("layer_norm", [S], lambda x: x.layer_norm(np.ones(8, np.float32), np.zeros(8, np.float32)),
      lambda v: (v-v.mean(-1, keepdims=True))/np.sqrt(((v-v.mean(-1, keepdims=True))**2).mean(-1, keepdims=True)+1e-5), False),
+    ("channel_layer_norm", [(1, 8, 1, 4)], lambda x: x.channel_layer_norm(np.ones(8, np.float32), np.zeros(8, np.float32)),
+     lambda v: (v-v.mean(1, keepdims=True))/np.sqrt(((v-v.mean(1, keepdims=True))**2).mean(1, keepdims=True)+1e-5), False),
     ("rms_norm", [S], lambda x: x.rms_norm(np.ones(8, np.float32)),
      lambda v: v/np.sqrt((v**2).mean(-1, keepdims=True)+1e-5), False),
     ("softmax", [S], lambda x: x.softmax(1), lambda v: np.exp(v-v.max(1, keepdims=True))/np.exp(v-v.max(1, keepdims=True)).sum(1, keepdims=True), False),


### PR DESCRIPTION
Follows up the channels-first Whisper encoder work, which added `channel_layer_norm` (LayerNorm over the channel axis of a channels-first [N, C, 1, S] tensor) as a graph method and MIL emitter. This wires it into the package the way the other composite norms (rms_norm, group_norm) are:

- backward VJP in autograd.py, so it is trainable (LayerNorm backward reduced over the channel axis)
- mention in the op-catalog composites list
- a capabilities snippet for the census
- forward case in test_op_coverage.py (matches numpy on the ANE)
- gradient test in test_autograd.py (matches finite differences, cos > 0.99)

148 passed across test_op_coverage.py + test_autograd.py, no regressions. The op is now usable for any ANE-native transformer, not just the Whisper encoder.