### PR TITLE
Unified rewrite engine + algebraic passes

### DIFF
--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1300,7 +1300,7 @@ def _retarget_for(out: Tensor, target) -> Tensor:
     return memo[id(out)]
 
 
-def compile(out: Tensor, int8: bool = False, build_dir=None, opt="routes",
+def compile(out: Tensor, int8: bool = False, build_dir=None, opt: "str | int | None" = "routes",
             compress: str | None = None, compress_atol: float = 0.05,
             block_size: int = 32, validate: bool = False, target=None,
             _check_precision: bool = True):

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1357,6 +1357,9 @@ def compile(out: Tensor, int8: bool = False, build_dir=None, opt="routes",
         opt = 0          # compressed weights always take the byte-identical lowering
         if compress == "auto":
             family = _resolve_family(target)   # auto is family-aware: stream-only candidates
+    if opt not in _OPT0:                  # lossless canon for routes/1/2/max; never opt=0 or compress
+        from ._rewrite import canonicalize
+        out = canonicalize(out)
     if opt == "routes":
         from . import _optimize
         return _optimize._compile_routes(out, int8=int8, build_dir=build_dir)

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -40,6 +40,7 @@ import numpy as np
 
 from ._compile import compile as _raw_compile, _topo
 from ._cost import estimate, precision_risk
+from .graph import Tensor
 
 # --------------------------------------------------------------------------- #
 # tolerance for variant correctness (vs the opt=0 baseline)                    #
@@ -272,53 +273,74 @@ def _route_ids(out):
             and not (t.op == "sdpa" and (t.attrs.get("causal") or t.attrs.get("masked")))]
 
 
+def _constfold_candidates(out):
+    """Topo indices of nodes whose whole source cone is constant (foldable to one
+    const_array). Excludes the const/input leaves themselves."""
+    from ._rewrite import _const_subgraph
+    return [i for i, t in enumerate(_topo(out))
+            if t.op not in ("const_array", "input") and _const_subgraph(t) is not None]
+
+
+def _scalarchain_candidates(out):
+    """Topo indices of muls/adds chain heads (a muls whose src is a muls, or adds
+    over adds) - the nodes a scalar-chain fold collapses."""
+    return [i for i, t in enumerate(_topo(out))
+            if t.op in ("muls", "adds") and t.srcs[0].op == t.op]
+
+
 def _apply_variant(out, cfg):
-    """Materialize the rewritten output DAG for a variant `cfg`. The compile-time
-    int8 flag is returned separately (it is a compiler arg, not a graph rewrite).
+    """Materialize the rewritten DAG for a variant `cfg` in ONE graph_rewrite pass.
+    Every axis composes over the ORIGINAL graph (indices resolved to original ids up
+    front), so there is no chained-rewrite index drift. The compile-time global int8
+    flag is returned separately (a compiler arg, not a graph rewrite).
 
-    cfg keys:
-      `int8`    : the GLOBAL int8 compile flag (legacy whole-graph int8).
-      `decomp`  : tuple of ROUTE-BEARING bridge topo-indices to rewrite to their
-                    fused decomposition (sdpa/minmax_norm/flatten - see the route
-                    registry / _rewrite._BRIDGE_DECOMPOSERS). Empty -> every bridge
-                    node stays native (the baseline all-cut route).
-      `int8_nodes` : tuple of weight-bearing (matmul/conv) topo-indices to stream
-                       int8 per-node.
-      `rs_matmul`  : tuple of reduce_sum topo-indices to rewrite to a `@ ones`
-                       matmul contraction (the WIDE-accumulator sum - a numerics-
-                       aware, accuracy-IMPROVING rewrite). Empty -> none.
-    """
-    new_out = out
-    rs_idx = set(cfg.get("rs_matmul", ()))
-    if rs_idx:
-        from ._rewrite import reduce_sum_to_matmul
-        new_out = reduce_sum_to_matmul(new_out, only_idx=rs_idx)
-    decomp = set(cfg.get("decomp", ()))
-    if decomp:
-        new_out = _rewrite_by_topo_index(new_out, decomp_idx=decomp)
-        # route indices in `decomp` reference the original graph; rs_matmul above only
-        # rewrites reduce_sum nodes (a different op set), so the topo positions of bridge
-        # nodes are unchanged - the indices stay stable.
-    int8_nodes = tuple(cfg.get("int8_nodes", ()))
-    if int8_nodes:
-        from ._rewrite import set_node_int8
-        order = _topo(new_out)
-        # int8_nodes indexes the (already route-rewritten) graph's weight-bearing nodes
-        # (matmul streamed wt, conv baked weight - both route per-channel int8).
-        sel = {id(order[i]) for i in int8_nodes
-               if i < len(order) and order[i].op in ("matmul", "conv")}
-        if sel:
-            new_out = set_node_int8(new_out, sel)
+    cfg axes: `decomp` (bridge topo-indices -> fused decomposition), `int8_nodes`
+    (matmul/conv topo-indices -> per-node int8 tag), `rs_matmul` (reduce_sum
+    topo-indices -> @ones contraction), `scalarfold` (muls/adds chain-head indices),
+    `constfold` (constant-cone indices -> one const_array)."""
+    from ._rewrite import (Rule, graph_rewrite, _BRIDGE_DECOMPOSERS, _reduce_sum_as_matmul,
+                           _b_fold_muls, _b_fold_adds, _b_const_fold)
+    order = _topo(out)
+
+    def ids(key, ok):
+        return {id(order[i]) for i in cfg.get(key, ()) if 0 <= i < len(order) and ok(order[i])}
+
+    sel: set[int] = set()
+    rules: list = []
+
+    rs = ids("rs_matmul", lambda t: t.op == "reduce_sum" and len(t.attrs.get("axes", ())) == 1)
+    if rs:
+        sel |= rs
+        rules.append(Rule("rsum_mm", "numeric", lambda t: t.op == "reduce_sum", _reduce_sum_as_matmul))
+
+    dec = ids("decomp", lambda t: t.op in _BRIDGE_DECOMPOSERS)
+    if dec:
+        sel |= dec
+        rules.append(Rule("bridge", "lossless", lambda t: t.op in _BRIDGE_DECOMPOSERS,
+                          lambda t: _BRIDGE_DECOMPOSERS[t.op](t)))
+
+    i8 = ids("int8_nodes", lambda t: t.op in ("matmul", "conv"))
+    if i8:
+        sel |= i8
+        rules.append(Rule("int8", "numeric", lambda t: t.op in ("matmul", "conv"),
+                          lambda t: Tensor(t.shape, t.op, t.srcs, {**t.attrs, "int8": True})))
+
+    sf = ids("scalarfold", lambda t: t.op in ("muls", "adds") and t.srcs[0].op == t.op)
+    if sf:
+        sel |= sf
+        rules += [
+            Rule("muls_chain", "numeric", lambda t: t.op == "muls" and t.srcs[0].op == "muls", _b_fold_muls),
+            Rule("adds_chain", "numeric", lambda t: t.op == "adds" and t.srcs[0].op == "adds", _b_fold_adds),
+        ]
+
+    cf = ids("constfold", lambda t: t.op not in ("const_array", "input"))
+    if cf:
+        sel |= cf
+        rules.append(Rule("const_fold", "numeric",
+                          lambda t: t.op not in ("const_array", "input"), _b_const_fold))
+
+    new_out = graph_rewrite(out, rules, select=sel) if rules else out
     return new_out, bool(cfg.get("int8", False))
-
-
-def _rewrite_by_topo_index(out, decomp_idx):
-    """Rewrite the ROUTE-BEARING bridge nodes at the given topo indices to their fused
-    decomposition (sdpa/minmax_norm/flatten - any op in the closed route registry),
-    walking the ORIGINAL graph so the indices stay stable. Thin wrapper over
-    `_rewrite.decompose_bridge` (the single executable route table)."""
-    from ._rewrite import decompose_bridge
-    return decompose_bridge(out, set(decomp_idx))
 
 
 def _variants(out):
@@ -353,6 +375,12 @@ def _variants(out):
             configs.append({"int8": False, "decomp": list(routes), "lossy": False})
     if _has_weights(out):
         configs.append({"int8": True, "decomp": [], "lossy": True})   # PRIMARY: global int8
+    cf = _constfold_candidates(out)
+    if cf:
+        configs.append({"int8": False, "decomp": [], "constfold": cf, "lossy": True})
+    sf = _scalarchain_candidates(out)
+    if sf:
+        configs.append({"int8": False, "decomp": [], "scalarfold": sf, "lossy": True})
     return configs
 
 

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -27,6 +27,7 @@ On top of that, two concrete rewrites the optimizer uses:
 """
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Callable, Optional
 
@@ -341,3 +342,42 @@ NUMERIC_RULES: list[Rule] = [
   Rule("muls_chain", "numeric", lambda t: t.op == "muls" and t.srcs[0].op == "muls", _b_fold_muls),
   Rule("adds_chain", "numeric", lambda t: t.op == "adds" and t.srcs[0].op == "adds", _b_fold_adds),
 ]
+
+# fp16 NumPy kernels for the foldable ops. Compute reproduces device fp16 where it can,
+# but is NEVER assumed bit-identical to the engine -> const_fold is gated (NUMERIC).
+def _f16(x: "np.ndarray") -> "np.ndarray": return np.asarray(x, np.float16)
+_EVAL: dict[str, "object"] = {
+  "muls":    lambda s, a: _f16(s[0] * _f16(a["k"])),
+  "adds":    lambda s, a: _f16(s[0] + _f16(a["k"])),
+  "add":     lambda s, a: _f16(s[0] + s[1]),
+  "sub":     lambda s, a: _f16(s[0] - s[1]),
+  "mul":     lambda s, a: _f16(s[0] * s[1]),
+  "relu":    lambda s, a: _f16(np.maximum(s[0], 0)),
+  "reshape": lambda s, a, shape=None: _f16(s[0].reshape(shape)),
+  "cast":    lambda s, a: _f16(s[0]),
+}
+
+def _const_subgraph(t: Tensor, max_elems: int = 1 << 16) -> "np.ndarray | None":
+  """fp16 value of `t` if its entire source cone is constant (const_array leaves,
+  no `input`) and the op set is foldable and the size is bounded; else None."""
+  if math.prod(t.shape) > max_elems: return None
+  memo: dict[int, "np.ndarray | None"] = {}
+  def ev(n: Tensor) -> "np.ndarray | None":
+    if id(n) in memo: return memo[id(n)]
+    if n.op == "const_array": memo[id(n)] = _f16(n.attrs["value"]); return memo[id(n)]
+    if n.op == "input" or n.op not in _EVAL: memo[id(n)] = None; return None
+    srcs = [ev(s) for s in n.srcs]
+    if any(s is None for s in srcs): memo[id(n)] = None; return None
+    fn = _EVAL[n.op]  # type: ignore[index]
+    v: "np.ndarray" = fn(srcs, n.attrs, n.shape) if n.op == "reshape" else fn(srcs, n.attrs)  # type: ignore[operator]
+    memo[id(n)] = v; return v
+  return ev(t)
+
+def _b_const_fold(t: Tensor) -> Tensor:
+  v = _const_subgraph(t); assert v is not None  # match guard makes None unreachable
+  return Tensor(t.shape, "const_array", [], {"value": v})
+
+NUMERIC_RULES.append(
+  Rule("const_fold", "numeric",
+       lambda t: t.op != "const_array" and t.op != "input" and _const_subgraph(t) is not None,
+       _b_const_fold))

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -73,24 +73,12 @@ def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:
     returned unchanged, so a no-op rule yields the SAME object - the optimizer relies
     on that to keep opt=0 byte-identical.
     """
-    memo: dict[int, Tensor] = {}
-
-    def visit(t: Tensor) -> Tensor:
-        cached = memo.get(id(t))
-        if cached is not None:
-            return cached
-        # rewrite sources first (bottom-up)
-        new_srcs = [visit(s) for s in t.srcs]
-        if all(ns is os for ns, os in zip(new_srcs, t.srcs)):
-            rebuilt = t                      # sources unchanged -> reuse the node
-        else:
-            rebuilt = Tensor(t.shape, t.op, new_srcs, dict(t.attrs))
-        replacement = rule(rebuilt)
-        result = replacement if replacement is not None else rebuilt
-        memo[id(t)] = result
-        return result
-
-    return visit(out)
+    # `rule` must be a pure node-local transform: it is called once in `match` and
+    # again in `build`, so a stateful/non-deterministic rule would be unsafe. The
+    # match-guard ensures `build` fires only when `rule` returns a Tensor (not None),
+    # which is why the build-lambda's None-able return is type-ignored as safe.
+    r = Rule("adhoc", "lossless", lambda t: rule(t) is not None, lambda t: rule(t))  # type: ignore[arg-type]
+    return graph_rewrite(out, [r])
 
 
 def _decompose_sdpa(node: Tensor) -> Tensor:
@@ -114,14 +102,9 @@ def sdpa_to_decomposed(out: Tensor, only_id: Optional[int] = None) -> Tensor:
     `only_id` (an `id()` of a node in the ORIGINAL graph) rewrites just that one
     sdpa node; None rewrites every sdpa node. Returns a new output DAG (the same
     object if there was nothing to rewrite)."""
-    def rule(t: Tensor) -> Optional[Tensor]:
-        if t.op != "sdpa":
-            return None
-        if only_id is not None and id(t) != only_id:
-            return None
-        return _decompose_sdpa(t)
-
-    return rewrite(out, rule)
+    sel = None if only_id is None else {only_id}
+    r = Rule("sdpa", "lossless", lambda t: t.op == "sdpa", _decompose_sdpa)
+    return graph_rewrite(out, [r], select=sel)
 
 
 def list_sdpa_nodes(out: Tensor) -> list[Tensor]:
@@ -134,35 +117,10 @@ def set_node_int8(out: Tensor, node_ids: set[int]) -> Tensor:
     """Return a new DAG where each weight-bearing node whose `id()` is in
     `node_ids` carries an `int8=True` attr (per-weight int8 override). The
     compiler's `weight()` honors `t.attrs['int8']` over the global flag."""
-    def rule(t: Tensor) -> Optional[Tensor]:
-        if id(t) in node_ids and t.op in ("matmul", "conv"):
-            attrs = dict(t.attrs)
-            attrs["int8"] = True
-            return Tensor(t.shape, t.op, t.srcs, attrs)
-        return None
-
-    # node_ids reference original nodes; rewrite() rebuilds bottom-up so a tagged
-    # node's id changes once its sources change. Tag by matching the original ids
-    # against the pre-rewrite identity during the walk.
-    memo: dict[int, Tensor] = {}
-
-    def visit(t: Tensor) -> Tensor:
-        cached = memo.get(id(t))
-        if cached is not None:
-            return cached
-        new_srcs = [visit(s) for s in t.srcs]
-        tag = id(t) in node_ids and t.op in ("matmul", "conv")
-        if not tag and all(ns is os for ns, os in zip(new_srcs, t.srcs)):
-            result = t
-        else:
-            attrs = dict(t.attrs)
-            if tag:
-                attrs["int8"] = True
-            result = Tensor(t.shape, t.op, new_srcs, attrs)
-        memo[id(t)] = result
-        return result
-
-    return visit(out)
+    if not node_ids: return out
+    r = Rule("int8", "numeric", lambda t: t.op in ("matmul", "conv"),
+             lambda t: Tensor(t.shape, t.op, t.srcs, {**t.attrs, "int8": True}))
+    return graph_rewrite(out, [r], select=set(node_ids))
 
 
 def list_weight_nodes(out: Tensor) -> list[Tensor]:
@@ -221,38 +179,12 @@ def reduce_sum_to_matmul(out: Tensor, only_idx: set[int] | None = None) -> Tenso
     nothing matched)."""
     from ._compile import _topo
     order = _topo(out)
-    if only_idx is None:
-        target_ids = {id(t) for t in order
-                      if t.op == "reduce_sum" and len(t.attrs.get("axes", ())) == 1}
-    else:
-        target_ids = {id(order[i]) for i in only_idx
-                      if i < len(order) and order[i].op == "reduce_sum"
-                      and len(order[i].attrs.get("axes", ())) == 1}
-
-    def rule(t: Tensor) -> Optional[Tensor]:
-        if id(t) in target_ids:
-            return _reduce_sum_as_matmul(t)
-        return None
-
-    # target_ids are pre-rewrite identities; match against the original nodes during
-    # the bottom-up walk (a reduce_sum's id changes once its source is rebuilt).
-    memo: dict[int, Tensor] = {}
-
-    def visit(t: Tensor) -> Tensor:
-        cached = memo.get(id(t))
-        if cached is not None:
-            return cached
-        new_srcs = [visit(s) for s in t.srcs]
-        hit = id(t) in target_ids
-        if not hit and all(ns is os for ns, os in zip(new_srcs, t.srcs)):
-            rebuilt = t
-        else:
-            rebuilt = Tensor(t.shape, t.op, new_srcs, dict(t.attrs))
-        result = _reduce_sum_as_matmul(rebuilt) if hit else rebuilt
-        memo[id(t)] = result
-        return result
-
-    return visit(out)
+    elig = lambda t: t.op == "reduce_sum" and len(t.attrs.get("axes", ())) == 1
+    if only_idx is None: sel = {id(t) for t in order if elig(t)}
+    else: sel = {id(order[i]) for i in only_idx if i < len(order) and elig(order[i])}
+    if not sel: return out
+    r = Rule("rsum_mm", "numeric", elig, _reduce_sum_as_matmul)
+    return graph_rewrite(out, [r], select=sel)
 
 
 # --------------------------------------------------------------------------- #
@@ -325,25 +257,12 @@ def decompose_bridge(out: Tensor, decomp_idx: set[int]) -> Tensor:
     no registered decomposer is left as-is (single-route). Returns a new output DAG."""
     from ._compile import _topo
     order = _topo(out)
-    targets = {id(order[i]): order[i].op for i in decomp_idx
-               if 0 <= i < len(order) and order[i].op in _BRIDGE_DECOMPOSERS}
-    memo: dict[int, Tensor] = {}
-
-    def visit(t: Tensor) -> Tensor:
-        c = memo.get(id(t))
-        if c is not None:
-            return c
-        new_srcs = [visit(s) for s in t.srcs]
-        hit_op = targets.get(id(t))
-        if hit_op is None and all(ns is os for ns, os in zip(new_srcs, t.srcs)):
-            rebuilt = t
-        else:
-            rebuilt = Tensor(t.shape, t.op, new_srcs, dict(t.attrs))
-        result = _BRIDGE_DECOMPOSERS[hit_op](rebuilt) if hit_op is not None else rebuilt
-        memo[id(t)] = result
-        return result
-
-    return visit(out)
+    sel = {id(order[i]) for i in decomp_idx
+           if 0 <= i < len(order) and order[i].op in _BRIDGE_DECOMPOSERS}
+    if not sel: return out
+    r = Rule("bridge", "lossless", lambda t: t.op in _BRIDGE_DECOMPOSERS,
+             lambda t: _BRIDGE_DECOMPOSERS[t.op](t))
+    return graph_rewrite(out, [r], select=sel)
 
 
 def paired_subtract(a, b):

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -281,3 +281,43 @@ def paired_subtract(a, b):
     pa = a if isinstance(a, Paired) else _mk_paired(a)
     pb = b if isinstance(b, Paired) else _mk_paired(b)
     return (pa - pb).to_tensor()
+
+
+# --------------------------------------------------------------------------- #
+# CANON_RULES: lossless identity/redundancy elimination                        #
+# --------------------------------------------------------------------------- #
+
+def _compose_perm(outer: tuple, inner: tuple) -> tuple:
+  """perm of (transpose(outer) o transpose(inner)): result[i] = inner[outer[i]]."""
+  return tuple(inner[i] for i in outer)
+
+# Each builder gets the REBUILT node; returns the simplified replacement.
+def _b_drop_to_src(t: Tensor) -> Tensor: return t.srcs[0]                       # identity node -> its src
+
+def _b_collapse_reshape(t: Tensor) -> Tensor:
+  return Tensor(t.shape, "reshape", t.srcs[0].srcs, dict(t.srcs[0].attrs))      # reshape o reshape -> one reshape
+
+def _b_collapse_transpose(t: Tensor) -> Tensor:
+  inner = t.srcs[0]; perm = _compose_perm(t.attrs["perm"], inner.attrs["perm"])
+  src = inner.srcs[0]
+  if perm == tuple(range(len(perm))): return src                                # composes to identity -> drop both
+  return Tensor(t.shape, "transpose", [src], {"perm": perm})
+
+CANON_RULES: list[Rule] = [
+  Rule("cast_same", "lossless",
+       lambda t: t.op == "cast" and t.srcs[0].op != "input" and t.attrs.get("dtype", "fp16") == "fp16",
+       _b_drop_to_src),                                                          # cast fp16->fp16 on a compute tensor (NOT the uint8 input port)
+  Rule("reshape_same", "lossless", lambda t: t.op == "reshape" and t.shape == t.srcs[0].shape, _b_drop_to_src),
+  Rule("reshape_chain", "lossless", lambda t: t.op == "reshape" and t.srcs[0].op == "reshape", _b_collapse_reshape),
+  Rule("transpose_chain", "lossless", lambda t: t.op == "transpose" and t.srcs[0].op == "transpose", _b_collapse_transpose),
+  Rule("mul_one", "lossless", lambda t: t.op == "muls" and t.attrs.get("k") == 1.0, _b_drop_to_src),
+  Rule("add_zero", "lossless", lambda t: t.op == "adds" and t.attrs.get("k") == 0.0, _b_drop_to_src),
+  Rule("not_not", "lossless", lambda t: t.op == "logical_not" and t.srcs[0].op == "logical_not", lambda t: t.srcs[0].srcs[0]),
+]
+
+def canonicalize(out: Tensor) -> Tensor:
+  """Apply the lossless CANON_RULES to a fixed point (a rule may expose a fresh
+  redundancy for the next pass). Returns the SAME object when nothing matches, so
+  a clean graph is unchanged."""
+  while (nxt := graph_rewrite(out, CANON_RULES)) is not out: out = nxt
+  return out

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -27,9 +27,40 @@ On top of that, two concrete rewrites the optimizer uses:
 """
 from __future__ import annotations
 
+from dataclasses import dataclass
 from typing import Callable, Optional
 
 from .graph import Tensor
+
+
+@dataclass(frozen=True)
+class Rule:
+  """One graph-rewrite rule. `match`/`build` both see the REBUILT node (sources
+  already rewritten); identity-based selection is delegated to graph_rewrite's
+  `select`. `kind` is "lossless" (always-on canon) or "numeric" (tuner-gated)."""
+  name: str; kind: str
+  match: Callable[[Tensor], bool]; build: Callable[[Tensor], Tensor]
+
+
+def graph_rewrite(out: Tensor, rules: list["Rule"], select: set[int] | None = None) -> Tensor:
+  """Return a new output DAG, rules applied bottom-up in ONE memoized pass.
+
+  Sources are rewritten first; the node is rebuilt on the (possibly new) sources;
+  then the first rule whose `match` accepts the rebuilt node fires (its `build`
+  replaces it). `select` (original-node id()s) gates eligibility; None = all
+  eligible. A node with no applied rule and unchanged sources is returned
+  unchanged (same object), so a no-op rule-set yields the SAME object."""
+  memo: dict[int, Tensor] = {}
+  def visit(t: Tensor) -> Tensor:
+    if (c := memo.get(id(t))) is not None: return c
+    new_srcs = [visit(s) for s in t.srcs]
+    rebuilt = t if all(a is b for a, b in zip(new_srcs, t.srcs)) else Tensor(t.shape, t.op, new_srcs, dict(t.attrs))
+    res = rebuilt
+    if select is None or id(t) in select:
+      for r in rules:
+        if r.match(rebuilt): res = r.build(rebuilt); break
+    memo[id(t)] = res; return res
+  return visit(out)
 
 
 def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -30,6 +30,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Callable, Optional
 
+import numpy as np
+
 from .graph import Tensor
 
 
@@ -127,7 +129,6 @@ def list_weight_nodes(out: Tensor) -> list[Tensor]:
     """Weight-bearing (int8-eligible) nodes in topo order: matmul (streamed `wt`) and
     conv (baked `weight`). Both honor per-channel int8 (constexpr_affine_dequantize)
     as a routable weight operand on the ANE."""
-    import numpy as np
     from ._compile import _topo
     return [t for t in _topo(out)
             if (t.op == "matmul" and isinstance(t.attrs.get("wt"), np.ndarray))
@@ -148,7 +149,6 @@ def _reduce_sum_as_matmul(t: Tensor) -> Tensor:
     non-last single axis we transpose the axis to the end, contract, and transpose
     back. Multi-axis sums are left to reduce_sum (the rewrite would need a reshape
     chain; not worth it, and the optimizer won't offer it)."""
-    import numpy as np
     src = t.srcs[0]
     axes = tuple(t.attrs.get("axes", ()))
     if len(axes) != 1:
@@ -321,3 +321,23 @@ def canonicalize(out: Tensor) -> Tensor:
   a clean graph is unchanged."""
   while (nxt := graph_rewrite(out, CANON_RULES)) is not out: out = nxt
   return out
+
+
+# --------------------------------------------------------------------------- #
+# NUMERIC_RULES: accuracy-affecting scalar-chain folding (fp16-gated)         #
+# --------------------------------------------------------------------------- #
+
+def _b_fold_muls(t: Tensor) -> Tensor:
+  """muls(b) o muls(a) -> muls(a*b). Folded in fp16 to match device semantics."""
+  inner = t.srcs[0]; k = float(np.float16(inner.attrs["k"]) * np.float16(t.attrs["k"]))
+  return Tensor(t.shape, "muls", inner.srcs, {"k": k})
+
+def _b_fold_adds(t: Tensor) -> Tensor:
+  """adds(b) o adds(a) -> adds(a+b). Folded in fp16 to match device semantics."""
+  inner = t.srcs[0]; k = float(np.float16(inner.attrs["k"]) + np.float16(t.attrs["k"]))
+  return Tensor(t.shape, "adds", inner.srcs, {"k": k})
+
+NUMERIC_RULES: list[Rule] = [
+  Rule("muls_chain", "numeric", lambda t: t.op == "muls" and t.srcs[0].op == "muls", _b_fold_muls),
+  Rule("adds_chain", "numeric", lambda t: t.op == "adds" and t.srcs[0].op == "adds", _b_fold_adds),
+]

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -53,17 +53,17 @@ def graph_rewrite(out: Tensor, rules: list["Rule"], select: set[int] | None = No
   replaces it). `select` (original-node id()s) gates eligibility; None = all
   eligible. A node with no applied rule and unchanged sources is returned
   unchanged (same object), so a no-op rule-set yields the SAME object."""
-  memo: dict[int, Tensor] = {}
-  def visit(t: Tensor) -> Tensor:
-    if (c := memo.get(id(t))) is not None: return c
-    new_srcs = [visit(s) for s in t.srcs]
+  from ._compile import _topo                 # iterative post-order (sources before consumers);
+  memo: dict[int, Tensor] = {}                 # a forward pass over it is stack-safe on deep unrolled graphs
+  for t in _topo(out):
+    new_srcs = [memo[id(s)] for s in t.srcs]   # every src precedes t in _topo, so it is already in memo
     rebuilt = t if all(a is b for a, b in zip(new_srcs, t.srcs)) else Tensor(t.shape, t.op, new_srcs, dict(t.attrs))
     res = rebuilt
     if select is None or id(t) in select:
       for r in rules:
         if r.match(rebuilt): res = r.build(rebuilt); break
-    memo[id(t)] = res; return res
-  return visit(out)
+    memo[id(t)] = res
+  return memo[id(out)]
 
 
 def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -1,0 +1,37 @@
+# tests/test_rewrite_engine.py
+import aneforge as af
+from aneforge.graph import Tensor
+from aneforge._rewrite import Rule, graph_rewrite
+
+def _noop_rules(): return []
+
+def test_noop_returns_same_object():
+  x = af.input((1, 4)); y = (x * 2.0).adds(1.0)
+  assert graph_rewrite(y, _noop_rules()) is y          # opt=0 byte-identity premise
+
+def test_diamond_stays_diamond():
+  x = af.input((1, 4)); a = x * 2.0
+  y = a + a                                             # a shared by both add operands
+  rules = [Rule("mul3", "lossless", lambda t: t.op == "muls",
+                lambda t: Tensor(t.shape, "muls", t.srcs, {"k": 3.0}))]
+  out = graph_rewrite(y, rules)
+  assert out.srcs[0] is out.srcs[1]                     # rewritten once, still shared
+
+def test_select_restricts_to_original_ids():
+  x = af.input((1, 4)); a = x * 2.0; b = a * 2.0       # two muls nodes
+  rules = [Rule("tag", "lossless", lambda t: t.op == "muls",
+                lambda t: Tensor(t.shape, "muls", t.srcs, {**t.attrs, "tagged": True}))]
+  out = graph_rewrite(b, rules, select={id(a)})         # only the inner muls eligible
+  assert out.attrs.get("tagged") is None                # outer untouched
+  assert out.srcs[0].attrs.get("tagged") is True        # inner tagged
+
+def test_multi_rule_one_pass_equals_sequential():
+  x = af.input((1, 4)); y = (x * 2.0).adds(1.0)
+  r_mul = Rule("m", "lossless", lambda t: t.op == "muls",
+               lambda t: Tensor(t.shape, "muls", t.srcs, {"k": t.attrs["k"] + 1}))
+  r_add = Rule("a", "lossless", lambda t: t.op == "adds",
+               lambda t: Tensor(t.shape, "adds", t.srcs, {"k": t.attrs["k"] + 1}))
+  one_pass = graph_rewrite(y, [r_mul, r_add])
+  seq = graph_rewrite(graph_rewrite(y, [r_mul]), [r_add])
+  assert one_pass.attrs["k"] == seq.attrs["k"] == 2.0
+  assert one_pass.srcs[0].attrs["k"] == seq.srcs[0].attrs["k"] == 3.0

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -175,7 +175,7 @@ def test_apply_variant_single_pass_composes_axes():
   cfg = {"int8": False, "decomp": [], "lossy": True,
          "scalarfold": [i for i, t in enumerate(order) if t.op == "muls" and t.srcs[0].op == "muls"],
          "constfold": O._constfold_candidates(y)}
-  new_out, int8 = O._apply_variant(y, cfg)
+  new_out, _ = O._apply_variant(y, cfg)
   ops = _ops(new_out)
   assert ops.count("muls") == 1                                # 2*3 folded
   assert "const_array" in ops                                  # const cone folded

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -1,7 +1,7 @@
 # tests/test_rewrite_engine.py
 import aneforge as af
 from aneforge.graph import Tensor
-from aneforge._rewrite import Rule, graph_rewrite
+from aneforge._rewrite import Rule, graph_rewrite, NUMERIC_RULES, graph_rewrite as _gr
 
 def _noop_rules(): return []
 
@@ -112,3 +112,28 @@ def test_canon_preserves_uint8_input_cast():
   assert "cast" in _ops(y) and "input" in _ops(y)     # the dequant cast is present
   out = canonicalize(y)
   assert "cast" in _ops(out)                           # NOT stripped (srcs[0].op == "input")
+
+
+# -- Task 4: NUMERIC_RULES -- scalar-chain folding -------------------------- #
+def _apply(out, names):
+  rules = [r for r in NUMERIC_RULES if r.name in names]
+  while (nxt := _gr(out, rules)) is not out: out = nxt
+  return out
+
+def test_muls_chain_folds():
+  x = af.input((1, 4)); y = (x * 2.0) * 3.0
+  out = _apply(y, {"muls_chain"})
+  assert _ops(out).count("muls") == 1 and out.attrs["k"] == 6.0
+
+def test_adds_chain_folds():
+  x = af.input((1, 4)); y = x.adds(2.0).adds(5.0)
+  out = _apply(y, {"adds_chain"})
+  assert _ops(out).count("adds") == 1 and out.attrs["k"] == 7.0
+
+def test_scalar_fold_matches_fp32_reference():
+  rng = np.random.default_rng(0); xv = rng.standard_normal((1, 16)).astype(np.float16)
+  x = af.input((1, 16)); y = (x * 0.5) * 4.0
+  folded = _apply(y, {"muls_chain"})
+  ref = (xv.astype(np.float32) * 0.5) * 4.0
+  net = af.compile(folded, opt=0); got = net(xv)
+  assert np.allclose(got.astype(np.float32), ref, atol=1e-2)

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -188,3 +188,16 @@ def test_apply_variant_noop_cfg_keeps_baseline():
   x = af.input((1, 4)); y = (x * 2.0).adds(1.0)
   new_out, int8 = O._apply_variant(y, {"int8": False, "decomp": [], "lossy": False})
   assert new_out is y and int8 is False
+
+
+# -- Task 7: README-example canon-equivalence (on-device) -------------------- #
+def test_readme_example_canon_equivalent():
+  rng = np.random.default_rng(1)
+  img = rng.integers(0, 255, (1, 3, 32, 32)).astype(np.uint8).astype(np.float16)
+  W = rng.standard_normal((8, 3, 3, 3)).astype(np.float16)
+  x = af.input((1, 3, 32, 32)); y = af.conv(x, W, pad=1).relu().mean((2, 3))
+  base = af.compile(y, opt=0)(img)                     # un-canonicalized baseline
+  opt = af.compile(y, opt=1)(img)                      # canonicalized + cost-model pick
+  cos = float((base.ravel() @ opt.ravel()) /
+              (np.linalg.norm(base) * np.linalg.norm(opt) + 1e-12))
+  assert cos > 0.9999

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -69,3 +69,46 @@ def test_sdpa_to_decomposed_noop_identity():
 def test_decompose_bridge_empty_set_identity():
   x = af.input((1, 8)); y = (x * 2.0).adds(1.0)
   assert decompose_bridge(y, set()) is y               # empty select -> same object
+
+
+# -- Task 3: CANON_RULES + canonicalize -------------------------------------- #
+from aneforge._rewrite import canonicalize
+
+def test_canon_drops_reshape_to_same_shape():
+  x = af.input((2, 3)); y = x.reshape(2, 3)            # no-op reshape
+  out = canonicalize(y * 1.0)                          # muls(1.0) also a no-op
+  assert "reshape" not in _ops(out) and "muls" not in _ops(out)
+
+def test_canon_drops_mul1_and_add0():
+  x = af.input((1, 4)); y = (x * 1.0).adds(0.0)
+  out = canonicalize(y)
+  assert out is x                                       # both no-ops removed -> x itself
+
+def test_canon_collapses_transpose_inverse():
+  x = af.input((2, 3, 4)); y = x.transpose((1, 0, 2)).transpose((1, 0, 2))  # self-inverse
+  out = canonicalize(y)
+  assert "transpose" not in _ops(out)
+
+def test_canon_collapses_double_logical_not():
+  import numpy as np
+  x = af.input((1, 4))
+  zero = Tensor((1, 4), "const_array", [], {"value": np.zeros((1, 4), dtype=np.float16)})
+  y = x.greater(zero).logical_not().logical_not()
+  out = canonicalize(y)
+  assert _ops(out).count("logical_not") == 0
+
+def test_canon_noop_keeps_identity():
+  x = af.input((1, 4)); y = (x * 2.0).adds(1.0)        # nothing redundant
+  assert canonicalize(y) is y
+
+def test_canon_drops_cast_on_compute_tensor():
+  x = af.input((1, 4)); c = x * 2.0                    # a compute tensor (not an input)
+  y = Tensor(c.shape, "cast", [c], {"dtype": "fp16"})  # redundant fp16->fp16 cast
+  out = canonicalize(y)
+  assert "cast" not in _ops(out)
+
+def test_canon_preserves_uint8_input_cast():
+  y = af.image_input((1, 3, 4, 4))                     # uint8 input -> cast(fp16) -> dequant
+  assert "cast" in _ops(y) and "input" in _ops(y)     # the dequant cast is present
+  out = canonicalize(y)
+  assert "cast" in _ops(out)                           # NOT stripped (srcs[0].op == "input")

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -137,3 +137,29 @@ def test_scalar_fold_matches_fp32_reference():
   ref = (xv.astype(np.float32) * 0.5) * 4.0
   net = af.compile(folded, opt=0); got = net(xv)
   assert np.allclose(got.astype(np.float32), ref, atol=1e-2)
+
+
+# -- Task 5: constant folding ------------------------------------------------ #
+from aneforge._rewrite import _const_subgraph
+
+def _const(v): return Tensor(v.shape, "const_array", [], {"value": np.asarray(v, np.float16)})
+
+def test_const_subgraph_folds_pure_constants():
+  a = _const(np.full((1, 4), 2.0)); y = (a * 3.0).adds(1.0)   # all-constant cone
+  val = _const_subgraph(y)
+  assert val is not None and np.allclose(val.astype(np.float32), 7.0)
+
+def test_const_subgraph_returns_none_with_input():
+  x = af.input((1, 4)); y = x * 2.0                            # depends on a runtime input
+  assert _const_subgraph(y) is None
+
+def test_const_subgraph_respects_size_bound():
+  a = _const(np.ones((1, 100), np.float16))
+  assert _const_subgraph(a, max_elems=10) is None             # too big to fold (leaf early-exit)
+  y = a.adds(1.0)                                             # multi-op cone with a large root
+  assert _const_subgraph(y, max_elems=10) is None             # bound blocks a real computation
+
+def test_const_fold_rule_replaces_with_const_array():
+  a = _const(np.full((1, 4), 2.0)); y = a.adds(5.0)
+  out = _apply(y, {"const_fold"})                              # _apply from Task 4
+  assert out.op == "const_array" and np.allclose(out.attrs["value"].astype(np.float32), 7.0)

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -163,3 +163,28 @@ def test_const_fold_rule_replaces_with_const_array():
   a = _const(np.full((1, 4), 2.0)); y = a.adds(5.0)
   out = _apply(y, {"const_fold"})                              # _apply from Task 4
   assert out.op == "const_array" and np.allclose(out.attrs["value"].astype(np.float32), 7.0)
+
+
+# -- Task 6: tuner integration — numeric passes as gated variant axes --------- #
+from aneforge import _optimize as O
+
+def test_apply_variant_single_pass_composes_axes():
+  a = Tensor((1, 4), "const_array", [], {"value": np.full((1, 4), 2.0, np.float16)})
+  x = af.input((1, 4)); y = (x * 2.0) * 3.0 + a.adds(1.0)     # scalar chain + foldable const cone
+  order = _topo(y)
+  cfg = {"int8": False, "decomp": [], "lossy": True,
+         "scalarfold": [i for i, t in enumerate(order) if t.op == "muls" and t.srcs[0].op == "muls"],
+         "constfold": O._constfold_candidates(y)}
+  new_out, int8 = O._apply_variant(y, cfg)
+  ops = _ops(new_out)
+  assert ops.count("muls") == 1                                # 2*3 folded
+  assert "const_array" in ops                                  # const cone folded
+
+def test_constfold_candidates_skip_inputs():
+  x = af.input((1, 4)); y = x * 2.0
+  assert O._constfold_candidates(y) == []                      # nothing constant
+
+def test_apply_variant_noop_cfg_keeps_baseline():
+  x = af.input((1, 4)); y = (x * 2.0).adds(1.0)
+  new_out, int8 = O._apply_variant(y, {"int8": False, "decomp": [], "lossy": False})
+  assert new_out is y and int8 is False

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -101,6 +101,16 @@ def test_canon_noop_keeps_identity():
   x = af.input((1, 4)); y = (x * 2.0).adds(1.0)        # nothing redundant
   assert canonicalize(y) is y
 
+def test_graph_rewrite_deep_graph_no_recursion():
+  # Iterative-solver graphs (eigh/svd unrolls) are thousands of nodes deep; the
+  # walk must not blow Python's recursion limit (_topo is iterative for the same
+  # reason). 4000 deep >> sys.getrecursionlimit() (default 1000). The add_zero
+  # canon rule drops every node, so a stack-unsafe walk would RecursionError here.
+  x = af.input((10, 1)); y = x
+  for _ in range(4000): y = y.adds(0.0)                # deep chain of no-op adds
+  out = canonicalize(y)                                # must not RecursionError
+  assert out is x                                      # all 4000 no-op adds dropped to x
+
 def test_canon_drops_cast_on_compute_tensor():
   x = af.input((1, 4)); c = x * 2.0                    # a compute tensor (not an input)
   y = Tensor(c.shape, "cast", [c], {"dtype": "fp16"})  # redundant fp16->fp16 cast

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -35,3 +35,37 @@ def test_multi_rule_one_pass_equals_sequential():
   seq = graph_rewrite(graph_rewrite(y, [r_mul]), [r_add])
   assert one_pass.attrs["k"] == seq.attrs["k"] == 2.0
   assert one_pass.srcs[0].attrs["k"] == seq.srcs[0].attrs["k"] == 3.0
+
+
+# -- back-compat wrapper tests (Task 2) -------------------------------------- #
+import numpy as np
+from aneforge._rewrite import (sdpa_to_decomposed, reduce_sum_to_matmul,
+                               set_node_int8, decompose_bridge)
+from aneforge._compile import _topo
+
+def _ops(out): return [t.op for t in _topo(out)]
+
+def test_reduce_sum_to_matmul_wrapper_decomposes():
+  x = af.input((1, 8)); y = x.sum(-1)                  # reduce_sum, single last axis (keepdims implicit)
+  out = reduce_sum_to_matmul(y)
+  assert "reduce_sum" not in _ops(out) and "matmul" in _ops(out)
+
+def test_set_node_int8_wrapper_tags_original_id():
+  x = af.input((1, 8)); W = np.ones((8, 4), np.float16); y = x @ W
+  order = _topo(y); mm = next(t for t in order if t.op == "matmul")
+  out = set_node_int8(y, {id(mm)})
+  assert any(t.op == "matmul" and t.attrs.get("int8") for t in _topo(out))
+
+def test_noop_wrappers_keep_identity():
+  x = af.input((1, 8)); y = (x * 2.0).adds(1.0)
+  assert reduce_sum_to_matmul(y) is y                  # no reduce_sum -> same object
+  assert set_node_int8(y, set()) is y
+
+def test_sdpa_to_decomposed_noop_identity():
+  x = af.input((1, 8)); y = (x * 2.0).adds(1.0)
+  assert "sdpa" not in _ops(y)
+  assert sdpa_to_decomposed(y) is y                    # no sdpa -> same object
+
+def test_decompose_bridge_empty_set_identity():
+  x = af.input((1, 8)); y = (x * 2.0).adds(1.0)
+  assert decompose_bridge(y, set()) is y               # empty select -> same object


### PR DESCRIPTION
## What

Collapses ANEForge's four hand-rolled graph-rewrite walks into **one** `graph_rewrite` primitive, then adds three accuracy-aware algebraic passes on top of it.

- **`graph_rewrite(out, rules, select)` + `Rule(name, kind, match, build)`** (`_rewrite.py`) — one memoized bottom-up pass. `match`/`build` see the rebuilt node; `select` (a set of *original* node `id()`s) gates eligibility. A no-op rule-set returns the *same object*, preserving `opt=0` byte-identity.
- **The four legacy walks** (`rewrite`, `sdpa_to_decomposed`, `reduce_sum_to_matmul`, `set_node_int8`, `decompose_bridge`) become thin wrappers over it — same signatures, same behavior.
- **`canonicalize` (lossless)** — identity/redundancy elimination (cast-to-same, reshape/transpose collapse, `x+0`, `x*1`, double-`not`), run always-on at `opt>=1`, never at `opt=0`.
- **`NUMERIC_RULES` (gated)** — scalar-chain folding (`muls∘muls`, `adds∘adds`) and constant folding (all-constant cones → one `const_array`, input-poisoned and size-bounded), validated against the fp32 reference and accuracy-gated through the existing tuner.
- **Tuner integration** — `_apply_variant` rebuilt as a *single* composed `graph_rewrite` pass; this deletes the fragile "topo indices don't shift between chained rewrites" reasoning (and `_rewrite_by_topo_index`). Cache key stays topo-index based.

## Why

The optimizer had reinvented a bottom-up memoized walk three times to work around `rewrite()` only offering the *rebuilt* node while selection needs *original* identity. One primitive removes that duplication and the chained-rewrite fragility, and gives a declarative substrate for the new passes.

## Invariants preserved

- `opt=0` byte-identity (canon gated behind `opt not in _OPT0`, after the `compress→opt=0` block).
- Lossless (always-on) vs numerics-affecting (tuner-gated) split — mirrors route vs int8.
- Topo-index cache key unchanged; no new public API.
- tinygrad-compact style confined to `_rewrite.py`, docstrings preserved.

## Testing

- `tests/test_rewrite_engine.py` — 27 unit tests (primitive, each pass, fp32-gated numerics, single-pass composition, back-compat wrappers).
- On-device (M-series ANE): `test_routes.py` 7/7; `op_smoketest.py` 22/22 ops; README conv→relu→mean example opt=0 vs opt=1 cosine > 0.9999.
- pyright clean on all changed files (pre-existing `_compile.py`/`_optimize.py` debt untouched).

Per-task TDD with spec+quality review on each, plus an opus whole-branch review (verdict: ready to merge). Design + plan in `docs/superpowers/`.

A repo-wide restyle of core + tests to this style is a deliberate **separate** follow-on.