### PR TITLE
Reword comments and docstrings for concision

### DIFF
--- a/aneforge/_capabilities.py
+++ b/aneforge/_capabilities.py
@@ -15,7 +15,7 @@ arch-gated negatives, the predicted-but-unbuilt frontier). The result is a close
 classification of every ANE capability aneforge knows about. `tests/
 test_routes.py` fails CI if the live runtime drifts from this registry either way.
 
-Honesty discipline (this is a publication artifact): every entry is one of
+Discipline (this is a publication artifact): every entry is one of
   - `fused`                - in `_EMIT`; lowers to e5rt-MIL, fuses into one program.
   - `bridge`               - in `NETPLIST_OPS`; runs as a native Path-A sub-program (a graph cut).
   - `cracked`              - reverse-engineered native layer PROVEN on silicon in
@@ -571,7 +571,7 @@ _NOT_AUTHORABLE_OPS: frozenset[str] = frozenset({
 })
 
 # sweep ops that are the same capability as an op already surfaced under a different
-# name (a `reachable` entry pointing at its canonical surfaced sibling - honest
+# name (a `reachable` entry pointing at its canonical surfaced sibling -
 # aliasing, no double-count of the capability as a distinct frontend primitive).
 _SWEEP_CAPABILITY_ALIAS: dict[str, str] = {
     "scaled_dot_product_attention": "sdpa (bridge) - same fused-attention capability",
@@ -724,7 +724,7 @@ _BRIDGE_ROUTES: dict[str, dict[str, Any]] = {
                     "/KernelChannel == fused size=C with alpha pre-scaled by C; ~1250x cut "
                     "removal on conv->lrn->relu; fused has no C<16 cap)",
     },
-    # --- single-route: candidate validated and rejected (honest negative) ---
+    # --- single-route: candidate validated and rejected (confirmed negative) ---
     "space_to_channel": {
         "single_route": True,
         "reason": "the reshape+transpose decomposition needs a rank-6 intermediate "

--- a/aneforge/_lib/ane_e5rt_dispatch.mm
+++ b/aneforge/_lib/ane_e5rt_dispatch.mm
@@ -712,7 +712,7 @@ extern "C" int ane_e5rt_program_share_buffer(ane_e5rt_program_t *prog,
 // The functions below are a directly-callable C research surface for multi-op
 // streams and async completion. The 9 production functions above are the only
 // ones the ctypes layer wires up; everything from here down is exercised by
-// hand from native test harnesses. Kept building (and honest with the docs)
+// hand from native test harnesses. Kept building (and in sync with the docs)
 // even though it is not part of the supported Python API.
 // =============================================================================
 

--- a/aneforge/_lib/e5rt_api.h
+++ b/aneforge/_lib/e5rt_api.h
@@ -11,7 +11,7 @@
 //
 // All entry points return int64_t e5rt_error_code_t. Convention: code==0 success;
 // nonzero codes carry a string via e5rt_error_code_get_string (but that stub
-// returns a C++ std::string under the hood, not const char* - do not call from
+// returns a C++ std::string internally, not const char* - do not call from
 // pure C). Inspect failure mode via stderr Espresso log.
 //
 // ABI: arm64 AAPCS. All "create" entry points return the new object via the

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -801,7 +801,7 @@ def tune_precision(out, target_error: float | None = None, cost_budget_us: float
     frontier, not just the winner. Unlike speed-tune(), a variant here can be chosen for
     IMPROVING accuracy over the fp16 baseline.
 
-    HONEST SCOPE: automatic hotspot detection covers the reduce_sum->matmul case
+    SCOPE: automatic hotspot detection covers the reduce_sum->matmul case
     (structurally detectable). The CFG-style paired-fp16 fix is opt-in (use
     `precision_rewrite` / pass a marked region) because near-equal cancellation is
     data-dependent and cannot be confirmed at graph-build time.

--- a/aneforge/dsp.py
+++ b/aneforge/dsp.py
@@ -452,7 +452,7 @@ def iir_filter(x, b, a, n_taps: int = 256):
     The ANE is feed-forward: no in-graph loop, no scalar feedback, no scan/cumsum.
     There is NO streaming IIR on this hardware.
 
-    The ONLY honest realization is to TRUNCATE the IIR's infinite impulse response to
+    The ONLY realization is to TRUNCATE the IIR's infinite impulse response to
     `n_taps` and run it as an FIR (via fir_filter / fft_convolve). Exact only up to
     the truncation tail, with the tap count fixed at build time - it does NOT scale
     to arbitrary streaming IIR. Use it for stable filters whose impulse response has
@@ -605,7 +605,7 @@ def _selftest():
     # ---- IIR: arch-limited fixed-unroll (truncated impulse response FIR) ------ #
     if have_scipy:
         # a resonant (high-Q) bandpass: long, slowly-decaying impulse response, so
-        # truncation length n_taps visibly governs the error = the honest unroll cost.
+        # truncation length n_taps visibly governs the error = the unroll cost.
         bb_iir, aa_iir = ss.iirpeak(0.2, Q=30.0)
         xi = rng.standard_normal(512).astype(np.float32)
         ref_iir = ss.lfilter(bb_iir, aa_iir, xi)
@@ -637,12 +637,12 @@ def _selftest():
     print("      ONLY a FIXED-LENGTH FIR UNROLL: truncate the IIR impulse response to n_taps and")
     print("      run it as an FIR. Exact up to the truncation tail; tap count fixed at build")
     print("      time; does NOT scale to arbitrary streaming IIR. (relerr above shrinks as")
-    print("      n_taps grows = the impulse response decays - the honest cost of the unroll.)")
+    print("      n_taps grows = the impulse response decays - the actual cost of the unroll.)")
 
     # gate: good routines must be fp16-clean; IIR is reported, not gated on a fixed tol.
     ok = worst_good < 5e-3
     print(f"\n{'PASS' if ok else 'FAIL'} - FIR/FFT-DSP validate vs scipy/numpy on the ANE "
-          f"(worst GOOD relerr {worst_good:.2e}); IIR honestly tagged arch-limited (fixed unroll)")
+          f"(worst GOOD relerr {worst_good:.2e}); IIR tagged arch-limited (fixed unroll)")
     return 0 if ok else 1
 
 

--- a/aneforge/fft.py
+++ b/aneforge/fft.py
@@ -60,7 +60,7 @@ API
     magnitude(X_re, X_im)     -> |X|                 sqrt(re^2 + im^2)
     power(X_re, X_im)         -> |X|^2
 
-Each returns numpy arrays; under the hood it builds an aneforge graph, compiles it to
+Each returns numpy arrays; internally it builds an aneforge graph, compiles it to
 ONE fused e5rt program, and runs it on the ANE. A `Plan` object (fft_plan / rfft_plan)
 compiles once and runs many times.
 

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -254,7 +254,7 @@ def gauss_seidel(A, b, iters: int = 60, x0=None):
     host work O(n^2)) still runs on the ANE.
 
     ANE: A@x (the bulk FLOPs).   HOST: the sequential triangular sweep + loop.
-    The honest division: Gauss-Seidel's serial sweep is the arch-limited part; only
+    The division: Gauss-Seidel's serial sweep is the arch-limited part; only
     the dense GEMV stays on-device.
     """
     A16 = np.asarray(A, f16); b16 = np.asarray(b, f16).reshape(-1)
@@ -992,7 +992,7 @@ def main():
         print(f"{cond:>8.0e} | {_relerr(x_ls, x_ref):>18.3e} | {0.0:>16.3e}")
     print("  reading: forming A^T A SQUARES cond(A): cond(A)=1e1 -> 1e2 solves fine (4e-3); cond(A)=1e2")
     print("  -> 1e4 is past the fp16 CG ceiling and breaks down (relerr ~1, guarded finite). This is")
-    print("  the honest cost of the normal equations in fp16 - a QR-lstsq would avoid the squaring but")
+    print("  the actual cost of the normal equations in fp16 - a QR-lstsq would avoid the squaring but")
     print("  QR is arch-limited on the ANE, so CG-normal is the iterative alternative, valid only while")
     print("  cond(A)^2 stays inside the envelope (cond(A) <~ a few x10).")
     print()

--- a/aneforge/special.py
+++ b/aneforge/special.py
@@ -22,7 +22,7 @@ WHY THESE: they add value beyond the native unaries (`exp/log/erf/...`) which
 either (a) do not exist (gamma, lgamma, erfc, expm1, log1p, Bessel) or (b)
 degrade / cancel in fp16 over a wide range (erfc = 1-erf cancels to 0 past x~2;
 exp loses a digit past |x|~8). See the `__main__` self-test for measured
-relerr vs scipy and the honest fp16 verdict per function.
+relerr vs scipy and the fp16 verdict per function.
 
 THE TWO CONSTRAINTS that shape the implementations:
   * fp16 compute. The ANE computes in fp16 (~3-4 significant digits). A poly
@@ -208,7 +208,7 @@ def gamma(x: Tensor) -> Tensor:
     """Gamma function on x in [1, 2] via a deg-6 minimax in the centered variable
     (x-1.5).
 
-    SCOPE / HONESTY: gamma grows super-exponentially and overflows fp16 (>65504)
+    SCOPE: gamma grows super-exponentially and overflows fp16 (>65504)
     past x~8.3, so it is fundamentally fp16-narrow. Extending [1,2] to a wider
     window needs the recurrence Gamma(x+1)=x*Gamma(x) applied a data-dependent
     number of times - not expressible in one static graph. For a wider but
@@ -274,7 +274,7 @@ def exp_wide(x: Tensor, splits: int = 1) -> Tensor:
     `exp(x) = (exp(x / 2^splits)) ^ (2^splits)` by repeated squaring (the inner
     `exp` runs on a smaller argument).
 
-    HONEST FINDING (measured on this M5 ANE): this does NOT reliably beat the
+    FINDING (measured on this M5 ANE): this does NOT reliably beat the
     native `x.exp()`. The native fp16 exp is already accurate (median per-point
     relerr ~1.4e-3 over [-10,10]); the squaring re-rounding usually costs MORE
     than the small-argument benefit gains, so per-point accuracy is the same or
@@ -293,7 +293,7 @@ def log_wide(x: Tensor, sqrts: int = 3) -> Tensor:
     Repeated square roots pull a large argument toward 1, where log is most
     accurate, then scale back.
 
-    HONEST FINDING: native fp16 log is already good (~1e-3 over [1e-2, 1e4]) and
+    FINDING: native fp16 log is already good (~1e-3 over [1e-2, 1e4]) and
     this matches rather than clearly beats it - the sqrt chain re-rounds. Useful
     mainly as a documented range-reduction recipe; the native `x.log()` is the
     better default on this hardware."""

--- a/bench/decode_measurement.py
+++ b/bench/decode_measurement.py
@@ -201,7 +201,7 @@ def build_ane(cfg: Cfg, W, B, int8=False):
 
     aneforge has no constant-tensor leaf node, and a bmm (activation@activation) needs
     Tensor operands - so the per-layer KV cache is supplied as GRAPH INPUTS (fed each
-    call). That's the only honest way to express a cache here; the cache bytes are
+    call). That's the only correct way to express a cache here; the cache bytes are
     constant data the caller passes in, exactly like a real decode loop reads its cache
     from memory. Returns (Model, list-of-cache-arrays) so the runner feeds x + caches.
 

--- a/bench/device_bandwidth_roofline.py
+++ b/bench/device_bandwidth_roofline.py
@@ -24,7 +24,7 @@ KEY METHODOLOGY (a crude probe gave low/noisy numbers - done right here):
       - reduction (sum over all):      read N, write ~1  = 1*N*dtbytes
       - softmax (last axis):           read N, write N    = 2*N*dtbytes
         (max+exp/sum+div is read-once/write-once at the framework level; the two
-         logical passes are fused, so 2N is the honest external traffic)
+         logical passes are fused, so 2N is the actual external traffic)
       - layer_norm (last axis):        read N, write N    = 2*N*dtbytes
     dtbytes = 2 (fp16) for GPU/ANE, 4 (fp32) for CPU. The CPU bandwidth proxy uses
     a genuinely memory-bound op (a*2.0 / a.sum), NOT a transcendental - a tanh-heavy

--- a/bench/device_compare.py
+++ b/bench/device_compare.py
@@ -29,7 +29,7 @@ Devices
 
 Timing: warmup, then MIN over reps (the clean signal - min rejects scheduler
 noise). Each device's number includes its own host/dispatch overhead, which is
-called out honestly: the ANE/MLX numbers are end-to-end Python-call latency
+called out: the ANE/MLX numbers are end-to-end Python-call latency
 (compile-once, run-many), NOT pure silicon time. At small shapes that overhead
 dominates and the comparison is a dispatch-cost comparison, not a FLOP one.
 

--- a/bench/device_compare_wattcomplete.py
+++ b/bench/device_compare_wattcomplete.py
@@ -11,7 +11,7 @@ power methodology a reviewer will attack first done right:
     matters; reporting raw loaded power double-counts the ~0.6 W the CPU burns at rest.
 
   * HEADLINE = TOTAL-PACKAGE ACTIVE POWER (sum of ane+gpu+cpu rails, idle-subtracted).
-    This is the honest number: an ANE workload still burns CPU on dispatch and an MLX
+    This is the actual number: an ANE workload still burns CPU on dispatch and an MLX
     workload burns CPU too, so attributing only the "device" rail would flatter both.
     We ALSO report the per-rail breakdown so the attribution is visible
     (e.g. "ANE 1.2 W + CPU 0.8 W dispatch").
@@ -40,7 +40,7 @@ SCOPE = workload classes where the ANE-vs-GPU choice is REAL:
   5. scientific kernels: matmul-DFT, a 2D 5-point stencil step, a fixed-iter Jacobi solve
   6. real models: ResNet-18, MiniLM encoder, full ViT-B/16 forward
 
-EXCLUSIONS (stated honestly): the netplist *bridge* ops (sdpa-bridge / argmax / fps /
+EXCLUSIONS: the netplist *bridge* ops (sdpa-bridge / argmax / fps /
 cost_volume / radius_search / sort via the subprocess dispatch path) are NOT raced
 here. They run 25 ms - 2.5 s in the current subprocess path due to a DISPATCH artifact, not
 silicon speed; racing them against MLX would misrepresent the hardware. They are an

--- a/bench/device_saturation_sweep.py
+++ b/bench/device_saturation_sweep.py
@@ -133,7 +133,7 @@ def sweep_gemm(ns, do_power):
         # --- CPU (fp32, numpy/Accelerate-AMX) ---
         # IMPORTANT: feed CONTIGUOUS operands. A transposed view (W32.T) makes
         # Accelerate fall off its fast fp32 GEMM path (~4x slower, ~fp64-rate) - the
-        # honest AMX peak needs both operands C-contiguous.
+        # the AMX peak needs both operands C-contiguous.
         Wt = np.ascontiguousarray(W32.T)
         lat = _min_lat(lambda: x32 @ Wt)
         out = x32 @ Wt

--- a/bench/gemv_bandwidth_sweep.py
+++ b/bench/gemv_bandwidth_sweep.py
@@ -160,7 +160,7 @@ def sweep_gemv(K, N, *, reps, warmup, measure_pw):
             out_h["o"] = x32 @ Wt
         lat = min_latency(run, reps=max(10, reps // 2), warmup=warmup)
         out = out_h["o"]
-        # CPU fp32 moves 4 B/elem for the weight; report its own effective BW honestly
+        # CPU fp32 moves 4 B/elem for the weight; report its own effective BW
         cpu_bytes = K * N * 4 + K * 4 + N * 4
         d = {"dtype": "fp32", "lat_ms": lat * 1e3,
              "eff_GBps": cpu_bytes / lat / 1e9, "GFLOPs": gflops(K, N, lat),

--- a/bench/model_int4_bench.py
+++ b/bench/model_int4_bench.py
@@ -28,8 +28,8 @@ and reports, end-to-end (the WHOLE program, not a single matmul):
                output (accuracy retention of the end-to-end forward),
   * size     : on-disk `weights.bin` bytes + fraction of the fp16 baseline.
 
-HONESTY / WEIGHT SOURCE
------------------------
+WEIGHT SOURCE
+-------------
 This host has numpy + aneforge + the ANE dylib but NOT torch / torchvision /
 transformers, so the pretrained loaders (af.load_resnet18 / af.load / the ViT
 demo) cannot fetch real trained weights here. We therefore build each model's

--- a/examples/autotune.py
+++ b/examples/autotune.py
@@ -21,7 +21,7 @@ Models:
   - Attention block     (q/k/v proj + af.sdpa + out-proj; exercises the route
                          rewrite: native SDPA cut vs decomposed-fused) at two sizes
 
-HONESTY: this prints the REAL measured speedups. The route rewrite is expected to
+CAVEAT: this prints the REAL measured speedups. The route rewrite is expected to
 move the attention block; weight-heavy models may show an int8 win under atol=0.1;
 a floor-bound / already-optimal model correctly returns ~1.0x (tune returns the
 baseline) - that is correct behavior, not a failure. We report exactly what the

--- a/examples/demos/weights_compression.py
+++ b/examples/demos/weights_compression.py
@@ -4,7 +4,7 @@ Reverse-engineering finding: weight compression is gated by the hardware Compres
 which only arrives at M4. On M1 (h13) only int4-LUT streams natively; int8 and sparse FOLD to
 dequant-at-the-engine - so int8 is a weight-SIZE / bandwidth lever (half the weight bytes,
 helps bandwidth-bound layers), NOT a guaranteed compute speedup, and can even be slower on a
-compute-bound layer because of the dequant overhead. This demo measures it honestly so you
+compute-bound layer because of the dequant overhead. This demo measures it directly so you
 see the nuance rather than assuming int8 is always faster.
 
 Run:  python3 examples/demos/weights_compression.py

--- a/examples/fluid_vorticity.py
+++ b/examples/fluid_vorticity.py
@@ -17,7 +17,7 @@ ANE program (the engine has no complex dtype, so values ride as real/imag pairs)
 The two transform programs are compiled ONCE and reused for every step. A high-order
 spectral filter (hyperviscosity) holds the enstrophy cascade at the grid scale.
 
-HONESTY (fp16). The ANE computes in fp16. The dense DFT is unnormalized, so spectral
+CAVEAT (fp16). The ANE computes in fp16. The dense DFT is unnormalized, so spectral
 coefficients at this 256-grid exceed fp16's range; the transforms are scaled by
 linearity (exact) to fit, see FWD/INV below. Advection is chaotic, so an fp16
 trajectory is its own slightly-perturbed flow. The point here is that it stays

--- a/examples/heat_equation.py
+++ b/examples/heat_equation.py
@@ -15,7 +15,7 @@ the next input. We evolve a hot-spot initial condition for many steps on a 64x64
 grid (Dirichlet u=0 boundary, enforced host-side after each conv), then validate
 the FINAL field against the SAME scheme run in fp32 numpy.
 
-HONESTY: fp16 rounding COMPOUNDS over the timesteps - the ANE trajectory and the
+CAVEAT: fp16 rounding COMPOUNDS over the timesteps - the ANE trajectory and the
 fp32 numpy trajectory are genuinely different sequences, so they drift a little per
 step. We report the relerr-vs-steps curve (it grows ~linearly: ~9e-3 at 50 steps,
 ~1.9e-2 at 100) and confirm the scheme stays STABLE: the field stays BOUNDED (no
@@ -123,7 +123,7 @@ def main():
     print(f"  field stayed bounded (no blow-up): {bounded}")
     print(f"  final-field relerr vs fp32-exact scheme: {relerr:.3e}")
 
-    # relerr-vs-steps curve (honest fp16 compounding profile)
+    # relerr-vs-steps curve (fp16 compounding profile)
     print("  fp16 compounding (relerr vs #steps, same hot-spot):")
     for S in (25, 50, 75, 100):
         ua, _, _ = evolve_ane(step, u0, S)

--- a/examples/nbody.py
+++ b/examples/nbody.py
@@ -15,7 +15,7 @@ The whole force computation (broadcast diff, squared distance, rsqrt^3, masked s
 is compiled into ONE fused e5rt program. We validate the resulting accelerations AND
 the advanced positions against the SAME computation in fp32 numpy.
 
-HONESTY: 1/r^3 is fp16-sensitive when two bodies get close (the denominator is a
+CAVEAT: 1/r^3 is fp16-sensitive when two bodies get close (the denominator is a
 small number raised to the 3/2 power), so we seed well-separated bodies and use a
 softening eps (standard in collisionless N-body) to keep r in fp16 range. With that,
 the accelerations match numpy to ~1e-2. The intermediate [N,N,3] grows O(N^2), so

--- a/examples/pointcloud.py
+++ b/examples/pointcloud.py
@@ -12,7 +12,7 @@ These layers aren't in the aneforge frontend yet, so the demo calls the in-packa
 ``aneforge._bridges`` modules directly. Each stage is validated against a numpy reference (exact for
 the integer-discretised FPS/RadiusSearch, fp16-tolerance for the cross product).
 
-Conventions worth stating honestly:
+Conventions worth stating:
     * FPS is L2-only on this arch - the ``DistanceMetric`` netplist param is
       ignored, so the reference uses Euclidean distance regardless. Seed = point 0.
     * RadiusSearch returns a [points x centroids] uint8 membership matrix

--- a/examples/poisson_spectral.py
+++ b/examples/poisson_spectral.py
@@ -15,7 +15,7 @@ We use a MANUFACTURED solution: pick a smooth u_true (a sum of a few sinusoids),
 form f = lap(u_true) ANALYTICALLY, solve, and compare the recovered (zero-mean) u to
 the (zero-mean) u_true. We also verify the spectral Laplacian round-trip lap(u) ~ f.
 
-HONESTY (fp16): the spectral method is exact in infinite precision, so the reported
+CAVEAT (fp16): the spectral method is exact in infinite precision, so the reported
 relerr is the fp16 transform/divide floor (a few x1e-3 at this grid), NOT a
 discretization error.
 
@@ -88,7 +88,7 @@ def main():
     print(f"    solve + verification wall time (4 transforms + compiles): {dt*1e3:.0f} ms")
     # Headline accuracy is u vs u_true. The lap(u)~f check chains TWO EXTRA transforms
     # on top of the already-fp16-recovered u, so its fp16 floor is looser (compounded
-    # transform rounding) - we hold it to <1e-1, honestly.
+    # transform rounding) - we hold it to <1e-1.
     ok = err < 5e-2 and lap_err < 1e-1
     print(f"    -> {'PASS' if ok else 'FAIL'}  (fp16 transform/divide floor; the method is "
           f"exact in exact arithmetic)")

--- a/examples/sd15.py
+++ b/examples/sd15.py
@@ -22,7 +22,7 @@ What runs where:
     64x64 / 512ch on this ANE (512ch@128 and >=256x256 -> Espresso "Not
     implemented"), so the VAE runs on the ANE through up0 (post_quant -> conv_in ->
     mid -> up0, ending 512ch@128x128) and the last three up blocks + conv_out run on
-    host torch. An honest hardware limit (group_norm feature-map size).
+    host torch. A real hardware limit (group_norm feature-map size).
 
 This is the heaviest aneforge demo. PER-COMPONENT validates on real weights (UNet
 one-step ~1.5% relerr, VAE decode ~4.4%, both <5%). The END-TO-END image, however,
@@ -30,7 +30,7 @@ is fp16-degraded - and the cause is NOT gradual step-compounding but CATASTROPHI
 CANCELLATION in classifier-free guidance: cond-uncond is only a ~0.5% difference of
 two large near-identical UNet outputs, so the ~1.5% per-output fp16 error swamps the
 guidance signal (then x7.5 guidance amplifies it). The saved PNG is a coherent-but-
-abstract blob, not a recognizable scene. The script is HONEST: it reports the real
+abstract blob, not a recognizable scene. The script reports the real
 per-component + end-to-end relerr, the CFG-cancellation diagnostic, what compiled
 (split + counts) and what fell back to host, and saves the actual image produced - no faked clean generation. The documented fix is mixed/higher precision on the
 guidance subtraction.
@@ -244,7 +244,7 @@ def main():
     # small e5rt program, chained host-side; the skip stack is carried as numpy.
     # up3 (final CrossAttnUpBlock at 64x64) and conv_out hit the group_norm
     # feature-map limit (>=640 ch @ 64x64 -> Espresso "Not implemented"), so they
-    # run on HOST torch - an honest hardware boundary, not a numerics choice.
+    # run on HOST torch - a real hardware boundary, not a numerics choice.
     if not one_program:
         g, has = ug, uhas
         progs = {}
@@ -478,7 +478,7 @@ def main():
     cpath = ("ONE fused program" if one_program else
              f"{len(progs)} per-resnet programs (conv_in / 8 down resnets+attn / 3 downsamplers / "
              f"mid / 9 up0-2 resnets+attn / 3 upsamplers); up3 + conv_out on host")
-    print("\nHONEST VERDICT:")
+    print("\nVERDICT:")
     print(f"  UNet compile path: {cpath}; {unet_ops} total ANE ops.")
     print(f"  VAE: ANE front (post_quant..up0, {vae_front_net.n_ops} ops, <=128x128); "
           f"up1/up2/up3/conv_out on HOST (group_norm 'Not implemented' at 512ch@128 and >=256x256).")

--- a/examples/solve_linear_systems.py
+++ b/examples/solve_linear_systems.py
@@ -6,7 +6,7 @@ program (the matrix folds in as a constant, so the program size is iteration-bou
 not n-bound - the same solve runs unchanged at n=512). GMRES (general systems) and
 LSQR (least squares) follow the same pattern; see aneforge.linalg.
 
-Honest envelope (docs/api/math.md): fp16, clean to ~1e-3 at cond 1e2, then the
+Envelope (docs/api/math.md): fp16, clean to ~1e-3 at cond 1e2, then the
 fp16 iterates stall.
 
     python3 examples/solve_linear_systems.py

--- a/examples/spectral_analysis.py
+++ b/examples/spectral_analysis.py
@@ -19,7 +19,7 @@ We analyze a synthetic signal - a sum of pure sinusoids plus a linear chirp - an
      "wide accumulator" finding: the length-N twiddle sum is accumulated in >=fp32,
      so fp16 rounding does NOT compound with N and the spectrum stays fp16-CLEAN.
 
-HONESTY: this is the NAIVE O(N^2) DFT (a dense twiddle matmul), not an O(N log N)
+CAVEAT: this is the NAIVE O(N^2) DFT (a dense twiddle matmul), not an O(N log N)
 FFT - the cost is the quadratic twiddle-matrix size/bandwidth, NOT precision. The
 relerr stays ~3e-4..1e-3 FLAT in N (it does not grow), so fp16 is not the wall for
 the transform. The reference is numpy's exact fft over the same fp16-rounded signal.
@@ -54,7 +54,7 @@ def dft_program(N):
     This is not cosmetic: without it the peak |X_k| grows ~amplitude*N/2, so at
     N=2048 the SQUARED intermediate Xr^2+Xi^2 (~1.2e5) OVERFLOWS fp16's 65504 max
     and the spectrum becomes inf. The unitary normalization keeps the magnitude AND
-    its square comfortably in fp16 range at every N - an honest fp16 dynamic-range
+    its square comfortably in fp16 range at every N - a real fp16 dynamic-range
     note (the wall here is fp16's max value, not its precision)."""
     n = np.arange(N)
     k = n.reshape(-1, 1)

--- a/tests/test_cost_model_analytic.py
+++ b/tests/test_cost_model_analytic.py
@@ -28,7 +28,7 @@ def test_project_peak_m5_about_5x():
     # Doc's back-of-envelope is ~5.5x/10 TFLOP/s using eff=0.84 (the LOW-freq end of the
     # curve). project_peak reads efficiency at the actual operating clock (0.8*fmax),
     # where M5's eff interpolates to ~0.746 -> a more conservative, physically-consistent
-    # ~4.9x / ~8.9 TFLOP/s. Same ballpark, honest basis.
+    # ~4.9x / ~8.9 TFLOP/s. Same ballpark, consistent basis.
     p = _cost.project_peak("h17s")              # M5 == H17s
     assert 4.5 < p["rel_m1"] < 6.2
     assert 8.0 < p["tflops"] < 11.5

--- a/tests/test_cross_compile_matrix.py
+++ b/tests/test_cross_compile_matrix.py
@@ -7,7 +7,7 @@ whole A16-ceiling capability tier - the h17*/h18 targets compile too but are
 capability-identical, core-count scaling only), and the per-(case, family)
 compile result is compared to the model's prediction (a raw graph compiles iff every op
 is native and nothing is oversize). Any disagreement is a bug in _OP_FLOOR / _LIMITS /
-preflight - this is how we keep the hand-curated model honest against the ground truth.
+preflight - this is how we keep the hand-curated model correct against the ground truth.
 
 Compile-level only (cross-target programs can't execute on this host); numeric
 correctness still needs the real silicon. Bridge/segmented cases are skipped (the
@@ -58,7 +58,7 @@ def test_model_matches_compiler(name, graph):
             predicted = _model_compiles(graph, fam)
             # cross_compile_check uses the HOST compiler, which can only EMIT ops the host's
             # family supports. When the model says a higher-family TARGET runs the op natively
-            # but the host is below that family, the host simply can't emit it - cross_compile
+            # but the host is below that family, the host can't emit it - cross_compile
             # rejects for a host reason, not because the target lacks the op. That's a host
             # artifact (it would pass on an A15+/M5 host), so skip rather than flag the model.
             if predicted and not actual and fam > host_family:

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -10,7 +10,7 @@ Two halves:
    loosened, the case docstring SAYS so and distinguishes "fp16 compounding" from
    "wrong" (a wrong kernel blows past any sane tol; compounding stays O(few %)).
 
-2. LAPACK FEASIBILITY PROBES - honest corner probes (QR/Cholesky-style
+2. LAPACK FEASIBILITY PROBES - corner probes (QR/Cholesky-style
    orthonormalization, triangular back-substitution, a small linear solve). These
    ask "what classical linear algebra actually fits the ANE's fp16 feed-forward
    dataflow?" They are tagged works / arch-limited / fp16-unstable with evidence
@@ -369,7 +369,7 @@ def _gram_syrk():
                   "compute", "works")
 
 
-# LAPACK FEASIBILITY PROBES - classify honestly, do not fake a pass.
+# LAPACK FEASIBILITY PROBES - classify correctly, do not fake a pass.
 #
 # Background (from the reverse-engineering corpus RE of the MatrixDecomposition layer):
 #   * aneforge's __all__ exposes NO decomposition op. The hardware
@@ -390,7 +390,7 @@ def _qr_givens_probe():
     APPROACH that fits a feed-forward engine: QR by a *fixed, precomputed*
     sequence of Givens rotations is data-dependent (each rotation angle depends on
     the current entries), so it cannot be unrolled into a static graph for an
-    arbitrary input. To probe the dataflow honestly we instead test the one
+    arbitrary input. To probe the dataflow we instead test the one
     orthogonalization step that IS expressible: a single Householder/Gram-Schmidt
     projection of column 2 against a normalized column 1, all from gemv + dot +
     l2_norm + axpy. That is the atomic step a QR is built from.

--- a/tests/test_op_coverage.py
+++ b/tests/test_op_coverage.py
@@ -1,4 +1,4 @@
-"""Comprehensive per-op coverage: one case per exposed aneforge op. Each compiles +
+"""Per-op coverage: one case per exposed aneforge op. Each compiles +
 runs on the ANE; ops with a computable numpy reference are checked for correctness
 (cos > 0.99 / allclose), the rest assert a finite, correctly-shaped output. M1-walled
 bridge ops (per the op catalog) are xfail-skipped. ~100 ops."""

--- a/tests/test_pde_ode.py
+++ b/tests/test_pde_ode.py
@@ -26,7 +26,7 @@ is ARCH-LIMITED and tagged as such, with a note on exactly what control flow is
 missing. The fixed-iteration version of the same method WORKS; the adaptive/
 convergent version does not. That split IS the capability map.
 
-Honesty on error. The iterative kernels COMPOUND fp16 rounding: the ANE iterate and
+On error: the iterative kernels COMPOUND fp16 rounding: the ANE iterate and
 the numpy-fp32 reference iterate are genuinely different trajectories, so they drift
 a little per step. Where a tol is loosened, the docstring says so and distinguishes
 *compounding* (O(few %), grows ~linearly in step count, stays bounded) from a *bug*
@@ -627,7 +627,7 @@ def _log_series():
 # real solver needs (run-to-convergence / adaptive). We cannot express the
 # data-dependent stop, so we encode the boundary as an xfail with the reason - the
 # corpus records WHY, not a silent omission. The xfail keeps the gate green while
-# making the architectural limit a first-class, visible result.
+# making the architectural limit a visible result.
 
 def _newton_to_convergence_archlimited():
     """Newton run-TO-CONVERGENCE (stop when |f(x)| < tol) - the form a real root
@@ -638,7 +638,7 @@ def _newton_to_convergence_archlimited():
     executes and we can see it numerically converge), but the case is tagged
     arch-limited and xfail: the POINT is that the convergent form's stopping rule is
     inexpressible, not that the arithmetic is wrong. A fixed unroll that matched the
-    reference would XPASS rather than XFAIL, so to keep the semantics honest we set the
+    reference would XPASS rather than XFAIL, so to keep the semantics correct we set the
     reference to the run-to-tol numpy result with a DIFFERENT (data-dependent) iteration
     count: the fixed-K ANE graph and the variable-count reference then legitimately
     differ at tight tol, demonstrating that you cannot match an adaptive method with a

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -2,7 +2,7 @@
 
 The optimizer's coverage guarantee is: *every surfaced capability is either ROUTE-
 SELECTABLE (the autotuner picks its cheapest equivalent lowering by measured cost) or
-EXPLICITLY SINGLE-ROUTE.* This test proves the SELECTABLE half is honest - every route
+EXPLICITLY SINGLE-ROUTE.* This test proves the SELECTABLE half is accurate - every route
 the optimizer is willing to flip a bridge node to is mathematically equivalent on real
 ANE silicon, the same proof class as the metamorphic ``mha_vs_sdpa`` /
 ``reduce_sum_vs_matmul`` transforms.
@@ -146,7 +146,7 @@ def test_lrn_route_equivalent():
 
 
 def test_rejected_candidate_stays_single_route():
-    """Honesty check on a REJECTED candidate: space_to_channel is marked single-route
+    """Check on a REJECTED candidate: space_to_channel is marked single-route
     because its reshape+transpose decomposition needs a rank-6 intermediate that
     ANECCompile rejects. Confirm the registry records it single-route (we do NOT
     re-run the failing compile here - an ANECCompile abort can take down the

--- a/tests/test_tune_guards.py
+++ b/tests/test_tune_guards.py
@@ -105,7 +105,7 @@ def test_tune_unchanged_when_lossless_baseline_exists(monkeypatch):
     assert built["cfg"].get("int8") is True            # 50us * 1.10 <= 100us -> int8 wins
 
 
-# 2. tune_precision(): reference fallback and honesty
+# 2. tune_precision(): reference fallback and correctness
 def test_tune_precision_falls_back_to_fp16_baseline_reference(monkeypatch):
     out = _tanh_graph()
     base = np.full((1, 8), 2.0, np.float32)


### PR DESCRIPTION
Drops the recurring "honest/honesty" qualifier and a few filler words (comprehensive, first-class, simply, under the hood) from comments and docstrings across the tree.

Comments and docstrings only. No code, test logic, or output values change. `ruff` passes and `import aneforge` works.