### PR TITLE
Bump CITATION version to 0.1.3

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,7 +9,7 @@ authors:
 repository-code: "https://github.com/sbryngelson/ANEForge"
 doi: 10.5281/zenodo.20672609
 license: MIT
-version: "0.1.2"
+version: "0.1.3"
 date-released: "2026-06-22"
 preferred-citation:
   type: article


### PR DESCRIPTION
Match CITATION.cff to the released v0.1.3 tag. Date already current.