### PR TITLE
attention: autotune the query-tile count per chip and shape

### DIFF
--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -101,7 +101,7 @@ from .graph import (Tensor, affine, batch_norm, batch_to_space, channel_to_space
 from ._compile import (Model, SegmentedModel, compile, PrecisionWarning,
                        CrossChipFP16Warning, DispatchFloorWarning)
 from ._paired import Paired, paired
-from ._optimize import tune, tune_precision
+from ._optimize import tune, tune_precision, tune_attention, attention_tiles
 from ._cost import estimate, estimate_provenance, precision_risk, project_peak
 from ._circuit import CompileBackoffError, reset as reset_compile_breaker
 from ._rewrite import reduce_sum_to_matmul, paired_subtract
@@ -122,7 +122,7 @@ __all__ = [
     "stack", "split", "select", "where", "OP_CATALOG", "op_info", "device_status", "is_native", "ops_on", "min_native_family", "walled_everywhere", "categories", "gather", "instance_norm", "local_response_norm", "einsum_native",
     "space_to_depth", "depth_to_space", "crop", "resize_nearest_neighbor",
     "resize_bilinear", "upsample_bilinear", "affine",
-    "compile", "tune", "tune_precision", "estimate", "estimate_provenance",
+    "compile", "tune", "tune_precision", "tune_attention", "attention_tiles", "estimate", "estimate_provenance",
     "precision_risk", "project_peak",
     "CompileBackoffError", "reset_compile_breaker",
     "reduce_sum_to_matmul", "paired_subtract",

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -125,6 +125,92 @@ def _save_cache(cache: dict) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# attention query-tile autotune                                                #
+# --------------------------------------------------------------------------- #
+# The query-tile count in mha/sdpa/cross_attention sets how the [H, S, T] score is
+# fissioned. The S-based heuristic (max(1,(S+256)//512)) avoids the un-tiled wall but is
+# not the per-shape optimum, and the optimum is bound by L2 residency / pipelining, so it
+# shifts with head count and chip. This measures the best count ONCE per (chip, S, T,
+# heads, head_dim) and caches it; the heuristic is the default until a tuned value exists.
+_TILE_MEMO: dict = {}
+_TILE_CANDIDATES = (1, 2, 3, 4, 5, 6, 8)
+
+
+def _heuristic_tiles(S: int) -> int:
+    return max(1, (S + 256) // 512)
+
+
+def _time_attention_core(S: int, T: int, n_heads: int, dh: int, n_tiles: int, reps: int = 20) -> float:
+    """Median wall time (s) of the query-tiled attention core [H,S,dh] x [H,dh,T] on the ANE."""
+    from . import graph as g
+    qh, kh, vh = g.input((n_heads, S, dh)), g.input((n_heads, T, dh)), g.input((n_heads, T, dh))
+    kt = kh.transpose([0, 2, 1]); scale = 1.0 / dh ** 0.5
+    if n_tiles == 1:
+        o = ((qh @ kt) * scale).softmax(-1) @ vh
+    else:
+        tile = -(-S // n_tiles); parts = []
+        for start in range(0, S, tile):
+            n = min(tile, S - start)
+            qt = qh.slice_by_size([0, start, 0], [n_heads, n, dh])
+            parts.append(((qt @ kt) * scale).softmax(-1) @ vh)
+        o = g.concat(parts, axis=1)
+    prog = _raw_compile(o)
+    rng = np.random.default_rng(0)
+    args = [rng.standard_normal((n_heads, S, dh)).astype(np.float32) * 0.1,
+            rng.standard_normal((n_heads, T, dh)).astype(np.float32) * 0.1,
+            rng.standard_normal((n_heads, T, dh)).astype(np.float32) * 0.1]
+    try:
+        for _ in range(5):
+            prog(*args)
+        ts = []
+        for _ in range(reps):
+            t0 = time.perf_counter(); prog(*args); ts.append(time.perf_counter() - t0)
+        return sorted(ts)[reps // 2]
+    finally:
+        try:
+            prog.release()
+        except Exception:
+            pass
+
+
+def attention_tiles(S: int, n_heads: int, dh: int, T: int | None = None,
+                    tune: bool = False, candidates=_TILE_CANDIDATES) -> int:
+    """Query-tile count for an [n_heads, S, dh] x [n_heads, dh, T] attention score.
+
+    Returns a chip+shape-cached tuned value if one exists, else the S-based heuristic.
+    With `tune=True` (or env ANEFORGE_TUNE_ATTENTION=1) it measures the candidate counts
+    once on the engine, caches the fastest (persisted in autotune.json, keyed by chip),
+    and returns it. Exact either way - the tile count only changes how the score fissions."""
+    T = S if T is None else T
+    from ._targets import _cpu_brand
+    key = f"attn_tiles:{_cpu_brand() or 'unknown'}:{S}:{T}:{n_heads}:{dh}"
+    if key in _TILE_MEMO:
+        return _TILE_MEMO[key]
+    cache = _load_cache()
+    if key in cache:
+        return _TILE_MEMO.setdefault(key, int(cache[key]))
+    want = tune or os.environ.get("ANEFORGE_TUNE_ATTENTION", "").lower() in ("1", "true", "yes")
+    if not want:
+        return _heuristic_tiles(S)
+    best_n, best_t = _heuristic_tiles(S), float("inf")
+    for nt in candidates:
+        try:
+            dt = _time_attention_core(S, T, n_heads, dh, nt)
+        except Exception:
+            continue
+        if dt < best_t:
+            best_t, best_n = dt, nt
+    cache[key] = best_n; _save_cache(cache); _TILE_MEMO[key] = best_n
+    return best_n
+
+
+def tune_attention(S: int, n_heads: int, dh: int, T: int | None = None,
+                   candidates=_TILE_CANDIDATES) -> int:
+    """Measure and cache the best query-tile count for this attention shape on this chip."""
+    return attention_tiles(S, n_heads, dh, T=T, tune=True, candidates=candidates)
+
+
+# --------------------------------------------------------------------------- #
 # variant space (legal == metamorphic-proven-safe)                            #
 # --------------------------------------------------------------------------- #
 def _has_weights(out) -> bool:

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -1092,8 +1092,10 @@ def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
     scale = 1.0 / dh ** 0.5
     # Query-tiling: compute [tile, S] score tiles per head instead of the full [H, S, S]
     # score matrix. Exact (each tile attends to all keys) and ~3x faster on the ANE at
-    # large S, which pipelines the smaller tiles better (same fission as af.sdpa).
-    n_tiles = max(1, (S + 256) // 512)
+    # large S, which pipelines the smaller tiles better (same fission as af.sdpa). The
+    # count is the S-based heuristic unless a tuned value is cached (af.tune_attention).
+    from . import _optimize as _opt
+    n_tiles = _opt.attention_tiles(S, n_heads, dh)
     if n_tiles == 1:
         o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
     else:
@@ -1125,7 +1127,8 @@ def cross_attention(x: Tensor, context: Tensor, Wq, Wk, Wv, Wo, n_heads: int,
     # [tile, T] score blocks avoids it, exact, the same fission as af.sdpa/af.mha. Gated
     # on score area so small-T cross-attention (SD text conditioning, T=77) stays
     # single-shot, where it is byte-identical and already fastest.
-    n_tiles = max(1, (S + 256) // 512) if (S >= 768 and T >= 512) else 1
+    from . import _optimize as _opt
+    n_tiles = _opt.attention_tiles(S, n_heads, dh, T=T) if (S >= 768 and T >= 512) else 1
     if n_tiles == 1:
         o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
     else:
@@ -1228,7 +1231,8 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
         # smaller score tiles far better than one big matmul+softmax (~3x at Sq=1500, H=16).
         # Tiles target ~512 query rows; a small query (e.g. KV-cache decode) takes one shot.
         kt = k.transpose([0, 1, 3, 2])
-        n_tiles = max(1, (q.shape[2] + 256) // 512)
+        from . import _optimize as _opt
+        n_tiles = _opt.attention_tiles(q.shape[2], q.shape[1], q.shape[3], T=k.shape[2])
         if n_tiles == 1:
             scores = q @ kt * float(scale)
             if attn_mask is not None:

--- a/tests/test_attention_tiles.py
+++ b/tests/test_attention_tiles.py
@@ -1,0 +1,54 @@
+"""Attention query-tile autotune: heuristic by default, exact across counts, cached.
+
+The autotune only changes HOW the [H,S,T] score is fissioned, never the result, so the
+key safety property is that the tile count does not change the output. Uses a temp cache
+dir so the test sees no previously-tuned values.
+"""
+import os
+import tempfile
+os.environ["ANEFORGE_CACHE_DIR"] = tempfile.mkdtemp()      # hermetic: no prior tuned values
+
+import numpy as np
+import aneforge as af
+from aneforge import _optimize as _opt
+from aneforge.graph import concat
+
+
+def _core(H, S, dh, nt, qn, kn, vn):
+    qh, kh, vh = af.input((H, S, dh)), af.input((H, S, dh)), af.input((H, S, dh))
+    kt = kh.transpose([0, 2, 1]); sc = 1.0 / dh ** 0.5
+    if nt == 1:
+        o = ((qh @ kt) * sc).softmax(-1) @ vh
+    else:
+        tile = -(-S // nt); parts = []
+        for st in range(0, S, tile):
+            n = min(tile, S - st)
+            qt = qh.slice_by_size([0, st, 0], [H, n, dh])
+            parts.append(((qt @ kt) * sc).softmax(-1) @ vh)
+        o = concat(parts, axis=1)
+    return np.asarray(af.compile(o)(qn, kn, vn), np.float32)
+
+
+def test_heuristic_is_default():
+    assert _opt._heuristic_tiles(512) == 1
+    assert _opt._heuristic_tiles(768) == 2
+    assert _opt._heuristic_tiles(1500) == 3
+    # with an empty cache and no tuning, attention_tiles returns the heuristic
+    assert af.attention_tiles(1500, 16, 64) == 3
+
+
+def test_tile_count_does_not_change_output():
+    H, S, dh = 8, 1500, 64
+    rng = np.random.default_rng(0)
+    qn, kn, vn = [rng.standard_normal((H, S, dh)).astype(np.float32) * 0.1 for _ in range(3)]
+    ref = _core(H, S, dh, 1, qn, kn, vn)
+    for nt in (3, 5):
+        o = _core(H, S, dh, nt, qn, kn, vn)
+        cos = float((ref.ravel() @ o.ravel()) / (np.linalg.norm(ref) * np.linalg.norm(o) + 1e-30))
+        assert cos > 0.999, (nt, cos)
+
+
+def test_tune_picks_and_caches():
+    n = af.tune_attention(512, 2, 32)                     # small shape -> quick measurement
+    assert n in (1, 2, 3, 4, 5, 6, 8)
+    assert af.attention_tiles(512, 2, 32) == n            # served from cache afterwards


### PR DESCRIPTION
The query-tile count in `mha`/`sdpa`/`cross_attention` was a fixed S-based heuristic, `max(1, (S+256)//512)`. That avoids the un-tiled materialization wall but is not the per-shape optimum, and the optimum is bound by L2 residency and pipelining, so it shifts with head count and chip.

Measured on an M5 Pro for the Whisper encoder attention (S=1500, head_dim=64, n_head 6 to 20):

```
size    H | t=1  t=2  t=3  t=4  t=5  t=6  t=8   (ms)
tiny    6 | 2.50 2.65 2.57 2.54 2.41 2.68 2.51
base    8 | 3.28 3.47 3.33 3.33 3.06 3.51 3.17
small  12 | 5.07 5.45 5.12 5.15 4.90 5.22 5.00
medium 16 |20.31 7.16 6.84 7.12 6.52 6.91 6.59
large  20 |26.83 8.99 8.77 8.60 8.03 8.59 8.20
```

The heuristic picks 3 at S=1500; 5 is consistently 5 to 10% faster here, and the basin (3 to 8) is shallow. The first-order effect is just tiling at all: at high head count the un-tiled `[H,1500,1500]` score is ~3x slower.

`af.tune_attention(S, n_heads, dh, T=None)` measures the candidate counts once on the engine and caches the fastest, keyed by `(chip, S, T, heads, head_dim)`, in `autotune.json`. `af.attention_tiles(...)` returns the cached value if present, else the heuristic, so default behavior is unchanged unless tuned (or `ANEFORGE_TUNE_ATTENTION=1`).

The tile count only changes how the score fissions, never the result. `tests/test_attention_tiles.py` checks 1 vs 3 vs 5 are identical and that the cache round-trips; the existing sdpa tests are unaffected.