### PR TITLE
release: bump to 0.1.2

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ authors:
 repository-code: "https://github.com/sbryngelson/ANEForge"
 doi: 10.5281/zenodo.20672609
 license: MIT
-version: "0.1.1"
-date-released: "2026-06-14"
+version: "0.1.2"
+date-released: "2026-06-22"
 preferred-citation:
   type: article
   title: "ANEForge: Python for direct computation on the Apple Neural Engine"


### PR DESCRIPTION
Bumps CITATION.cff to 0.1.2 (date 2026-06-22) ahead of tagging v0.1.2. The release adds the channel_layer_norm op (LayerNorm over the channel axis) since 0.1.1. The wheel version is derived from the tag by hatch-vcs; this keeps the citation metadata in step.