### PR TITLE
readme: point to the LangChain RAG embeddings drop-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ PYTHONPATH=. python3 tests/op_smoketest.py    # compile + run each op on the ANE
 ```
 
 Then browse [`examples/`](examples/), starting with
-[`examples/quickstart.py`](examples/quickstart.py).
+[`examples/quickstart.py`](examples/quickstart.py). For retrieval,
+[`examples/rag_embeddings.py`](examples/rag_embeddings.py) is a LangChain
+`Embeddings` drop-in backed by the on-ANE encoder (4-5x faster than the GPU,
+cosine 1.0000).
 
 ## How it compares
 


### PR DESCRIPTION
Adds a README line under the examples pointer to examples/rag_embeddings.py (merged in #22), so the LangChain Embeddings drop-in is discoverable from the README. Docs only.