### PR TITLE
Semantic refactor: clever-but-clear Python

### DIFF
--- a/aneforge/_bridges/_netplist.py
+++ b/aneforge/_bridges/_netplist.py
@@ -1373,7 +1373,7 @@ def build_matrix_decomposition(
   params: dict[str, object] = {"Type": unit_type}
   if unit_type == "NonQRGivens":
     params["Epsilon"] = fp16_bits(epsilon)
-    axes = rotation_axis if rotation_axis is not None else [7 for _ in range(batch_size)]
+    axes = rotation_axis if rotation_axis is not None else [7] * batch_size
     if len(axes) != batch_size: raise ValueError("matrix_decomposition rotation_axis length must equal batch_size")
     params["RotationAxis"] = [int(axis) for axis in axes]
   elif rotation_axis is not None:
@@ -1419,7 +1419,7 @@ def build_matrix_decomposition_relu(
   if unit_type != "NonQRGivens":
     raise ValueError("matrix_decomposition_relu is currently recovered only for NonQRGivens")
   if batch_size < 1: raise ValueError("matrix_decomposition_relu batch_size must be positive")
-  axes = rotation_axis if rotation_axis is not None else [7 for _ in range(batch_size)]
+  axes = rotation_axis if rotation_axis is not None else [7] * batch_size
   if len(axes) != batch_size: raise ValueError("matrix_decomposition_relu rotation_axis length must equal batch_size")
   md_name = "matrix_decomposition_relu-1_md"
   relu_name = "matrix_decomposition_relu-1_relu"
@@ -1465,7 +1465,7 @@ def build_matrix_decomposition_add(
   if unit_type != "NonQRGivens":
     raise ValueError("matrix_decomposition_add is currently recovered only for NonQRGivens")
   if batch_size < 1: raise ValueError("matrix_decomposition_add batch_size must be positive")
-  axes = rotation_axis if rotation_axis is not None else [7 for _ in range(batch_size)]
+  axes = rotation_axis if rotation_axis is not None else [7] * batch_size
   if len(axes) != batch_size: raise ValueError("matrix_decomposition_add rotation_axis length must equal batch_size")
   md_name = "matrix_decomposition_add-1_md"
   add_name = "matrix_decomposition_add-1_add"
@@ -1524,7 +1524,7 @@ def build_matrix_decomposition_matmul(
   network_name = "network_matrix_decomposition_matmul-1"
   params: dict[str, object] = {"Type": unit_type}
   if unit_type == "NonQRGivens":
-    axes = rotation_axis if rotation_axis is not None else [7 for _ in range(batch_size)]
+    axes = rotation_axis if rotation_axis is not None else [7] * batch_size
     if len(axes) != batch_size:
       raise ValueError("matrix_decomposition_matmul rotation_axis length must equal batch_size")
     params["Epsilon"] = fp16_bits(epsilon)
@@ -1706,7 +1706,7 @@ def input_view_unit(name: str, bottom: str, dimension: str, offset: int, size: i
 def concat_unit(name: str, bottom: list[str], dimension: str, channels: int) -> dict:
   return {
     "Bottom": bottom,
-    "InputType": ["Float16" for _ in bottom],
+    "InputType": ["Float16"] * len(bottom),
     "Name": name,
     "OutputChannels": channels,
     "OutputType": "Float16",
@@ -2551,7 +2551,7 @@ def build(
   sdpa_subtract_max: bool = True,
 ) -> dict:
   op = canonical_op(op)
-  if op == "sdpa" or op == "scaled_dot_product_attention":
+  if op in {"sdpa", "scaled_dot_product_attention"}:
     return build_sdpa(
       channels=sdpa_channels,
       sequence=sdpa_sequence,

--- a/aneforge/_capabilities.py
+++ b/aneforge/_capabilities.py
@@ -130,33 +130,23 @@ _BRIDGE_EVIDENCE: dict[str, str] = {
 
 def _introspect_fused() -> list[dict[str, Any]]:
   """Every op live in `_compile._EMIT` -> a `fused` registry entry."""
-  out = []
-  for name in sorted(_compile._EMIT):
-    out.append({
-      "name": name,
-      "status": "fused",
-      "route": "e5rt-MIL (fused into one program; no graph cut)",
-      "frontend": _FRONTEND_SPELLING.get(name),
-      "verified": "silicon",
-      "evidence": "aneforge/_compile.py @op(...) registry; "
-                  "the reverse-engineering corpus (37/42 verified correct on e5rt)",
-    })
-  return out
+  return [{
+    "name": name, "status": "fused",
+    "route": "e5rt-MIL (fused into one program; no graph cut)",
+    "frontend": _FRONTEND_SPELLING.get(name), "verified": "silicon",
+    "evidence": "aneforge/_compile.py @op(...) registry; "
+                "the reverse-engineering corpus (37/42 verified correct on e5rt)",
+  } for name in sorted(_compile._EMIT)]
 
 
 def _introspect_bridge() -> list[dict[str, Any]]:
   """Every op live in `_compile.NETPLIST_OPS` -> a `bridge` registry entry."""
-  out = []
-  for name in sorted(_compile.NETPLIST_OPS):
-    out.append({
-      "name": name,
-      "status": "bridge",
-      "route": "native Path-A netplist sub-program (graph cut; SegmentedModel)",
-      "frontend": _FRONTEND_SPELLING.get(name),
-      "verified": "silicon",
-      "evidence": _BRIDGE_EVIDENCE.get(name, "aneforge/_compile.py NETPLIST_OPS"),
-    })
-  return out
+  return [{
+    "name": name, "status": "bridge",
+    "route": "native Path-A netplist sub-program (graph cut; SegmentedModel)",
+    "frontend": _FRONTEND_SPELLING.get(name), "verified": "silicon",
+    "evidence": _BRIDGE_EVIDENCE.get(name, "aneforge/_compile.py NETPLIST_OPS"),
+  } for name in sorted(_compile.NETPLIST_OPS)]
 
 
 # --------------------------------------------------------------------------- #
@@ -637,11 +627,10 @@ def _introspect_sweep(already: set[str]) -> list[dict[str, Any]]:
       }
       if op in _SWEEP_CAPABILITY_ALIAS: entry["alias_of"] = _SWEEP_CAPABILITY_ALIAS[op]
       if op in _SWEEP_NOTE: entry["note"] = _SWEEP_NOTE[op]
-      if klass == "reachable":
-        entry["note"] = (entry.get("note") or "") + (
+      if klass == "reachable" and op not in _SWEEP_NOTE:
+        entry["note"] = ((entry.get("note") or "") +
           " Sweep klass 'reachable' = compiles + runs (presence), correctness not "
-          "numerically pinned against a reference." if op not in _SWEEP_NOTE else "")
-        entry["note"] = entry["note"].strip()
+          "numerically pinned against a reference.").strip()
       out.append(entry)
     elif op in _NOT_AUTHORABLE_OPS:
       out.append({
@@ -947,24 +936,16 @@ def build_registry() -> dict[str, Any]:
   entries += _introspect_fused()
   entries += _introspect_bridge()
 
-  for e in _CRACKED:
-    entries.append({
-      "name": e["name"], "status": "cracked", "route": e["route"],
-      "frontend": None, "verified": "silicon",
-      "evidence": e["evidence"], "note": e.get("note"),
-    })
-  for e in _NEGATIVES:
-    entries.append({
-      "name": e["name"], "status": "arch-gated-negative",
-      "route": None, "frontend": None, "verified": "negative-confirmed",
-      "wall": e["wall"], "evidence": e["evidence"], "probe": e.get("probe"),
-    })
-  for e in _PREDICTED:
-    entries.append({
-      "name": e["name"], "status": "predicted", "route": e["route"],
-      "frontend": None, "verified": "no",
-      "evidence": e["evidence"],
-    })
+  entries += [{"name": e["name"], "status": "cracked", "route": e["route"], "frontend": None,
+               "verified": "silicon", "evidence": e["evidence"], "note": e.get("note")}
+              for e in _CRACKED]
+  entries += [{"name": e["name"], "status": "arch-gated-negative", "route": None, "frontend": None,
+               "verified": "negative-confirmed", "wall": e["wall"],
+               "evidence": e["evidence"], "probe": e.get("probe")}
+              for e in _NEGATIVES]
+  entries += [{"name": e["name"], "status": "predicted", "route": e["route"], "frontend": None,
+               "verified": "no", "evidence": e["evidence"]}
+              for e in _PREDICTED]
 
   # (D) extend exhaustively over the full 166-op MIL vocabulary sweep: synthesize an
   # entry for every swept op not already represented (curated entries win - same name

--- a/aneforge/_cost.py
+++ b/aneforge/_cost.py
@@ -451,12 +451,6 @@ def _bridge_model() -> dict:
   return out
 
 
-def _prod(shape) -> int:
-  n = 1
-  for d in shape: n *= int(d)
-  return n
-
-
 def _node_size(fam: str, t):
   """Extract a bridge node's size tuple in the SAME convention _parse_bridge_key
     produces for `fam` (so the work scalar matches the measured-key parse).
@@ -501,10 +495,10 @@ def _node_size(fam: str, t):
     return (int(C), int(H), int(W))
   if fam == "bridge_input_view":  # src flattened to W, out=(size,) -> (W, size)
     if not s: return None
-    return (_prod(s[0].shape), int(t.shape[0]))
+    return (_elems(s[0].shape), int(t.shape[0]))
   if fam == "bridge_scaled_elementwise":  # src flattened to W -> (W,)
     if not s: return None
-    return (_prod(s[0].shape),)
+    return (_elems(s[0].shape),)
   return None
 
 
@@ -533,10 +527,8 @@ def bridge_cost(t):
     # dispatch floor - an order-of-magnitude estimate beats none.
     return max(floor, 2.0 * q / _constants()["flops_per_us"])
   # nearest measured point by work scalar (in log space so ratios are symmetric)
-  def _key(pt):
-    pw = work_fn(pt[0])
-    return abs(np.log(max(q, 1e-9)) - np.log(max(pw, 1e-9)))
-  (psize, pmin) = min(pts, key=_key)
+  log_q = np.log(max(q, 1e-9))
+  (psize, pmin) = min(pts, key=lambda pt: abs(log_q - np.log(max(work_fn(pt[0]), 1e-9))))
   pw = work_fn(psize)
   # proportional scaling along the dominant work axis, clamped at the floor.
   scaled = pmin * (q / pw) if pw > 0 else pmin
@@ -555,10 +547,7 @@ def _elems(shape) -> int:
 def _weight_elems(t) -> int:
   """Total constant-weight elements a node carries (generic over attrs): any attr
     value that is a numpy array counts as streamed weight bytes."""
-  n = 0
-  for v in t.attrs.values():
-    if isinstance(v, np.ndarray): n += v.size
-  return n
+  return sum(v.size for v in t.attrs.values() if isinstance(v, np.ndarray))
 
 
 def _node_flops(t) -> float:
@@ -736,9 +725,8 @@ def _reduce_len(t) -> int:
   """Number of elements summed per output element of a reduce node."""
   src = t.srcs[0] if t.srcs else None
   if src is None: return 1
-  axes = t.attrs.get("axes", ())
   n = 1
-  for ax in axes:
+  for ax in t.attrs.get("axes", ()):
     if 0 <= ax < len(src.shape): n *= int(src.shape[ax])
   return n
 

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -421,18 +421,11 @@ def _compile_routes(out, int8: bool, build_dir=None):
 
 
 def _config_label(cfg: dict) -> str:
-  parts = [f"int8={cfg.get('int8', False)}"]
   decomp = cfg.get("decomp", ())
-  if decomp:
-    parts.append(f"decomp={list(decomp)}")
-  else:
-    parts.append("route=native")
-  if cfg.get("int8_nodes"):
-    parts.append(f"int8_nodes={list(cfg['int8_nodes'])}")
-  if cfg.get("rs_matmul"):
-    parts.append(f"rs_matmul={list(cfg['rs_matmul'])}")
-  if cfg.get("paired_sub"):
-    parts.append(f"paired_sub={list(cfg['paired_sub'])}")
+  parts = [f"int8={cfg.get('int8', False)}",
+           f"decomp={list(decomp)}" if decomp else "route=native"]
+  for key in ("int8_nodes", "rs_matmul", "paired_sub"):
+    if cfg.get(key): parts.append(f"{key}={list(cfg[key])}")
   return "+".join(parts)
 
 
@@ -548,18 +541,15 @@ def _gen_inputs(input_shapes):
   """Deterministic synthetic inputs for measurement/validation (fp16 ~N(0,1),
     nudged off zero so divides/rsqrt don't blow up - same recipe as the fuzzer)."""
   rng = np.random.default_rng(0xA9E)
-  out = []
-  for sh in input_shapes:
+  def _make(sh):
     a = rng.standard_normal(tuple(sh)).astype(np.float32)
-    a = np.where(np.abs(a) < 0.25, a + np.sign(a + 1e-6) * 0.5, a)
-    out.append(a.astype(np.float16))
-  return out
+    return np.where(np.abs(a) < 0.25, a + np.sign(a + 1e-6) * 0.5, a).astype(np.float16)
+  return [_make(sh) for sh in input_shapes]
 
 
 def _input_shapes(out):
-  order = _topo(out)
-  ins = sorted((t for t in order if t.op == "input"), key=lambda t: t.attrs.get("idx", 0))
-  return [tuple(t.shape) for t in ins]
+  inputs = (n for n in _topo(out) if n.op == "input")
+  return [tuple(n.shape) for n in sorted(inputs, key=lambda n: n.attrs.get("idx", 0))]
 
 
 def _estimate_variant(out, cfg):
@@ -762,6 +752,34 @@ def tune_report(out, budget: int = 8, inputs=None, reps: int = 20):
 # a rewrite can be selected for improving accuracy, which speed-only tune()       #
 # cannot do.                                                                      #
 # =========================================================================== #
+def _f16(x):  # fp16 rounding of operands/products (the ANE storage), wide accum
+  return np.asarray(x, np.float16).astype(np.float64)
+
+
+# op -> numpy evaluator for the fp32-faithful reference. Each takes the node's
+# fp16-rounded source values `s` and the node `t`. Built once (module scope), not
+# per-node. An op absent here has no faithful reference (the graph falls back).
+_FP32_EVAL = {
+  "add":         lambda s, t: _f16(s[0]) + _f16(s[1]),
+  "sub":         lambda s, t: _f16(s[0]) - _f16(s[1]),
+  "mul":         lambda s, t: _f16(s[0]) * _f16(s[1]),
+  "muls":        lambda s, t: _f16(s[0]) * np.float16(t.attrs["k"]).astype(np.float64),
+  "real_div":    lambda s, t: _f16(s[0]) / _f16(s[1]),
+  "maximum":     lambda s, t: np.maximum(_f16(s[0]), _f16(s[1])),
+  "minimum":     lambda s, t: np.minimum(_f16(s[0]), _f16(s[1])),
+  "relu":        lambda s, t: np.maximum(_f16(s[0]), 0.0),
+  "square":      lambda s, t: _f16(s[0]) ** 2,
+  "abs":         lambda s, t: np.abs(_f16(s[0])),
+  "exp":         lambda s, t: np.exp(_f16(s[0])),
+  "reduce_sum":  lambda s, t: _f16(s[0]).sum(tuple(t.attrs["axes"]), keepdims=True),
+  "reduce_mean": lambda s, t: _f16(s[0]).mean(tuple(t.attrs["axes"]), keepdims=True),
+  "reshape":     lambda s, t: _f16(s[0]).reshape(t.shape),
+  "transpose":   lambda s, t: np.transpose(_f16(s[0]), t.attrs["perm"]),
+  "matmul":      lambda s, t: _f16(s[0]) @ _f16(t.attrs["wt"].astype(np.float64)).T,
+  "bmm":         lambda s, t: _f16(s[0]) @ _f16(s[1]),
+}
+
+
 def _fp32_reference(out, inputs):
   """Compute a fp64/fp32-faithful reference for the graph on numpy, so accuracy can be
     measured as IMPROVEMENT (not just preservation). Uses the same wide-accumulator
@@ -778,37 +796,14 @@ def _fp32_reference(out, inputs):
   for t, a in zip(in_nodes, ins):
     vals[id(t)] = a
 
-  def f16(x):  # fp16 rounding of operands/products (the ANE storage), wide accum
-    return np.asarray(x, np.float16).astype(np.float64)
-
   for t in order:
     if id(t) in vals: continue
     s = [vals.get(id(src)) for src in t.srcs]
     if any(v is None for v in s): return None
-    op = t.op
+    fn = _FP32_EVAL.get(t.op)
+    if fn is None: return None  # unknown op -> no faithful reference
     try:
-      if op == "add":            r = f16(s[0]) + f16(s[1])
-      elif op == "sub":          r = f16(s[0]) - f16(s[1])
-      elif op == "mul":          r = f16(s[0]) * f16(s[1])
-      elif op == "muls":         r = f16(s[0]) * np.float16(t.attrs["k"]).astype(np.float64)
-      elif op == "real_div":     r = f16(s[0]) / f16(s[1])
-      elif op == "maximum":      r = np.maximum(f16(s[0]), f16(s[1]))
-      elif op == "minimum":      r = np.minimum(f16(s[0]), f16(s[1]))
-      elif op == "relu":         r = np.maximum(f16(s[0]), 0.0)
-      elif op == "square":       r = f16(s[0]) ** 2
-      elif op == "abs":          r = np.abs(f16(s[0]))
-      elif op == "exp":          r = np.exp(f16(s[0]))
-      elif op == "reduce_sum":   r = f16(s[0]).sum(tuple(t.attrs["axes"]), keepdims=True)
-      elif op == "reduce_mean":  r = f16(s[0]).mean(tuple(t.attrs["axes"]), keepdims=True)
-      elif op == "reshape":      r = f16(s[0]).reshape(t.shape)
-      elif op == "transpose":    r = np.transpose(f16(s[0]), t.attrs["perm"])
-      elif op == "matmul":
-        # x @ W with W stored transposed as [N,K]; wide accumulate over K
-        W = t.attrs["wt"].astype(np.float64)
-        r = f16(s[0]) @ f16(W).T
-      elif op == "bmm":          r = f16(s[0]) @ f16(s[1])
-      else:
-        return None            # unknown op -> no faithful reference
+      r = fn(s, t)
     except Exception:
       return None
     vals[id(t)] = np.asarray(r, np.float64).reshape(t.shape)

--- a/aneforge/_targets.py
+++ b/aneforge/_targets.py
@@ -264,9 +264,7 @@ _LIMITS = {
 def limit(name: str, family: int) -> int:
   """Measured numeric limit for `name` on the given target family."""
   table = _LIMITS[name]
-  val = None
-  for thresh in sorted(table):
-    if int(family) >= int(thresh): val = table[thresh]
+  val = next((table[t] for t in sorted(table, reverse=True) if int(family) >= int(t)), None)
   if val is None: raise ValueError(f"family {family} below the floor for limit {name!r}")
   return val
 
@@ -299,10 +297,7 @@ _HAL_FIELDS = {
 
 def _field_for(name: str, family: int) -> int:
   table = _HAL_FIELDS[name]
-  val = None
-  for thresh in sorted(table):
-    if int(family) >= int(thresh): val = table[thresh]
-  return val
+  return next((table[t] for t in sorted(table, reverse=True) if int(family) >= int(t)), None)
 
 
 # Op-kind classes the predictor recognizes, mapped to the divergence axis they ride.

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -199,8 +199,7 @@ def _vjp_reduce_mean(t, g):
   # fails on a reduce output - see reduce_muls_fusion_probe.py. The tensor*tensor
   # form is kept as the uniform, wall-proof pattern.)
   x = t.srcs[0]
-  n = 1
-  for a in t.attrs["axes"]: n *= x.shape[a]
+  n = math.prod(x.shape[a] for a in t.attrs["axes"])
   return [g * _const_like(x, 1.0 / n)]
 
 
@@ -1101,34 +1100,23 @@ class Trainer:
       entry["p"].attrs["value"] = w.reshape(entry["p"].shape)
     self._res_dirty = False
 
-  def _feed_update(self, net, p, extra):
-    """Feed a per-param update program: the param leaf -> its master value;
-        every other input -> the value mapped in `extra` (keyed by Tensor)."""
-    vals = []
-    for t in net._input_tensors:
-      if t.attrs.get("trainable"):
-        vals.append(t.attrs["value"].astype(np.float16))
-      elif t in extra:
-        vals.append(np.asarray(extra[t]).astype(np.float16))
-      else:
-        vals.append(np.asarray(t.attrs["value"]).astype(np.float16))   # baked value-input (e.g. norm gamma)
-    return vals
+  def _feed(self, model, override: dict | None = None):
+    """Map each compiled input Tensor to a fp16 array: trainable -> current
+        master value; present in `override` -> override[t] (used by the device
+        optimizer to inject grads/lr); otherwise a baked value-input carrying
+        attrs['value'] (e.g. the gamma a norm VJP re-injects).
+        `model._input_tensors` is the ordered input list stored by compile."""
+    lk = self.data if override is None else override
+    return [
+      t.attrs["value"].astype(np.float16) if t.attrs.get("trainable")
+      else np.asarray(lk[t] if t in lk else t.attrs["value"]).astype(np.float16)
+      for t in model._input_tensors
+    ]
 
-  def _feed(self, model):
-    # Map each compiled input Tensor to a value: trainable -> current master
-    # value; provided data -> its data value; otherwise a baked value-input
-    # carrying attrs['value'] (e.g. the gamma a norm VJP re-injects).
-    # `model._input_tensors` is the ordered input list stored by compile
-    # (matches the call signature).
-    vals = []
-    for t in model._input_tensors:
-      if t.attrs.get("trainable"):
-        vals.append(t.attrs["value"].astype(np.float16))
-      elif t in self.data:
-        vals.append(np.asarray(self.data[t]).astype(np.float16))
-      else:
-        vals.append(np.asarray(t.attrs["value"]).astype(np.float16))   # baked value-input (e.g. norm gamma)
-    return vals
+  def _feed_update(self, net, p, extra):
+    """Feed a per-param update program; delegates to _feed with the `extra`
+        override dict (grad/lr inputs keyed by their Tensor leaves)."""
+    return self._feed(net, extra)
 
   def set_dataset(self, x_input, X_full, target_input, Y_onehot, seed: int = 0):
     """Provide the full dataset for mini-batch sampling. `x_input`/`target_input`

--- a/aneforge/dsp.py
+++ b/aneforge/dsp.py
@@ -96,7 +96,7 @@ _WINDOWS = {"hann": hann, "hamming": hamming, "blackman": blackman}
 def get_window(window, M: int) -> np.ndarray:
   """Resolve `window` (name str, 'boxcar'/None for rectangular, or an array) to a
     length-M fp32 coefficient vector (periodic form for the named cosine windows)."""
-  if window is None or window == "boxcar" or window == "rect":
+  if window in (None, "boxcar", "rect"):
     return np.ones(M, np.float32)
   if isinstance(window, str):
     if window not in _WINDOWS:

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -50,6 +50,7 @@ from __future__ import annotations
 import os
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
+from collections import Counter
 
 import numpy as np
 
@@ -84,10 +85,7 @@ def _parse(equation: str, n_operands: int) -> tuple[list[str], str]:
             if not ch.isalpha():
                 raise ValueError(f"einsum: subscript '{s}' has a non-letter index {ch!r}")
     if rhs is None:
-        counts: dict[str, int] = {}
-        for s in ins:
-            for ch in s:
-                counts[ch] = counts.get(ch, 0) + 1
+        counts = Counter("".join(ins))
         rhs = "".join(sorted(ch for ch, c in counts.items() if c == 1))
     else:
         for ch in rhs:

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -1100,12 +1100,8 @@ def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
     o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
   else:
     tile = -(-S // n_tiles)                                 # ceil -> near-even chunks
-    parts = []
-    for start in range(0, S, tile):
-      n = min(tile, S - start)
-      qt = qh.slice_by_size([0, start, 0], [n_heads, n, dh])
-      parts.append(((qt @ kt) * scale).softmax(-1) @ vh)  # [H, n, dh]
-    o = concat(parts, axis=1)                               # [H, S, dh]
+    o = concat([((qh.slice_by_size([0, s, 0], [n_heads, min(tile, S-s), dh]) @ kt)
+                 * scale).softmax(-1) @ vh for s in range(0, S, tile)], axis=1)  # [H, S, dh]
   o = o.transpose([1, 0, 2]).reshape(S, D)
   return o.linear(Wo, bo)
 
@@ -1133,12 +1129,8 @@ def cross_attention(x: Tensor, context: Tensor, Wq, Wk, Wv, Wo, n_heads: int,
     o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
   else:
     tile = -(-S // n_tiles)                                 # ceil -> near-even chunks
-    parts = []
-    for start in range(0, S, tile):
-      n = min(tile, S - start)
-      qt = qh.slice_by_size([0, start, 0], [n_heads, n, dh])
-      parts.append(((qt @ kt) * scale).softmax(-1) @ vh)  # [H, n, dh]
-    o = concat(parts, axis=1)                               # [H, S, dh]
+    o = concat([((qh.slice_by_size([0, s, 0], [n_heads, min(tile, S-s), dh]) @ kt)
+                 * scale).softmax(-1) @ vh for s in range(0, S, tile)], axis=1)  # [H, S, dh]
   o = o.transpose([1, 0, 2]).reshape(S, D)
   return o.linear(Wo, bo)
 

--- a/aneforge/streaming.py
+++ b/aneforge/streaming.py
@@ -79,9 +79,8 @@ class CheckpointedStack:
         checkpoints = []
         for lp in layers_params:
             checkpoints.append(x)
-            feed = {id(self._x): x.astype(_F16)}
-            for t, v in zip(self._p, lp):
-                feed[id(t)] = np.asarray(v, _F16)
+            feed = {id(self._x): x.astype(_F16),
+                    **{id(t): np.asarray(v, _F16) for t, v in zip(self._p, lp)}}
             # any other input port is a baked constant (e.g. a causal mask): feed its value
             vals = [feed[id(t)] if id(t) in feed else np.asarray(t.attrs["value"], _F16)
                     for t in self._fwd._input_tensors]


### PR DESCRIPTION
## What

Curated modern-Python refactors across `aneforge/` core that shorten **and** clarify — taste, not golf. Behavior-preserving; **zero** change to numerics or the emitted ANE program.

5 subsystem commits (compiler core, frontend, autograd, applied-math, bridges). Models were reviewed and left unchanged (already lean).

## Highlights

- `_optimize.py`: an 18-branch `if/elif` in `_fp32_reference` → a module-scope `_FP32_EVAL` dict-dispatch table (loop body 25→6 lines); `_input_shapes`/`_gen_inputs` loops → comprehensions.
- `_cost.py`: removed a duplicate `_prod` (identical to `_elems`); inlined a nested helper.
- `autograd.py`: `math.prod` for the reduce-mean gradient divisor; merged near-identical `_feed`/`_feed_update`.
- `graph.py`: `mha`/`cross_attention` per-head tiling loops → comprehensions.
- `einsum.py`: `Counter` for subscript counts; `dsp.py`: tuple-membership idiom; `_netplist.py`: `[x]*n` and set-membership idioms.

## Safety / verification

Because these change the AST, the restyle's `ast.dump` proof doesn't apply. Three guards replaced it:

- **Golden-MIL guard:** 6 representative graphs lowered to MIL and compared byte-for-byte (build-info stripped) against `main`. **All byte-identical** ⟹ the emitted ANE program — and thus device runtime — is unchanged.
- **Host-timing canary:** a 3000-op deep chain lowered within +1.8% (no O(n²) regression introduced).
- **Correctness:** full on-device suite (Apple Silicon, `--forked`) **563 passed, 0 failed**; each batch also independently reviewed for equivalence + a "shorter AND ≥ readable" bar.
- pyright: **71 = unchanged baseline**; `ruff check` clean.

Net: cleaner, ~64 fewer lines, identical behavior. Out of scope: numerics/emit changes, public-API renames, `tests/` (the behavior oracle), `examples/`, `bench/`, `_version.py`.