### PR TITLE
sentence-transformers drop-in on the ANE (per-model pooling)

### DIFF
--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -27,7 +27,7 @@ def _l2_normalizer(D: int) -> Model:
     return net
 
 
-def load(name: str, int8: bool = False) -> "Encoder":
+def load(name: str, int8: bool = False, pooling: str = "mean") -> "Encoder":
     """Load a BERT-family sentence encoder from HF weights as an ANE embedder.
 
         embed = af.load("sentence-transformers/all-MiniLM-L6-v2")
@@ -35,9 +35,14 @@ def load(name: str, int8: bool = False) -> "Encoder":
 
     Tokenisation + embedding lookup run on the host (gather is not an ANE op); the
     transformer layers run on the ANE as fused programs (cached per sequence
-    length); mean-pooling + normalise run on the host.
+    length); pooling + normalise run on the host / ANE.
+
+    `pooling` selects how the per-token states reduce to one vector: "mean" (the
+    default, MiniLM / E5), "cls" (the first token, BGE / GTE), or "max". A model's
+    correct mode is in its sentence-transformers config; `aneforge.sentence_transformers`
+    reads it for you.
     """
-    return Encoder(name, int8=int8)
+    return Encoder(name, int8=int8, pooling=pooling)
 
 
 def load_resnet18(int8: bool = False, compress: str | None = None,
@@ -127,7 +132,12 @@ _BERT_KEYS = {
 
 
 class Encoder:
-    def __init__(self, name: str, int8: bool = False) -> None:
+    _POOL = ("mean", "cls", "max")
+
+    def __init__(self, name: str, int8: bool = False, pooling: str = "mean") -> None:
+        if pooling not in self._POOL:
+            raise ValueError(f"pooling must be one of {self._POOL}, got {pooling!r}")
+        self.pooling = pooling
         from transformers import AutoConfig, AutoModel, AutoTokenizer  # lazy
         cfg = AutoConfig.from_pretrained(name)
         self.tok = AutoTokenizer.from_pretrained(name)
@@ -166,7 +176,13 @@ class Encoder:
         for t in texts:
             ids = np.asarray(self.tok(t)["input_ids"], dtype=np.int64)
             net = self._cache.get(len(ids)) or self._cache.setdefault(len(ids), self._build(len(ids)))
-            v = net(self._embed(ids)).mean(0)            # ANE encode -> host mean-pool
+            states = net(self._embed(ids))               # [S, D] per-token states on the ANE
+            if self.pooling == "cls":                    # first token (BERT [CLS])
+                v = states[0]
+            elif self.pooling == "max":
+                v = states.max(0)
+            else:
+                v = states.mean(0)                       # mean over all (unpadded) tokens
             if normalize:
                 # final L2-normalize runs on the ANE (fused reduce_l2_norm + real_div)
                 v = _l2_normalizer(self.D)(v.reshape(1, self.D))[0]

--- a/aneforge/sentence_transformers.py
+++ b/aneforge/sentence_transformers.py
@@ -1,0 +1,86 @@
+"""A drop-in `SentenceTransformer` that runs the encoder on the Apple Neural Engine.
+
+    from aneforge.sentence_transformers import SentenceTransformer
+    model = SentenceTransformer("BAAI/bge-small-en-v1.5")
+    emb = model.encode(["a query", "a passage"])     # [2, D] on the ANE
+
+The transformer layers run on the ANE as one fused e5rt program (cached per
+sequence length); embeddings match the reference to cosine ~1.0 at a fraction of
+the GPU's energy. The pooling mode (mean / cls / max) and whether the output is
+L2-normalised are read from the model's own sentence-transformers config, so a
+mean-pooled model (MiniLM, E5) and a cls-pooled model (BGE, GTE) both come out
+right. Only numpy + aneforge are needed; the sentence-transformers package is not
+imported (this mirrors its `.encode` surface, it does not wrap it).
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import numpy as np
+
+from .models import Encoder
+
+
+def _read_text(name: str, rel: str) -> str | None:
+    """Read one config file from a local model dir or the HF hub, or None."""
+    if os.path.isdir(name):
+        path = os.path.join(name, rel)
+        return open(path).read() if os.path.exists(path) else None
+    from huggingface_hub import hf_hub_download  # lazy
+    try:
+        return open(hf_hub_download(name, rel)).read()
+    except Exception:
+        return None
+
+
+def _read_st_config(name: str) -> tuple[str, bool]:
+    """Return (pooling_mode, has_normalize) from the model's sentence-transformers
+    config. Defaults to ("mean", False) for a raw model with no such config."""
+    pooling = "mean"
+    pc = _read_text(name, "1_Pooling/config.json")
+    if pc:
+        d = json.loads(pc)
+        if d.get("pooling_mode_cls_token"):
+            pooling = "cls"
+        elif d.get("pooling_mode_max_tokens"):
+            pooling = "max"
+        elif d.get("pooling_mode_mean_tokens"):
+            pooling = "mean"
+    normalize = False
+    mj = _read_text(name, "modules.json")
+    if mj:
+        normalize = any("Normalize" in m.get("type", "") for m in json.loads(mj))
+    return pooling, normalize
+
+
+class SentenceTransformer:
+    """`sentence_transformers.SentenceTransformer`-compatible encoder on the ANE.
+
+    `int8=True` streams int8 weights (half the size, cosine ~0.9999). The `device`
+    argument is accepted for signature parity and ignored: the encoder always runs
+    on the Neural Engine.
+    """
+
+    def __init__(self, model_name_or_path: str, *, int8: bool = False, device: str | None = None) -> None:
+        self.pooling_mode, self._normalize_module = _read_st_config(model_name_or_path)
+        self._enc = Encoder(model_name_or_path, int8=int8, pooling=self.pooling_mode)
+
+    def encode(self, sentences, batch_size: int = 32, normalize_embeddings: bool = False,
+               convert_to_numpy: bool = True, convert_to_tensor: bool = False, **kwargs):
+        """Encode `sentences` (a str or list of str) to embeddings on the ANE.
+
+        `batch_size` is accepted for parity; the ANE path is fused per sequence
+        length and cached, so it does not change the result. A model that ships a
+        Normalize module is L2-normalised regardless of `normalize_embeddings`,
+        matching sentence-transformers.
+        """
+        single = isinstance(sentences, str)
+        texts = [sentences] if single else list(sentences)
+        normalize = self._normalize_module or normalize_embeddings
+        out = self._enc(texts, normalize=normalize).astype(np.float32)
+        out = out[0] if single else out
+        if convert_to_tensor:
+            import torch  # lazy
+            return torch.from_numpy(np.ascontiguousarray(out))
+        return out

--- a/examples/sentence_transformers_ane.py
+++ b/examples/sentence_transformers_ane.py
@@ -1,0 +1,40 @@
+"""Drop-in sentence-transformers on the Apple Neural Engine.
+
+`aneforge.sentence_transformers.SentenceTransformer` mirrors the `.encode` surface
+of the sentence-transformers package, but runs the encoder on the ANE. It reads the
+model's own pooling config, so a mean-pooled model (MiniLM, E5) and a cls-pooled
+model (BGE, GTE) both produce the right vectors, matching the reference to cosine
+~1.0 at a fraction of the GPU's energy.
+
+    pip install "aneforge[models]"
+    python3 examples/sentence_transformers_ane.py
+"""
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+import numpy as np
+
+from aneforge.sentence_transformers import SentenceTransformer
+
+
+def main():
+    model = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+    print(f"  pooling mode read from config: {model.pooling_mode}")
+
+    corpus = [
+        "The Apple Neural Engine accelerates neural networks at low power.",
+        "Cats are independent animals that enjoy sleeping in the sun.",
+        "Transformers process whole sequences in a single forward pass.",
+    ]
+    query = "What hardware runs networks efficiently?"
+
+    docs = model.encode(corpus)                    # [N, D] on the ANE
+    q = model.encode(query)                        # a single string -> [D]
+    scores = docs @ q
+    best = int(np.argmax(scores))
+
+    print(f"  query : {query}")
+    print(f"  match : {corpus[best]}   (score {scores[best]:.3f})")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Run sentence-transformers models on the Apple Neural Engine with a one-line import.

```python
from aneforge.sentence_transformers import SentenceTransformer
model = SentenceTransformer("BAAI/bge-small-en-v1.5")
emb = model.encode(["a query", "a passage"])   # on the ANE
```

- `af.load` / `Encoder` gain a `pooling` option (mean / cls / max). The old code hardcoded mean, which is wrong for cls-pooled models like BGE.
- `aneforge.sentence_transformers.SentenceTransformer` mirrors the `.encode` surface and reads each model's pooling mode + normalize flag from its own sentence-transformers config, so mean-pooled (MiniLM, E5) and cls-pooled (BGE, GTE) models both come out right. It does not import the sentence-transformers package.
- Verified on-device: mean / cls / max pooling each match a transformers reference to cosine > 0.9999, and the config reader resolves cls/mean/max + normalize correctly.

Example: `examples/sentence_transformers_ane.py`.