### PR TITLE
Query-tile cross_attention at large query and context

### DIFF
--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -1113,12 +1113,30 @@ def cross_attention(x: Tensor, context: Tensor, Wq, Wk, Wv, Wo, n_heads: int,
     """Cross-attention: queries from `x` [S, D], keys/values from `context`
     [T, Dctx]. Wq:[D,D]; Wk,Wv:[D,Dctx]; Wo:[D,D]. (SD UNet text conditioning.)"""
     S, D = x.shape
+    T = context.shape[0]
     dh = D // n_heads
     qh = _heads(x.linear(Wq, bq), n_heads, dh)                              # [H,S,dh]
     kh = _heads(context.linear(Wk, bk), n_heads, dh)                        # [H,T,dh]
     vh = _heads(context.linear(Wv, bv), n_heads, dh)
-    a = ((qh @ kh.transpose([0, 2, 1])) * (1.0 / dh ** 0.5)).softmax(-1)     # [H,S,T]
-    o = (a @ vh).transpose([1, 0, 2]).reshape(S, D)
+    kt = kh.transpose([0, 2, 1])                                            # [H,dh,T]
+    scale = 1.0 / dh ** 0.5
+    # Query-tiling: when query and context are both long the [H, S, T] score matrix hits
+    # the ANE's materialization wall (~2.4x slower past it). Tiling the query into
+    # [tile, T] score blocks avoids it, exact, the same fission as af.sdpa/af.mha. Gated
+    # on score area so small-T cross-attention (SD text conditioning, T=77) stays
+    # single-shot, where it is byte-identical and already fastest.
+    n_tiles = max(1, (S + 256) // 512) if (S >= 768 and T >= 512) else 1
+    if n_tiles == 1:
+        o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
+    else:
+        tile = -(-S // n_tiles)                                 # ceil -> near-even chunks
+        parts = []
+        for start in range(0, S, tile):
+            n = min(tile, S - start)
+            qt = qh.slice_by_size([0, start, 0], [n_heads, n, dh])
+            parts.append(((qt @ kt) * scale).softmax(-1) @ vh)  # [H, n, dh]
+        o = concat(parts, axis=1)                               # [H, S, dh]
+    o = o.transpose([1, 0, 2]).reshape(S, D)
     return o.linear(Wo, bo)
 
 

--- a/tests/test_sdpa_causal.py
+++ b/tests/test_sdpa_causal.py
@@ -123,3 +123,26 @@ def test_af_mha_query_tiled():
     a = np.exp(s - s.max(-1, keepdims=True)); a = a / a.sum(-1, keepdims=True)
     o = (a @ v).transpose(1, 0, 2).reshape(S, D)
     assert _cos(out, o @ Wo.astype(np.float32).T + bo.astype(np.float32)) > 0.99
+
+
+@requires_ane
+def test_af_cross_attention_query_tiled():
+    # cross_attention query-tiles when query and context are both long (S >= 768, T >= 512),
+    # materializing [tile, T] score blocks instead of the full [H, S, T]; verify exact
+    # against a numpy cross-attention reference. (Small-T stays single-shot; same result.)
+    S, T, D, H = 768, 512, 256, 8                   # S>=768 and T>=512 -> tiles the query
+    dh = D // H
+    w = lambda *s: (rng.standard_normal(s) * 0.05).astype(np.float16)   # noqa: E731
+    Wq, Wk, Wv, Wo = w(D, D), w(D, D), w(D, D), w(D, D)
+    x = rng.standard_normal((S, D)).astype(np.float16)
+    ctx = rng.standard_normal((T, D)).astype(np.float16)
+    out = np.asarray(af.compile(af.cross_attention(af.input((S, D)), af.input((T, D)),
+                                                   Wq, Wk, Wv, Wo, H))(x, ctx))
+
+    def lin(t, W): return t.astype(np.float32) @ W.astype(np.float32).T
+    def hd(t, n): return t.reshape(n, H, dh).transpose(1, 0, 2)
+    q, k, v = hd(lin(x, Wq), S), hd(lin(ctx, Wk), T), hd(lin(ctx, Wv), T)
+    s = (q @ k.transpose(0, 2, 1)) * dh ** -0.5
+    a = np.exp(s - s.max(-1, keepdims=True)); a = a / a.sum(-1, keepdims=True)
+    o = (a @ v).transpose(1, 0, 2).reshape(S, D)
+    assert _cos(out, o @ Wo.astype(np.float32).T) > 0.99


### PR DESCRIPTION
`cross_attention` built the full `[H, S, T]` score matrix. Past a point that hits the ANE's materialization wall (~2.4x slower at S=T=2560, untiled 21.9ms vs tiled 9.1ms). This tiles the query into `[tile, T]` score blocks, the same fission as `af.sdpa`/`af.mha`.

Gated on `S >= 768 and T >= 512` so small-T cross-attention (SD UNet text conditioning, T=77) stays single-shot and byte-identical to before; below the wall, tiling is neutral. Exact (each tile attends to all keys); tiled output matches untiled to 0.

Adds `test_af_cross_attention_query_tiled`. All sdpa/mha/cross tests pass on-device; ruff clean.