### PR TITLE
Tooling gates: pyright→0 + lint pack (ruff C4/A, 2-space lock, pre-commit)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install ruff pylint
       - run: ruff check
       # Lock the tinygrad-compact 2-space style: W0311 (bad indentation) + C0303
@@ -45,6 +47,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       # pyright must resolve the lazily-imported OPTIONAL deps so it doesn't report
       # them as missing: scipy (dsp/special reference paths) and the model-loader
       # stack (torch/torchvision/transformers/huggingface_hub via the `models` extra).
@@ -62,6 +66,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install build twine
       - run: python -m build
       - run: twine check dist/*
@@ -80,6 +86,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
       # Every module byte-compiles (no import, so no dylib/ANE needed).
       - run: python -m compileall -q aneforge
       # The package imports with only NumPy and builds a graph; compile/dispatch is lazy
@@ -97,6 +105,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install -e ".[dev]"
       # The compile-backoff rate-limiter is a pure unit test (fake clock, no ANE).
       - run: pytest tests/test_compile_breaker.py -q
@@ -111,6 +121,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       - run: pip install -r docs/requirements.txt
       - run: mkdocs build --strict
 
@@ -124,6 +136,8 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
       # The Objective-C++ dispatch shim links Apple frameworks and only builds on macOS;
       # this proves it compiles. The hosted runner has no ANE, so it is never dispatched
       # (the dylib loads lazily on first dispatch, which does not happen here).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,11 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install -e ".[dev]"
+      # pyright must resolve the lazily-imported OPTIONAL deps so it doesn't report
+      # them as missing: scipy (dsp/special reference paths) and the model-loader
+      # stack (torch/torchvision/transformers/huggingface_hub via the `models` extra).
+      # This matches the local type-check environment.
+      - run: pip install -e ".[dev,models]" scipy
       - run: pyright aneforge   # gate at 0 errors (pyright pinned in the dev extra)
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   lint:
-    name: lint (ruff)
+    name: lint (ruff + 2-space)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
@@ -29,8 +29,24 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - run: pip install ruff
+      - run: pip install ruff pylint
       - run: ruff check
+      # Lock the tinygrad-compact 2-space style: W0311 (bad indentation) + C0303
+      # (trailing whitespace), enforced with a 2-space indent string. Nothing else.
+      - run: python -m pylint --disable=all -e W0311 -e C0303 --indent-string='  ' --recursive=y aneforge tests
+
+  types:
+    name: types (pyright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0   # hatch-vcs derives the version from tags
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - run: pip install -e ".[dev]"
+      - run: pyright aneforge   # gate at 0 errors (pyright pinned in the dev extra)
 
   build:
     name: package (build + twine)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,9 @@
-# Local pre-commit hooks mirroring CI (.github/workflows/ci.yml): ruff lint, the
-# tinygrad-compact 2-space lock (pylint W0311/C0303), and pyright. Install with
-#   pip install pre-commit && pre-commit install
-# Run on all files with `pre-commit run --all-files`.
+# Local pre-commit hooks: ruff lint + the tinygrad-compact 2-space lock (pylint
+# W0311/C0303). These are fast and dependency-light. pyright is intentionally NOT
+# here — it needs the full optional-dep stack (torch/scipy/...) to resolve the lazy
+# model-loader imports, so it runs in CI (.github/workflows/ci.yml `types` job).
+# Install with: pip install pre-commit && pre-commit install
+# Run on all files with: pre-commit run --all-files
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.14.10
@@ -18,10 +20,3 @@ repos:
         types: [python]
         # lint only the shippable code + tests (matches CI); skip examples/bench/utils
         files: ^(aneforge|tests)/.*\.py$
-
-      - id: pyright
-        name: pyright (0 errors)
-        entry: pyright aneforge
-        language: system
-        pass_filenames: false   # pyright analyzes the whole package, not per-file
-        files: ^aneforge/.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,27 @@
+# Local pre-commit hooks mirroring CI (.github/workflows/ci.yml): ruff lint, the
+# tinygrad-compact 2-space lock (pylint W0311/C0303), and pyright. Install with
+#   pip install pre-commit && pre-commit install
+# Run on all files with `pre-commit run --all-files`.
+repos:
+  - repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.14.10
+    hooks:
+      - id: ruff               # uses [tool.ruff] in pyproject.toml (E/F/C4/A, 120 cols, 2-space)
+        args: [--no-fix]       # report only; do not silently rewrite on commit
+
+  - repo: local
+    hooks:
+      - id: two-space
+        name: 2-space indent + no trailing whitespace (pylint W0311/C0303)
+        entry: python -m pylint --disable=all -e W0311 -e C0303 --indent-string='  '
+        language: system
+        types: [python]
+        # lint only the shippable code + tests (matches CI); skip examples/bench/utils
+        files: ^(aneforge|tests)/.*\.py$
+
+      - id: pyright
+        name: pyright (0 errors)
+        entry: pyright aneforge
+        language: system
+        pass_filenames: false   # pyright analyzes the whole package, not per-file
+        files: ^aneforge/.*\.py$

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
-# Local pre-commit hooks: ruff lint + the tinygrad-compact 2-space lock (pylint
-# W0311/C0303). Both run via the tools installed in your environment (`pip install
-# -e ".[dev]"`), mirroring the CI `lint` job exactly and avoiding an isolated-venv
-# build. pyright is intentionally NOT here — it needs the full optional-dep stack
-# (torch/scipy/...) to resolve the lazy model-loader imports, so it runs in CI
-# (.github/workflows/ci.yml `types` job).
-# Install with: pip install -e ".[dev]" pre-commit && pre-commit install
+# Local pre-commit hooks, all `language: system` (they call the tools installed in
+# your environment), mirroring the CI gates: ruff lint, the tinygrad-compact 2-space
+# lock (pylint W0311/C0303), and pyright. Like tinygrad, the type checker runs in
+# pre-commit too — so it assumes a full type-check env. Install everything with:
+#   pip install -e ".[dev,models]" scipy pre-commit && pre-commit install
+# (the `models` extra + scipy let pyright resolve the lazy model-loader / dsp imports;
+# without them pyright reports those as missing — same as the CI `types` job env.)
 # Run on all files with: pre-commit run --all-files
 repos:
   - repo: local
@@ -23,3 +23,10 @@ repos:
         types: [python]
         # lint only the shippable code + tests (matches CI); skip examples/bench/utils
         files: ^(aneforge|tests)/.*\.py$
+
+      - id: pyright
+        name: pyright (0 errors)
+        entry: pyright aneforge
+        language: system
+        pass_filenames: false        # pyright analyzes the whole package, not per-file
+        always_run: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,18 +1,21 @@
 # Local pre-commit hooks: ruff lint + the tinygrad-compact 2-space lock (pylint
-# W0311/C0303). These are fast and dependency-light. pyright is intentionally NOT
-# here — it needs the full optional-dep stack (torch/scipy/...) to resolve the lazy
-# model-loader imports, so it runs in CI (.github/workflows/ci.yml `types` job).
-# Install with: pip install pre-commit && pre-commit install
+# W0311/C0303). Both run via the tools installed in your environment (`pip install
+# -e ".[dev]"`), mirroring the CI `lint` job exactly and avoiding an isolated-venv
+# build. pyright is intentionally NOT here — it needs the full optional-dep stack
+# (torch/scipy/...) to resolve the lazy model-loader imports, so it runs in CI
+# (.github/workflows/ci.yml `types` job).
+# Install with: pip install -e ".[dev]" pre-commit && pre-commit install
 # Run on all files with: pre-commit run --all-files
 repos:
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.14.10
-    hooks:
-      - id: ruff               # uses [tool.ruff] in pyproject.toml (E/F/C4/A, 120 cols, 2-space)
-        args: [--no-fix]       # report only; do not silently rewrite on commit
-
   - repo: local
     hooks:
+      - id: ruff
+        name: ruff check
+        entry: ruff check --no-fix   # report only; do not silently rewrite on commit
+        language: system
+        types: [python]
+        pass_filenames: false        # ruff resolves its own paths from pyproject.toml
+
       - id: two-space
         name: 2-space indent + no trailing whitespace (pylint W0311/C0303)
         entry: python -m pylint --disable=all -e W0311 -e C0303 --indent-string='  '

--- a/aneforge/_bridges/_netplist.py
+++ b/aneforge/_bridges/_netplist.py
@@ -2423,6 +2423,7 @@ def build_sdpa(
   # Inputs: Q, K, V are tensor inputs; Scale is a weight-backed constant.
   # The Bottom array places Scale as the 4th input (index 3), matching
   # Apple's __Z18ValidateLayer_Impl<ANECSDPALayerDesc, ...> 4-tensor layout.
+  params: dict[str, object] = {"SubtractMax": bool(subtract_max)}
   unit: dict[str, object] = {
     "Bottom": ["query", "key", "value", "scale"],
     "InputType": ["Float16", "Float16", "Float16", "Float16"],
@@ -2435,7 +2436,7 @@ def build_sdpa(
     # defaults desc[0x00]=kCFBooleanFalse (no stabilization) - the source of
     # the original "Y depends on Q,K,V,scale but doesn't equal
     # softmax(Q@K^T*s)@V" numerics gap.
-    "Params": {"SubtractMax": bool(subtract_max)},
+    "Params": params,
     "Type": "SDPA",
   }
 
@@ -2446,7 +2447,7 @@ def build_sdpa(
   if constant_flag_spelling in {"ConstantTensor_unit", "all"}: unit["ConstantTensor"] = [False, False, False, True]
   if constant_flag_spelling in {"ScaleMutable_false", "all"}:
     unit["ScaleMutable"] = False
-    unit["Params"]["ScaleMutable"] = False  # type: ignore[index]
+    params["ScaleMutable"] = False
 
   plist = build_plist(
     network_name,
@@ -2486,7 +2487,7 @@ def build_plist(
   outputs: list[dict],
   units_by_name: dict[str, dict],
 ) -> dict:
-  network = dict(units_by_name)
+  network: dict[str, object] = dict(units_by_name)
   network["Units"] = list(units_by_name)
   network["Weights"] = ["weights.0"]
   network["y"] = {

--- a/aneforge/_bridges/ane_cost_volume_fused.py
+++ b/aneforge/_bridges/ane_cost_volume_fused.py
@@ -15,6 +15,7 @@ import json
 import subprocess
 import tempfile
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -22,7 +23,7 @@ _ROOT = Path(__file__).resolve().parents[2]
 
 
 def cost_volume_fused(aux: np.ndarray, ref: np.ndarray,
-                      disparity_range: int = 1) -> np.ndarray:
+                      disparity_range: int | np.integer[Any] = 1) -> np.ndarray:
   """L1 cost volume of two single-channel rows.
 
     Args:
@@ -36,7 +37,7 @@ def cost_volume_fused(aux: np.ndarray, ref: np.ndarray,
   ref = np.asarray(ref, dtype=np.float16).reshape(-1)
   Wa, Wr = aux.size, ref.size
   R = int(disparity_range)
-  from ._netplist import write_model, ensure_invoker  # type: ignore
+  from ._netplist import write_model, ensure_invoker
 
   with tempfile.TemporaryDirectory(prefix="ane_costvol_") as d:
     wd = Path(d)
@@ -67,7 +68,7 @@ def cost_volume_fused(aux: np.ndarray, ref: np.ndarray,
 
 
 def numpy_reference(aux: np.ndarray, ref: np.ndarray,
-                    disparity_range: int = 1) -> np.ndarray:
+                    disparity_range: int | np.integer[Any] = 1) -> np.ndarray:
   a = np.asarray(aux, np.float16).astype(np.float32).reshape(-1)
   r = np.asarray(ref, np.float16).astype(np.float32).reshape(-1)
   Wa, R = a.size, int(disparity_range)

--- a/aneforge/_bridges/ane_cross_correlation_fused.py
+++ b/aneforge/_bridges/ane_cross_correlation_fused.py
@@ -32,7 +32,7 @@ def cross_correlation_fused(x: np.ndarray, template: np.ndarray) -> np.ndarray:
   H, W = x.shape
   Th, Tw = template.shape
   out_h, out_w = H - Th + 1, W - Tw + 1
-  from ._netplist import write_model, ensure_invoker  # type: ignore
+  from ._netplist import write_model, ensure_invoker
 
   with tempfile.TemporaryDirectory(prefix="ane_xcorr_") as d:
     wd = Path(d)

--- a/aneforge/_bridges/ane_cross_product_fused.py
+++ b/aneforge/_bridges/ane_cross_product_fused.py
@@ -26,7 +26,7 @@ def cross_product_fused(x: np.ndarray, z: np.ndarray) -> np.ndarray:
     """
   x = np.asarray(x, dtype=np.float16).reshape(3)
   z = np.asarray(z, dtype=np.float16).reshape(3)
-  from ._netplist import write_model, ensure_invoker  # type: ignore
+  from ._netplist import write_model, ensure_invoker
 
   with tempfile.TemporaryDirectory(prefix="ane_xprod_") as d:
     wd = Path(d)

--- a/aneforge/_bridges/ane_sdpa_fused.py
+++ b/aneforge/_bridges/ane_sdpa_fused.py
@@ -57,7 +57,7 @@ def _write_netplist(
   subtract_max: bool = True,
 ) -> tuple[Path, list[Path]]:
   """Generate a one-op SDPA netplist + weights at workdir."""
-  from ._netplist import write_model  # type: ignore
+  from ._netplist import write_model
   write_model(
     "sdpa",
     workdir,

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -9,9 +9,12 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
-from typing import Any, Callable
+from typing import TYPE_CHECKING, Any, Callable
 
 import numpy as np
+
+if TYPE_CHECKING:
+  from ._netplist_worker import _Worker
 
 from ._runtime import E5RT, ANE_MASK
 
@@ -1592,7 +1595,7 @@ class SegmentedModel:
     # route. Built lazily on first call (keyed by the stage), reused for the
     # rest of this model's lifetime, released in release(). Set
     # ANEFORGE_NETPLIST_WORKER=0 to force the A1 (subprocess-per-call) path.
-    self._workers: dict[int, object] = {}
+    self._workers: dict[int, "_Worker"] = {}
     self._worker_runs: dict[int, Callable[..., Any]] = {}
     self._worker_warned: set[str] = set()
 
@@ -1660,7 +1663,7 @@ class SegmentedModel:
       if st["kind"] == "region": st["prog"].release()
     for w in self._workers.values():
       try:
-        w.release()  # type: ignore[union-attr]  # workers are _Worker objects with .release()
+        w.release()
       except Exception:
         pass
     self._workers.clear()

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import tempfile
 from pathlib import Path
+from typing import Any, Callable
 
 import numpy as np
 
@@ -47,7 +48,7 @@ def _topo(out: Tensor) -> list[Tensor]:
 # per-op MIL emitters (registry)                                              #
 # --------------------------------------------------------------------------- #
 
-_EMIT: dict[str, "callable"] = {}
+_EMIT: dict[str, Callable[..., Any]] = {}
 
 
 def op(*names: str):
@@ -886,7 +887,7 @@ def _emit_program_dir(em, inputs, out_var, out_shape, build_dir):
 def _assemble_and_compile(em, inputs, out_var, out_shape, build_dir):
   """Write one e5rt program (MIL + weights) for a set of input tensors and compile it."""
   d = _emit_program_dir(em, inputs, out_var, out_shape, build_dir)
-  return E5RT.compile(mil_path=d / "model.mil", cache_dir=d / "cache",
+  return E5RT.compile(mil_path=d / "model.mil", cache_dir=str(d / "cache"),
             inputs={t._name: t.shape for t in inputs}, outputs={out_var: out_shape},
             device_mask=ANE_MASK, input_dtypes=_input_dtypes(inputs))
 
@@ -1029,7 +1030,7 @@ def compile_multi(outs, build_dir=None) -> MultiModel:
   d.mkdir(parents=True, exist_ok=True)
   (d / "model.mil").write_text(mil)
   (d / "weights.bin").write_bytes(em.blob.build())
-  prog = E5RT.compile(mil_path=d / "model.mil", cache_dir=d / "cache",
+  prog = E5RT.compile(mil_path=d / "model.mil", cache_dir=str(d / "cache"),
             inputs={t._name: t.shape for t in inputs},
             outputs={o._name: o.shape for o in outs}, device_mask=ANE_MASK,
             input_dtypes=_input_dtypes(inputs))
@@ -1192,7 +1193,7 @@ def _warn_fp16_cross_chip(out: Tensor, host_family: int, target_family: int) -> 
 
   from . import _targets as TG
   if int(host_family) == int(target_family): return
-  risks: dict[tuple, str] = {}
+  risks: dict[tuple, tuple] = {}
   for t in _topo(out):
     kind = _fp16_risk_kind(t)
     if not kind: continue
@@ -1592,7 +1593,7 @@ class SegmentedModel:
     # rest of this model's lifetime, released in release(). Set
     # ANEFORGE_NETPLIST_WORKER=0 to force the A1 (subprocess-per-call) path.
     self._workers: dict[int, object] = {}
-    self._worker_runs: dict[int, object] = {}
+    self._worker_runs: dict[int, Callable[..., Any]] = {}
     self._worker_warned: set[str] = set()
 
   def __call__(self, *arrays: np.ndarray) -> np.ndarray:
@@ -1612,7 +1613,7 @@ class SegmentedModel:
         env[st["tid"]] = np.asarray(runner(src_arrays, st["attrs"]), dtype=np.float16)
     return env[self._out_id].astype(np.float32)
 
-  def _netplist_runner(self, st):
+  def _netplist_runner(self, st) -> Callable[..., Any]:
     """Resolve the runner for a netplist stage. Prefer a persistent Path-A worker
         (load-once-eval-many), built lazily on first use and cached for this model's
         lifetime. Fall back to the subprocess-per-call bridge when no worker route
@@ -1659,7 +1660,7 @@ class SegmentedModel:
       if st["kind"] == "region": st["prog"].release()
     for w in self._workers.values():
       try:
-        w.release()
+        w.release()  # type: ignore[union-attr]  # workers are _Worker objects with .release()
       except Exception:
         pass
     self._workers.clear()

--- a/aneforge/_cost.py
+++ b/aneforge/_cost.py
@@ -75,9 +75,9 @@ def _constants() -> dict:
       # cut penalty: a native bridge sub-program's floor sits ~90-110us above
       # nothing; use the smallest bridge min as the marginal cut cost when present.
       bridge = model.get("bridge_ops", {})
-      mins = [v.get("min_us") for v in bridge.values()
+      mins = [float(v["min_us"]) for v in bridge.values()
               if isinstance(v, dict) and v.get("min_us") and v["min_us"] < 1000]
-      if mins: c["cut_us"] = float(min(mins))
+      if mins: c["cut_us"] = min(mins)
     except Exception:
       pass
   return c
@@ -613,7 +613,8 @@ def _estimate_analytic(out, arch: str, int8: bool) -> float:
   region_nodes = [t for t in nodes if t.op not in NETPLIST_OPS]
   region_work = sum(_node_roofline_us(t, c, int8) for t in region_nodes)
   if not cut_nodes: return c["floor_us"] + region_work
-  n_regions = (n_cuts := len(cut_nodes)) + 1 if region_nodes else 0
+  n_cuts = len(cut_nodes)
+  n_regions = n_cuts + 1 if region_nodes else 0
   cut_work = sum(_node_roofline_us(t, c, int8) for t in cut_nodes)
   return n_regions * c["floor_us"] + region_work + cut_work + n_cuts * c["cut_us"]
 

--- a/aneforge/_netplist_worker.py
+++ b/aneforge/_netplist_worker.py
@@ -85,9 +85,16 @@ class _Worker:
       # Python-level read buffering in front of it.
       self._proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
                                     stderr=subprocess.PIPE, bufsize=0)
-      ready = self._proc.stdout.readline()
+      assert self._proc.stdin is not None
+      assert self._proc.stdout is not None
+      assert self._proc.stderr is not None
+      # Store pipes as non-Optional IO so pyright can narrow in other methods.
+      self._stdin = self._proc.stdin
+      self._stdout = self._proc.stdout
+      self._stderr = self._proc.stderr
+      ready = self._stdout.readline()
       if not ready:
-        err = self._proc.stderr.read().decode(errors="replace")
+        err = self._stderr.read().decode(errors="replace")
         raise RuntimeError(f"persistent worker failed to start: {err}")
       info = json.loads(ready.decode())
       if info.get("status") != "ready":
@@ -128,10 +135,10 @@ class _Worker:
         try:
           data = memoryview(b"".join(parts))
           while data:
-            data = data[self._proc.stdin.write(data):]
-          self._proc.stdin.flush()
+            data = data[self._stdin.write(data):]
+          self._stdin.flush()
         except (BrokenPipeError, OSError):
-          err = self._proc.stderr.read().decode(errors="replace")
+          err = self._stderr.read().decode(errors="replace")
           raise RuntimeError(f"persistent worker ({self._op}) died on request: {err}")
         raw = self._read_exact(self._out_bytes * n)
         out_sets, off = [], 0
@@ -145,7 +152,7 @@ class _Worker:
 
     def _read_exact(self, n: int) -> bytes:
       timeout = float(os.environ.get("ANEFORGE_WORKER_TIMEOUT_S", "120"))
-      fd = self._proc.stdout.fileno()
+      fd = self._stdout.fileno()
       buf = bytearray()
       while len(buf) < n:
         if timeout > 0:
@@ -153,13 +160,13 @@ class _Worker:
           if not ready:
             self._proc.kill()
             self._proc.wait()
-            err = self._proc.stderr.read().decode(errors="replace")
+            err = self._stderr.read().decode(errors="replace")
             raise RuntimeError(
               f"persistent worker ({self._op}) unresponsive after "
               f"{timeout:g}s: {err}")
         chunk = os.read(fd, n - len(buf))
         if not chunk:
-          err = self._proc.stderr.read().decode(errors="replace")
+          err = self._stderr.read().decode(errors="replace")
           raise RuntimeError(f"persistent worker ({self._op}) died mid-eval: {err}")
         buf += chunk
       return bytes(buf)
@@ -167,7 +174,7 @@ class _Worker:
     def release(self) -> None:
       if self._proc.poll() is None:
         try:
-          self._proc.stdin.close()  # EOF -> clean shutdown
+          self._stdin.close()  # EOF -> clean shutdown
           self._proc.wait(timeout=5)
         except Exception:
           self._proc.kill()

--- a/aneforge/_netplist_worker.py
+++ b/aneforge/_netplist_worker.py
@@ -42,25 +42,25 @@ _INVOKER_BIN_NAME = "persistent_worker"
 
 
 def _ensure_worker_built() -> Path:
-    """Build the persistent-worker invoker once if missing/stale (UNIQUE path so
+  """Build the persistent-worker invoker once if missing/stale (UNIQUE path so
     it never clobbers the one-shot invokers)."""
-    binp = bin_dir() / _INVOKER_BIN_NAME
-    src = Path(__file__).resolve().parent / "_invokers" / "persistent_worker.mm"
-    if binp.exists() and src.exists() and binp.stat().st_mtime >= src.stat().st_mtime: return binp
-    binp.parent.mkdir(parents=True, exist_ok=True)
-    cmd = [
-      "xcrun", "clang++", "-O2", "-Wall", "-Wextra", "-fobjc-arc", "-std=gnu++17",
-      "-framework", "Foundation", "-framework", "IOSurface",
-      str(src), "-o", str(binp),
-    ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-      raise RuntimeError(f"failed to build persistent worker:\n{proc.stderr}")
-    return binp
+  binp = bin_dir() / _INVOKER_BIN_NAME
+  src = Path(__file__).resolve().parent / "_invokers" / "persistent_worker.mm"
+  if binp.exists() and src.exists() and binp.stat().st_mtime >= src.stat().st_mtime: return binp
+  binp.parent.mkdir(parents=True, exist_ok=True)
+  cmd = [
+    "xcrun", "clang++", "-O2", "-Wall", "-Wextra", "-fobjc-arc", "-std=gnu++17",
+    "-framework", "Foundation", "-framework", "IOSurface",
+    str(src), "-o", str(binp),
+  ]
+  proc = subprocess.run(cmd, capture_output=True, text=True)
+  if proc.returncode != 0:
+    raise RuntimeError(f"failed to build persistent worker:\n{proc.stderr}")
+  return binp
 
 
 class _Worker:
-    """Owns one spawned worker process holding ONE compiled+loaded netplist.
+  """Owns one spawned worker process holding ONE compiled+loaded netplist.
 
     The wire protocol is batched: per request we write a 4-byte little-endian
     uint32 count `N` followed by `N` input sets packed back-to-back as raw fp16
@@ -70,118 +70,118 @@ class _Worker:
     packs many input sets into ONE round-trip (the per-row-tiled topk/sort win).
     """
 
-    def __init__(self, netplist: Path, weights: list[Path], in_syms: list[str],
-                 out_syms: list[str], workdir: tempfile.TemporaryDirectory,
-                 op: str = "netplist"):
-      self._workdir = workdir  # keep the netplist + weights alive on disk
-      self._op = op
-      binp = _ensure_worker_built()
-      cmd = [str(binp), "--net-plist", str(netplist)]
-      for w in weights: cmd += ["--weights", str(w)]
-      for s in in_syms: cmd += ["--input", s]
-      for s in out_syms: cmd += ["--output", s]
-      # bufsize=0: the protocol is length-prefixed binary and `_read_exact`
-      # select()s on the raw stdout fd, which is only correct with no
-      # Python-level read buffering in front of it.
-      self._proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
-                                    stderr=subprocess.PIPE, bufsize=0)
-      assert self._proc.stdin is not None
-      assert self._proc.stdout is not None
-      assert self._proc.stderr is not None
-      # Store pipes as non-Optional IO so pyright can narrow in other methods.
-      self._stdin = self._proc.stdin
-      self._stdout = self._proc.stdout
-      self._stderr = self._proc.stderr
-      ready = self._stdout.readline()
-      if not ready:
-        err = self._stderr.read().decode(errors="replace")
-        raise RuntimeError(f"persistent worker failed to start: {err}")
-      info = json.loads(ready.decode())
-      if info.get("status") != "ready":
-        raise RuntimeError(f"persistent worker not ready: {info}")
-      self.compile_ms = info["compile_ms"]
-      self.load_ms = info["load_ms"]
-      self.in_elems = list(info["input_elems"])
-      self.out_elems = list(info["output_elems"])
-      self._out_bytes = 2 * sum(self.out_elems)
+  def __init__(self, netplist: Path, weights: list[Path], in_syms: list[str],
+               out_syms: list[str], workdir: tempfile.TemporaryDirectory,
+               op: str = "netplist"):
+    self._workdir = workdir  # keep the netplist + weights alive on disk
+    self._op = op
+    binp = _ensure_worker_built()
+    cmd = [str(binp), "--net-plist", str(netplist)]
+    for w in weights: cmd += ["--weights", str(w)]
+    for s in in_syms: cmd += ["--input", s]
+    for s in out_syms: cmd += ["--output", s]
+    # bufsize=0: the protocol is length-prefixed binary and `_read_exact`
+    # select()s on the raw stdout fd, which is only correct with no
+    # Python-level read buffering in front of it.
+    self._proc = subprocess.Popen(cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE,
+                                  stderr=subprocess.PIPE, bufsize=0)
+    assert self._proc.stdin is not None
+    assert self._proc.stdout is not None
+    assert self._proc.stderr is not None
+    # Store pipes as non-Optional IO so pyright can narrow in other methods.
+    self._stdin = self._proc.stdin
+    self._stdout = self._proc.stdout
+    self._stderr = self._proc.stderr
+    ready = self._stdout.readline()
+    if not ready:
+      err = self._stderr.read().decode(errors="replace")
+      raise RuntimeError(f"persistent worker failed to start: {err}")
+    info = json.loads(ready.decode())
+    if info.get("status") != "ready":
+      raise RuntimeError(f"persistent worker not ready: {info}")
+    self.compile_ms = info["compile_ms"]
+    self.load_ms = info["load_ms"]
+    self.in_elems = list(info["input_elems"])
+    self.out_elems = list(info["output_elems"])
+    self._out_bytes = 2 * sum(self.out_elems)
 
-    def eval(self, inputs: list[np.ndarray]) -> list[np.ndarray]:
-        """One eval. `inputs` are contiguous fp16 arrays in spawn symbol order;
+  def eval(self, inputs: list[np.ndarray]) -> list[np.ndarray]:
+    """One eval. `inputs` are contiguous fp16 arrays in spawn symbol order;
         returns the output tensors as flat fp16 arrays in spawn symbol order."""
-        return self.eval_batch([inputs])[0]
+    return self.eval_batch([inputs])[0]
 
-    def eval_batch(self, input_sets: list[list[np.ndarray]]) -> list[list[np.ndarray]]:
-        """Run `N = len(input_sets)` evals in ONE pipe round-trip.  Each entry of
+  def eval_batch(self, input_sets: list[list[np.ndarray]]) -> list[list[np.ndarray]]:
+    """Run `N = len(input_sets)` evals in ONE pipe round-trip.  Each entry of
         `input_sets` is a full input set (one array per spawn symbol, in order).
         Returns N output sets (one flat fp16 array per output symbol).  Bit-identical
         to calling `eval` N times, but pays a single request/reply instead of N --
         the per-row-tiled topk/sort win."""
-        if self._proc.poll() is not None: raise RuntimeError("persistent worker has exited")
-        n = len(input_sets)
-        if n == 0: return []
-        parts = [struct.pack("<I", n)]
-        for inputs in input_sets:
-          if len(inputs) != len(self.in_elems):
-            raise ValueError(
-              f"persistent worker ({self._op}) expects {len(self.in_elems)} "
-              f"input arrays per set; got {len(inputs)}")
-          for i, a in enumerate(inputs):
-            raw_in = np.ascontiguousarray(a, np.float16).tobytes()
-            if len(raw_in) != 2 * self.in_elems[i]:
-              raise ValueError(
-                f"persistent worker ({self._op}) input {i} is {len(raw_in)} "
-                f"bytes; expected {2 * self.in_elems[i]} ({self.in_elems[i]} fp16 elems)")
-            parts.append(raw_in)
-        try:
-          data = memoryview(b"".join(parts))
-          while data:
-            data = data[self._stdin.write(data):]
-          self._stdin.flush()
-        except (BrokenPipeError, OSError):
-          err = self._stderr.read().decode(errors="replace")
-          raise RuntimeError(f"persistent worker ({self._op}) died on request: {err}")
-        raw = self._read_exact(self._out_bytes * n)
-        out_sets, off = [], 0
-        for _ in range(n):
-          outs = []
-          for ne in self.out_elems:
-            outs.append(np.frombuffer(raw[off:off + 2 * ne], dtype=np.float16).copy())
-            off += 2 * ne
-          out_sets.append(outs)
-        return out_sets
+    if self._proc.poll() is not None: raise RuntimeError("persistent worker has exited")
+    n = len(input_sets)
+    if n == 0: return []
+    parts = [struct.pack("<I", n)]
+    for inputs in input_sets:
+      if len(inputs) != len(self.in_elems):
+        raise ValueError(
+          f"persistent worker ({self._op}) expects {len(self.in_elems)} "
+          f"input arrays per set; got {len(inputs)}")
+      for i, a in enumerate(inputs):
+        raw_in = np.ascontiguousarray(a, np.float16).tobytes()
+        if len(raw_in) != 2 * self.in_elems[i]:
+          raise ValueError(
+            f"persistent worker ({self._op}) input {i} is {len(raw_in)} "
+            f"bytes; expected {2 * self.in_elems[i]} ({self.in_elems[i]} fp16 elems)")
+        parts.append(raw_in)
+    try:
+      data = memoryview(b"".join(parts))
+      while data:
+        data = data[self._stdin.write(data):]
+      self._stdin.flush()
+    except (BrokenPipeError, OSError):
+      err = self._stderr.read().decode(errors="replace")
+      raise RuntimeError(f"persistent worker ({self._op}) died on request: {err}")
+    raw = self._read_exact(self._out_bytes * n)
+    out_sets, off = [], 0
+    for _ in range(n):
+      outs = []
+      for ne in self.out_elems:
+        outs.append(np.frombuffer(raw[off:off + 2 * ne], dtype=np.float16).copy())
+        off += 2 * ne
+      out_sets.append(outs)
+    return out_sets
 
-    def _read_exact(self, n: int) -> bytes:
-      timeout = float(os.environ.get("ANEFORGE_WORKER_TIMEOUT_S", "120"))
-      fd = self._stdout.fileno()
-      buf = bytearray()
-      while len(buf) < n:
-        if timeout > 0:
-          ready, _, _ = select.select([fd], [], [], timeout)
-          if not ready:
-            self._proc.kill()
-            self._proc.wait()
-            err = self._stderr.read().decode(errors="replace")
-            raise RuntimeError(
-              f"persistent worker ({self._op}) unresponsive after "
-              f"{timeout:g}s: {err}")
-        chunk = os.read(fd, n - len(buf))
-        if not chunk:
-          err = self._stderr.read().decode(errors="replace")
-          raise RuntimeError(f"persistent worker ({self._op}) died mid-eval: {err}")
-        buf += chunk
-      return bytes(buf)
-
-    def release(self) -> None:
-      if self._proc.poll() is None:
-        try:
-          self._stdin.close()  # EOF -> clean shutdown
-          self._proc.wait(timeout=5)
-        except Exception:
+  def _read_exact(self, n: int) -> bytes:
+    timeout = float(os.environ.get("ANEFORGE_WORKER_TIMEOUT_S", "120"))
+    fd = self._stdout.fileno()
+    buf = bytearray()
+    while len(buf) < n:
+      if timeout > 0:
+        ready, _, _ = select.select([fd], [], [], timeout)
+        if not ready:
           self._proc.kill()
+          self._proc.wait()
+          err = self._stderr.read().decode(errors="replace")
+          raise RuntimeError(
+            f"persistent worker ({self._op}) unresponsive after "
+            f"{timeout:g}s: {err}")
+      chunk = os.read(fd, n - len(buf))
+      if not chunk:
+        err = self._stderr.read().decode(errors="replace")
+        raise RuntimeError(f"persistent worker ({self._op}) died mid-eval: {err}")
+      buf += chunk
+    return bytes(buf)
+
+  def release(self) -> None:
+    if self._proc.poll() is None:
       try:
-        self._workdir.cleanup()
+        self._stdin.close()  # EOF -> clean shutdown
+        self._proc.wait(timeout=5)
       except Exception:
-        pass
+        self._proc.kill()
+    try:
+      self._workdir.cleanup()
+    except Exception:
+      pass
 
 
 # --------------------------------------------------------------------------- #
@@ -191,120 +191,120 @@ class _Worker:
 # --------------------------------------------------------------------------- #
 
 def _build_sdpa_worker(shape, attrs):
-    """Persistent SDPA. `shape` is the Q/K/V shape [1, H, S, D]; `attrs` has `scale`.
+  """Persistent SDPA. `shape` is the Q/K/V shape [1, H, S, D]; `attrs` has `scale`.
     Mirrors ane_sdpa_fused.sdpa_fused's ANE layout: pre/post transpose Q,K,V
     (heads<->seq) so the netplist sees seq-in-C, heads-in-H."""
-    from ._bridges import ane_sdpa_fused as af  # the A1 bridge = the netplist author
+  from ._bridges import ane_sdpa_fused as af  # the A1 bridge = the netplist author
 
-    B, H, S, D = shape
-    if B != 1:
-      raise ValueError(f"SDPA worker only supports B=1; got B={B}")
-    scale = attrs.get("scale")
-    if scale is None: scale = 1.0 / math.sqrt(D)
+  B, H, S, D = shape
+  if B != 1:
+    raise ValueError(f"SDPA worker only supports B=1; got B={B}")
+  scale = attrs.get("scale")
+  if scale is None: scale = 1.0 / math.sqrt(D)
 
-    workdir = tempfile.TemporaryDirectory(prefix="ane_sdpa_worker_")
-    wd = Path(workdir.name)
-    # channels=S (ANE C=seq after transpose), sequence=H (ANE H=heads), dim=D.
-    netplist, weights = af._write_netplist(
-      wd, channels=S, sequence=H, dim=D, scale=float(scale),
-      constant_flag_spelling="Constants_array", subtract_max=True,
-    )
-    worker = _Worker(netplist, list(weights), ["query", "key", "value"], ["y"], workdir,
-                     op="sdpa")
+  workdir = tempfile.TemporaryDirectory(prefix="ane_sdpa_worker_")
+  wd = Path(workdir.name)
+  # channels=S (ANE C=seq after transpose), sequence=H (ANE H=heads), dim=D.
+  netplist, weights = af._write_netplist(
+    wd, channels=S, sequence=H, dim=D, scale=float(scale),
+    constant_flag_spelling="Constants_array", subtract_max=True,
+  )
+  worker = _Worker(netplist, list(weights), ["query", "key", "value"], ["y"], workdir,
+           op="sdpa")
 
-    def run(srcs, attrs2):
-      q, k, v = srcs
-      # to ANE layout (B, S, H, D)
-      qa = np.ascontiguousarray(np.asarray(q, np.float16).transpose(0, 2, 1, 3))
-      ka = np.ascontiguousarray(np.asarray(k, np.float16).transpose(0, 2, 1, 3))
-      va = np.ascontiguousarray(np.asarray(v, np.float16).transpose(0, 2, 1, 3))
-      (y_flat,) = worker.eval([qa, ka, va])
-      y_ane = y_flat.reshape(B, S, H, D)
-      return np.ascontiguousarray(y_ane.transpose(0, 2, 1, 3))  # back to [B,H,S,D]
+  def run(srcs, attrs2):
+    q, k, v = srcs
+    # to ANE layout (B, S, H, D)
+    qa = np.ascontiguousarray(np.asarray(q, np.float16).transpose(0, 2, 1, 3))
+    ka = np.ascontiguousarray(np.asarray(k, np.float16).transpose(0, 2, 1, 3))
+    va = np.ascontiguousarray(np.asarray(v, np.float16).transpose(0, 2, 1, 3))
+    (y_flat,) = worker.eval([qa, ka, va])
+    y_ane = y_flat.reshape(B, S, H, D)
+    return np.ascontiguousarray(y_ane.transpose(0, 2, 1, 3))  # back to [B,H,S,D]
 
-    return worker, run
+  return worker, run
 
 
 def _write_rank_netplist(wd: Path, layer_type: str, params: dict, *,
-                         channels: int, width: int, height: int = 1):
-    """Author a single-op rank netplist (Sort/TopK/ArgMinMax/GlobalArgMinMax) into
+             channels: int, width: int, height: int = 1):
+  """Author a single-op rank netplist (Sort/TopK/ArgMinMax/GlobalArgMinMax) into
     `wd` via the A1 bridge's own generator (`ane_rank_fused._build_plist`) so the
     worker sees byte-identical layout.  Returns (netplist_path, [weight])."""
-    import plistlib
-    from ._bridges import ane_rank_fused as rf  # the A1 bridge = the netplist author
-    plist = rf._build_plist(layer_type, params, width=width, height=height,
-                            channels=channels)
-    netplist = wd / "net.plist"
-    with netplist.open("wb") as f:
-      plistlib.dump(plist, f, fmt=plistlib.FMT_BINARY)
-    weight = wd / "weights.0"
-    weight.write_bytes(b"\x00" * 1024)
-    return netplist, [weight]
+  import plistlib
+  from ._bridges import ane_rank_fused as rf  # the A1 bridge = the netplist author
+  plist = rf._build_plist(layer_type, params, width=width, height=height,
+              channels=channels)
+  netplist = wd / "net.plist"
+  with netplist.open("wb") as f:
+    plistlib.dump(plist, f, fmt=plistlib.FMT_BINARY)
+  weight = wd / "weights.0"
+  weight.write_bytes(b"\x00" * 1024)
+  return netplist, [weight]
 
 
 def _build_argmax_worker(shape, attrs):
-    """Persistent GlobalArgMinMax (argmax).  `shape` is the input `[C, W]`; `attrs`
+  """Persistent GlobalArgMinMax (argmax).  `shape` is the input `[C, W]`; `attrs`
     has `axis` (1=Width, 0=Channel).  One loaded program, one eval per call.  Output
     matches the A1 `_run_argmax` contract: keepdims `[C,1]` for axis=1 (Width) or
     `[1,W]` for axis=0 (Channel)."""
-    C, W = shape
-    axis = attrs["axis"]
-    dim = "Width" if axis == 1 else "Channel"
-    params = {"Type": "Max", "Dimension": dim}
+  C, W = shape
+  axis = attrs["axis"]
+  dim = "Width" if axis == 1 else "Channel"
+  params = {"Type": "Max", "Dimension": dim}
 
-    workdir = tempfile.TemporaryDirectory(prefix="ane_argmax_worker_")
-    wd = Path(workdir.name)
-    netplist, weights = _write_rank_netplist(wd, "GlobalArgMinMax", params,
-                                             channels=C, width=W)
-    worker = _Worker(netplist, list(weights), ["x"], ["y"], workdir, op="argmax")
+  workdir = tempfile.TemporaryDirectory(prefix="ane_argmax_worker_")
+  wd = Path(workdir.name)
+  netplist, weights = _write_rank_netplist(wd, "GlobalArgMinMax", params,
+                       channels=C, width=W)
+  worker = _Worker(netplist, list(weights), ["x"], ["y"], workdir, op="argmax")
 
-    def run(srcs, attrs2):
-      (x,) = srcs
-      xa = np.ascontiguousarray(np.asarray(x, np.float16).reshape(C, W))
-      (y_flat,) = worker.eval([xa])
-      # GlobalArgMinMax(Width) -> one index per channel (C); Channel -> per width (W).
-      return y_flat.reshape((C, 1) if axis == 1 else (1, W))
+  def run(srcs, attrs2):
+    (x,) = srcs
+    xa = np.ascontiguousarray(np.asarray(x, np.float16).reshape(C, W))
+    (y_flat,) = worker.eval([xa])
+    # GlobalArgMinMax(Width) -> one index per channel (C); Channel -> per width (W).
+    return y_flat.reshape((C, 1) if axis == 1 else (1, W))
 
-    return worker, run
+  return worker, run
 
 
 def _build_topk_worker(shape, attrs):
-    """Persistent per-row TopK.  `shape` is the input `[C, W]`; `attrs` has `k` and
+  """Persistent per-row TopK.  `shape` is the input `[C, W]`; `attrs` has `k` and
     `largest`.  The native TopK keys *all* channels by ONE lane's order, so
     PyTorch-style per-row top-k requires each row run as its own 1-channel program.
     We load ONE 1-channel (channels=1, width=W, K=k) program and eval it C times (one
     row per eval), reproducing the A1 stack exactly.  Output is `[C, k]` values."""
-    C, W = shape
-    k, largest = attrs["k"], attrs["largest"]
-    params = {
-      "Type": "Max" if largest else "Min", "K": int(k),
-      "SortDimension": "Width", "VectorDimension": "Channel",
-      "SortIndices": [0],
-    }
+  C, W = shape
+  k, largest = attrs["k"], attrs["largest"]
+  params = {
+    "Type": "Max" if largest else "Min", "K": int(k),
+    "SortDimension": "Width", "VectorDimension": "Channel",
+    "SortIndices": [0],
+  }
 
-    workdir = tempfile.TemporaryDirectory(prefix="ane_topk_worker_")
-    wd = Path(workdir.name)
-    netplist, weights = _write_rank_netplist(wd, "TopK", params,
-                                             channels=1, width=W)
-    worker = _Worker(netplist, list(weights), ["x"], ["y"], workdir, op="topk")
+  workdir = tempfile.TemporaryDirectory(prefix="ane_topk_worker_")
+  wd = Path(workdir.name)
+  netplist, weights = _write_rank_netplist(wd, "TopK", params,
+                       channels=1, width=W)
+  worker = _Worker(netplist, list(weights), ["x"], ["y"], workdir, op="topk")
 
-    def run(srcs, attrs2):
-      (x,) = srcs
-      xa = np.ascontiguousarray(np.asarray(x, np.float16).reshape(C, W))
-      # note: the C row-tiles dispatch as C separate eval() round-trips, not one
-      # eval_batch(). Measured on M5 Pro, topk's per-call floor is set by the C
-      # sequential ANE evaluateWithQoS dispatches (~0.08 ms each), not by pipe
-      # round-trips (a single trip+eval is ~0.083 ms; the worker blocks on read and
-      # replies immediately, so the trip is ~free). Packing all C rows into one
-      # round-trip removes only the ~free trips and regresses the median (per-eval
-      # cost rose 0.079->0.28 ms at N=16) because the worker's back-to-back eval
-      # loop loses the pipe pacing that keeps the ANE warm. So we keep the per-call
-      # dispatch; eval_batch stays available (and bit-identical) when the round-trip
-      # truly dominates.
-      rows = [worker.eval([xa[c]])[0].reshape(k) for c in range(C)]
-      return np.stack(rows, axis=0)
+  def run(srcs, attrs2):
+    (x,) = srcs
+    xa = np.ascontiguousarray(np.asarray(x, np.float16).reshape(C, W))
+    # note: the C row-tiles dispatch as C separate eval() round-trips, not one
+    # eval_batch(). Measured on M5 Pro, topk's per-call floor is set by the C
+    # sequential ANE evaluateWithQoS dispatches (~0.08 ms each), not by pipe
+    # round-trips (a single trip+eval is ~0.083 ms; the worker blocks on read and
+    # replies immediately, so the trip is ~free). Packing all C rows into one
+    # round-trip removes only the ~free trips and regresses the median (per-eval
+    # cost rose 0.079->0.28 ms at N=16) because the worker's back-to-back eval
+    # loop loses the pipe pacing that keeps the ANE warm. So we keep the per-call
+    # dispatch; eval_batch stays available (and bit-identical) when the round-trip
+    # truly dominates.
+    rows = [worker.eval([xa[c]])[0].reshape(k) for c in range(C)]
+    return np.stack(rows, axis=0)
 
-    return worker, run
+  return worker, run
 
 
 # op name -> builder. Ops absent here have no worker route yet and fall back to
@@ -321,6 +321,6 @@ def has_worker(op: str) -> bool:
 
 
 def build_worker(op: str, shape, attrs):
-    """Return `(worker, run_fn)` for `op` at `shape`/`attrs`.  Raises
+  """Return `(worker, run_fn)` for `op` at `shape`/`attrs`.  Raises
     KeyError if no worker route exists for `op`."""
-    return _WORKER_BUILDERS[op](shape, attrs)
+  return _WORKER_BUILDERS[op](shape, attrs)

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -447,6 +447,7 @@ def measure(out, inputs, cfg, baseline_out=None, reps: int = 20, warmup: int = 5
   except Exception:
     return float("inf"), None
   try:
+    res = None
     for _ in range(warmup):
       res = net(*arrs)
     # correctness gate vs baseline

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -67,7 +67,7 @@ def graph_rewrite(out: Tensor, rules: list["Rule"], select: set[int] | None = No
 
 
 def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:
-    """Return a NEW output DAG with `rule` applied bottom-up to every node.
+  """Return a NEW output DAG with `rule` applied bottom-up to every node.
 
     `rule(node) -> Tensor | None`: a replacement for `node` (already built on the
     rewritten sources), or None to keep the rebuilt node as-is. The clone is memoized
@@ -76,74 +76,74 @@ def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:
     returned unchanged, so a no-op rule yields the SAME object - the optimizer relies
     on that to keep opt=0 byte-identical.
     """
-    # `rule` must be a pure node-local transform: it is called once in `match` and
-    # again in `build`, so a stateful/non-deterministic rule would be unsafe. The
-    # match-guard ensures `build` fires only when `rule` returns a Tensor (not None),
-    # which is why the build-lambda's None-able return is type-ignored as safe.
-    # cast: the match-guard (`rule(t) is not None`) guarantees build is only called
-    # when rule returns a Tensor, so the None-able return type is safe to narrow here.
-    r = Rule("adhoc", "lossless", lambda t: rule(t) is not None,
-             cast(Callable[[Tensor], Tensor], lambda t: rule(t)))
-    return graph_rewrite(out, [r])
+  # `rule` must be a pure node-local transform: it is called once in `match` and
+  # again in `build`, so a stateful/non-deterministic rule would be unsafe. The
+  # match-guard ensures `build` fires only when `rule` returns a Tensor (not None),
+  # which is why the build-lambda's None-able return is type-ignored as safe.
+  # cast: the match-guard (`rule(t) is not None`) guarantees build is only called
+  # when rule returns a Tensor, so the None-able return type is safe to narrow here.
+  r = Rule("adhoc", "lossless", lambda t: rule(t) is not None,
+       cast(Callable[[Tensor], Tensor], lambda t: rule(t)))
+  return graph_rewrite(out, [r])
 
 
 def _decompose_sdpa(node: Tensor) -> Tensor:
-    """Build the decomposed equivalent of an `sdpa` node from aneforge ops.
+  """Build the decomposed equivalent of an `sdpa` node from aneforge ops.
 
     Matches the reverse-engineering corpus's `dec` exactly:
         scores = (q @ k.transpose([0,1,3,2])) * scale
         a      = scores.softmax(-1)
         out    = a @ v
     q/k/v are [1, H, S, D]; the result is [1, H, S, D]. Pure fused MIL - no cut."""
-    q, k, v = node.srcs
-    scale = node.attrs["scale"]
-    scores = (q @ k.transpose([0, 1, 3, 2])) * float(scale)
-    a = scores.softmax(-1)
-    return a @ v
+  q, k, v = node.srcs
+  scale = node.attrs["scale"]
+  scores = (q @ k.transpose([0, 1, 3, 2])) * float(scale)
+  a = scores.softmax(-1)
+  return a @ v
 
 
 def sdpa_to_decomposed(out: Tensor, only_id: Optional[int] = None) -> Tensor:
-    """Rewrite native `sdpa` node(s) to the decomposed (fused-MIL) form.
+  """Rewrite native `sdpa` node(s) to the decomposed (fused-MIL) form.
 
     `only_id` (an `id()` of a node in the ORIGINAL graph) rewrites just that one
     sdpa node; None rewrites every sdpa node. Returns a new output DAG (the same
     object if there was nothing to rewrite)."""
-    sel = None if only_id is None else {only_id}
-    r = Rule("sdpa", "lossless", lambda t: t.op == "sdpa", _decompose_sdpa)
-    return graph_rewrite(out, [r], select=sel)
+  sel = None if only_id is None else {only_id}
+  r = Rule("sdpa", "lossless", lambda t: t.op == "sdpa", _decompose_sdpa)
+  return graph_rewrite(out, [r], select=sel)
 
 
 def list_sdpa_nodes(out: Tensor) -> list[Tensor]:
-    """The sdpa nodes in topo order (the coordinate-descent route axes)."""
-    from ._compile import _topo
-    return [t for t in _topo(out) if t.op == "sdpa"]
+  """The sdpa nodes in topo order (the coordinate-descent route axes)."""
+  from ._compile import _topo
+  return [t for t in _topo(out) if t.op == "sdpa"]
 
 
 def set_node_int8(out: Tensor, node_ids: set[int]) -> Tensor:
-    """Return a new DAG where each weight-bearing node whose `id()` is in
+  """Return a new DAG where each weight-bearing node whose `id()` is in
     `node_ids` carries an `int8=True` attr (per-weight int8 override). The
     compiler's `weight()` honors `t.attrs['int8']` over the global flag."""
-    if not node_ids: return out
-    r = Rule("int8", "numeric", lambda t: t.op in ("matmul", "conv"),
-             lambda t: Tensor(t.shape, t.op, t.srcs, {**t.attrs, "int8": True}))
-    return graph_rewrite(out, [r], select=set(node_ids))
+  if not node_ids: return out
+  r = Rule("int8", "numeric", lambda t: t.op in ("matmul", "conv"),
+       lambda t: Tensor(t.shape, t.op, t.srcs, {**t.attrs, "int8": True}))
+  return graph_rewrite(out, [r], select=set(node_ids))
 
 
 def list_weight_nodes(out: Tensor) -> list[Tensor]:
-    """Weight-bearing (int8-eligible) nodes in topo order: matmul (streamed `wt`) and
+  """Weight-bearing (int8-eligible) nodes in topo order: matmul (streamed `wt`) and
     conv (baked `weight`). Both honor per-channel int8 (constexpr_affine_dequantize)
     as a routable weight operand on the ANE."""
-    from ._compile import _topo
-    return [t for t in _topo(out)
-            if (t.op == "matmul" and isinstance(t.attrs.get("wt"), np.ndarray))
-            or (t.op == "conv" and isinstance(t.attrs.get("weight"), np.ndarray))]
+  from ._compile import _topo
+  return [t for t in _topo(out)
+      if (t.op == "matmul" and isinstance(t.attrs.get("wt"), np.ndarray))
+      or (t.op == "conv" and isinstance(t.attrs.get("weight"), np.ndarray))]
 
 
 # --------------------------------------------------------------------------- #
 # NUMERICS-aware rewrites (accuracy-improving, each validated vs fp32)          #
 # --------------------------------------------------------------------------- #
 def _reduce_sum_as_matmul(t: Tensor) -> Tensor:
-    """Rebuild a single `reduce_sum` node as a contraction against a ones-vector,
+  """Rebuild a single `reduce_sum` node as a contraction against a ones-vector,
     so the sum runs through the WIDE matmul accumulator instead of the NARROW
     reduce_sum accumulator. Mathematically identical (sum_k x_k == x @ 1), strictly
     >= accuracy under cancellation (fp16_envelope: comp_mm beats comp_rsum).
@@ -153,42 +153,42 @@ def _reduce_sum_as_matmul(t: Tensor) -> Tensor:
     non-last single axis we transpose the axis to the end, contract, and transpose
     back. Multi-axis sums are left to reduce_sum (the rewrite would need a reshape
     chain; not worth it, and the optimizer won't offer it)."""
-    src = t.srcs[0]
-    axes = tuple(t.attrs.get("axes", ()))
-    if len(axes) != 1:
-        return t                       # multi-axis: leave as-is (not offered)
-    (ax,) = axes
-    rank = len(src.shape)
-    ax = ax % rank
-    K = int(src.shape[ax])
-    ones = np.ones((K, 1), dtype=np.float16)
+  src = t.srcs[0]
+  axes = tuple(t.attrs.get("axes", ()))
+  if len(axes) != 1:
+    return t                       # multi-axis: leave as-is (not offered)
+  (ax,) = axes
+  rank = len(src.shape)
+  ax = ax % rank
+  K = int(src.shape[ax])
+  ones = np.ones((K, 1), dtype=np.float16)
 
-    if ax == rank - 1:
-        # x[..., K] @ ones[K, 1] -> [..., 1]   (keepdims, matches reduce_sum keep_dims)
-        return src @ ones
-    # move `ax` to the last position, contract, move the resulting size-1 dim back.
-    perm = [i for i in range(rank) if i != ax] + [ax]
-    inv = [0] * rank
-    for new_pos, old in enumerate(perm):
-        inv[old] = new_pos
-    contracted = src.transpose(perm) @ ones          # [..., 1] with ax-data last
-    return contracted.transpose(inv)                  # restore original axis order
+  if ax == rank - 1:
+    # x[..., K] @ ones[K, 1] -> [..., 1]   (keepdims, matches reduce_sum keep_dims)
+    return src @ ones
+  # move `ax` to the last position, contract, move the resulting size-1 dim back.
+  perm = [i for i in range(rank) if i != ax] + [ax]
+  inv = [0] * rank
+  for new_pos, old in enumerate(perm):
+    inv[old] = new_pos
+  contracted = src.transpose(perm) @ ones          # [..., 1] with ax-data last
+  return contracted.transpose(inv)                  # restore original axis order
 
 
 def reduce_sum_to_matmul(out: Tensor, only_idx: set[int] | None = None) -> Tensor:
-    """Rewrite single-axis `reduce_sum` node(s) to a `@ ones` matmul contraction
+  """Rewrite single-axis `reduce_sum` node(s) to a `@ ones` matmul contraction
     (the WIDE-accumulator sum). LOSSLESS-or-better: identical math, >= accuracy under
     cancellation. `only_idx` selects nodes by topo index in the ORIGINAL graph;
     None rewrites every eligible reduce_sum. Returns a new output DAG (same object if
     nothing matched)."""
-    from ._compile import _topo
-    order = _topo(out)
-    elig = lambda t: t.op == "reduce_sum" and len(t.attrs.get("axes", ())) == 1
-    if only_idx is None: sel = {id(t) for t in order if elig(t)}
-    else: sel = {id(order[i]) for i in only_idx if i < len(order) and elig(order[i])}
-    if not sel: return out
-    r = Rule("rsum_mm", "numeric", elig, _reduce_sum_as_matmul)
-    return graph_rewrite(out, [r], select=sel)
+  from ._compile import _topo
+  order = _topo(out)
+  elig = lambda t: t.op == "reduce_sum" and len(t.attrs.get("axes", ())) == 1
+  if only_idx is None: sel = {id(t) for t in order if elig(t)}
+  else: sel = {id(order[i]) for i in only_idx if i < len(order) and elig(order[i])}
+  if not sel: return out
+  r = Rule("rsum_mm", "numeric", elig, _reduce_sum_as_matmul)
+  return graph_rewrite(out, [r], select=sel)
 
 
 # --------------------------------------------------------------------------- #
@@ -199,32 +199,32 @@ def reduce_sum_to_matmul(out: Tensor, only_idx: set[int] | None = None) -> Tenso
 # one e5rt program (estimate() costs it cheaper accordingly).                       #
 # --------------------------------------------------------------------------- #
 def _decompose_minmax_norm(node: Tensor) -> Tensor:
-    """Build the fused equivalent of a `minmax_norm` node from _EMIT ops:
+  """Build the fused equivalent of a `minmax_norm` node from _EMIT ops:
         y = (x - amin(x, dim)) / (amax(x, dim) - amin(x, dim) + eps)
     over the reduction axis (Width=-1, Height=-2). reduce_min/reduce_max/sub/
     real_div are all fused; the `+ eps` is the scalar-add `adds` op. The native
     layer is bit-faithful to this formula (aneforge/_bridges/minmax_norm_fused.py header), so
     the rewrite is LOSSLESS: the two agree within fp16 op-noise (test_routes.py), and
     the degenerate max==min row yields 0/eps==0 on BOTH sides (no NaN divergence)."""
-    (x,) = node.srcs
-    ax = -1 if node.attrs["dimension"] == "Width" else -2
-    eps = float(node.attrs["eps"])
-    mn = x.amin(ax)
-    mx = x.amax(ax)
-    return (x - mn) / (mx - mn).adds(eps)
+  (x,) = node.srcs
+  ax = -1 if node.attrs["dimension"] == "Width" else -2
+  eps = float(node.attrs["eps"])
+  mn = x.amin(ax)
+  mx = x.amax(ax)
+  return (x - mn) / (mx - mn).adds(eps)
 
 
 def _flatten_to_reshape(node: Tensor) -> Tensor:
-    """Rebuild a `flatten` node (native Flatten bridge, [C,H,W] -> [prod]) as a plain
+  """Rebuild a `flatten` node (native Flatten bridge, [C,H,W] -> [prod]) as a plain
     fused `reshape` to the same 1-D shape. BIT-IDENTICAL (both are a contiguous
     row-major collapse - test_routes.py measures relerr 0.0), so it is LOSSLESS and
     removes the netplist cut entirely."""
-    (x,) = node.srcs
-    return x.reshape(node.shape)
+  (x,) = node.srcs
+  return x.reshape(node.shape)
 
 
 def _decompose_lrn(node: Tensor) -> Tensor:
-    """Rebuild an `lrn` node (native LocalResponseNormalization bridge, a graph cut)
+  """Rebuild an `lrn` node (native LocalResponseNormalization bridge, a graph cut)
     as the fused MIL `local_response_norm` op (one program, no cut). BIT-EQUIVALENT
     (test_routes.py measures cos 1.000000 / relerr 0.0 across C/alpha/beta/k): the
     bridge fixes the layer's channel window to N = C and divides the window sum by
@@ -235,11 +235,11 @@ def _decompose_lrn(node: Tensor) -> Tensor:
     where C = x.shape[1]. LOSSLESS, so the optimizer picks native-vs-fused purely by
     speed - and the fused route removes the cut (~1250x faster on a conv->lrn->relu
     block). The fused op also drops the C<16 cap the bridge carries."""
-    (x,) = node.srcs
-    C = node.shape[1]
-    a = node.attrs
-    from .graph import local_response_norm
-    return local_response_norm(x, size=C, alpha=a["alpha"] * C, beta=a["beta"], k=a["k"])
+  (x,) = node.srcs
+  C = node.shape[1]
+  a = node.attrs
+  from .graph import local_response_norm
+  return local_response_norm(x, size=C, alpha=a["alpha"] * C, beta=a["beta"], k=a["k"])
 
 
 # rewrite op-name -> (matched bridge op, decomposition builder). The route registry
@@ -247,30 +247,30 @@ def _decompose_lrn(node: Tensor) -> Tensor:
 # selectable; this table is just the executable builders, keyed identically.
 # Reconciled by tests/test_routes.py.
 _BRIDGE_DECOMPOSERS = {
-    "sdpa": _decompose_sdpa,
-    "minmax_norm": _decompose_minmax_norm,
-    "flatten": _flatten_to_reshape,
-    "lrn": _decompose_lrn,
+  "sdpa": _decompose_sdpa,
+  "minmax_norm": _decompose_minmax_norm,
+  "flatten": _flatten_to_reshape,
+  "lrn": _decompose_lrn,
 }
 
 
 def decompose_bridge(out: Tensor, decomp_idx: set[int]) -> Tensor:
-    """Rewrite the bridge nodes at the given ORIGINAL-graph topo indices to their fused
+  """Rewrite the bridge nodes at the given ORIGINAL-graph topo indices to their fused
     decomposition (sdpa/minmax_norm/flatten/lrn - see `_BRIDGE_DECOMPOSERS`). Walks the
     original graph so the indices are stable, rebuilding bottom-up. A node whose op has
     no registered decomposer is left as-is (single-route). Returns a new output DAG."""
-    from ._compile import _topo
-    order = _topo(out)
-    sel = {id(order[i]) for i in decomp_idx
-           if 0 <= i < len(order) and order[i].op in _BRIDGE_DECOMPOSERS}
-    if not sel: return out
-    r = Rule("bridge", "lossless", lambda t: t.op in _BRIDGE_DECOMPOSERS,
-             lambda t: _BRIDGE_DECOMPOSERS[t.op](t))
-    return graph_rewrite(out, [r], select=sel)
+  from ._compile import _topo
+  order = _topo(out)
+  sel = {id(order[i]) for i in decomp_idx
+       if 0 <= i < len(order) and order[i].op in _BRIDGE_DECOMPOSERS}
+  if not sel: return out
+  r = Rule("bridge", "lossless", lambda t: t.op in _BRIDGE_DECOMPOSERS,
+       lambda t: _BRIDGE_DECOMPOSERS[t.op](t))
+  return graph_rewrite(out, [r], select=sel)
 
 
 def paired_subtract(a, b):
-    """Carry a single `a - b` through paired-fp16 (compensated TwoSum), returning a
+  """Carry a single `a - b` through paired-fp16 (compensated TwoSum), returning a
     plain fp16 Tensor whose value is the best-fp16 result of the compensated subtract.
 
     This is the CFG-style cancellation fix from fp16_envelope: the compensated
@@ -281,10 +281,10 @@ def paired_subtract(a, b):
 
     Returns a Tensor (`.to_tensor()` of the Paired difference) so it drops straight
     into an existing fp16 graph at the hotspot."""
-    from ._paired import Paired, paired as _mk_paired
-    pa = a if isinstance(a, Paired) else _mk_paired(a)
-    pb = b if isinstance(b, Paired) else _mk_paired(b)
-    return (pa - pb).to_tensor()
+  from ._paired import Paired, paired as _mk_paired
+  pa = a if isinstance(a, Paired) else _mk_paired(a)
+  pb = b if isinstance(b, Paired) else _mk_paired(b)
+  return (pa - pb).to_tensor()
 
 
 # --------------------------------------------------------------------------- #

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 
 import math
 from dataclasses import dataclass
-from typing import Callable, Optional
+from typing import Any, Callable, Optional, cast
 
 import numpy as np
 
@@ -80,7 +80,10 @@ def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:
     # again in `build`, so a stateful/non-deterministic rule would be unsafe. The
     # match-guard ensures `build` fires only when `rule` returns a Tensor (not None),
     # which is why the build-lambda's None-able return is type-ignored as safe.
-    r = Rule("adhoc", "lossless", lambda t: rule(t) is not None, lambda t: rule(t))  # type: ignore[arg-type]
+    # cast: the match-guard (`rule(t) is not None`) guarantees build is only called
+    # when rule returns a Tensor, so the None-able return type is safe to narrow here.
+    r = Rule("adhoc", "lossless", lambda t: rule(t) is not None,
+             cast(Callable[[Tensor], Tensor], lambda t: rule(t)))
     return graph_rewrite(out, [r])
 
 
@@ -346,15 +349,16 @@ NUMERIC_RULES: list[Rule] = [
 # fp16 NumPy kernels for the foldable ops. Compute reproduces device fp16 where it can,
 # but is NEVER assumed bit-identical to the engine -> const_fold is gated (NUMERIC).
 def _f16(x: "np.ndarray") -> "np.ndarray": return np.asarray(x, np.float16)
-_EVAL: dict[str, "object"] = {
-  "muls":    lambda s, a: _f16(s[0] * _f16(a["k"])),
-  "adds":    lambda s, a: _f16(s[0] + _f16(a["k"])),
-  "add":     lambda s, a: _f16(s[0] + s[1]),
-  "sub":     lambda s, a: _f16(s[0] - s[1]),
-  "mul":     lambda s, a: _f16(s[0] * s[1]),
-  "relu":    lambda s, a: _f16(np.maximum(s[0], 0)),
-  "reshape": lambda s, a, shape=None: _f16(s[0].reshape(shape)),
-  "cast":    lambda s, a: _f16(s[0]),
+_EvalFn = Callable[["list[np.ndarray]", "dict[str, Any]", "tuple[int, ...]"], "np.ndarray"]
+_EVAL: dict[str, _EvalFn] = {
+  "muls":    lambda s, a, sh=(): _f16(s[0] * _f16(a["k"])),
+  "adds":    lambda s, a, sh=(): _f16(s[0] + _f16(a["k"])),
+  "add":     lambda s, a, sh=(): _f16(s[0] + s[1]),
+  "sub":     lambda s, a, sh=(): _f16(s[0] - s[1]),
+  "mul":     lambda s, a, sh=(): _f16(s[0] * s[1]),
+  "relu":    lambda s, a, sh=(): _f16(np.maximum(s[0], 0)),
+  "reshape": lambda s, a, sh=(): _f16(s[0].reshape(sh)),
+  "cast":    lambda s, a, sh=(): _f16(s[0]),
 }
 
 def _const_subgraph(t: Tensor, max_elems: int = 1 << 16) -> "np.ndarray | None":
@@ -366,10 +370,11 @@ def _const_subgraph(t: Tensor, max_elems: int = 1 << 16) -> "np.ndarray | None":
     if id(n) in memo: return memo[id(n)]
     if n.op == "const_array": memo[id(n)] = _f16(n.attrs["value"]); return memo[id(n)]
     if n.op == "input" or n.op not in _EVAL: memo[id(n)] = None; return None
-    srcs = [ev(s) for s in n.srcs]
-    if any(s is None for s in srcs): memo[id(n)] = None; return None
-    fn = _EVAL[n.op]  # type: ignore[index]
-    v: "np.ndarray" = fn(srcs, n.attrs, n.shape) if n.op == "reshape" else fn(srcs, n.attrs)  # type: ignore[operator]
+    srcs_maybe = [ev(s) for s in n.srcs]
+    if any(s is None for s in srcs_maybe): memo[id(n)] = None; return None
+    srcs = cast("list[np.ndarray]", srcs_maybe)
+    fn = _EVAL[n.op]
+    v: "np.ndarray" = fn(srcs, n.attrs, n.shape)
     memo[id(n)] = v; return v
   return ev(t)
 

--- a/aneforge/_targets.py
+++ b/aneforge/_targets.py
@@ -295,7 +295,7 @@ _HAL_FIELDS = {
 }
 
 
-def _field_for(name: str, family: int) -> int:
+def _field_for(name: str, family: int) -> int | None:
   table = _HAL_FIELDS[name]
   return next((table[t] for t in sorted(table, reverse=True) if int(family) >= int(t)), None)
 

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -4,13 +4,15 @@ updated host-side, no recompile)."""
 from __future__ import annotations
 
 import math
+from typing import Callable
 
 import numpy as np
 
 from . import graph
+from ._compile import Model as _Model
 from .graph import Tensor
 
-VJP: dict[str, "callable"] = {}
+VJP: dict[str, Callable] = {}
 
 
 def vjp(*names: str):
@@ -1198,6 +1200,7 @@ class Trainer:
     # the feature input is the non-trainable, non-target input whose per-sample
     # shape matches X (handles 2-D [B,D] MLP and N-D [B,...] CNN inputs).
     feat_shape = X.shape[1:]
+    assert isinstance(self._fwd, _Model)  # Trainer always compiles non-sdpa graphs
     xin = next(t for t in self._fwd._input_tensors
                if not t.attrs.get("trainable") and t is not getattr(self.ce, "target", None)
                and tuple(t.shape[1:]) == tuple(feat_shape))
@@ -1411,6 +1414,7 @@ class UnrolledTrainer:
       if pad:
         chunk = np.concatenate([chunk, np.zeros((pad, *chunk.shape[1:]), np.float32)])
       # eval inputs are [weight leaves..., xe]; feed masters then the chunk
+      assert isinstance(self._eval, _Model)  # UnrolledTrainer eval never uses sdpa nodes
       args = []
       for t in self._eval._input_tensors:
         args.append(feeds_w[self._ev_w.index(t)] if t in self._ev_w

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -1043,8 +1043,8 @@ class Trainer:
     mm = _c.compile_multi(outs)
     self._res = mm
     prog = mm.prog
-    self._res_in_name = {t: n for t, n in mm.input_ports}
-    self._res_out_name = {t: n for t, n in mm.output_ports}
+    self._res_in_name = dict(mm.input_ports)
+    self._res_out_name = dict(mm.output_ports)
     # alias each updated-state output onto its own input port (resident), then
     # seed the (now shared) buffers once - params to their masters, moments to 0.
     for out_t, in_t in alias:
@@ -1306,7 +1306,7 @@ class UnrolledTrainer:
         g = backward(mse(out, t_inputs[k]), P, loss_scale=self.scale)
       P, M, V = adam_step(P, M, V, g, lr_ins[k], (self.b1, self.b2), self.eps)
     self._net = _c.compile_multi([*P, *M, *V])
-    self._oname = {t: n for t, n in self._net.output_ports}
+    self._oname = dict(self._net.output_ports)
     self._P_out, self._M_out, self._V_out = P, M, V
     self._m_in, self._v_in, self._lr_ins = m_in, v_in, lr_ins
     # map each data input tensor -> (step k, 'x'|'t') for feeding

--- a/aneforge/dsp.py
+++ b/aneforge/dsp.py
@@ -47,6 +47,7 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import math
 import sys
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 
@@ -450,7 +451,7 @@ def iir_filter(x, b, a, n_taps: int = 256):
   # truncated impulse response: response of the IIR to a unit impulse, n_taps long.
   imp = np.zeros(n_taps, np.float64)
   imp[0] = 1.0
-  ir = ss.lfilter(b, a, imp).astype(np.float32)        # FIR approximation of the IIR
+  ir = ss.lfilter(b, a, imp).astype(np.float32)        # type: ignore[union-attr]  # lfilter returns ndarray; stubs over-constrain return
   return fir_filter(x, ir, mode="lfilter")
 
 
@@ -473,6 +474,7 @@ def _relerr(y, ref):
 
 
 def _selftest():
+  ss: Any = None  # pre-bound so pyright sees it as bound below (guarded by have_scipy)
   try:
     import scipy.signal as ss
     have_scipy = True
@@ -555,7 +557,7 @@ def _selftest():
     w = get_window("hann", win_len)
     # scipy stft scales by 1/sum(win); we compute raw windowed-FFT magnitude, so
     # compare against scipy's raw (scaling='spectrum' off): multiply scipy by sum(win).
-    f, tt, Zs = ss.stft(sx, nperseg=win_len, noverlap=win_len - hop, window=w,
+    f, tt, Zs = ss.stft(sx, nperseg=win_len, noverlap=win_len - hop, window=w,  # type: ignore[call-arg]  # stubs type window as str but ndarray is valid; boundary=None is valid at runtime
                         boundary=None, padded=False, return_onesided=True)
     mag_ref = np.abs(Zs) * w.sum()
     m = min(mag_ane.shape[1], mag_ref.shape[1])

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -58,7 +58,7 @@ from aneforge.graph import Tensor
 
 
 class EinsumUnsupported(NotImplementedError):
-    """Raised for einsum equations that cannot be lowered to ANE matmul/reduce ops
+  """Raised for einsum equations that cannot be lowered to ANE matmul/reduce ops
     (diagonal/trace via repeated indices, ellipsis, invented output dims)."""
 
 
@@ -67,48 +67,48 @@ class EinsumUnsupported(NotImplementedError):
 # --------------------------------------------------------------------------- #
 
 def _parse(equation: str, n_operands: int) -> tuple[list[str], str]:
-    """Return (input_subscripts, output_subscript). Implied output is the set of
+  """Return (input_subscripts, output_subscript). Implied output is the set of
     indices appearing exactly once, in alphabetical order (numpy's rule)."""
-    eq = equation.replace(" ", "")
-    if "..." in eq:
-        raise EinsumUnsupported("einsum: ellipsis '...' is not supported (v1)")
-    if "->" in eq:
-        lhs, rhs = eq.split("->")
-    else:
-        lhs, rhs = eq, None
-    ins = lhs.split(",")
-    if len(ins) != n_operands:
-        raise ValueError(f"einsum: equation '{equation}' has {len(ins)} operand(s) "
-                         f"but {n_operands} tensor(s) were given")
-    for s in ins:
-        for ch in s:
-            if not ch.isalpha():
-                raise ValueError(f"einsum: subscript '{s}' has a non-letter index {ch!r}")
-    if rhs is None:
-        counts = Counter("".join(ins))
-        rhs = "".join(sorted(ch for ch, c in counts.items() if c == 1))
-    else:
-        for ch in rhs:
-            if not ch.isalpha():
-                raise ValueError(f"einsum: output '{rhs}' has a non-letter index {ch!r}")
-        if len(set(rhs)) != len(rhs):
-            raise EinsumUnsupported(f"einsum: repeated output index in '{rhs}' "
-                                    f"(diagonal-write / broadcast-back needs gather; unsupported)")
-        all_in = set("".join(ins))
-        invented = [ch for ch in rhs if ch not in all_in]
-        if invented:
-            raise ValueError(f"einsum: output index {invented} not present in any input")
-    return ins, rhs
+  eq = equation.replace(" ", "")
+  if "..." in eq:
+    raise EinsumUnsupported("einsum: ellipsis '...' is not supported (v1)")
+  if "->" in eq:
+    lhs, rhs = eq.split("->")
+  else:
+    lhs, rhs = eq, None
+  ins = lhs.split(",")
+  if len(ins) != n_operands:
+    raise ValueError(f"einsum: equation '{equation}' has {len(ins)} operand(s) "
+             f"but {n_operands} tensor(s) were given")
+  for s in ins:
+    for ch in s:
+      if not ch.isalpha():
+        raise ValueError(f"einsum: subscript '{s}' has a non-letter index {ch!r}")
+  if rhs is None:
+    counts = Counter("".join(ins))
+    rhs = "".join(sorted(ch for ch, c in counts.items() if c == 1))
+  else:
+    for ch in rhs:
+      if not ch.isalpha():
+        raise ValueError(f"einsum: output '{rhs}' has a non-letter index {ch!r}")
+    if len(set(rhs)) != len(rhs):
+      raise EinsumUnsupported(f"einsum: repeated output index in '{rhs}' "
+                  f"(diagonal-write / broadcast-back needs gather; unsupported)")
+    all_in = set("".join(ins))
+    invented = [ch for ch in rhs if ch not in all_in]
+    if invented:
+      raise ValueError(f"einsum: output index {invented} not present in any input")
+  return ins, rhs
 
 
 def _reduce_repeats_check(sub: str) -> None:
-    """A repeated index within one operand is a diagonal extraction (gather)."""
-    if len(set(sub)) != len(sub):
-        dup = sorted({ch for ch in sub if sub.count(ch) > 1})
-        raise EinsumUnsupported(
-            f"einsum: repeated index {dup} within operand '{sub}' is a diagonal/trace "
-            f"extraction, which needs gather - unsupported on the ANE. "
-            f"(Reject rather than return wrong results.)")
+  """A repeated index within one operand is a diagonal extraction (gather)."""
+  if len(set(sub)) != len(sub):
+    dup = sorted({ch for ch in sub if sub.count(ch) > 1})
+    raise EinsumUnsupported(
+      f"einsum: repeated index {dup} within operand '{sub}' is a diagonal/trace "
+      f"extraction, which needs gather - unsupported on the ANE. "
+      f"(Reject rather than return wrong results.)")
 
 
 # --------------------------------------------------------------------------- #
@@ -116,27 +116,27 @@ def _reduce_repeats_check(sub: str) -> None:
 # --------------------------------------------------------------------------- #
 
 def _sum_to(t: Tensor, sub: str, keep: str) -> tuple[Tensor, str]:
-    """Sum `t` over the axes whose index is not in `keep`, then drop the size-1
+  """Sum `t` over the axes whose index is not in `keep`, then drop the size-1
     reduced axes via reshape (numpy keepdims=False semantics)."""
-    drop_axes = tuple(i for i, ch in enumerate(sub) if ch not in keep)
-    if not drop_axes: return t, sub
-    t = t.sum(drop_axes)                       # af.sum keeps dims (size 1)
-    new_sub = "".join(ch for i, ch in enumerate(sub) if i not in drop_axes)
-    # squeeze the reduced (size-1) axes out
-    t = t.reshape(*[t.shape[i] for i in range(len(sub)) if i not in drop_axes] or [1])
-    return t, new_sub
+  drop_axes = tuple(i for i, ch in enumerate(sub) if ch not in keep)
+  if not drop_axes: return t, sub
+  t = t.sum(drop_axes)                       # af.sum keeps dims (size 1)
+  new_sub = "".join(ch for i, ch in enumerate(sub) if i not in drop_axes)
+  # squeeze the reduced (size-1) axes out
+  t = t.reshape(*[t.shape[i] for i in range(len(sub)) if i not in drop_axes] or [1])
+  return t, new_sub
 
 
 def _align(t: Tensor, sub: str, order: str) -> Tensor:
-    """Transpose `t` so its indices appear in the index-order given by `order`
+  """Transpose `t` so its indices appear in the index-order given by `order`
     (a permutation of the letters of `sub`)."""
-    if list(sub) == list(order): return t
-    perm = [sub.index(ch) for ch in order]
-    return t.transpose(perm)
+  if list(sub) == list(order): return t
+  perm = [sub.index(ch) for ch in order]
+  return t.transpose(perm)
 
 
 def _size(t: Tensor, sub: str, ch: str) -> int:
-    return t.shape[sub.index(ch)]
+  return t.shape[sub.index(ch)]
 
 
 # --------------------------------------------------------------------------- #
@@ -144,87 +144,87 @@ def _size(t: Tensor, sub: str, ch: str) -> int:
 # --------------------------------------------------------------------------- #
 
 def _contract_pair(a: Tensor, sa: str, b: Tensor, sb: str, out: str) -> tuple[Tensor, str]:
-    """Contract operands a (sub sa) and b (sub sb) producing the indices in `out`
+  """Contract operands a (sub sa) and b (sub sb) producing the indices in `out`
     (the subset of sa|sb that must survive this step). Returns (tensor, its_sub)."""
-    _reduce_repeats_check(sa)
-    _reduce_repeats_check(sb)
+  _reduce_repeats_check(sa)
+  _reduce_repeats_check(sb)
 
-    set_a, set_b, set_out = set(sa), set(sb), set(out)
+  set_a, set_b, set_out = set(sa), set(sb), set(out)
 
-    # indices that this step must not keep can be summed away early if they live in
-    # only one operand (a partial reduce); shared ones are the contraction.
-    keep_a = set_a & (set_b | set_out)
-    keep_b = set_b & (set_a | set_out)
-    a, sa = _sum_to(a, sa, "".join(keep_a))
-    b, sb = _sum_to(b, sb, "".join(keep_b))
-    set_a, set_b = set(sa), set(sb)
+  # indices that this step must not keep can be summed away early if they live in
+  # only one operand (a partial reduce); shared ones are the contraction.
+  keep_a = set_a & (set_b | set_out)
+  keep_b = set_b & (set_a | set_out)
+  a, sa = _sum_to(a, sa, "".join(keep_a))
+  b, sb = _sum_to(b, sb, "".join(keep_b))
+  set_a, set_b = set(sa), set(sb)
 
-    batch = [ch for ch in sa if ch in set_b and ch in set_out]              # B
-    contract = [ch for ch in sa if ch in set_b and ch not in set_out]       # K
-    keepM = [ch for ch in sa if ch not in set_b]                            # M (a-only, in out)
-    keepN = [ch for ch in sb if ch not in set_a]                            # N (b-only, in out)
+  batch = [ch for ch in sa if ch in set_b and ch in set_out]              # B
+  contract = [ch for ch in sa if ch in set_b and ch not in set_out]       # K
+  keepM = [ch for ch in sa if ch not in set_b]                            # M (a-only, in out)
+  keepN = [ch for ch in sb if ch not in set_a]                            # N (b-only, in out)
 
-    # --- pure elementwise / outer (no contraction) ------------------------ #
-    if not contract: return _broadcast_mul(a, sa, b, sb, batch, keepM, keepN)
+  # --- pure elementwise / outer (no contraction) ------------------------ #
+  if not contract: return _broadcast_mul(a, sa, b, sb, batch, keepM, keepN)
 
-    # --- batched matmul path ---------------------------------------------- #
-    a = _align(a, sa, "".join(batch + keepM + contract))   # [B.., M.., K..]
-    b = _align(b, sb, "".join(batch + contract + keepN))   # [B.., K.., N..]
+  # --- batched matmul path ---------------------------------------------- #
+  a = _align(a, sa, "".join(batch + keepM + contract))   # [B.., M.., K..]
+  b = _align(b, sb, "".join(batch + contract + keepN))   # [B.., K.., N..]
 
-    Bdims = [a.shape[i] for i in range(len(batch))]
-    Mdims = [a.shape[len(batch) + i] for i in range(len(keepM))]
-    Kdims = [a.shape[len(batch) + len(keepM) + i] for i in range(len(contract))]
-    Ndims = [b.shape[len(batch) + len(contract) + i] for i in range(len(keepN))]
-    Bsz = int(np.prod(Bdims)) if Bdims else 1
-    Msz = int(np.prod(Mdims)) if Mdims else 1
-    Ksz = int(np.prod(Kdims)) if Kdims else 1
-    Nsz = int(np.prod(Ndims)) if Ndims else 1
+  Bdims = [a.shape[i] for i in range(len(batch))]
+  Mdims = [a.shape[len(batch) + i] for i in range(len(keepM))]
+  Kdims = [a.shape[len(batch) + len(keepM) + i] for i in range(len(contract))]
+  Ndims = [b.shape[len(batch) + len(contract) + i] for i in range(len(keepN))]
+  Bsz = int(np.prod(Bdims)) if Bdims else 1
+  Msz = int(np.prod(Mdims)) if Mdims else 1
+  Ksz = int(np.prod(Kdims)) if Kdims else 1
+  Nsz = int(np.prod(Ndims)) if Ndims else 1
 
-    if batch:
-        a3 = a.reshape(Bsz, Msz, Ksz); b3 = b.reshape(Bsz, Ksz, Nsz)
-        c = a3 @ b3                                        # bmm -> [Bsz, Msz, Nsz]
-    else:
-        a2 = a.reshape(Msz, Ksz); b2 = b.reshape(Ksz, Nsz)
-        c = a2 @ b2                                        # bmm 2D -> [Msz, Nsz]
+  if batch:
+    a3 = a.reshape(Bsz, Msz, Ksz); b3 = b.reshape(Bsz, Ksz, Nsz)
+    c = a3 @ b3                                        # bmm -> [Bsz, Msz, Nsz]
+  else:
+    a2 = a.reshape(Msz, Ksz); b2 = b.reshape(Ksz, Nsz)
+    c = a2 @ b2                                        # bmm 2D -> [Msz, Nsz]
 
-    res_sub = "".join(batch + keepM + keepN)
-    c = c.reshape(*(Bdims + Mdims + Ndims) or [1])
-    return c, res_sub
+  res_sub = "".join(batch + keepM + keepN)
+  c = c.reshape(*(Bdims + Mdims + Ndims) or [1])
+  return c, res_sub
 
 
 def _broadcast_mul(a: Tensor, sa: str, b: Tensor, sb: str,
-                   batch: list, keepM: list, keepN: list) -> tuple[Tensor, str]:
-    """No shared contracted index: result = elementwise/outer product. We align
+           batch: list, keepM: list, keepN: list) -> tuple[Tensor, str]:
+  """No shared contracted index: result = elementwise/outer product. We align
     both operands to [batch.., M.., N..] and broadcast-multiply (M absent in b,
     N absent in a appear as size-1 and broadcast)."""
-    res = batch + keepM + keepN
-    # build a-aligned tensor with size-1 placeholders for N dims
-    a = _align(a, sa, "".join([c for c in res if c in set(sa)]))
-    b = _align(b, sb, "".join([c for c in res if c in set(sb)]))
-    a = _expand_to(a, [c for c in res if c in set(sa)], res,
-                   {c: _len(a, [x for x in res if x in set(sa)], c) for c in sa})
-    b = _expand_to(b, [c for c in res if c in set(sb)], res,
-                   {c: _len(b, [x for x in res if x in set(sb)], c) for c in sb})
-    c = a * b
-    return c, "".join(res)
+  res = batch + keepM + keepN
+  # build a-aligned tensor with size-1 placeholders for N dims
+  a = _align(a, sa, "".join([c for c in res if c in set(sa)]))
+  b = _align(b, sb, "".join([c for c in res if c in set(sb)]))
+  a = _expand_to(a, [c for c in res if c in set(sa)], res,
+           {c: _len(a, [x for x in res if x in set(sa)], c) for c in sa})
+  b = _expand_to(b, [c for c in res if c in set(sb)], res,
+           {c: _len(b, [x for x in res if x in set(sb)], c) for c in sb})
+  c = a * b
+  return c, "".join(res)
 
 
 def _len(t: Tensor, present: list, ch: str) -> int:
-    return t.shape[present.index(ch)]
+  return t.shape[present.index(ch)]
 
 
 def _expand_to(t: Tensor, present: list, target: list, _sizes) -> Tensor:
-    """Reshape `t` (whose dims are `present`, a subsequence of `target`) to
+  """Reshape `t` (whose dims are `present`, a subsequence of `target`) to
     rank `len(target)` with size-1 at the missing positions, so it broadcasts."""
-    if list(present) == list(target): return t
-    shape = []
-    pi = 0
-    for ch in target:
-        if pi < len(present) and present[pi] == ch:
-            shape.append(t.shape[pi]); pi += 1
-        else:
-            shape.append(1)
-    return t.reshape(*shape)
+  if list(present) == list(target): return t
+  shape = []
+  pi = 0
+  for ch in target:
+    if pi < len(present) and present[pi] == ch:
+      shape.append(t.shape[pi]); pi += 1
+    else:
+      shape.append(1)
+  return t.reshape(*shape)
 
 
 # --------------------------------------------------------------------------- #
@@ -232,7 +232,7 @@ def _expand_to(t: Tensor, present: list, target: list, _sizes) -> Tensor:
 # --------------------------------------------------------------------------- #
 
 def einsum(equation: str, *operands: Tensor) -> Tensor:
-    """numpy-style `einsum` lowered to aneforge ops (matmul-reducible patterns).
+  """numpy-style `einsum` lowered to aneforge ops (matmul-reducible patterns).
 
     Supports: matmul (`ij,jk->ik`), batched matmul (`bij,bjk->bik`), transpose
     (`ij->ji`), outer product (`i,j->ij`), elementwise+reduce (`ij,ij->i`,
@@ -241,41 +241,41 @@ def einsum(equation: str, *operands: Tensor) -> Tensor:
 
     Rejects (`EinsumUnsupported`): diagonal/trace via repeated indices in one
     operand (`ii->i`, `ii->`), repeated output indices, and ellipsis."""
-    if not operands:
-        raise ValueError("einsum: at least one operand is required")
-    if not all(isinstance(o, Tensor) for o in operands):
-        raise TypeError("einsum: all operands must be aneforge Tensors (build them with af.input)")
+  if not operands:
+    raise ValueError("einsum: at least one operand is required")
+  if not all(isinstance(o, Tensor) for o in operands):
+    raise TypeError("einsum: all operands must be aneforge Tensors (build them with af.input)")
 
-    ins, out = _parse(equation, len(operands))
-    for s, t in zip(ins, operands):
-        if len(s) != len(t.shape):
-            raise ValueError(f"einsum: subscript '{s}' has {len(s)} indices but operand "
-                             f"shape {t.shape} has {len(t.shape)} dims")
-        _reduce_repeats_check(s)
+  ins, out = _parse(equation, len(operands))
+  for s, t in zip(ins, operands):
+    if len(s) != len(t.shape):
+      raise ValueError(f"einsum: subscript '{s}' has {len(s)} indices but operand "
+               f"shape {t.shape} has {len(t.shape)} dims")
+    _reduce_repeats_check(s)
 
-    # ---- single operand: pure transpose / reduce ------------------------- #
-    if len(operands) == 1:
-        t, sub = operands[0], ins[0]
-        t, sub = _sum_to(t, sub, out)            # drop summed indices
-        if sub == out: return t
-        return _align(t, sub, out)               # transpose to requested order
+  # ---- single operand: pure transpose / reduce ------------------------- #
+  if len(operands) == 1:
+    t, sub = operands[0], ins[0]
+    t, sub = _sum_to(t, sub, out)            # drop summed indices
+    if sub == out: return t
+    return _align(t, sub, out)               # transpose to requested order
 
-    # ---- multi-operand: left-fold pairwise ------------------------------- #
-    cur, csub = operands[0], ins[0]
-    for i in range(1, len(operands)):
-        nxt, nsub = operands[i], ins[i]
-        remaining = "".join(ins[i + 1:])
-        # indices we must keep after this pair: anything in the final output OR
-        # still needed by a later operand.
-        survive = set(out) | set(remaining)
-        step_out = "".join(dict.fromkeys(
-            [ch for ch in csub + nsub if ch in survive]))
-        cur, csub = _contract_pair(cur, csub, nxt, nsub, step_out)
+  # ---- multi-operand: left-fold pairwise ------------------------------- #
+  cur, csub = operands[0], ins[0]
+  for i in range(1, len(operands)):
+    nxt, nsub = operands[i], ins[i]
+    remaining = "".join(ins[i + 1:])
+    # indices we must keep after this pair: anything in the final output OR
+    # still needed by a later operand.
+    survive = set(out) | set(remaining)
+    step_out = "".join(dict.fromkeys(
+      [ch for ch in csub + nsub if ch in survive]))
+    cur, csub = _contract_pair(cur, csub, nxt, nsub, step_out)
 
-    # final: sum away any leftover non-output indices, then order to `out`
-    cur, csub = _sum_to(cur, csub, out)
-    if csub != out: cur = _align(cur, csub, out)
-    return cur
+  # final: sum away any leftover non-output indices, then order to `out`
+  cur, csub = _sum_to(cur, csub, out)
+  if csub != out: cur = _align(cur, csub, out)
+  return cur
 
 
 __all__ = ["EinsumUnsupported", "einsum"]

--- a/aneforge/fft.py
+++ b/aneforge/fft.py
@@ -115,11 +115,11 @@ def _dft_matrix(M: int):
     Used as a streamed fp16 weight: y = x @ W  (x is [.., M], W is [M, M])."""
     n = np.arange(M)
     k = n.reshape(-1, 1)
-    W = np.exp(-2j * np.pi * k * n / M)        # W[k,n]
+    W = np.exp(-2j * np.pi * k * n / M).astype(np.complex128)   # W[k,n]
     # we compute X[k] = sum_n x[n] W[k,n] = x @ W^T ; fold W^T as the weight.
     Wt = W.T                                   # [n, k] so x@Wt gives X[k]
-    Wt_re = Wt.real  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
-    Wt_im = Wt.imag  # type: ignore[union-attr]
+    Wt_re = Wt.real
+    Wt_im = Wt.imag
     return np.ascontiguousarray(Wt_re).astype(np.float16), \
            np.ascontiguousarray(Wt_im).astype(np.float16)
 
@@ -128,10 +128,10 @@ def _idft_matrix(M: int):
     """Inverse DFT twiddle (conjugate, UNSCALED): W[k,n] = exp(+2pi i k n / M)."""
     n = np.arange(M)
     k = n.reshape(-1, 1)
-    W = np.exp(+2j * np.pi * k * n / M)
+    W = np.exp(+2j * np.pi * k * n / M).astype(np.complex128)
     Wt = W.T
-    Wt_re = Wt.real  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
-    Wt_im = Wt.imag  # type: ignore[union-attr]
+    Wt_re = Wt.real
+    Wt_im = Wt.imag
     return np.ascontiguousarray(Wt_re).astype(np.float16), \
            np.ascontiguousarray(Wt_im).astype(np.float16)
 
@@ -200,10 +200,10 @@ class _Builder:
         `aux_values`, fed in creation order == the compiled input order)."""
         k1 = np.arange(N1).reshape(-1, 1)
         n2 = np.arange(restlen).reshape(1, -1)
-        T = np.exp(self.sign * 2j * np.pi * k1 * n2 / Ntot)   # [N1, restlen]
+        T = np.exp(self.sign * 2j * np.pi * k1 * n2 / Ntot).astype(np.complex128)   # [N1, restlen]
         Tr = af.input((N1, restlen)); Ti = af.input((N1, restlen))
         self.aux_inputs += [Tr, Ti]
-        self.aux_values += [T.real.astype(np.float16), T.imag.astype(np.float16)]  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
+        self.aux_values += [T.real.astype(np.float16), T.imag.astype(np.float16)]
         return Tr.reshape(*bshape), Ti.reshape(*bshape)
 
     def _axis_dft(self, re: Tensor, im: Tensor, axis: int, r: int):
@@ -490,9 +490,9 @@ def _naive_dft_relerr(N: int, xr: np.ndarray, xi: np.ndarray):
     computed in numpy with fp16-rounded inputs/twiddles and a wide accumulator - i.e.
     what the ANE's naive DFT-matmul produces. Lets us compare staged vs naive fp16."""
     n = np.arange(N); k = n.reshape(-1, 1)
-    W = np.exp(-2j * np.pi * k * n / N)
-    Wr = W.real.astype(np.float16).astype(np.float64)  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
-    Wi = W.imag.astype(np.float16).astype(np.float64)  # type: ignore[union-attr]
+    W = np.exp(-2j * np.pi * k * n / N).astype(np.complex128)
+    Wr = W.real.astype(np.float16).astype(np.float64)
+    Wi = W.imag.astype(np.float16).astype(np.float64)
     xr16 = xr.astype(np.float16).astype(np.float64)
     xi16 = xi.astype(np.float16).astype(np.float64)
     Xr = xr16 @ Wr.T - xi16 @ Wi.T

--- a/aneforge/fft.py
+++ b/aneforge/fft.py
@@ -88,14 +88,14 @@ from aneforge.graph import Tensor  # noqa: E402
 # A "cplx" is just a (re, im) tuple of aneforge Tensors with identical shape.
 
 def _cmatmul_const(re: Tensor, im: Tensor, Wr: np.ndarray, Wi: np.ndarray):
-    """Complex matmul (re+im*i) @ (Wr+Wi*i) where W is a fp16 constant matrix.
+  """Complex matmul (re+im*i) @ (Wr+Wi*i) where W is a fp16 constant matrix.
     Four real matmuls against streamed twiddle constants:
         Cre = re@Wr - im@Wi ;  Cim = re@Wi + im@Wr
     """
-    Wr = Wr.astype(np.float16); Wi = Wi.astype(np.float16)
-    Cre = (re @ Wr) - (im @ Wi)
-    Cim = (re @ Wi) + (im @ Wr)
-    return Cre, Cim
+  Wr = Wr.astype(np.float16); Wi = Wi.astype(np.float16)
+  Cre = (re @ Wr) - (im @ Wi)
+  Cim = (re @ Wi) + (im @ Wr)
+  return Cre, Cim
 
 
 # note on cross twiddles. They are data-shaped [N1,restlen] constants. The public
@@ -111,28 +111,28 @@ def _cmatmul_const(re: Tensor, im: Tensor, Wr: np.ndarray, Wi: np.ndarray):
 # --------------------------------------------------------------------------- #
 
 def _dft_matrix(M: int):
-    """The [M,M] DFT twiddle W[k,n] = exp(-2pi i k n / M), split into (Wr, Wi).
+  """The [M,M] DFT twiddle W[k,n] = exp(-2pi i k n / M), split into (Wr, Wi).
     Used as a streamed fp16 weight: y = x @ W  (x is [.., M], W is [M, M])."""
-    n = np.arange(M)
-    k = n.reshape(-1, 1)
-    W = np.exp(-2j * np.pi * k * n / M).astype(np.complex128)   # W[k,n]
-    # we compute X[k] = sum_n x[n] W[k,n] = x @ W^T ; fold W^T as the weight.
-    Wt = W.T                                   # [n, k] so x@Wt gives X[k]
-    Wt_re = Wt.real
-    Wt_im = Wt.imag
-    return np.ascontiguousarray(Wt_re).astype(np.float16), \
+  n = np.arange(M)
+  k = n.reshape(-1, 1)
+  W = np.exp(-2j * np.pi * k * n / M).astype(np.complex128)   # W[k,n]
+  # we compute X[k] = sum_n x[n] W[k,n] = x @ W^T ; fold W^T as the weight.
+  Wt = W.T                                   # [n, k] so x@Wt gives X[k]
+  Wt_re = Wt.real
+  Wt_im = Wt.imag
+  return np.ascontiguousarray(Wt_re).astype(np.float16), \
            np.ascontiguousarray(Wt_im).astype(np.float16)
 
 
 def _idft_matrix(M: int):
-    """Inverse DFT twiddle (conjugate, UNSCALED): W[k,n] = exp(+2pi i k n / M)."""
-    n = np.arange(M)
-    k = n.reshape(-1, 1)
-    W = np.exp(+2j * np.pi * k * n / M).astype(np.complex128)
-    Wt = W.T
-    Wt_re = Wt.real
-    Wt_im = Wt.imag
-    return np.ascontiguousarray(Wt_re).astype(np.float16), \
+  """Inverse DFT twiddle (conjugate, UNSCALED): W[k,n] = exp(+2pi i k n / M)."""
+  n = np.arange(M)
+  k = n.reshape(-1, 1)
+  W = np.exp(+2j * np.pi * k * n / M).astype(np.complex128)
+  Wt = W.T
+  Wt_re = Wt.real
+  Wt_im = Wt.imag
+  return np.ascontiguousarray(Wt_re).astype(np.float16), \
            np.ascontiguousarray(Wt_im).astype(np.float16)
 
 
@@ -156,20 +156,20 @@ def _prime_factors(N: int) -> list[int]:
 
 
 def _factor(N: int) -> list[int]:
-    """Factor N into AT MOST 3 balanced groups (each a dense-DFT matmul stage), so the
+  """Factor N into AT MOST 3 balanced groups (each a dense-DFT matmul stage), so the
     fully-split tensor stays rank<=4 (the ANE limit). Groups are made as close to N**(1/k)
     as possible (balanced -> minimal total matmul work). A prime (or near-prime) N falls
     back to a single dense DFT (one group == N)."""
-    primes = _prime_factors(N)
-    if len(primes) == 1: return [N]                                  # prime -> one dense DFT block
-    k = min(_MAX_GROUPS, len(primes))
-    groups = [1] * k
-    # greedy balanced bin-packing: assign largest primes first to the currently-smallest group
-    for p in sorted(primes, reverse=True):
-      i = min(range(k), key=lambda j: groups[j])
-      groups[i] *= p
-    groups.sort()
-    return groups
+  primes = _prime_factors(N)
+  if len(primes) == 1: return [N]                                  # prime -> one dense DFT block
+  k = min(_MAX_GROUPS, len(primes))
+  groups = [1] * k
+  # greedy balanced bin-packing: assign largest primes first to the currently-smallest group
+  for p in sorted(primes, reverse=True):
+    i = min(range(k), key=lambda j: groups[j])
+    groups[i] *= p
+  groups.sort()
+  return groups
 
 
 # --------------------------------------------------------------------------- #
@@ -177,20 +177,20 @@ def _factor(N: int) -> list[int]:
 # --------------------------------------------------------------------------- #
 
 class _Builder:
-    """Builds the staged FFT graph for one direction (forward or inverse).
+  """Builds the staged FFT graph for one direction (forward or inverse).
     Collects the cross-twiddle constant arrays as auxiliary graph inputs."""
 
-    def __init__(self, inverse: bool):
-      self.inverse = inverse
-      self.sign = +1.0 if inverse else -1.0
-      self.aux_inputs: list[Tensor] = []     # extra graph inputs (cross twiddles)
-      self.aux_values: list[np.ndarray] = []  # the constant arrays to feed
+  def __init__(self, inverse: bool):
+    self.inverse = inverse
+    self.sign = +1.0 if inverse else -1.0
+    self.aux_inputs: list[Tensor] = []     # extra graph inputs (cross twiddles)
+    self.aux_values: list[np.ndarray] = []  # the constant arrays to feed
 
-    def _dft(self, M: int):
-      return _idft_matrix(M) if self.inverse else _dft_matrix(M)
+  def _dft(self, M: int):
+    return _idft_matrix(M) if self.inverse else _dft_matrix(M)
 
-    def _cross(self, N1: int, restlen: int, Ntot: int, bshape):
-        """Cross twiddle T[k1, n2] = exp(sign*2pi i k1 n2 / Ntot) where k1 in [0,N1),
+  def _cross(self, N1: int, restlen: int, Ntot: int, bshape):
+    """Cross twiddle T[k1, n2] = exp(sign*2pi i k1 n2 / Ntot) where k1 in [0,N1),
         n2 in [0,restlen). Registered as a pair of graph INPUTS (the frontend has no
         free constant op; only matmul/conv weights fold, while elementwise mul needs
         two graph Tensors - an input IS a graph Tensor). Returned reshaped to `bshape`
@@ -198,16 +198,16 @@ class _Builder:
 
         The plan threads the constant arrays in automatically at call time (recorded in
         `aux_values`, fed in creation order == the compiled input order)."""
-        k1 = np.arange(N1).reshape(-1, 1)
-        n2 = np.arange(restlen).reshape(1, -1)
-        T = np.exp(self.sign * 2j * np.pi * k1 * n2 / Ntot).astype(np.complex128)   # [N1, restlen]
-        Tr = af.input((N1, restlen)); Ti = af.input((N1, restlen))
-        self.aux_inputs += [Tr, Ti]
-        self.aux_values += [T.real.astype(np.float16), T.imag.astype(np.float16)]
-        return Tr.reshape(*bshape), Ti.reshape(*bshape)
+    k1 = np.arange(N1).reshape(-1, 1)
+    n2 = np.arange(restlen).reshape(1, -1)
+    T = np.exp(self.sign * 2j * np.pi * k1 * n2 / Ntot).astype(np.complex128)   # [N1, restlen]
+    Tr = af.input((N1, restlen)); Ti = af.input((N1, restlen))
+    self.aux_inputs += [Tr, Ti]
+    self.aux_values += [T.real.astype(np.float16), T.imag.astype(np.float16)]
+    return Tr.reshape(*bshape), Ti.reshape(*bshape)
 
-    def _axis_dft(self, re: Tensor, im: Tensor, axis: int, r: int):
-        """DFT of radix `r` along `axis` of a fully-split tensor, realized as ONE
+  def _axis_dft(self, re: Tensor, im: Tensor, axis: int, r: int):
+    """DFT of radix `r` along `axis` of a fully-split tensor, realized as ONE
         transpose (move the axis last) + a complex matmul + ONE transpose (move back).
 
         IMPORTANT (ANE compiler workaround): each stage uses at most a SINGLE transpose
@@ -216,45 +216,45 @@ class _Builder:
         returns the correct VALUES in a permuted ORDER. Keeping the tensor fully split
         (never collapsing to 1-D between stages) with one isolated transpose per move
         sidesteps the bug entirely (verified on-device)."""
-        nd = len(re.shape)
-        perm = list(range(nd))
-        perm[axis], perm[nd - 1] = perm[nd - 1], perm[axis]
-        re = re.transpose(perm); im = im.transpose(perm)         # axis -> last
-        Wr, Wi = self._dft(r)
-        re, im = _cmatmul_const(re, im, Wr, Wi)                  # radix-r DFT (matmul)
-        re = re.transpose(perm); im = im.transpose(perm)         # last -> axis
-        return re, im
+    nd = len(re.shape)
+    perm = list(range(nd))
+    perm[axis], perm[nd - 1] = perm[nd - 1], perm[axis]
+    re = re.transpose(perm); im = im.transpose(perm)         # axis -> last
+    Wr, Wi = self._dft(r)
+    re, im = _cmatmul_const(re, im, Wr, Wi)                  # radix-r DFT (matmul)
+    re = re.transpose(perm); im = im.transpose(perm)         # last -> axis
+    return re, im
 
-    def _rec(self, re: Tensor, im: Tensor, axes: list[int], lengths: list[int]):
-        """Two-factor Cooley-Tukey unrolled over the split axes (decimation-in-time).
+  def _rec(self, re: Tensor, im: Tensor, axes: list[int], lengths: list[int]):
+    """Two-factor Cooley-Tukey unrolled over the split axes (decimation-in-time).
         Transforms the block formed by `axes` (total length prod(lengths)) in place,
         leaving the result on the SAME axes. Each level: one radix-N1 DFT on the first
         axis, a cross twiddle against the trailing block, then recurse the rest."""
-        if len(axes) == 1: return self._axis_dft(re, im, axes[0], lengths[0])
-        N1 = lengths[0]
-        restlen = int(np.prod(lengths[1:]))
-        Ntot = N1 * restlen
-        a0 = axes[0]
-        ndim = len(re.shape)
+    if len(axes) == 1: return self._axis_dft(re, im, axes[0], lengths[0])
+    N1 = lengths[0]
+    restlen = int(np.prod(lengths[1:]))
+    Ntot = N1 * restlen
+    a0 = axes[0]
+    ndim = len(re.shape)
 
-        # (1) radix-N1 DFT along the first axis (single transpose + matmul + transpose)
-        re, im = self._axis_dft(re, im, a0, N1)
+    # (1) radix-N1 DFT along the first axis (single transpose + matmul + transpose)
+    re, im = self._axis_dft(re, im, a0, N1)
 
-        # (2) cross twiddle T[k0, n2] over axis a0 (= k0) and the trailing block (= n2),
-        #     broadcast against the running tensor. bshape places N1 on axis a0 and the
-        #     trailing radices on their axes; 1 elsewhere.
-        bshape = [1] * ndim
-        bshape[a0] = N1
-        for ax, L in zip(axes[1:], lengths[1:]):
-          bshape[ax] = L
-        Tr, Ti = self._cross(N1, restlen, Ntot, bshape)
-        re, im = (re * Tr) - (im * Ti), (re * Ti) + (im * Tr)
+    # (2) cross twiddle T[k0, n2] over axis a0 (= k0) and the trailing block (= n2),
+    #     broadcast against the running tensor. bshape places N1 on axis a0 and the
+    #     trailing radices on their axes; 1 elsewhere.
+    bshape = [1] * ndim
+    bshape[a0] = N1
+    for ax, L in zip(axes[1:], lengths[1:]):
+      bshape[ax] = L
+    Tr, Ti = self._cross(N1, restlen, Ntot, bshape)
+    re, im = (re * Tr) - (im * Ti), (re * Ti) + (im * Tr)
 
-        # (3) recurse on the remaining axes
-        return self._rec(re, im, axes[1:], lengths[1:])
+    # (3) recurse on the remaining axes
+    return self._rec(re, im, axes[1:], lengths[1:])
 
-    def transform(self, re: Tensor, im: Tensor, N: int):
-        """Length-N FFT of the LAST axis of (re, im) (shape [1, N]); returns [1, N] in
+  def transform(self, re: Tensor, im: Tensor, N: int):
+    """Length-N FFT of the LAST axis of (re, im) (shape [1, N]); returns [1, N] in
         natural (numpy.fft) order.
 
         Multi-stage mixed-radix Cooley-Tukey on a FULLY-SPLIT tensor. With
@@ -266,36 +266,36 @@ class _Builder:
         in natural order, and one reshape collapses back to [1, N].
 
         Work ~ O(N * sum_k r_k)  <<  the dense DFT's O(N^2)."""
-        factors = _factor(N)
-        m = len(factors)
-        if m == 1:
-          Wr, Wi = self._dft(N)                               # single dense DFT
-          return _cmatmul_const(re, im, Wr, Wi)
+    factors = _factor(N)
+    m = len(factors)
+    if m == 1:
+      Wr, Wi = self._dft(N)                               # single dense DFT
+      return _cmatmul_const(re, im, Wr, Wi)
 
         # one reshape: [1, N] -> [1, r0, r1, ..., r_{m-1}]   (n0 most-significant digit)
-        re = re.reshape(1, *factors); im = im.reshape(1, *factors)
+    re = re.reshape(1, *factors); im = im.reshape(1, *factors)
 
-        re, im = self._rec(re, im, list(range(1, m + 1)), list(factors))
+    re, im = self._rec(re, im, list(range(1, m + 1)), list(factors))
 
-        # DIT output is in DIGIT-reversed order: reverse the split axes in ONE transpose.
-        rev = [0] + list(range(m, 0, -1))                       # [1, m, m-1, ..., 1]
-        re = re.transpose(rev); im = im.transpose(rev)
-        re = re.reshape(1, N); im = im.reshape(1, N)
-        return re, im
+    # DIT output is in DIGIT-reversed order: reverse the split axes in ONE transpose.
+    rev = [0] + list(range(m, 0, -1))                       # [1, m, m-1, ..., 1]
+    re = re.transpose(rev); im = im.transpose(rev)
+    re = re.reshape(1, N); im = im.reshape(1, N)
+    return re, im
 
 
 def _stage_count(N: int) -> int:
-    """Number of dense-DFT matmul stages emitted (== number of factor groups)."""
-    return len(_factor(N))
+  """Number of dense-DFT matmul stages emitted (== number of factor groups)."""
+  return len(_factor(N))
 
 
 def _leaf_cost(N: int) -> int:
-    """Total complex-matmul scalar work: each group g_i is a [g_i, g_i] DFT applied to
+  """Total complex-matmul scalar work: each group g_i is a [g_i, g_i] DFT applied to
     N/g_i independent rows, costing N*g_i MACs; total = N * sum_i g_i.
     The dense single DFT is N*N, so the staged build is ~N*sum(g) << N^2."""
-    groups = _factor(N)
-    if len(groups) == 1: return N * N
-    return N * sum(groups)
+  groups = _factor(N)
+  if len(groups) == 1: return N * N
+  return N * sum(groups)
 
 
 # --------------------------------------------------------------------------- #
@@ -303,44 +303,44 @@ def _leaf_cost(N: int) -> int:
 # --------------------------------------------------------------------------- #
 
 class Plan:
-    """A compiled staged-FFT program. Holds the e5rt Model plus the cross-twiddle
+  """A compiled staged-FFT program. Holds the e5rt Model plus the cross-twiddle
     constant arrays, which it threads in automatically on every call."""
 
-    def __init__(self, N: int, inverse: bool, real_input: bool):
-      self.N = N
-      self.inverse = inverse
-      self.real_input = real_input
-      b = _Builder(inverse)
-      # two user inputs: real and imag parts of the signal. For rfft the imag input is
-      # fed as zeros (kept as a declared input so the graph stays a pure function).
-      xr = af.input((1, N)); xi = af.input((1, N))
-      Xr, Xi = b.transform(xr, xi, N)
-      if inverse:
-        Xr = Xr * (1.0 / N)
-        Xi = Xi * (1.0 / N)
+  def __init__(self, N: int, inverse: bool, real_input: bool):
+    self.N = N
+    self.inverse = inverse
+    self.real_input = real_input
+    b = _Builder(inverse)
+    # two user inputs: real and imag parts of the signal. For rfft the imag input is
+    # fed as zeros (kept as a declared input so the graph stays a pure function).
+    xr = af.input((1, N)); xi = af.input((1, N))
+    Xr, Xi = b.transform(xr, xi, N)
+    if inverse:
+      Xr = Xr * (1.0 / N)
+      Xi = Xi * (1.0 / N)
       # one fused program with a single output: concat(re, im) -> [1, 2N], split on host
-      out = af.concat([Xr, Xi], axis=1)
-      self._aux_values = b.aux_values
-      self.n_stages = _stage_count(N)          # number of dense-DFT matmul stages (<=3)
-      # The DFT butterfly has exact-by-construction subtracts that trip the generic
-      # cancel_sub precision heuristic; this kernel is numerically verified (spectrum
-      # matches np.fft to fp16), so it vouches for itself and skips the check.
-      self.model = af.compile(out, _check_precision=False)
-      self.n_ops = self.model.n_ops
+    out = af.concat([Xr, Xi], axis=1)
+    self._aux_values = b.aux_values
+    self.n_stages = _stage_count(N)          # number of dense-DFT matmul stages (<=3)
+    # The DFT butterfly has exact-by-construction subtracts that trip the generic
+    # cancel_sub precision heuristic; this kernel is numerically verified (spectrum
+    # matches np.fft to fp16), so it vouches for itself and skips the check.
+    self.model = af.compile(out, _check_precision=False)
+    self.n_ops = self.model.n_ops
 
-    def __call__(self, x_re: np.ndarray, x_im: np.ndarray | None = None):
-      x_re = np.asarray(x_re, np.float16).reshape(1, self.N)
-      if x_im is None:
-        x_im = np.zeros((1, self.N), np.float16)
-      else:
-        x_im = np.asarray(x_im, np.float16).reshape(1, self.N)
-      out = self.model(x_re, x_im, *self._aux_values)
-      out = out.reshape(2, self.N)
-      return out[0].copy(), out[1].copy()
+  def __call__(self, x_re: np.ndarray, x_im: np.ndarray | None = None):
+    x_re = np.asarray(x_re, np.float16).reshape(1, self.N)
+    if x_im is None:
+      x_im = np.zeros((1, self.N), np.float16)
+    else:
+      x_im = np.asarray(x_im, np.float16).reshape(1, self.N)
+    out = self.model(x_re, x_im, *self._aux_values)
+    out = out.reshape(2, self.N)
+    return out[0].copy(), out[1].copy()
 
 
 class Plan2:
-    """A compiled 2-D FFT program for [M,N] complex fields - ONE fused e5rt program.
+  """A compiled 2-D FFT program for [M,N] complex fields - ONE fused e5rt program.
 
     The 2-D DFT is separable:  X_hat = F_M @ X @ F_N^T.  Applied to a whole matrix,
     each axis transform is a single complex matmul (a DFT of every row at once), NOT a
@@ -354,37 +354,37 @@ class Plan2:
     transpose sits between matmuls (the safe pattern; only transpose->reshape CHAINS
     mis-fuse - see _axis_dft)."""
 
-    def __init__(self, M: int, N: int, inverse: bool):
-      self.M, self.N, self.inverse = M, N, inverse
-      mk = _idft_matrix if inverse else _dft_matrix
-      WrN, WiN = mk(N)                                          # row twiddle (x @ Wt)
-      WrM, WiM = mk(M)                                          # column twiddle
-      if inverse:
+  def __init__(self, M: int, N: int, inverse: bool):
+    self.M, self.N, self.inverse = M, N, inverse
+    mk = _idft_matrix if inverse else _dft_matrix
+    WrN, WiN = mk(N)                                          # row twiddle (x @ Wt)
+    WrM, WiM = mk(M)                                          # column twiddle
+    if inverse:
         # Fold the 1/(M*N) normalization INTO the twiddles, 1/N on the row pass and
         # 1/M on the column pass - NOT one scale at the end. A real spectrum is large
         # (O(M*N) at the dominant modes), so an unscaled first-axis transform would
         # push intermediates past fp16 max (65504) and shred precision.
-        WrN, WiN = WrN * (1.0 / N), WiN * (1.0 / N)
-        WrM, WiM = WrM * (1.0 / M), WiM * (1.0 / M)
-      xr = af.input((M, N)); xi = af.input((M, N))
-      re, im = _cmatmul_const(xr, xi, WrN, WiN)                 # all M rows, one matmul
-      re = re.transpose([1, 0]); im = im.transpose([1, 0])      # columns -> rows
-      re, im = _cmatmul_const(re, im, WrM, WiM)                 # all N columns, one matmul
-      re = re.transpose([1, 0]); im = im.transpose([1, 0])
-      out = af.concat([re, im], axis=0)                          # [2M, N], split on host
-      # exact-by-construction DFT subtracts trip the generic cancel_sub heuristic;
-      # numerically verified vs np.fft.fft2 (tests/test_fft2.py), so it vouches for itself.
-      self.model = af.compile(out, _check_precision=False)
-      self.n_ops = self.model.n_ops
+      WrN, WiN = WrN * (1.0 / N), WiN * (1.0 / N)
+      WrM, WiM = WrM * (1.0 / M), WiM * (1.0 / M)
+    xr = af.input((M, N)); xi = af.input((M, N))
+    re, im = _cmatmul_const(xr, xi, WrN, WiN)                 # all M rows, one matmul
+    re = re.transpose([1, 0]); im = im.transpose([1, 0])      # columns -> rows
+    re, im = _cmatmul_const(re, im, WrM, WiM)                 # all N columns, one matmul
+    re = re.transpose([1, 0]); im = im.transpose([1, 0])
+    out = af.concat([re, im], axis=0)                          # [2M, N], split on host
+    # exact-by-construction DFT subtracts trip the generic cancel_sub heuristic;
+    # numerically verified vs np.fft.fft2 (tests/test_fft2.py), so it vouches for itself.
+    self.model = af.compile(out, _check_precision=False)
+    self.n_ops = self.model.n_ops
 
-    def __call__(self, x_re: np.ndarray, x_im: np.ndarray | None = None):
-      x_re = np.asarray(x_re, np.float16).reshape(self.M, self.N)
-      if x_im is None:
-        x_im = np.zeros((self.M, self.N), np.float16)
-      else:
-        x_im = np.asarray(x_im, np.float16).reshape(self.M, self.N)
-      out = self.model(x_re, x_im).reshape(2, self.M, self.N)
-      return out[0].copy(), out[1].copy()
+  def __call__(self, x_re: np.ndarray, x_im: np.ndarray | None = None):
+    x_re = np.asarray(x_re, np.float16).reshape(self.M, self.N)
+    if x_im is None:
+      x_im = np.zeros((self.M, self.N), np.float16)
+    else:
+      x_im = np.asarray(x_im, np.float16).reshape(self.M, self.N)
+    out = self.model(x_re, x_im).reshape(2, self.M, self.N)
+    return out[0].copy(), out[1].copy()
 
 
 # plan cache so repeated calls at the same N reuse the compiled program
@@ -426,48 +426,48 @@ def ifft2_plan(M: int, N: int) -> Plan2:
 # --------------------------------------------------------------------------- #
 
 def fft(x_re, x_im, N: int):
-    """Forward FFT of a complex signal (real/imag arrays), length N, on the ANE.
+  """Forward FFT of a complex signal (real/imag arrays), length N, on the ANE.
     Returns (X_re, X_im) numpy arrays of length N."""
-    return fft_plan(N)(x_re, x_im)
+  return fft_plan(N)(x_re, x_im)
 
 
 def ifft(X_re, X_im, N: int):
-    """Inverse FFT (1/N normalized) of a complex spectrum on the ANE.
+  """Inverse FFT (1/N normalized) of a complex spectrum on the ANE.
     Returns (x_re, x_im)."""
-    return ifft_plan(N)(X_re, X_im)
+  return ifft_plan(N)(X_re, X_im)
 
 
 def rfft(x_real, N: int):
-    """Forward FFT of a REAL signal (imag = 0) on the ANE. Returns the full-length
+  """Forward FFT of a REAL signal (imag = 0) on the ANE. Returns the full-length
     complex spectrum (X_re, X_im); the upper half is the conjugate mirror."""
-    return rfft_plan(N)(x_real, None)
+  return rfft_plan(N)(x_real, None)
 
 
 def fft2(x_re, x_im=None):
-    """2-D FFT of an [M,N] complex field on the ANE as ONE fused program
+  """2-D FFT of an [M,N] complex field on the ANE as ONE fused program
     (F_M @ X @ F_N^T as eight real GEMMs). x_im=None means a real field.
     Returns (X_re, X_im) [M,N] numpy arrays, np.fft.fft2 convention."""
-    x_re = np.asarray(x_re)
-    M, N = x_re.shape
-    return fft2_plan(M, N)(x_re, x_im)
+  x_re = np.asarray(x_re)
+  M, N = x_re.shape
+  return fft2_plan(M, N)(x_re, x_im)
 
 
 def ifft2(X_re, X_im):
-    """Inverse 2-D FFT (1/(M*N) normalized) on the ANE, one fused program.
+  """Inverse 2-D FFT (1/(M*N) normalized) on the ANE, one fused program.
     Returns (x_re, x_im), np.fft.ifft2 convention."""
-    X_re = np.asarray(X_re)
-    M, N = X_re.shape
-    return ifft2_plan(M, N)(X_re, X_im)
+  X_re = np.asarray(X_re)
+  M, N = X_re.shape
+  return ifft2_plan(M, N)(X_re, X_im)
 
 
 def magnitude(X_re, X_im):
-    """|X| = sqrt(re^2 + im^2) (numpy on host outputs)."""
-    return np.sqrt(np.asarray(X_re, np.float32) ** 2 + np.asarray(X_im, np.float32) ** 2)
+  """|X| = sqrt(re^2 + im^2) (numpy on host outputs)."""
+  return np.sqrt(np.asarray(X_re, np.float32) ** 2 + np.asarray(X_im, np.float32) ** 2)
 
 
 def power(X_re, X_im):
-    """|X|^2 power spectrum (numpy on host outputs)."""
-    return np.asarray(X_re, np.float32) ** 2 + np.asarray(X_im, np.float32) ** 2
+  """|X|^2 power spectrum (numpy on host outputs)."""
+  return np.asarray(X_re, np.float32) ** 2 + np.asarray(X_im, np.float32) ** 2
 
 
 __all__ = [
@@ -481,105 +481,105 @@ __all__ = [
 # --------------------------------------------------------------------------- #
 
 def _relerr(a, b):
-    a = np.asarray(a); b = np.asarray(b)
-    return float(np.linalg.norm(a - b) / (np.linalg.norm(b) + 1e-30))
+  a = np.asarray(a); b = np.asarray(b)
+  return float(np.linalg.norm(a - b) / (np.linalg.norm(b) + 1e-30))
 
 
 def _naive_dft_relerr(N: int, xr: np.ndarray, xi: np.ndarray):
-    """Reference: the single dense [N,N] DFT-matmul in fp16 (the previous approach),
+  """Reference: the single dense [N,N] DFT-matmul in fp16 (the previous approach),
     computed in numpy with fp16-rounded inputs/twiddles and a wide accumulator - i.e.
     what the ANE's naive DFT-matmul produces. Lets us compare staged vs naive fp16."""
-    n = np.arange(N); k = n.reshape(-1, 1)
-    W = np.exp(-2j * np.pi * k * n / N).astype(np.complex128)
-    Wr = W.real.astype(np.float16).astype(np.float64)
-    Wi = W.imag.astype(np.float16).astype(np.float64)
-    xr16 = xr.astype(np.float16).astype(np.float64)
-    xi16 = xi.astype(np.float16).astype(np.float64)
-    Xr = xr16 @ Wr.T - xi16 @ Wi.T
-    Xi = xr16 @ Wi.T + xi16 @ Wr.T
-    return Xr.ravel(), Xi.ravel()
+  n = np.arange(N); k = n.reshape(-1, 1)
+  W = np.exp(-2j * np.pi * k * n / N).astype(np.complex128)
+  Wr = W.real.astype(np.float16).astype(np.float64)
+  Wi = W.imag.astype(np.float16).astype(np.float64)
+  xr16 = xr.astype(np.float16).astype(np.float64)
+  xi16 = xi.astype(np.float16).astype(np.float64)
+  Xr = xr16 @ Wr.T - xi16 @ Wi.T
+  Xi = xr16 @ Wi.T + xi16 @ Wr.T
+  return Xr.ravel(), Xi.ravel()
 
 
 def _selftest():
-    rng = np.random.default_rng(20260530)
-    print("aneforge.fft - staged Cooley-Tukey FFT on the ANE (complex as real pairs)\n")
+  rng = np.random.default_rng(20260530)
+  print("aneforge.fft - staged Cooley-Tukey FFT on the ANE (complex as real pairs)\n")
 
-    Ns = [64, 256, 1024, 2048, 1536, 1280]
-    print(f"{'N':>6} {'factors':>16} {'stages':>7} {'n_ops':>6} "
+  Ns = [64, 256, 1024, 2048, 1536, 1280]
+  print(f"{'N':>6} {'factors':>16} {'stages':>7} {'n_ops':>6} "
           f"{'staged_relerr':>14} {'naiveDFT_relerr':>15} {'staged_cost':>12} {'naive N^2':>10} {'speedup':>8}")
-    print("-" * 110)
+  print("-" * 110)
 
-    all_ok = True
-    for N in Ns:
-        xr = rng.standard_normal(N).astype(np.float32)
-        xi = rng.standard_normal(N).astype(np.float32)
+  all_ok = True
+  for N in Ns:
+    xr = rng.standard_normal(N).astype(np.float32)
+    xi = rng.standard_normal(N).astype(np.float32)
 
-        # ANE staged FFT
-        plan = fft_plan(N)
-        Xr, Xi = plan(xr, xi)
+    # ANE staged FFT
+    plan = fft_plan(N)
+    Xr, Xi = plan(xr, xi)
 
-        # numpy golden
-        ref = np.fft.fft(xr.astype(np.float64) + 1j * xi.astype(np.float64))
-        staged_err = _relerr(Xr + 1j * Xi, ref)
+    # numpy golden
+    ref = np.fft.fft(xr.astype(np.float64) + 1j * xi.astype(np.float64))
+    staged_err = _relerr(Xr + 1j * Xi, ref)
 
-        # naive single-matrix fp16 DFT (the previous approach) for comparison
-        nr, ni = _naive_dft_relerr(N, xr, xi)
-        naive_err = _relerr(nr + 1j * ni, ref)
+    # naive single-matrix fp16 DFT (the previous approach) for comparison
+    nr, ni = _naive_dft_relerr(N, xr, xi)
+    naive_err = _relerr(nr + 1j * ni, ref)
 
-        cost = _leaf_cost(N)
-        naive = N * N
-        speedup = naive / cost
-        factors = _factor(N)
-        ok = staged_err < 0.02
-        all_ok &= ok
-        flag = "" if ok else "  <-- FAIL"
-        print(f"{N:>6} {str(factors):>16} {plan.n_stages:>7} {plan.n_ops:>6} "
+    cost = _leaf_cost(N)
+    naive = N * N
+    speedup = naive / cost
+    factors = _factor(N)
+    ok = staged_err < 0.02
+    all_ok &= ok
+    flag = "" if ok else "  <-- FAIL"
+    print(f"{N:>6} {str(factors):>16} {plan.n_stages:>7} {plan.n_ops:>6} "
               f"{staged_err:>14.3e} {naive_err:>15.3e} {cost:>12} {naive:>10} {speedup:>7.1f}x{flag}")
 
     # ---- rfft + magnitude check ----
-    print()
-    N = 1024
-    sig = rng.standard_normal(N).astype(np.float32)
-    Rr, Ri = rfft(sig, N)
-    ref = np.fft.fft(sig.astype(np.float64))
-    rfft_err = _relerr(Rr + 1j * Ri, ref)
-    mag_err = _relerr(magnitude(Rr, Ri), np.abs(ref))
-    print(f"rfft  N={N}: spectrum relerr {rfft_err:.3e}   |magnitude| relerr {mag_err:.3e}")
+  print()
+  N = 1024
+  sig = rng.standard_normal(N).astype(np.float32)
+  Rr, Ri = rfft(sig, N)
+  ref = np.fft.fft(sig.astype(np.float64))
+  rfft_err = _relerr(Rr + 1j * Ri, ref)
+  mag_err = _relerr(magnitude(Rr, Ri), np.abs(ref))
+  print(f"rfft  N={N}: spectrum relerr {rfft_err:.3e}   |magnitude| relerr {mag_err:.3e}")
 
-    # ---- ifft round-trip ----
-    N = 256
-    xr = rng.standard_normal(N).astype(np.float32)
-    xi = rng.standard_normal(N).astype(np.float32)
-    Xr, Xi = fft(xr, xi, N)
-    br, bi = ifft(Xr, Xi, N)
-    rt_err = _relerr(br + 1j * bi, xr + 1j * xi)
-    print(f"ifft  N={N}: round-trip fft->ifft relerr {rt_err:.3e}")
-    all_ok &= (rfft_err < 0.02 and rt_err < 0.05)
+  # ---- ifft round-trip ----
+  N = 256
+  xr = rng.standard_normal(N).astype(np.float32)
+  xi = rng.standard_normal(N).astype(np.float32)
+  Xr, Xi = fft(xr, xi, N)
+  br, bi = ifft(Xr, Xi, N)
+  rt_err = _relerr(br + 1j * bi, xr + 1j * xi)
+  print(f"ifft  N={N}: round-trip fft->ifft relerr {rt_err:.3e}")
+  all_ok &= (rfft_err < 0.02 and rt_err < 0.05)
 
-    # ---- complexity / accuracy verdict ----
-    print("\n" + "=" * 110)
-    print("VERDICT - staged matmul-FFT on the ANE")
-    print("-" * 110)
-    print("  * Every stage is a matmul (4 real matmuls per complex DFT block) + an")
-    print("    elementwise cross-twiddle multiply: ANE-native, fused into ONE e5rt program.")
-    print("  * 3-stage Cooley-Tukey (N = g0*g1*g2 balanced groups) cuts the scalar matmul")
-    print("    work from O(N^2) to N*(g0+g1+g2): e.g. N=1024 -> [8,8,16] => 32x fewer MACs,")
-    print("    N=2048 -> [8,16,16] => 51x. The speedup GROWS with N (sub-quadratic).")
-    print("  * WHY exactly 3 stages: the ANE caps transpose+matmul at rank-4 tensors, so the")
-    print("    fully-split FFT tensor [1,g0,g1,g2] can carry at most 3 factor groups. (A finer")
-    print("    log-depth radix-2 split would be rank > 4 and fails ANECCompile; and stacking")
-    print("    the recursive transpose->reshape collapses mis-fuses on this ANE - so we keep")
-    print("    the tensor fully-split with ONE isolated transpose per stage. Both are real")
-    print("    architectural walls, not numerics.)")
-    print("  * fp16 accuracy: staged ~5e-4..8e-4, FLAT in N (wide accumulator => the per-stage")
-    print("    sums don't compound). That is ~3x the naive single-DFT floor (~2.5e-4) - the")
-    print("    extra cross-twiddle multiplies add a little fp16 rounding - but still fp16-clean")
-    print("    to N=2048+. So staged is NOT more accurate than the dense DFT, but it IS far")
-    print("    cheaper (sub-quadratic) at the same precision class. Max usable N is bounded by")
-    print("    fp16 dynamic range (normalize by 1/sqrt(N) for power spectra), not by stage error.")
-    print(f"\n{'PASS' if all_ok else 'FAIL'} - staged Cooley-Tukey FFT validates vs numpy.fft on the ANE")
-    return 0 if all_ok else 1
+  # ---- complexity / accuracy verdict ----
+  print("\n" + "=" * 110)
+  print("VERDICT - staged matmul-FFT on the ANE")
+  print("-" * 110)
+  print("  * Every stage is a matmul (4 real matmuls per complex DFT block) + an")
+  print("    elementwise cross-twiddle multiply: ANE-native, fused into ONE e5rt program.")
+  print("  * 3-stage Cooley-Tukey (N = g0*g1*g2 balanced groups) cuts the scalar matmul")
+  print("    work from O(N^2) to N*(g0+g1+g2): e.g. N=1024 -> [8,8,16] => 32x fewer MACs,")
+  print("    N=2048 -> [8,16,16] => 51x. The speedup GROWS with N (sub-quadratic).")
+  print("  * WHY exactly 3 stages: the ANE caps transpose+matmul at rank-4 tensors, so the")
+  print("    fully-split FFT tensor [1,g0,g1,g2] can carry at most 3 factor groups. (A finer")
+  print("    log-depth radix-2 split would be rank > 4 and fails ANECCompile; and stacking")
+  print("    the recursive transpose->reshape collapses mis-fuses on this ANE - so we keep")
+  print("    the tensor fully-split with ONE isolated transpose per stage. Both are real")
+  print("    architectural walls, not numerics.)")
+  print("  * fp16 accuracy: staged ~5e-4..8e-4, FLAT in N (wide accumulator => the per-stage")
+  print("    sums don't compound). That is ~3x the naive single-DFT floor (~2.5e-4) - the")
+  print("    extra cross-twiddle multiplies add a little fp16 rounding - but still fp16-clean")
+  print("    to N=2048+. So staged is NOT more accurate than the dense DFT, but it IS far")
+  print("    cheaper (sub-quadratic) at the same precision class. Max usable N is bounded by")
+  print("    fp16 dynamic range (normalize by 1/sqrt(N) for power spectra), not by stage error.")
+  print(f"\n{'PASS' if all_ok else 'FAIL'} - staged Cooley-Tukey FFT validates vs numpy.fft on the ANE")
+  return 0 if all_ok else 1
 
 
 if __name__ == "__main__":
-    sys.exit(_selftest())
+  sys.exit(_selftest())

--- a/aneforge/fft.py
+++ b/aneforge/fft.py
@@ -73,6 +73,7 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 import sys
 from pathlib import Path
+from typing import cast
 
 import numpy as np
 
@@ -117,8 +118,10 @@ def _dft_matrix(M: int):
     W = np.exp(-2j * np.pi * k * n / M)        # W[k,n]
     # we compute X[k] = sum_n x[n] W[k,n] = x @ W^T ; fold W^T as the weight.
     Wt = W.T                                   # [n, k] so x@Wt gives X[k]
-    return np.ascontiguousarray(Wt.real).astype(np.float16), \
-           np.ascontiguousarray(Wt.imag).astype(np.float16)
+    Wt_re = Wt.real  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
+    Wt_im = Wt.imag  # type: ignore[union-attr]
+    return np.ascontiguousarray(Wt_re).astype(np.float16), \
+           np.ascontiguousarray(Wt_im).astype(np.float16)
 
 
 def _idft_matrix(M: int):
@@ -127,8 +130,10 @@ def _idft_matrix(M: int):
     k = n.reshape(-1, 1)
     W = np.exp(+2j * np.pi * k * n / M)
     Wt = W.T
-    return np.ascontiguousarray(Wt.real).astype(np.float16), \
-           np.ascontiguousarray(Wt.imag).astype(np.float16)
+    Wt_re = Wt.real  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
+    Wt_im = Wt.imag  # type: ignore[union-attr]
+    return np.ascontiguousarray(Wt_re).astype(np.float16), \
+           np.ascontiguousarray(Wt_im).astype(np.float16)
 
 
 # The ANE caps transpose+matmul at rank-4 (4D) tensors (verified on-device: rank>=5
@@ -198,7 +203,7 @@ class _Builder:
         T = np.exp(self.sign * 2j * np.pi * k1 * n2 / Ntot)   # [N1, restlen]
         Tr = af.input((N1, restlen)); Ti = af.input((N1, restlen))
         self.aux_inputs += [Tr, Ti]
-        self.aux_values += [T.real.astype(np.float16), T.imag.astype(np.float16)]
+        self.aux_values += [T.real.astype(np.float16), T.imag.astype(np.float16)]  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
         return Tr.reshape(*bshape), Ti.reshape(*bshape)
 
     def _axis_dft(self, re: Tensor, im: Tensor, axis: int, r: int):
@@ -383,37 +388,37 @@ class Plan2:
 
 
 # plan cache so repeated calls at the same N reuse the compiled program
-_PLAN_CACHE: dict[tuple, Plan] = {}
+_PLAN_CACHE: dict[tuple, Plan | Plan2] = {}
 
 
 def fft_plan(N: int) -> Plan:
   key = (N, False, False)
   if key not in _PLAN_CACHE: _PLAN_CACHE[key] = Plan(N, inverse=False, real_input=False)
-  return _PLAN_CACHE[key]
+  return cast(Plan, _PLAN_CACHE[key])
 
 
 def ifft_plan(N: int) -> Plan:
   key = (N, True, False)
   if key not in _PLAN_CACHE: _PLAN_CACHE[key] = Plan(N, inverse=True, real_input=False)
-  return _PLAN_CACHE[key]
+  return cast(Plan, _PLAN_CACHE[key])
 
 
 def rfft_plan(N: int) -> Plan:
   key = (N, False, True)
   if key not in _PLAN_CACHE: _PLAN_CACHE[key] = Plan(N, inverse=False, real_input=True)
-  return _PLAN_CACHE[key]
+  return cast(Plan, _PLAN_CACHE[key])
 
 
 def fft2_plan(M: int, N: int) -> Plan2:
   key = ("2d", M, N, False)
   if key not in _PLAN_CACHE: _PLAN_CACHE[key] = Plan2(M, N, inverse=False)
-  return _PLAN_CACHE[key]
+  return cast(Plan2, _PLAN_CACHE[key])
 
 
 def ifft2_plan(M: int, N: int) -> Plan2:
   key = ("2d", M, N, True)
   if key not in _PLAN_CACHE: _PLAN_CACHE[key] = Plan2(M, N, inverse=True)
-  return _PLAN_CACHE[key]
+  return cast(Plan2, _PLAN_CACHE[key])
 
 
 # --------------------------------------------------------------------------- #
@@ -486,8 +491,8 @@ def _naive_dft_relerr(N: int, xr: np.ndarray, xi: np.ndarray):
     what the ANE's naive DFT-matmul produces. Lets us compare staged vs naive fp16."""
     n = np.arange(N); k = n.reshape(-1, 1)
     W = np.exp(-2j * np.pi * k * n / N)
-    Wr = W.real.astype(np.float16).astype(np.float64)
-    Wi = W.imag.astype(np.float16).astype(np.float64)
+    Wr = W.real.astype(np.float16).astype(np.float64)  # type: ignore[union-attr]  # complex exp -> NDArray[Incomplete]; .real/.imag are valid
+    Wi = W.imag.astype(np.float16).astype(np.float64)  # type: ignore[union-attr]
     xr16 = xr.astype(np.float16).astype(np.float64)
     xi16 = xi.astype(np.float16).astype(np.float64)
     Xr = xr16 @ Wr.T - xi16 @ Wi.T

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -465,6 +465,7 @@ def image_input(shape: Sequence[int], scale: float = 1.0 / 255.0, bias=0.0) -> T
   if bi_v is not None:                                    # per-channel bias: broadcast add
     y = y + Tensor(bi_v.shape, "const_array", [], {"value": bi_v})
   elif bi_s != 0.0:
+    assert bi_s is not None
     y = y.adds(bi_s)
   return y
 
@@ -1197,8 +1198,7 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
         f"{[1, 1, q.shape[2], k.shape[2]]} (one mask for all heads, full query axis); "
         f"got {list(attn_mask.shape)}. Per-head masks (H>1) and query-broadcast "
         f"(Sq-axis=1 while q_seq>1) are not supported by the native layer.")
-  if scale is None:
-    scale = 1.0 / q.shape[-1] ** 0.5
+  _scale: float = scale if scale is not None else 1.0 / q.shape[-1] ** 0.5
   seq = max(q.shape[2], k.shape[2])               # attention spans the K/V (cached) length
   both = min(q.shape[2], k.shape[2])              # the native layer breaks when BOTH axes are large
   # Native fused-attention is reliable only inside this envelope; outside it returns garbage.
@@ -1226,7 +1226,7 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
     from . import _optimize as _opt
     n_tiles = _opt.attention_tiles(q.shape[2], q.shape[1], q.shape[3], T=k.shape[2])
     if n_tiles == 1:
-      scores = q @ kt * float(scale)
+      scores = q @ kt * float(_scale)
       if attn_mask is not None:
         scores = scores + attn_mask
       return scores.softmax(-1) @ v
@@ -1236,15 +1236,15 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
     for start in range(0, Sq, tile):
       n = min(tile, Sq - start)
       qt = q.slice_by_size([0, 0, start, 0], [q.shape[0], q.shape[1], n, q.shape[3]])
-      st = qt @ kt * float(scale)
+      st = qt @ kt * float(_scale)
       if attn_mask is not None:
         st = st + attn_mask.slice_by_size(
           [0, 0, start, 0], [attn_mask.shape[0], attn_mask.shape[1], n, attn_mask.shape[3]])
       out_tiles.append(st.softmax(-1) @ v)
     return concat(out_tiles, axis=2)
   if attn_mask is not None:                       # runtime mask rides the 5th bottom (stays native)
-    return Tensor(q.shape, "sdpa", [q, k, v, attn_mask], {"scale": float(scale), "masked": True})
-  return Tensor(q.shape, "sdpa", [q, k, v], {"scale": float(scale), "causal": bool(is_causal)})
+    return Tensor(q.shape, "sdpa", [q, k, v, attn_mask], {"scale": float(_scale), "masked": True})
+  return Tensor(q.shape, "sdpa", [q, k, v], {"scale": float(_scale), "causal": bool(is_causal)})
 
 
 def geglu(x: Tensor, W, b) -> Tensor:

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -701,7 +701,7 @@ def qr(A):
     z = rjj - rjj if z is None else z                      # exact-zero [1,1]
     Rcols.append(af.concat(rcol + [z] * (n - j - 1), axis=0))   # R column j -> [n,1]
   net = compile_multi([af.concat(Q, axis=1), af.concat(Rcols, axis=1)])
-  nm = {t: nme for t, nme in net.output_ports}
+  nm = dict(net.output_ports)
   out = net(A16)
   Qv = np.asarray(out[nm[net.output_tensors[0]]], np.float32)
   Rv = np.asarray(out[nm[net.output_tensors[1]]], np.float32)
@@ -746,7 +746,7 @@ def lu(A):
       for t in range(i): s = s - L[(k, t)] * U[(t, i)]
       L[(k, i)] = s / U[(i, i)]
   net = compile_multi([_grid(L, n, z), _grid(U, n, z)])
-  nm = {t: nme for t, nme in net.output_ports}
+  nm = dict(net.output_ports)
   out = net(A16)
   Lv = np.asarray(out[nm[net.output_tensors[0]]], np.float32)
   Uv = np.asarray(out[nm[net.output_tensors[1]]], np.float32)

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -69,6 +69,7 @@ Run the self-test:
 from __future__ import annotations
 
 import os
+from typing import Any
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 
 import numpy as np
@@ -111,7 +112,7 @@ def _ane_gemm(A16: np.ndarray, B16: np.ndarray, transpose_a: bool = False) -> np
 # host helpers                                                                 #
 # =========================================================================== #
 
-def _spectral_omega(A16: np.ndarray) -> float:
+def _spectral_omega(A16: np.ndarray | np.floating[Any]) -> float:
   """Richardson/Jacobi relaxation factor omega from the max abs row-sum (an
     upper bound on the spectral radius). Host-side scalar."""
   rowsum = np.abs(np.asarray(A16, np.float64)).sum(1).max()

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -13,12 +13,12 @@ import numpy as np
 
 from .graph import Tensor, conv, input, mha
 from .autograd import conv2d, conv_param, parameter
-from ._compile import Model, compile
+from ._compile import Model, SegmentedModel, compile
 
-_NORM_CACHE: dict[int, Model] = {}
+_NORM_CACHE: dict[int, Model | SegmentedModel] = {}
 
 
-def _l2_normalizer(D: int) -> Model:
+def _l2_normalizer(D: int) -> Model | SegmentedModel:
   """A tiny cached fused-ANE program that L2-normalizes a [1, D] vector over its
     last axis (the verified reduce_l2_norm + real_div path)."""
   net = _NORM_CACHE.get(D)
@@ -91,7 +91,7 @@ class Vision:
       idn = conv(x, wd, stride=stride, pad=0, bias=bd)
     return (out + idn).relu()
 
-  def _build(self) -> Model:
+  def _build(self) -> Model | SegmentedModel:
     x = input((1, 3, 224, 224))
     w, b = self._fold("conv1", "bn1")
     h = conv(x, w, stride=2, pad=3, bias=b).relu().max_pool(3, stride=2, pad=1)
@@ -147,9 +147,9 @@ class Encoder:
     self.eln_w, self.eln_b = g("embeddings.LayerNorm.weight"), g("embeddings.LayerNorm.bias")
     self.layers = [{k: g(f"encoder.layer.{i}." + v) for k, v in _BERT_KEYS.items()}
                    for i in range(self.L)]
-    self._cache: dict[int, Model] = {}
+    self._cache: dict[int, Model | SegmentedModel] = {}
 
-  def _build(self, S: int) -> Model:
+  def _build(self, S: int) -> Model | SegmentedModel:
     h = input((S, self.D))
     for w in self.layers:
       attn = mha(h, w["Wq"], w["bq"], w["Wk"], w["bk"], w["Wv"], w["bv"], w["Wo"], w["bo"], self.H)

--- a/aneforge/special.py
+++ b/aneforge/special.py
@@ -52,7 +52,7 @@ except ImportError:  # run directly as `python3 aneforge/special.py`
 # --------------------------------------------------------------------------- #
 
 def _const(like: Tensor, c: float) -> Tensor:
-    """A constant tensor of value `c` broadcasting against `like`.
+  """A constant tensor of value `c` broadcasting against `like`.
 
     There is no scalar-add op, but `exp(0) == 1` gives a ones tensor of the
     right shape for free (`like * 0` is the zeros), and `* c` scales it. So
@@ -63,23 +63,23 @@ def _const(like: Tensor, c: float) -> Tensor:
     cos-based constant would silently break this whole module on M1/H13 - and
     `special.cos` below is one of the things that must run there.
     """
-    return (like * 0.0).exp() * float(c)
+  return (like * 0.0).exp() * float(c)
 
 
 def _horner(x: Tensor, coeffs) -> Tensor:
-    """Evaluate `coeffs[0]*x^n + ... + coeffs[-1]` by Horner's rule as a fused
+  """Evaluate `coeffs[0]*x^n + ... + coeffs[-1]` by Horner's rule as a fused
     mul/add chain. `coeffs` is highest-degree first (numpy `polyfit` order).
     """
-    acc = _const(x, coeffs[0])
-    for c in coeffs[1:]:
-        acc = acc * x + _const(x, c)
-    return acc
+  acc = _const(x, coeffs[0])
+  for c in coeffs[1:]:
+    acc = acc * x + _const(x, c)
+  return acc
 
 
 def _poly_in(x2: Tensor, coeffs_low_first) -> Tensor:
-    """Horner in `x2` with coefficients given LOW-degree first (the natural
+  """Horner in `x2` with coefficients given LOW-degree first (the natural
     order for the Abramowitz-Stegun series `c0 + c1 t + c2 t^2 + ...`)."""
-    return _horner(x2, list(coeffs_low_first)[::-1])
+  return _horner(x2, list(coeffs_low_first)[::-1])
 
 
 # --------------------------------------------------------------------------- #
@@ -107,20 +107,20 @@ _COS_Q = [1.0, -0.4999308182201791, 0.041511585587052556, -0.0012786608784929124
 
 
 def sin(x: Tensor) -> Tensor:
-    """`sin(x)` for x in [-pi/2, pi/2] as a fused fp16 polynomial (`x * P(x^2)`).
+  """`sin(x)` for x in [-pi/2, pi/2] as a fused fp16 polynomial (`x * P(x^2)`).
 
     Portable trig: only mul/sub/exp, so it runs on ANE families lacking the native
     sin op (A15+), M1/H13 included. Outside [-pi/2, pi/2] reduce the argument on the
     host first (the static graph has no data-dependent range reduction)."""
-    return x * _poly_in(x * x, _SIN_P)
+  return x * _poly_in(x * x, _SIN_P)
 
 
 def cos(x: Tensor) -> Tensor:
-    """`cos(x)` for x in [-pi/2, pi/2] as a fused fp16 polynomial (`Q(x^2)`).
+  """`cos(x)` for x in [-pi/2, pi/2] as a fused fp16 polynomial (`Q(x^2)`).
 
     Portable companion to `sin` above - native cos is A15+, this runs everywhere
     M1 included. Reduce arguments outside [-pi/2, pi/2] on the host."""
-    return _poly_in(x * x, _COS_Q)
+  return _poly_in(x * x, _COS_Q)
 
 
 # --------------------------------------------------------------------------- #
@@ -136,17 +136,17 @@ _ERFC_A = [0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429]
 
 
 def erfc(x: Tensor) -> Tensor:
-    """Complementary error function `erfc(x) = 1 - erf(x)` for `x >= 0`.
+  """Complementary error function `erfc(x) = 1 - erf(x)` for `x >= 0`.
 
     Direct rational*exp form (A&S 7.1.26) - does NOT cancel for large x, unlike
     `1 - native_erf`. Valid for x in [0, ~6] (erfc decays smoothly; the exp
     underflows to 0 past x~6, the correct limit). For x<0 use the identity
     erfc(-x)=2-erfc(x) on the host (a branch the static graph can't do).
     """
-    t = _const(x, 1.0) / (_const(x, 1.0) + x * _ERFC_P)
-    # poly(t) = (((a4 t + a3) t + a2) t + a1) t + a0) * t   -> a0..a4 low-first, then *t
-    poly = _poly_in(t, _ERFC_A) * t
-    return poly * (x * x * -1.0).exp()
+  t = _const(x, 1.0) / (_const(x, 1.0) + x * _ERFC_P)
+  # poly(t) = (((a4 t + a3) t + a2) t + a1) t + a0) * t   -> a0..a4 low-first, then *t
+  poly = _poly_in(t, _ERFC_A) * t
+  return poly * (x * x * -1.0).exp()
 
 
 # --------------------------------------------------------------------------- #
@@ -154,12 +154,12 @@ def erfc(x: Tensor) -> Tensor:
 # --------------------------------------------------------------------------- #
 
 def expm1(x: Tensor) -> Tensor:
-    """`exp(x) - 1` accurate near 0 (where `exp(x)-1` cancels). Taylor
+  """`exp(x) - 1` accurate near 0 (where `exp(x)-1` cancels). Taylor
     `x(1 + x/2 + x^2/6 + ... + x^5/720)` - valid for |x| <= ~0.7. Outside that,
     use `x.exp()` and subtract 1 with `_const` (no cancellation there)."""
-    # x * (1 + x(1/2 + x(1/6 + x(1/24 + x(1/120 + x/720)))))
-    inner = _horner(x, [1.0 / 720, 1.0 / 120, 1.0 / 24, 1.0 / 6, 0.5, 1.0])
-    return x * inner
+  # x * (1 + x(1/2 + x(1/6 + x(1/24 + x(1/120 + x/720)))))
+  inner = _horner(x, [1.0 / 720, 1.0 / 120, 1.0 / 24, 1.0 / 6, 0.5, 1.0])
+  return x * inner
 
 
 _LOG1P_RATIO = [-0.052037525556684096, 0.15799617916430397, -0.20925805696435787,
@@ -168,10 +168,10 @@ _LOG1P_RATIO = [-0.052037525556684096, 0.15799617916430397, -0.20925805696435787
 
 
 def log1p(x: Tensor) -> Tensor:
-    """`log(1 + x)` accurate near 0 (where `log(1+x)` cancels). Evaluated as
+  """`log(1 + x)` accurate near 0 (where `log(1+x)` cancels). Evaluated as
     `x * poly(x)` with a deg-7 minimax of `log1p(x)/x` - valid for x in
     [-0.5, 1.0]. The `x*` factor keeps it exact at 0."""
-    return x * _horner(x, _LOG1P_RATIO)
+  return x * _horner(x, _LOG1P_RATIO)
 
 
 # --------------------------------------------------------------------------- #
@@ -197,15 +197,15 @@ _GAMMA_12 = [0.07271315700819278, -0.09524680924569022, 0.14250568218370452,
 
 
 def lgamma(x: Tensor) -> Tensor:
-    """Log-gamma `log|Gamma(x)|` for x in [1, 8] via a deg-8 minimax in the
+  """Log-gamma `log|Gamma(x)|` for x in [1, 8] via a deg-8 minimax in the
     centered variable (x-4.5). Accurate in ABSOLUTE terms (~3e-3); relative error
     is large only at the zeros x=1, x=2 where lgamma -> 0 (relative error is
     ill-defined there)."""
-    return _horner(x + _const(x, -_LGAMMA_C), _LGAMMA)
+  return _horner(x + _const(x, -_LGAMMA_C), _LGAMMA)
 
 
 def gamma(x: Tensor) -> Tensor:
-    """Gamma function on x in [1, 2] via a deg-6 minimax in the centered variable
+  """Gamma function on x in [1, 2] via a deg-6 minimax in the centered variable
     (x-1.5).
 
     SCOPE: gamma grows super-exponentially and overflows fp16 (>65504)
@@ -215,14 +215,14 @@ def gamma(x: Tensor) -> Tensor:
     still-fp16-bounded range use `gamma_via_lgamma` (x in [1, ~7.5]), which routes
     through `exp(lgamma(x))` instead.
     """
-    return _horner(x + _const(x, -_GAMMA_C), _GAMMA_12)
+  return _horner(x + _const(x, -_GAMMA_C), _GAMMA_12)
 
 
 def gamma_via_lgamma(x: Tensor) -> Tensor:
-    """`Gamma(x) = exp(lgamma(x))` for x in [1, ~7.5] (output stays under the
+  """`Gamma(x) = exp(lgamma(x))` for x in [1, ~7.5] (output stays under the
     fp16 max). Wider range than `gamma` at a small accuracy cost (the exp
     re-rounds)."""
-    return lgamma(x).exp()
+  return lgamma(x).exp()
 
 
 # --------------------------------------------------------------------------- #
@@ -238,31 +238,31 @@ _K0 = [-0.57721566, 0.42278420, 0.23069756, 0.03488590, 0.00262698, 0.00010750, 
 
 
 def bessel_j0(x: Tensor) -> Tensor:
-    """Bessel J0(x) for |x| <= 3 (A&S 9.4.1 polynomial in (x/3)^2). Smooth,
+  """Bessel J0(x) for |x| <= 3 (A&S 9.4.1 polynomial in (x/3)^2). Smooth,
     bounded; the dominant first lobe and first zero (x~2.405) are in range."""
-    t = (x * x) * (1.0 / 9.0)
-    return _poly_in(t, _J0)
+  t = (x * x) * (1.0 / 9.0)
+  return _poly_in(t, _J0)
 
 
 def bessel_i0(x: Tensor) -> Tensor:
-    """Modified Bessel I0(x) for |x| <= 3.75 (A&S 9.8.1 in (x/3.75)^2). I0 grows
+  """Modified Bessel I0(x) for |x| <= 3.75 (A&S 9.8.1 in (x/3.75)^2). I0 grows
     exponentially and overflows fp16 past x~12, so this small-argument branch is
     the fp16-useful range."""
-    t = (x * x) * (1.0 / (3.75 * 3.75))
-    return _poly_in(t, _I0)
+  t = (x * x) * (1.0 / (3.75 * 3.75))
+  return _poly_in(t, _I0)
 
 
 def bessel_k0(x: Tensor) -> Tensor:
-    """Modified Bessel K0(x) for 0 < x <= 2 (A&S 9.8.5):
+  """Modified Bessel K0(x) for 0 < x <= 2 (A&S 9.8.5):
     `K0(x) = -ln(x/2) I0(x) + series((x/2)^2)`. K0 has a -ln singularity at 0,
     so x must be strictly positive (and not tiny: log underflow). I0 here reuses
     the 9.8.1 polynomial (in (x/3.75)^2), valid through x=2; the K0 series part is
     in (x/2)^2 -- the two use DIFFERENT scaled arguments."""
-    half = x * 0.5
-    t_k0 = half * half                       # (x/2)^2  for the K0 series
-    t_i0 = (x * x) * (1.0 / (3.75 * 3.75))    # (x/3.75)^2 for the I0 factor
-    i0 = _poly_in(t_i0, _I0)
-    return half.log() * (i0 * -1.0) + _poly_in(t_k0, _K0)
+  half = x * 0.5
+  t_k0 = half * half                       # (x/2)^2  for the K0 series
+  t_i0 = (x * x) * (1.0 / (3.75 * 3.75))    # (x/3.75)^2 for the I0 factor
+  i0 = _poly_in(t_i0, _I0)
+  return half.log() * (i0 * -1.0) + _poly_in(t_k0, _K0)
 
 
 # --------------------------------------------------------------------------- #
@@ -270,7 +270,7 @@ def bessel_k0(x: Tensor) -> Tensor:
 # --------------------------------------------------------------------------- #
 
 def exp_wide(x: Tensor, splits: int = 1) -> Tensor:
-    """exp for wide `x` via argument splitting:
+  """exp for wide `x` via argument splitting:
     `exp(x) = (exp(x / 2^splits)) ^ (2^splits)` by repeated squaring (the inner
     `exp` runs on a smaller argument).
 
@@ -282,13 +282,13 @@ def exp_wide(x: Tensor, splits: int = 1) -> Tensor:
     caps exp at x~11 regardless of method - splitting can never extend the range,
     only (at best marginally) trade accuracy.
     """
-    e = (x * (1.0 / (1 << splits))).exp()
-    for _ in range(splits): e = e * e
-    return e
+  e = (x * (1.0 / (1 << splits))).exp()
+  for _ in range(splits): e = e * e
+  return e
 
 
 def log_wide(x: Tensor, sqrts: int = 3) -> Tensor:
-    """log for wide positive `x` via `log(x) = 2^sqrts * log(x^(1/2^sqrts))`.
+  """log for wide positive `x` via `log(x) = 2^sqrts * log(x^(1/2^sqrts))`.
     Repeated square roots pull a large argument toward 1, where log is most
     accurate, then scale back.
 
@@ -296,9 +296,9 @@ def log_wide(x: Tensor, sqrts: int = 3) -> Tensor:
     this matches rather than clearly beats it - the sqrt chain re-rounds. Useful
     mainly as a documented range-reduction recipe; the native `x.log()` is the
     better default on this hardware."""
-    r = x
-    for _ in range(sqrts): r = r.sqrt()
-    return r.log() * float(1 << sqrts)
+  r = x
+  for _ in range(sqrts): r = r.sqrt()
+  return r.log() * float(1 << sqrts)
 
 
 __all__ = [

--- a/aneforge/streaming.py
+++ b/aneforge/streaming.py
@@ -30,7 +30,7 @@ _F16 = np.float16
 
 
 class CheckpointedStack:
-    """A depth-independent compile for a stack of identical layers.
+  """A depth-independent compile for a stack of identical layers.
 
     `layer_fn(params, x)` builds one layer: `params` is a list of graph `Tensor`
     parameters and `x` is the input activation `Tensor`; it returns the output
@@ -43,70 +43,70 @@ class CheckpointedStack:
     reused for every layer, so compile cost does not grow with depth.
     """
 
-    def __init__(self, layer_fn, example_params, io_shape):
-        self.io_shape = tuple(io_shape)
-        self._nparam = len(example_params)
+  def __init__(self, layer_fn, example_params, io_shape):
+    self.io_shape = tuple(io_shape)
+    self._nparam = len(example_params)
 
-        # per-layer forward: y = layer_fn(params, x)
-        self._x = _g.input(self.io_shape)
-        self._p = [_ag.parameter(np.asarray(p, np.float32)) for p in example_params]
-        y = layer_fn(self._p, self._x)
-        if tuple(y.shape) != self.io_shape:
-            raise ValueError(f"layer_fn output shape {y.shape} != io_shape {self.io_shape}")
-        self._fwd = _compile(y)
+    # per-layer forward: y = layer_fn(params, x)
+    self._x = _g.input(self.io_shape)
+    self._p = [_ag.parameter(np.asarray(p, np.float32)) for p in example_params]
+    y = layer_fn(self._p, self._x)
+    if tuple(y.shape) != self.io_shape:
+      raise ValueError(f"layer_fn output shape {y.shape} != io_shape {self.io_shape}")
+    self._fwd = _compile(y)
 
-        # per-layer backward: given the upstream gradient at the output, return the
-        # param gradients and the input gradient (recompute-in-backward checkpointing).
-        self._xb = _g.input(self.io_shape)
-        self._pb = [_ag.parameter(np.asarray(p, np.float32)) for p in example_params]
-        self._gout = _g.input(self.io_shape)
-        yb = layer_fn(self._pb, self._xb)
-        grads = _ag.backward_from(self._gout, yb, [*self._pb, self._xb])
-        self._g_param = [grads[p] for p in self._pb]
-        self._g_in = grads[self._xb]
-        self._bwd = _compile_multi([*self._g_param, self._g_in])
-        self._bwd_in = {id(t): n for t, n in self._bwd.input_ports}
-        self._bwd_out = {t: n for t, n in self._bwd.output_ports}
-        # baked-constant input ports (e.g. a causal mask) carried into the backward graph
-        _fed = {id(self._xb), id(self._gout), *(id(p) for p in self._pb)}
-        self._bwd_consts = [(t, n) for t, n in self._bwd.input_ports if id(t) not in _fed]
+    # per-layer backward: given the upstream gradient at the output, return the
+    # param gradients and the input gradient (recompute-in-backward checkpointing).
+    self._xb = _g.input(self.io_shape)
+    self._pb = [_ag.parameter(np.asarray(p, np.float32)) for p in example_params]
+    self._gout = _g.input(self.io_shape)
+    yb = layer_fn(self._pb, self._xb)
+    grads = _ag.backward_from(self._gout, yb, [*self._pb, self._xb])
+    self._g_param = [grads[p] for p in self._pb]
+    self._g_in = grads[self._xb]
+    self._bwd = _compile_multi([*self._g_param, self._g_in])
+    self._bwd_in = {id(t): n for t, n in self._bwd.input_ports}
+    self._bwd_out = dict(self._bwd.output_ports)
+    # baked-constant input ports (e.g. a causal mask) carried into the backward graph
+    _fed = {id(self._xb), id(self._gout), *(id(p) for p in self._pb)}
+    self._bwd_consts = [(t, n) for t, n in self._bwd.input_ports if id(t) not in _fed]
 
-    def forward(self, layers_params, x0):
-        """Run the stack. `layers_params` is a list (per layer) of lists (per-layer
+  def forward(self, layers_params, x0):
+    """Run the stack. `layers_params` is a list (per layer) of lists (per-layer
         parameter numpy arrays). Returns `(output, checkpoints)` where `checkpoints[i]`
         is the input activation to layer `i` (needed by `backward`)."""
-        x = np.asarray(x0, np.float32)
-        checkpoints = []
-        for lp in layers_params:
-            checkpoints.append(x)
-            feed = {id(self._x): x.astype(_F16),
-                    **{id(t): np.asarray(v, _F16) for t, v in zip(self._p, lp)}}
-            # any other input port is a baked constant (e.g. a causal mask): feed its value
-            assert isinstance(self._fwd, _Model)  # layer_fn never contains sdpa nodes
-            vals = [feed[id(t)] if id(t) in feed else np.asarray(t.attrs["value"], _F16)
-                    for t in self._fwd._input_tensors]
-            x = np.asarray(self._fwd(*vals), np.float32)
-        return x, checkpoints
+    x = np.asarray(x0, np.float32)
+    checkpoints = []
+    for lp in layers_params:
+      checkpoints.append(x)
+      feed = {id(self._x): x.astype(_F16),
+          **{id(t): np.asarray(v, _F16) for t, v in zip(self._p, lp)}}
+      # any other input port is a baked constant (e.g. a causal mask): feed its value
+      assert isinstance(self._fwd, _Model)  # layer_fn never contains sdpa nodes
+      vals = [feed[id(t)] if id(t) in feed else np.asarray(t.attrs["value"], _F16)
+          for t in self._fwd._input_tensors]
+      x = np.asarray(self._fwd(*vals), np.float32)
+    return x, checkpoints
 
-    def backward(self, layers_params, checkpoints, g_out):
-        """Backprop the stack. `g_out` is the gradient at the stack output. Returns
+  def backward(self, layers_params, checkpoints, g_out):
+    """Backprop the stack. `g_out` is the gradient at the stack output. Returns
         `(param_grads, g_in)`: `param_grads[i]` is the list of gradients for layer
         `i`'s params, and `g_in` is the gradient at the stack input."""
-        g = np.asarray(g_out, np.float32)
-        param_grads: list[list[np.ndarray] | None] = [None] * len(layers_params)
-        for i in range(len(layers_params) - 1, -1, -1):
-            self._bwd.prog.set_input(self._bwd_in[id(self._gout)], g.astype(_F16))
-            self._bwd.prog.set_input(self._bwd_in[id(self._xb)], checkpoints[i].astype(_F16))
-            for t, v in zip(self._pb, layers_params[i]):
-                self._bwd.prog.set_input(self._bwd_in[id(t)], np.asarray(v, _F16))
-            for t, n in self._bwd_consts:                   # baked constants (e.g. mask)
-                self._bwd.prog.set_input(n, np.asarray(t.attrs["value"], _F16))
-            self._bwd.prog.execute()
-            param_grads[i] = [np.asarray(self._bwd.prog.read_output(self._bwd_out[gp]), np.float32)
-                              for gp in self._g_param]
-            g = np.asarray(self._bwd.prog.read_output(self._bwd_out[self._g_in]), np.float32)
-        return param_grads, g
+    g = np.asarray(g_out, np.float32)
+    param_grads: list[list[np.ndarray] | None] = [None] * len(layers_params)
+    for i in range(len(layers_params) - 1, -1, -1):
+      self._bwd.prog.set_input(self._bwd_in[id(self._gout)], g.astype(_F16))
+      self._bwd.prog.set_input(self._bwd_in[id(self._xb)], checkpoints[i].astype(_F16))
+      for t, v in zip(self._pb, layers_params[i]):
+        self._bwd.prog.set_input(self._bwd_in[id(t)], np.asarray(v, _F16))
+      for t, n in self._bwd_consts:                   # baked constants (e.g. mask)
+        self._bwd.prog.set_input(n, np.asarray(t.attrs["value"], _F16))
+      self._bwd.prog.execute()
+      param_grads[i] = [np.asarray(self._bwd.prog.read_output(self._bwd_out[gp]), np.float32)
+                for gp in self._g_param]
+      g = np.asarray(self._bwd.prog.read_output(self._bwd_out[self._g_in]), np.float32)
+    return param_grads, g
 
-    def release(self):
-        self._fwd.release()
-        self._bwd.release()
+  def release(self):
+    self._fwd.release()
+    self._bwd.release()

--- a/aneforge/streaming.py
+++ b/aneforge/streaming.py
@@ -24,7 +24,7 @@ import numpy as np
 
 from . import autograd as _ag
 from . import graph as _g
-from ._compile import compile as _compile, compile_multi as _compile_multi
+from ._compile import Model as _Model, compile as _compile, compile_multi as _compile_multi
 
 _F16 = np.float16
 
@@ -82,6 +82,7 @@ class CheckpointedStack:
             feed = {id(self._x): x.astype(_F16),
                     **{id(t): np.asarray(v, _F16) for t, v in zip(self._p, lp)}}
             # any other input port is a baked constant (e.g. a causal mask): feed its value
+            assert isinstance(self._fwd, _Model)  # layer_fn never contains sdpa nodes
             vals = [feed[id(t)] if id(t) in feed else np.asarray(t.attrs["value"], _F16)
                     for t in self._fwd._input_tensors]
             x = np.asarray(self._fwd(*vals), np.float32)
@@ -92,7 +93,7 @@ class CheckpointedStack:
         `(param_grads, g_in)`: `param_grads[i]` is the list of gradients for layer
         `i`'s params, and `g_in` is the gradient at the stack input."""
         g = np.asarray(g_out, np.float32)
-        param_grads = [None] * len(layers_params)
+        param_grads: list[list[np.ndarray] | None] = [None] * len(layers_params)
         for i in range(len(layers_params) - 1, -1, -1):
             self._bwd.prog.set_input(self._bwd_in[id(self._gout)], g.astype(_F16))
             self._bwd.prog.set_input(self._bwd_in[id(self._xb)], checkpoints[i].astype(_F16))

--- a/bench/below_ridge_fusion.py
+++ b/bench/below_ridge_fusion.py
@@ -94,9 +94,9 @@ def build_block_ops(C, H, W):
     act_bytes = C * H * W * BYTES_FP16              # one CxHxW fp16 tensor
     weight_bytes = (C * C + 2 * C) * BYTES_FP16     # conv + gn gamma/beta
     n_ops = 4   # conv, group_norm, gelu, gelu
-    return dict(Wc=Wc, gn_g=gn_g, gn_b=gn_b, GROUPS=GROUPS, ref=ref, flops=flops,
-                act_bytes=act_bytes, weight_bytes=weight_bytes, n_ops=n_ops,
-                C=C, H=H, W=W)
+    return {"Wc": Wc, "gn_g": gn_g, "gn_b": gn_b, "GROUPS": GROUPS, "ref": ref, "flops": flops,
+                "act_bytes": act_bytes, "weight_bytes": weight_bytes, "n_ops": n_ops,
+                "C": C, "H": H, "W": W}
 
 
 def gelu_np(x):

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -72,10 +72,10 @@ def main():
     P = lambda sh, s=0.08: agrad.parameter((rng.standard_normal(sh) * s).astype(np.float32))
     W_emb, W_pos, W_out = P((V, D)), P((S, D)), P((D, V))
     fin = agrad.parameter(np.ones((1, D), np.float32))
-    blocks = [dict(Wq=P((D, D)), Wk=P((D, D)), Wv=P((D, D)), Wo=P((D, D)),
-                   Wg=P((D, FF)), Wu=P((D, FF)), Wd=P((FF, D)),
-                   rn1=agrad.parameter(np.ones((1, D), np.float32)),
-                   rn2=agrad.parameter(np.ones((1, D), np.float32))) for _ in range(NLAYERS)]
+    blocks = [{"Wq": P((D, D)), "Wk": P((D, D)), "Wv": P((D, D)), "Wo": P((D, D)),
+                   "Wg": P((D, FF)), "Wu": P((D, FF)), "Wd": P((FF, D)),
+                   "rn1": agrad.parameter(np.ones((1, D), np.float32)),
+                   "rn2": agrad.parameter(np.ones((1, D), np.float32))} for _ in range(NLAYERS)]
     params = [W_emb, W_pos, W_out, fin] + [p for b in blocks for p in b.values()]
     heads = lambda t: t.reshape(S, HEADS, dh).transpose([1, 0, 2])
     cmask = np.triu(np.full((S, S), -1e4, np.float32), 1)

--- a/examples/demos/weights_compression.py
+++ b/examples/demos/weights_compression.py
@@ -21,7 +21,7 @@ def _time_conv(Cin, Cout, HW, int8):
     rng = np.random.default_rng(0)
     W = (rng.standard_normal((Cout, Cin, 3, 3)) * 0.02).astype(np.float32)
     x = af.input((1, Cin, HW, HW))
-    net = af.compile(af.conv(x, W, pad=1), **(dict(int8=True) if int8 else {}))
+    net = af.compile(af.conv(x, W, pad=1), **({"int8": True} if int8 else {}))
     img = (rng.standard_normal((1, Cin, HW, HW)) * 0.1).astype(np.float32)
     for _ in range(10):
         net(img)

--- a/examples/gpt_generate_ane.py
+++ b/examples/gpt_generate_ane.py
@@ -115,7 +115,7 @@ class TinyDecoderANE:
         hn = h.rms_norm(self.rn2)
         hout = h + ((hn @ self.W["Wg"]).silu() * (hn @ self.W["Wu"])) @ self.W["Wd"]
         net = compile_multi([hout, Kout, Vout])
-        inm = {id(t): n for t, n in net.input_ports}; om = {t: n for t, n in net.output_ports}
+        inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
         net.prog.share_buffer(0, om[Kout], 0, inm[id(Kin)])   # cache stays resident across execute()
         net.prog.share_buffer(0, om[Vout], 0, inm[id(Vin)])
         net.prog.set_input(inm[id(Kin)], np.zeros((H, M, dh), f16))   # seed once

--- a/examples/gpt_multilayer_resident.py
+++ b/examples/gpt_multilayer_resident.py
@@ -53,14 +53,14 @@ class TinyGPTResident:
             h, Ko, Vo = self._block(h, self.lyr[l], Kin[l], Vin[l], oh, inv, mask)
             Kout.append(Ko); Vout.append(Vo)
         net = compile_multi([h] + Kout + Vout)
-        inm = {id(t): n for t, n in net.input_ports}; om = {t: n for t, n in net.output_ports}
+        inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
         for l in range(L):                       # every layer's cache resident, seeded once
             net.prog.share_buffer(0, om[Kout[l]], 0, inm[id(Kin[l])])
             net.prog.share_buffer(0, om[Vout[l]], 0, inm[id(Vin[l])])
             net.prog.set_input(inm[id(Kin[l])], np.zeros((H, M, dh), np.float16))
             net.prog.set_input(inm[id(Vin[l])], np.zeros((H, M, dh), np.float16))
         self.net, self.inm, self.om = net, inm, om
-        self.ports = dict(x=inm[id(x)], oh=inm[id(oh)], inv=inm[id(inv)], mask=inm[id(mask)], h=om[h])
+        self.ports = {"x": inm[id(x)], "oh": inm[id(oh)], "inv": inm[id(inv)], "mask": inm[id(mask)], "h": om[h]}
 
     def _step(self, tok, p):
         M, f16 = self.M, np.float16

--- a/examples/train_charlm.py
+++ b/examples/train_charlm.py
@@ -45,10 +45,10 @@ def main():
     P = lambda sh, s=0.08: agrad.parameter((rng.standard_normal(sh) * s).astype(np.float32))
     W_emb, W_pos, W_out = P((V, D)), P((S, D)), P((D, V))
     fin = agrad.parameter(np.ones((1, D), np.float32))       # final RMSNorm gain
-    blocks = [dict(Wq=P((D, D)), Wk=P((D, D)), Wv=P((D, D)), Wo=P((D, D)),
-                   Wg=P((D, FF)), Wu=P((D, FF)), Wd=P((FF, D)),
-                   rn1=agrad.parameter(np.ones((1, D), np.float32)),
-                   rn2=agrad.parameter(np.ones((1, D), np.float32)))
+    blocks = [{"Wq": P((D, D)), "Wk": P((D, D)), "Wv": P((D, D)), "Wo": P((D, D)),
+                   "Wg": P((D, FF)), "Wu": P((D, FF)), "Wd": P((FF, D)),
+                   "rn1": agrad.parameter(np.ones((1, D), np.float32)),
+                   "rn2": agrad.parameter(np.ones((1, D), np.float32))}
               for _ in range(NLAYERS)]
     params = [W_emb, W_pos, W_out, fin] + [p for b in blocks for p in b.values()]
     heads = lambda t: t.reshape(S, HEADS, dh).transpose([1, 0, 2])

--- a/examples/train_charlm_corpus.py
+++ b/examples/train_charlm_corpus.py
@@ -53,10 +53,10 @@ def main():
     P = lambda sh, s=0.08: agrad.parameter((rng.standard_normal(sh) * s).astype(np.float32))
     W_emb, W_pos, W_out = P((V, D)), P((S, D)), P((D, V))
     fin = agrad.parameter(np.ones((1, D), np.float32))
-    blocks = [dict(Wq=P((D, D)), Wk=P((D, D)), Wv=P((D, D)), Wo=P((D, D)),
-                   Wg=P((D, FF)), Wu=P((D, FF)), Wd=P((FF, D)),
-                   rn1=agrad.parameter(np.ones((1, D), np.float32)),
-                   rn2=agrad.parameter(np.ones((1, D), np.float32)))
+    blocks = [{"Wq": P((D, D)), "Wk": P((D, D)), "Wv": P((D, D)), "Wo": P((D, D)),
+                   "Wg": P((D, FF)), "Wu": P((D, FF)), "Wd": P((FF, D)),
+                   "rn1": agrad.parameter(np.ones((1, D), np.float32)),
+                   "rn2": agrad.parameter(np.ones((1, D), np.float32))}
               for _ in range(NLAYERS)]
     params = [W_emb, W_pos, W_out, fin] + [p for b in blocks for p in b.values()]
     heads = lambda t: t.reshape(S, HEADS, dh).transpose([1, 0, 2])

--- a/examples/train_charlm_deep.py
+++ b/examples/train_charlm_deep.py
@@ -41,7 +41,7 @@ def run_multi(mm, vals, outs):              # MultiModel -> list of named output
     for t, n in mm.input_ports:
         mm.prog.set_input(n, np.asarray(_val(t, vals), np.float16))
     mm.prog.execute()
-    om = {t: n for t, n in mm.output_ports}
+    om = dict(mm.output_ports)
     return [np.asarray(mm.prog.read_output(om[o]), np.float32) for o in outs]
 
 

--- a/examples/train_transformer.py
+++ b/examples/train_transformer.py
@@ -65,7 +65,7 @@ def main():
     net = compile_multi([loss_row, *P, *M, *V])
     prog = net.prog
     inm = {id(t): n for t, n in net.input_ports}
-    om = {t: n for t, n in net.output_ports}
+    om = dict(net.output_ports)
 
     # SEED ONCE, then the host does nothing but press "go". Everything the program
     # needs lives on-device across dispatches:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,6 +65,9 @@ models = [
 # suites need real ANE hardware to run.
 dev = [
     "ruff",
+    "pyright==1.1.410",  # type checker; pinned so a new release can't add errors out from under CI
+    "pylint",            # CI 2-space + trailing-whitespace lock (W0311/C0303); see .github/workflows/ci.yml
+    "pre-commit",        # local hooks mirroring CI; see .pre-commit-config.yaml
     "pytest",
     "pytest-forked",   # per-test process isolation (--forked); see tests/conftest.py
 ]
@@ -103,11 +106,19 @@ addopts = "--forked"
 
 [tool.ruff]
 line-length = 120
+indent-width = 2          # tinygrad-compact: the codebase is 2-space (also enforced via pylint W0311 in CI)
 # Lint the shippable code only; utils/ is gitignored local tooling.
 extend-exclude = ["utils"]
 
 [tool.ruff.lint]
-# Default rule set (E4/E7/E9 + F) minus the dense-style idioms this codebase uses
-# deliberately: multi-import lines, module imports after a sys.path shim, semicolon /
-# colon multi-statements, assigned lambdas, and short math names (l, I, af, ...).
+# E4/E7/E9 + F (pyflakes), plus flake8-comprehensions (C4) and flake8-builtins (A).
+select = ["E4", "E7", "E9", "F", "C4", "A"]
+# Minus the dense-style idioms this codebase uses deliberately: multi-import lines,
+# module imports after a sys.path shim, semicolon / colon multi-statements, assigned
+# lambdas, and short math names (l, I, af, ...).
 ignore = ["E401", "E402", "E701", "E702", "E703", "E731", "E741"]
+
+[tool.ruff.lint.flake8-builtins]
+# `input` and `compile` are intentional public-API op names (af.input / af.compile),
+# like torch/tinygrad; allow them while A still catches accidental builtin shadowing.
+builtins-ignorelist = ["input", "compile"]

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -630,9 +630,9 @@ def test_charlm_trains_and_predicts():
   rng = np.random.default_rng(0)
   P = lambda sh, s=0.08: agrad.parameter((rng.standard_normal(sh) * s).astype(np.float32))
   W_emb, W_pos, W_out = P((V, D)), P((S, D)), P((D, V)); fin = agrad.parameter(np.ones((1, D), np.float32))
-  blocks = [dict(Wq=P((D, D)), Wk=P((D, D)), Wv=P((D, D)), Wo=P((D, D)), Wg=P((D, FF)), Wu=P((D, FF)),
-                 Wd=P((FF, D)), rn1=agrad.parameter(np.ones((1, D), np.float32)),
-                 rn2=agrad.parameter(np.ones((1, D), np.float32))) for _ in range(NL)]
+  blocks = [{"Wq": P((D, D)), "Wk": P((D, D)), "Wv": P((D, D)), "Wo": P((D, D)), "Wg": P((D, FF)), "Wu": P((D, FF)),
+                 "Wd": P((FF, D)), "rn1": agrad.parameter(np.ones((1, D), np.float32)),
+                 "rn2": agrad.parameter(np.ones((1, D), np.float32))} for _ in range(NL)]
   params = [W_emb, W_pos, W_out, fin] + [p for b in blocks for p in b.values()]
   heads = lambda t: t.reshape(S, Hh, dh).transpose([1, 0, 2])
   x = af.input((S, V)); y = af.input((S, V)); mask = af.input((S, S)); mask.attrs["value"] = cmask
@@ -679,9 +679,9 @@ def test_charlm_generalizes_on_corpus():
   cmask = np.triu(np.full((S, S), -1e4, np.float32), 1)
   P = lambda sh, s=0.08: agrad.parameter((rng.standard_normal(sh) * s).astype(np.float32))
   W_emb, W_pos, W_out = P((V, D)), P((S, D)), P((D, V)); fin = agrad.parameter(np.ones((1, D), np.float32))
-  blocks = [dict(Wq=P((D, D)), Wk=P((D, D)), Wv=P((D, D)), Wo=P((D, D)), Wg=P((D, FF)), Wu=P((D, FF)),
-                 Wd=P((FF, D)), rn1=agrad.parameter(np.ones((1, D), np.float32)),
-                 rn2=agrad.parameter(np.ones((1, D), np.float32))) for _ in range(NL)]
+  blocks = [{"Wq": P((D, D)), "Wk": P((D, D)), "Wv": P((D, D)), "Wo": P((D, D)), "Wg": P((D, FF)), "Wu": P((D, FF)),
+                 "Wd": P((FF, D)), "rn1": agrad.parameter(np.ones((1, D), np.float32)),
+                 "rn2": agrad.parameter(np.ones((1, D), np.float32))} for _ in range(NL)]
   params = [W_emb, W_pos, W_out, fin] + [p for b in blocks for p in b.values()]
   heads = lambda t: t.reshape(S, Hh, dh).transpose([1, 0, 2])
   x = af.input((S, V)); y = af.input((S, V)); mask = af.input((S, S)); mask.attrs["value"] = cmask
@@ -1048,7 +1048,7 @@ def test_resident_sgd_matches_host_reference():
   W1n = agrad._sgd_update(W1, grads[W1], lr)
   W2n = agrad._sgd_update(W2, grads[W2], lr)
   mm = _c.compile_multi([W1n, W2n]); prog = mm.prog
-  inn = {t: n for t, n in mm.input_ports}; out = {t: n for t, n in mm.output_ports}
+  inn = dict(mm.input_ports); out = dict(mm.output_ports)
   prog.share_buffer(0, out[W1n], 0, inn[W1]); prog.share_buffer(0, out[W2n], 0, inn[W2])
   prog.set_input(inn[W1], W1_0); prog.set_input(inn[W2], W2_0)
   lr_arr = np.array([[LR]], np.float32)

--- a/tests/test_op_coverage.py
+++ b/tests/test_op_coverage.py
@@ -163,7 +163,7 @@ def test_op(case):
   assert np.isfinite(res).all() or name in _MAYBE_WALLED_M1, f"{name}: non-finite"
   if ref is not None:
     try:
-      r = ref(*[f for f in feeds])
+      r = ref(*list(feeds))
       _check(res, r)
     except AssertionError:
       if name in _MAYBE_WALLED_M1:

--- a/tests/test_spectral_sci.py
+++ b/tests/test_spectral_sci.py
@@ -70,7 +70,7 @@ def tagged(case: Case, cost: str, feasibility: str) -> Case:
 # SPECTRAL - the "can the ANE do an FFT?" probe (complex as real pairs)
 
 def _dft_matmul(N: int, tol: float):
-    """Discrete Fourier transform as a dense twiddle-matrix matmul, complex emulated
+  """Discrete Fourier transform as a dense twiddle-matrix matmul, complex emulated
     as a (real, imag) tensor pair.
 
         X_k = sum_n x_n * exp(-2*pi*i*k*n/N) = x @ W^T,  W[k,n] = exp(-2*pi*i*k*n/N).
@@ -93,33 +93,33 @@ def _dft_matmul(N: int, tol: float):
     itself; the real ceiling is the O(N^2) weight-matrix size/bandwidth, not precision.
     Tolerances are set just above the measured fp16 floor per N.
     """
-    n = np.arange(N)
-    k = n.reshape(-1, 1)
-    W = np.exp(-2j * np.pi * k * n / N)                  # [N,N] DFT matrix
-    Wr = np.ascontiguousarray(np.real(W)).astype(np.float16)
-    Wi = np.ascontiguousarray(np.imag(W)).astype(np.float16)
-    xr = f16(1, N); xi = f16(1, N)
+  n = np.arange(N)
+  k = n.reshape(-1, 1)
+  W = np.exp(-2j * np.pi * k * n / N)                  # [N,N] DFT matrix
+  Wr = np.ascontiguousarray(np.real(W)).astype(np.float16)
+  Wi = np.ascontiguousarray(np.imag(W)).astype(np.float16)
+  xr = f16(1, N); xi = f16(1, N)
 
-    def build(rt, it):
-        a = rt @ Wr.T.astype(np.float16)                # xr @ Wr^T
-        b = it @ Wi.T.astype(np.float16)                # xi @ Wi^T
-        Xr = a - b
-        c = rt @ Wi.T.astype(np.float16)                # xr @ Wi^T
-        d = it @ Wr.T.astype(np.float16)                # xi @ Wr^T
-        Xi = c + d
-        return af.concat([Xr, Xi], axis=1)              # [1, 2N]
+  def build(rt, it):
+    a = rt @ Wr.T.astype(np.float16)                # xr @ Wr^T
+    b = it @ Wi.T.astype(np.float16)                # xi @ Wi^T
+    Xr = a - b
+    c = rt @ Wi.T.astype(np.float16)                # xr @ Wi^T
+    d = it @ Wr.T.astype(np.float16)                # xi @ Wr^T
+    Xi = c + d
+    return af.concat([Xr, Xi], axis=1)              # [1, 2N]
 
-    def ref(ra, ia):
-        xc = ra.astype(np.float32) + 1j * ia.astype(np.float32)
-        X = xc @ W.T                                     # W symmetric: x @ W^T == DFT
-        return np.concatenate([np.real(X), np.imag(X)], axis=1).astype(np.float32)
+  def ref(ra, ia):
+    xc = ra.astype(np.float32) + 1j * ia.astype(np.float32)
+    X = xc @ W.T                                     # W symmetric: x @ W^T == DFT
+    return np.concatenate([np.real(X), np.imag(X)], axis=1).astype(np.float32)
 
-    return tagged(Case(f"dft_matmul_N{N}", "spectral", build, ref, [xr, xi], tol=tol),
+  return tagged(Case(f"dft_matmul_N{N}", "spectral", build, ref, [xr, xi], tol=tol),
                   "compute", "works")
 
 
 def _fft_butterfly_radix2(N: int, tol: float):
-    """Radix-2 decimation-in-time (Cooley-Tukey) FFT, FULLY UNROLLED as a static graph
+  """Radix-2 decimation-in-time (Cooley-Tukey) FFT, FULLY UNROLLED as a static graph
     over (real, imag) lane pairs - the genuine butterfly, not a matmul.
 
     Inputs are bit-reversed (a static permutation, expressed via one-hot matmul lane
@@ -142,52 +142,52 @@ def _fft_butterfly_radix2(N: int, tol: float):
     butterfly's only theoretical win (O(N log N)) is not realizable as a static graph at
     useful N. fp16 is NOT the limiter here; the static-unroll requirement is.
     """
-    bits = int(round(np.log2(N)))
-    assert (1 << bits) == N, "radix-2 requires power-of-two N"
+  bits = int(round(np.log2(N)))
+  assert (1 << bits) == N, "radix-2 requires power-of-two N"
 
-    def _bitrev(x, b):
-        r = 0
-        for _ in range(b):
-            r = (r << 1) | (x & 1)
-            x >>= 1
-        return r
+  def _bitrev(x, b):
+    r = 0
+    for _ in range(b):
+      r = (r << 1) | (x & 1)
+      x >>= 1
+    return r
 
-    order = [_bitrev(i, bits) for i in range(N)]
+  order = [_bitrev(i, bits) for i in range(N)]
 
-    def _lane(t, i):                                     # [1,N] -> [1,1] (one-hot select)
-        s = np.zeros((N, 1), np.float16); s[i, 0] = 1.0
-        return t @ s.astype(np.float16)
+  def _lane(t, i):                                     # [1,N] -> [1,1] (one-hot select)
+    s = np.zeros((N, 1), np.float16); s[i, 0] = 1.0
+    return t @ s.astype(np.float16)
 
-    xr = f16(1, N); xi = f16(1, N)
+  xr = f16(1, N); xi = f16(1, N)
 
-    def build(rt, it):
-        re = [_lane(rt, order[i]) for i in range(N)]
-        im = [_lane(it, order[i]) for i in range(N)]
-        size = 2
-        while size <= N:
-            half = size // 2
-            for start in range(0, N, size):
-                for j in range(half):
-                    ang = -2.0 * np.pi * j / size
-                    wr, wi = float(np.cos(ang)), float(np.sin(ang))
-                    a, b = start + j, start + j + half
-                    tr = re[b] * wr - im[b] * wi         # twiddle * operand (complex)
-                    ti = re[b] * wi + im[b] * wr
-                    re[a], re[b] = re[a] + tr, re[a] - tr
-                    im[a], im[b] = im[a] + ti, im[a] - ti
-            size *= 2
-        return af.concat(re + im, axis=1)               # [1, 2N]
+  def build(rt, it):
+    re = [_lane(rt, order[i]) for i in range(N)]
+    im = [_lane(it, order[i]) for i in range(N)]
+    size = 2
+    while size <= N:
+      half = size // 2
+      for start in range(0, N, size):
+        for j in range(half):
+          ang = -2.0 * np.pi * j / size
+          wr, wi = float(np.cos(ang)), float(np.sin(ang))
+          a, b = start + j, start + j + half
+          tr = re[b] * wr - im[b] * wi         # twiddle * operand (complex)
+          ti = re[b] * wi + im[b] * wr
+          re[a], re[b] = re[a] + tr, re[a] - tr
+          im[a], im[b] = im[a] + ti, im[a] - ti
+      size *= 2
+    return af.concat(re + im, axis=1)               # [1, 2N]
 
-    def ref(ra, ia):
-        X = np.fft.fft(ra.astype(np.float32) + 1j * ia.astype(np.float32))
-        return np.concatenate([np.real(X), np.imag(X)], axis=1).astype(np.float32)
+  def ref(ra, ia):
+    X = np.fft.fft(ra.astype(np.float32) + 1j * ia.astype(np.float32))
+    return np.concatenate([np.real(X), np.imag(X)], axis=1).astype(np.float32)
 
-    return tagged(Case(f"fft_butterfly_radix2_N{N}", "spectral", build, ref, [xr, xi], tol=tol),
+  return tagged(Case(f"fft_butterfly_radix2_N{N}", "spectral", build, ref, [xr, xi], tol=tol),
                   "floor/fusion", "works")
 
 
 def _rfft_power_spectrum(N: int, tol: float):
-    """Real-input FFT power spectrum |X_k|^2 via the DFT-matmul (real x only).
+  """Real-input FFT power spectrum |X_k|^2 via the DFT-matmul (real x only).
 
     A common DSP endpoint: feed a real signal, get the power spectrum. xi is identically
     zero (real input), so Xr = x @ Wr^T, Xi = x @ Wi^T, and P = Xr^2 + Xi^2 (one fused
@@ -197,29 +197,29 @@ def _rfft_power_spectrum(N: int, tol: float):
     feasibility: WORKS (fp16-clean; |.|^2 squares the relerr scale but the wide
       accumulator keeps the underlying DFT tight, so the power spectrum stays usable).
     """
-    n = np.arange(N); k = n.reshape(-1, 1)
-    W = np.exp(-2j * np.pi * k * n / N)
-    Wr = np.ascontiguousarray(np.real(W)).astype(np.float16)
-    Wi = np.ascontiguousarray(np.imag(W)).astype(np.float16)
-    x = f16(1, N)
+  n = np.arange(N); k = n.reshape(-1, 1)
+  W = np.exp(-2j * np.pi * k * n / N)
+  Wr = np.ascontiguousarray(np.real(W)).astype(np.float16)
+  Wi = np.ascontiguousarray(np.imag(W)).astype(np.float16)
+  x = f16(1, N)
 
-    def build(xt):
-        Xr = xt @ Wr.T.astype(np.float16)
-        Xi = xt @ Wi.T.astype(np.float16)
-        return Xr.square() + Xi.square()                # [1,N] power
+  def build(xt):
+    Xr = xt @ Wr.T.astype(np.float16)
+    Xi = xt @ Wi.T.astype(np.float16)
+    return Xr.square() + Xi.square()                # [1,N] power
 
-    def ref(xa):
-        X = xa.astype(np.float32) @ W.T
-        return (np.abs(X) ** 2).astype(np.float32)
+  def ref(xa):
+    X = xa.astype(np.float32) @ W.T
+    return (np.abs(X) ** 2).astype(np.float32)
 
-    return tagged(Case(f"rfft_power_spectrum_N{N}", "spectral", build, ref, [x], tol=tol),
+  return tagged(Case(f"rfft_power_spectrum_N{N}", "spectral", build, ref, [x], tol=tol),
                   "compute", "works")
 
 
 # SIGNAL - FIR filter and autocorrelation
 
 def _fir_filter(L: int, K: int, tol: float):
-    """FIR filter as a 1D convolution: y = conv(signal, taps), valid mode.
+  """FIR filter as a 1D convolution: y = conv(signal, taps), valid mode.
 
     Built on the ANE conv layer with the signal as [1,1,1,L] and the taps as a
     [1,1,1,K] kernel. NOTE the convention: the ANE conv is a CROSS-CORRELATION (no
@@ -230,24 +230,24 @@ def _fir_filter(L: int, K: int, tol: float):
     cost: COMPUTE (a real conv - the ANE's home turf).
     feasibility: WORKS.
     """
-    sig = f16(1, 1, 1, L)
-    taps = f16(1, 1, 1, K, scale=0.5)
+  sig = f16(1, 1, 1, L)
+  taps = f16(1, 1, 1, K, scale=0.5)
 
-    def build(st):
-        return af.conv(st, taps, pad=0)                 # [1,1,1,L-K+1], valid
+  def build(st):
+    return af.conv(st, taps, pad=0)                 # [1,1,1,L-K+1], valid
 
-    def ref(sa):
-        s = sa[0, 0, 0].astype(np.float32)
-        t = taps[0, 0, 0].astype(np.float32)
-        y = np.correlate(s, t, mode="valid")            # ANE conv == correlation
-        return y.reshape(1, 1, 1, -1)
+  def ref(sa):
+    s = sa[0, 0, 0].astype(np.float32)
+    t = taps[0, 0, 0].astype(np.float32)
+    y = np.correlate(s, t, mode="valid")            # ANE conv == correlation
+    return y.reshape(1, 1, 1, -1)
 
-    return tagged(Case(f"fir_filter_L{L}_K{K}", "signal", build, ref, [sig], tol=tol),
+  return tagged(Case(f"fir_filter_L{L}_K{K}", "signal", build, ref, [sig], tol=tol),
                   "compute", "works")
 
 
 def _autocorr_crosscorr(H: int, W: int, Th: int, Tw: int, tol: float):
-    """Template autocorrelation via the cracked CrossCorrelation bridge (native ANE
+  """Template autocorrelation via the cracked CrossCorrelation bridge (native ANE
     CrossCorrelation layer - a path Apple's MIL frontend rejects).
 
     Valid (no-flip) correlation of a 2D map [H,W] with a smaller template [Th,Tw]:
@@ -260,26 +260,26 @@ def _autocorr_crosscorr(H: int, W: int, Th: int, Tw: int, tol: float):
     cost: MIXED (cut) - one native sub-program (graph cut), no surrounding fusion.
     feasibility: WORKS (cross_correlation is RE-recovered and runtime-proven).
     """
-    x = f16(H, W)
-    tmpl = np.ascontiguousarray(x[:Th, :Tw]).astype(np.float16)   # patch -> autocorr-style
+  x = f16(H, W)
+  tmpl = np.ascontiguousarray(x[:Th, :Tw]).astype(np.float16)   # patch -> autocorr-style
 
-    def build(xt, tt):
-        return af.cross_correlation(xt, tt)             # [H-Th+1, W-Tw+1]
+  def build(xt, tt):
+    return af.cross_correlation(xt, tt)             # [H-Th+1, W-Tw+1]
 
-    def ref(xa, ta):
-        xf = xa.astype(np.float32); tf = ta.astype(np.float32)
-        out = np.zeros((H - Th + 1, W - Tw + 1), np.float32)
-        for i in range(H - Th + 1):
-            for j in range(W - Tw + 1):
-                out[i, j] = (xf[i:i + Th, j:j + Tw] * tf).sum()
-        return out
+  def ref(xa, ta):
+    xf = xa.astype(np.float32); tf = ta.astype(np.float32)
+    out = np.zeros((H - Th + 1, W - Tw + 1), np.float32)
+    for i in range(H - Th + 1):
+      for j in range(W - Tw + 1):
+        out[i, j] = (xf[i:i + Th, j:j + Tw] * tf).sum()
+    return out
 
-    return tagged(Case(f"autocorr_xcorr_{H}x{W}_t{Th}x{Tw}", "signal", build, ref,
+  return tagged(Case(f"autocorr_xcorr_{H}x{W}_t{Th}x{Tw}", "signal", build, ref,
                        [x, tmpl], tol=tol), "mixed (cut)", "works")
 
 
 def _autocorr_conv(L: int, Lk: int, tol: float):
-    """Lagged autocorrelation r[k] = sum_n s[n] s[n+k], built as a 1D conv of the signal
+  """Lagged autocorrelation r[k] = sum_n s[n] s[n+k], built as a 1D conv of the signal
     against a prefix of ITSELF (that prefix folded as the conv kernel).
 
     The signal [1,1,1,L] is convolved (valid) with its first ``Lk`` samples folded as a
@@ -295,25 +295,25 @@ def _autocorr_conv(L: int, Lk: int, tol: float):
     feasibility: WORKS (small lag window; wide windows are arch-limited by the conv
       backend).
     """
-    sig = f16(1, 1, 1, L)
-    kern = np.ascontiguousarray(sig[0, 0, 0, :Lk]).astype(np.float16).reshape(1, 1, 1, Lk)
+  sig = f16(1, 1, 1, L)
+  kern = np.ascontiguousarray(sig[0, 0, 0, :Lk]).astype(np.float16).reshape(1, 1, 1, Lk)
 
-    def build(st):
-        return af.conv(st, kern, pad=0)                 # correlation of s with its prefix
+  def build(st):
+    return af.conv(st, kern, pad=0)                 # correlation of s with its prefix
 
-    def ref(sa):
-        s = sa[0, 0, 0].astype(np.float32)
-        k = kern[0, 0, 0].astype(np.float32)
-        return np.correlate(s, k, mode="valid").reshape(1, 1, 1, -1)
+  def ref(sa):
+    s = sa[0, 0, 0].astype(np.float32)
+    k = kern[0, 0, 0].astype(np.float32)
+    return np.correlate(s, k, mode="valid").reshape(1, 1, 1, -1)
 
-    return tagged(Case(f"autocorr_conv_L{L}_k{Lk}", "signal", build, ref, [sig], tol=tol),
+  return tagged(Case(f"autocorr_conv_L{L}_k{Lk}", "signal", build, ref, [sig], tol=tol),
                   "compute", "works")
 
 
 # MONTE CARLO - host-drawn samples (see module RANDOMNESS NOTE), ANE reduces
 
 def _mc_integral(M: int, tol: float):
-    """Monte-Carlo integral of g(x)=exp(-x^2) over [0,1]: I ~ mean(g(U)), U~Uniform.
+  """Monte-Carlo integral of g(x)=exp(-x^2) over [0,1]: I ~ mean(g(U)), U~Uniform.
 
     Samples U are drawn on the HOST (aneforge exposes no on-device RNG; see module note)
     and fed as a [1,M] input; the reference integrates over the SAME samples, so the
@@ -324,20 +324,20 @@ def _mc_integral(M: int, tol: float):
     feasibility: WORKS (the wide accumulator keeps the M-lane mean clean; residual is
       fp16 input rounding).
     """
-    u = rng.random((1, M)).astype(np.float16)
+  u = rng.random((1, M)).astype(np.float16)
 
-    def build(ut):
-        return (ut.square() * (-1.0)).exp().mean(1)     # [1,1]
+  def build(ut):
+    return (ut.square() * (-1.0)).exp().mean(1)     # [1,1]
 
-    def ref(ua):
-        return np.exp(-(ua.astype(np.float32) ** 2)).mean(1, keepdims=True)
+  def ref(ua):
+    return np.exp(-(ua.astype(np.float32) ** 2)).mean(1, keepdims=True)
 
-    return tagged(Case(f"mc_integral_exp_M{M}", "montecarlo", build, ref, [u], tol=tol),
+  return tagged(Case(f"mc_integral_exp_M{M}", "montecarlo", build, ref, [u], tol=tol),
                   "reduction", "works")
 
 
 def _mc_mean_var(M: int, tol: float):
-    """MC mean & variance over a large sample (the core MC estimator state).
+  """MC mean & variance over a large sample (the core MC estimator state).
 
     Var via E[g^2]-E[g]^2 (the cancellation-prone form) - the wide ANE accumulator
     keeps the two reductions clean so the residual is fp16 input rounding, not
@@ -346,28 +346,28 @@ def _mc_mean_var(M: int, tol: float):
     cost: REDUCTION.
     feasibility: WORKS.
     """
-    s = rng.standard_normal((1, M)).astype(np.float16)
+  s = rng.standard_normal((1, M)).astype(np.float16)
 
-    def build(st):
-        mean = st.mean(1)
-        meansq = st.square().mean(1)
-        var = meansq - mean * mean
-        return af.concat([mean, var], axis=1)           # [1,2]
+  def build(st):
+    mean = st.mean(1)
+    meansq = st.square().mean(1)
+    var = meansq - mean * mean
+    return af.concat([mean, var], axis=1)           # [1,2]
 
-    def ref(sa):
-        a = sa.astype(np.float32)
-        mean = a.mean(1, keepdims=True)
-        var = (a ** 2).mean(1, keepdims=True) - mean * mean
-        return np.concatenate([mean, var], axis=1)
+  def ref(sa):
+    a = sa.astype(np.float32)
+    mean = a.mean(1, keepdims=True)
+    var = (a ** 2).mean(1, keepdims=True) - mean * mean
+    return np.concatenate([mean, var], axis=1)
 
-    return tagged(Case(f"mc_mean_var_M{M}", "montecarlo", build, ref, [s], tol=tol),
+  return tagged(Case(f"mc_mean_var_M{M}", "montecarlo", build, ref, [s], tol=tol),
                   "reduction", "works")
 
 
 # N-BODY - pairwise interactions via broadcast diff + reduction
 
 def _nbody_spring(N: int, tol: float):
-    """Pairwise spring (linear) net force on N points: F_i = sum_j (p_j - p_i).
+  """Pairwise spring (linear) net force on N points: F_i = sum_j (p_j - p_i).
 
     The pairwise displacement is a broadcast: p[1,N,3] - p[N,1,3] -> [N,N,3], then sum
     over j. This exercises the broadcast-diff + reduction pattern that underlies any
@@ -377,24 +377,24 @@ def _nbody_spring(N: int, tol: float):
       O(N^2) in the intermediate, reduction over j).
     feasibility: WORKS (small N).
     """
-    P = f16(N, 3, scale=1.0)
+  P = f16(N, 3, scale=1.0)
 
-    def build(pt):
-        pi = pt.reshape(N, 1, 3)
-        pj = pt.reshape(1, N, 3)
-        diff = pj - pi                                  # [N,N,3] broadcast
-        return diff.sum(1).reshape(N, 3)               # sum over j
+  def build(pt):
+    pi = pt.reshape(N, 1, 3)
+    pj = pt.reshape(1, N, 3)
+    diff = pj - pi                                  # [N,N,3] broadcast
+    return diff.sum(1).reshape(N, 3)               # sum over j
 
-    def ref(pa):
-        a = pa.astype(np.float32)
-        return (a[None, :, :] - a[:, None, :]).sum(1)
+  def ref(pa):
+    a = pa.astype(np.float32)
+    return (a[None, :, :] - a[:, None, :]).sum(1)
 
-    return tagged(Case(f"nbody_spring_N{N}", "nbody", build, ref, [P], tol=tol),
+  return tagged(Case(f"nbody_spring_N{N}", "nbody", build, ref, [P], tol=tol),
                   "mixed", "works")
 
 
 def _nbody_invsq_potential(N: int, tol: float):
-    """Pairwise inverse-distance potential energy proxy: U_i = sum_{j!=i} 1/sqrt(|p_i-p_j|^2+eps).
+  """Pairwise inverse-distance potential energy proxy: U_i = sum_{j!=i} 1/sqrt(|p_i-p_j|^2+eps).
 
     Probes the squared-distance broadcast + rsqrt + reduction (the gravity/Coulomb
     kernel shape). The self term j=i is killed by a large eps-shift via masking with a
@@ -404,33 +404,33 @@ def _nbody_invsq_potential(N: int, tol: float):
     cost: MIXED (broadcast [N,N,3] squared-distance reduction to [N,N], rsqrt, reduce).
     feasibility: WORKS (fp16-limited near coincident points; we keep points separated).
     """
-    P = (rng.standard_normal((N, 3)).astype(np.float32) * 1.5).astype(np.float16)
-    eps = 0.5
-    bigdiag = (np.eye(N, dtype=np.float32) * 1e3).astype(np.float16)   # folded mask
+  P = (rng.standard_normal((N, 3)).astype(np.float32) * 1.5).astype(np.float16)
+  eps = 0.5
+  bigdiag = (np.eye(N, dtype=np.float32) * 1e3).astype(np.float16)   # folded mask
 
-    def build(pt, mt):
-        pi = pt.reshape(N, 1, 3)
-        pj = pt.reshape(1, N, 3)
-        d = pj - pi                                     # [N,N,3]
-        d2 = d.square().sum(2).reshape(N, N)            # [N,N] squared distances
-        d2 = d2 + mt                                    # add huge value on the diagonal
-        inv = d2.rsqrt(eps=eps)                         # 1/sqrt(d2+eps), diag -> ~0
-        return inv.sum(1).reshape(N, 1)                 # potential per point
+  def build(pt, mt):
+    pi = pt.reshape(N, 1, 3)
+    pj = pt.reshape(1, N, 3)
+    d = pj - pi                                     # [N,N,3]
+    d2 = d.square().sum(2).reshape(N, N)            # [N,N] squared distances
+    d2 = d2 + mt                                    # add huge value on the diagonal
+    inv = d2.rsqrt(eps=eps)                         # 1/sqrt(d2+eps), diag -> ~0
+    return inv.sum(1).reshape(N, 1)                 # potential per point
 
-    def ref(pa, ma):
-        a = pa.astype(np.float32)
-        d2 = ((a[None, :, :] - a[:, None, :]) ** 2).sum(2) + ma.astype(np.float32)
-        inv = 1.0 / np.sqrt(d2 + eps)
-        return inv.sum(1, keepdims=True)
+  def ref(pa, ma):
+    a = pa.astype(np.float32)
+    d2 = ((a[None, :, :] - a[:, None, :]) ** 2).sum(2) + ma.astype(np.float32)
+    inv = 1.0 / np.sqrt(d2 + eps)
+    return inv.sum(1, keepdims=True)
 
-    return tagged(Case(f"nbody_invsq_pot_N{N}", "nbody", build, ref, [P, bigdiag], tol=tol),
+  return tagged(Case(f"nbody_invsq_pot_N{N}", "nbody", build, ref, [P, bigdiag], tol=tol),
                   "mixed", "fp16-limited")
 
 
 # QUADRATURE - weighted reduction (cumsum is unsupported: a boundary)
 
 def _simpson(n: int, tol: float):
-    """Composite Simpson integration of sin(x) on [0,pi] as a weighted reduction.
+  """Composite Simpson integration of sin(x) on [0,pi] as a weighted reduction.
 
     Simpson's rule is I ~ sum_k w_k f(x_k) with w = (h/3)*[1,4,2,4,...,4,1]. Both the
     samples f(x_k) and the weights w_k are precomputed on the host and fed as [1,n+1]
@@ -446,25 +446,25 @@ def _simpson(n: int, tol: float):
     inclusive-scan op and no in-graph loop). So definite integrals (one weighted
     reduction) fit, but cumulative/indefinite integrals do not.
     """
-    a, b = 0.0, np.pi
-    h = (b - a) / n
-    x = np.linspace(a, b, n + 1)
-    w = np.ones(n + 1); w[1:-1:2] = 4.0; w[2:-1:2] = 2.0; w *= h / 3.0
-    fx = np.sin(x).astype(np.float16).reshape(1, n + 1)
-    wv = w.astype(np.float16).reshape(1, n + 1)
+  a, b = 0.0, np.pi
+  h = (b - a) / n
+  x = np.linspace(a, b, n + 1)
+  w = np.ones(n + 1); w[1:-1:2] = 4.0; w[2:-1:2] = 2.0; w *= h / 3.0
+  fx = np.sin(x).astype(np.float16).reshape(1, n + 1)
+  wv = w.astype(np.float16).reshape(1, n + 1)
 
-    def build(ft, wt):
-        return (ft * wt).sum(1)                          # [1,1]
+  def build(ft, wt):
+    return (ft * wt).sum(1)                          # [1,1]
 
-    def ref(fa, wa):
-        return (fa.astype(np.float32) * wa.astype(np.float32)).sum(1, keepdims=True)
+  def ref(fa, wa):
+    return (fa.astype(np.float32) * wa.astype(np.float32)).sum(1, keepdims=True)
 
-    return tagged(Case(f"simpson_sin_n{n}", "quadrature", build, ref, [fx, wv], tol=tol),
+  return tagged(Case(f"simpson_sin_n{n}", "quadrature", build, ref, [fx, wv], tol=tol),
                   "reduction", "works")
 
 
 def _gauss_legendre(n: int, tol: float):
-    """Gauss-Legendre quadrature of exp(x) on [-1,1] as a weighted reduction.
+  """Gauss-Legendre quadrature of exp(x) on [-1,1] as a weighted reduction.
 
     Nodes/weights from numpy.polynomial.legendre.leggauss(n); samples exp(node) and the
     weights are host-fed [1,n] inputs, the ANE forms sum_k w_k f(x_k). Same "weighted
@@ -473,17 +473,17 @@ def _gauss_legendre(n: int, tol: float):
     cost: REDUCTION.
     feasibility: WORKS (true value = e - 1/e ~ 2.3504).
     """
-    nodes, weights = np.polynomial.legendre.leggauss(n)
-    fx = np.exp(nodes).astype(np.float16).reshape(1, n)
-    wv = weights.astype(np.float16).reshape(1, n)
+  nodes, weights = np.polynomial.legendre.leggauss(n)
+  fx = np.exp(nodes).astype(np.float16).reshape(1, n)
+  wv = weights.astype(np.float16).reshape(1, n)
 
-    def build(ft, wt):
-        return (ft * wt).sum(1)
+  def build(ft, wt):
+    return (ft * wt).sum(1)
 
-    def ref(fa, wa):
-        return (fa.astype(np.float32) * wa.astype(np.float32)).sum(1, keepdims=True)
+  def ref(fa, wa):
+    return (fa.astype(np.float32) * wa.astype(np.float32)).sum(1, keepdims=True)
 
-    return tagged(Case(f"gauss_legendre_exp_n{n}", "quadrature", build, ref, [fx, wv], tol=tol),
+  return tagged(Case(f"gauss_legendre_exp_n{n}", "quadrature", build, ref, [fx, wv], tol=tol),
                   "reduction", "works")
 
 
@@ -538,7 +538,7 @@ CASES = SPECTRAL + SIGNAL + MONTECARLO + NBODY + QUADRATURE
 
 
 def run_spectral(cases, verbose: bool = True):
-    """Mirror of _corpus.run_corpus, extended to print cost/feasibility tags and a
+  """Mirror of _corpus.run_corpus, extended to print cost/feasibility tags and a
     SPECTRAL verdict block. Returns (results, exit_code).
 
     Gate: PASS and XFAIL are green; FAIL, ERROR, XPASS are red. The feasibility tag is
@@ -546,104 +546,104 @@ def run_spectral(cases, verbose: bool = True):
     "passes" if its tiny fixed-N instance is numerically correct; the tag carries the
     *generalization* verdict.
     """
-    all_results = []
-    relerrs = []
-    dft_curve: list[tuple[int, str]] = []     # (N, relerr_str) for the verdict block
-    if verbose:
-        print(f"{'case':30s} {'var':4s} {'status':6s} {'cost':14s} {'feasible':13s} detail")
-        print("-" * 104)
-    for case in cases:
-        cost, feas = TAGS.get(case.name, ("?", "?"))
-        for rec in eval_case(case):
-            rec["cost"], rec["feasibility"] = cost, feas
-            all_results.append(rec)
-            line = (f"{rec['name']:30s} {rec['variant']:4s} {rec['status']:6s} "
-                    f"{cost:14s} {feas:13s} {rec['metric']}")
-            if rec["err"]:
-                line += f"  [{rec['err']}]"
-            if verbose:
-                print(line)
-                if rec.get("traceback"):
-                    print("    " + rec["traceback"].replace("\n", "\n    "))
-            m = rec["metric"]
-            if m.startswith("relerr "):
-                try:
-                    relerrs.append(float(m.split()[1]))
-                except ValueError:
-                    pass
-                if rec["name"].startswith("dft_matmul_N"):
-                    dft_curve.append((int(rec["name"].split("_N")[1]), m.split()[1]))
+  all_results = []
+  relerrs = []
+  dft_curve: list[tuple[int, str]] = []     # (N, relerr_str) for the verdict block
+  if verbose:
+    print(f"{'case':30s} {'var':4s} {'status':6s} {'cost':14s} {'feasible':13s} detail")
+    print("-" * 104)
+  for case in cases:
+    cost, feas = TAGS.get(case.name, ("?", "?"))
+    for rec in eval_case(case):
+      rec["cost"], rec["feasibility"] = cost, feas
+      all_results.append(rec)
+      line = (f"{rec['name']:30s} {rec['variant']:4s} {rec['status']:6s} "
+          f"{cost:14s} {feas:13s} {rec['metric']}")
+      if rec["err"]:
+        line += f"  [{rec['err']}]"
+      if verbose:
+        print(line)
+        if rec.get("traceback"):
+          print("    " + rec["traceback"].replace("\n", "\n    "))
+      m = rec["metric"]
+      if m.startswith("relerr "):
+        try:
+          relerrs.append(float(m.split()[1]))
+        except ValueError:
+          pass
+        if rec["name"].startswith("dft_matmul_N"):
+          dft_curve.append((int(rec["name"].split("_N")[1]), m.split()[1]))
 
-    n_pass = sum(r["status"] == "PASS" for r in all_results)
-    n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
-    n_fail = sum(r["status"] == "FAIL" for r in all_results)
-    n_err = sum(r["status"] == "ERROR" for r in all_results)
-    n_xpass = sum(r["status"] == "XPASS" for r in all_results)
-    total = len(all_results)
-    red = n_fail + n_err + n_xpass
+  n_pass = sum(r["status"] == "PASS" for r in all_results)
+  n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
+  n_fail = sum(r["status"] == "FAIL" for r in all_results)
+  n_err = sum(r["status"] == "ERROR" for r in all_results)
+  n_xpass = sum(r["status"] == "XPASS" for r in all_results)
+  total = len(all_results)
+  red = n_fail + n_err + n_xpass
 
-    print("\n" + "=" * 104)
-    print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
+  print("\n" + "=" * 104)
+  print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
           f"FAIL {n_fail}   ERROR {n_err}   XPASS {n_xpass}")
-    if relerrs:
-        print(f"relerr across {len(relerrs)} numeric variants: "
+  if relerrs:
+    print(f"relerr across {len(relerrs)} numeric variants: "
               f"min {min(relerrs):.2e}  median {np.median(relerrs):.2e}  max {max(relerrs):.2e}")
 
-    # ------- SPECTRAL verdict block (the marquee finding) ----------------- #
-    print("\n" + "-" * 104)
-    print("CAN THE ANE DO AN FFT?  (complex emulated as real/imag tensor pairs)")
-    print("-" * 104)
-    if dft_curve:
-        print("  DFT-as-matmul precision vs transform size N (fp16 weights, wide accumulator):")
-        for N, e in sorted(dft_curve):
-            print(f"    N={N:<5d} relerr {e}")
-        print("    => relerr is essentially FLAT in N (no compounding): the ANE matmul")
-        print("       accumulator is wide (>=fp32), so the length-N twiddle sum is not")
-        print("       re-rounded per term. fp16 is NOT the wall for the transform.")
-    bf = [r for r in all_results if r["name"].startswith("fft_butterfly")]
-    if bf:
-        bfst = ", ".join(f"{r['name'].split('_N')[1]}:{r['status']}({r['metric']})" for r in bf)
-        print(f"  Radix-2 butterfly FFT (fully unrolled): {bfst}")
-    print("\n  VERDICT:")
-    print("    YES - both a dense DFT (twiddle-matrix matmul) and a radix-2 butterfly FFT")
-    print("    are EXPRESSIBLE and CORRECT on the ANE via complex-as-real-pairs")
-    print("    arithmetic ((a+bi)(c+di) = (ac-bd)+(ad+bc)i over paired real tensors).")
-    print("    * DFT-matmul: fp16-CLEAN to at least N=2048 (relerr ~ few e-4, flat in N).")
-    print("      The limiter is NOT precision but the O(N^2) twiddle-matrix size/bandwidth")
-    print("      - it is a naive DFT, so cost grows quadratically; precision does not.")
-    print("    * Butterfly FFT: correct for small fixed N, but expressible ONLY as a")
-    print("      per-N STATIC UNROLL (the ANE is feed-forward: no in-graph loop, no scalar")
-    print("      feedback, and bit-reversal needs a folded one-hot since there is no")
-    print("      gather). So its O(N log N) advantage is not realizable as a graph at")
-    print("      useful N - the wall is ARCHITECTURAL (static unroll), not fp16.")
-    print("    BOTTOM LINE: the ANE has no complex dtype, but FFT/DFT is viable through")
-    print("    real-pair emulation; for practical sizes the dense DFT-matmul is the")
-    print("    right tool (fp16-robust, fuses), and a true scaling FFT is blocked by the")
-    print("    missing loop/gather, not by numerics.")
+  # ------- SPECTRAL verdict block (the marquee finding) ----------------- #
+  print("\n" + "-" * 104)
+  print("CAN THE ANE DO AN FFT?  (complex emulated as real/imag tensor pairs)")
+  print("-" * 104)
+  if dft_curve:
+    print("  DFT-as-matmul precision vs transform size N (fp16 weights, wide accumulator):")
+    for N, e in sorted(dft_curve):
+      print(f"    N={N:<5d} relerr {e}")
+    print("    => relerr is essentially FLAT in N (no compounding): the ANE matmul")
+    print("       accumulator is wide (>=fp32), so the length-N twiddle sum is not")
+    print("       re-rounded per term. fp16 is NOT the wall for the transform.")
+  bf = [r for r in all_results if r["name"].startswith("fft_butterfly")]
+  if bf:
+    bfst = ", ".join(f"{r['name'].split('_N')[1]}:{r['status']}({r['metric']})" for r in bf)
+    print(f"  Radix-2 butterfly FFT (fully unrolled): {bfst}")
+  print("\n  VERDICT:")
+  print("    YES - both a dense DFT (twiddle-matrix matmul) and a radix-2 butterfly FFT")
+  print("    are EXPRESSIBLE and CORRECT on the ANE via complex-as-real-pairs")
+  print("    arithmetic ((a+bi)(c+di) = (ac-bd)+(ad+bc)i over paired real tensors).")
+  print("    * DFT-matmul: fp16-CLEAN to at least N=2048 (relerr ~ few e-4, flat in N).")
+  print("      The limiter is NOT precision but the O(N^2) twiddle-matrix size/bandwidth")
+  print("      - it is a naive DFT, so cost grows quadratically; precision does not.")
+  print("    * Butterfly FFT: correct for small fixed N, but expressible ONLY as a")
+  print("      per-N STATIC UNROLL (the ANE is feed-forward: no in-graph loop, no scalar")
+  print("      feedback, and bit-reversal needs a folded one-hot since there is no")
+  print("      gather). So its O(N log N) advantage is not realizable as a graph at")
+  print("      useful N - the wall is ARCHITECTURAL (static unroll), not fp16.")
+  print("    BOTTOM LINE: the ANE has no complex dtype, but FFT/DFT is viable through")
+  print("    real-pair emulation; for practical sizes the dense DFT-matmul is the")
+  print("    right tool (fp16-robust, fuses), and a true scaling FFT is blocked by the")
+  print("    missing loop/gather, not by numerics.")
 
-    # ------- other capability findings ------------------------------------ #
-    print("\n" + "-" * 104)
-    print("OTHER SCIENTIFIC-KERNEL FINDINGS")
-    print("-" * 104)
-    print("  SIGNAL    : FIR filter (1D conv) and 2D autocorrelation (CrossCorrelation")
-    print("              bridge + conv-of-self) WORK, fp16-clean. ANE conv == cross-")
-    print("              correlation (no kernel flip); CrossCorrelation needs the template")
-    print("              strictly smaller than the map (same-size fails ANECCompile).")
-    print("  MONTECARLO: map+reduction estimators (integral, mean/variance) WORK; the wide")
-    print("              accumulator keeps large-M reductions clean. Caveat: aneforge")
-    print("              exposes NO on-device RNG, so samples are host-drawn and fed in")
-    print("              (reference uses the same samples -> exact, not statistical).")
-    print("  N-BODY    : pairwise broadcast-diff ([N,1,3]-[1,N,3]) + reduction WORKS for")
-    print("              small N (linear forces fp16-clean; 1/r potential is fp16-limited")
-    print("              near coincident points and grows O(N^2) in the intermediate).")
-    print("  QUADRATURE: definite integrals as a weighted reduction (Simpson, Gauss-")
-    print("              Legendre) WORK to ~1e-5. BOUNDARY: cumsum/prefix-scan is NOT")
-    print("              expressible (no scan op, no in-graph loop), so cumulative/")
-    print("              indefinite integrals do not fit.")
+  # ------- other capability findings ------------------------------------ #
+  print("\n" + "-" * 104)
+  print("OTHER SCIENTIFIC-KERNEL FINDINGS")
+  print("-" * 104)
+  print("  SIGNAL    : FIR filter (1D conv) and 2D autocorrelation (CrossCorrelation")
+  print("              bridge + conv-of-self) WORK, fp16-clean. ANE conv == cross-")
+  print("              correlation (no kernel flip); CrossCorrelation needs the template")
+  print("              strictly smaller than the map (same-size fails ANECCompile).")
+  print("  MONTECARLO: map+reduction estimators (integral, mean/variance) WORK; the wide")
+  print("              accumulator keeps large-M reductions clean. Caveat: aneforge")
+  print("              exposes NO on-device RNG, so samples are host-drawn and fed in")
+  print("              (reference uses the same samples -> exact, not statistical).")
+  print("  N-BODY    : pairwise broadcast-diff ([N,1,3]-[1,N,3]) + reduction WORKS for")
+  print("              small N (linear forces fp16-clean; 1/r potential is fp16-limited")
+  print("              near coincident points and grows O(N^2) in the intermediate).")
+  print("  QUADRATURE: definite integrals as a weighted reduction (Simpson, Gauss-")
+  print("              Legendre) WORK to ~1e-5. BOUNDARY: cumsum/prefix-scan is NOT")
+  print("              expressible (no scan op, no in-graph loop), so cumulative/")
+  print("              indefinite integrals do not fit.")
 
-    print(f"\nGATE: {'GREEN' if red == 0 else 'RED'}  "
+  print(f"\nGATE: {'GREEN' if red == 0 else 'RED'}  "
           f"({n_pass + n_xfail}/{total} green, {red} red)")
-    return all_results, (0 if red == 0 else 1)
+  return all_results, (0 if red == 0 else 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Adopts tinygrad-style code-quality gates. **No runtime behavior change** (golden-MIL byte-identical across representative graphs; full on-device suite 563 passed). No line cap (declined).

## pyright → 0, gated

Fixed all **71 pre-existing pyright errors** (annotation widening, `int()` casts, `assert`-narrowing of Optionals, var pre-init, `dict[str,"callable"]`→`Callable`, `Model|SegmentedModel` narrowing) — **no logic changes**. Type-ignores driven from ~18 down to **2**, both genuine scipy-stub bugs (`# type: ignore[code]` + reason; the 5 bare bridge ignores were removed — they suppressed nothing). A CI `types` job now gates pyright at 0 (pinned `pyright==1.1.410`).

## Lint pack

- **ruff:** added flake8-comprehensions (C4) + flake8-builtins (A); `indent-width=2`; kept `line-length=120` and the compact-idiom ignores. `input`/`compile` allowlisted (intentional public-API op names). 21 C4 cleanups applied.
- **2-space lock:** a pylint step (`-e W0311 -e C0303 --indent-string='  '`) in CI. **This caught that the earlier restyle (#34) left 7 files still 4-space** (the AST checker is indentation-blind) — those are now fully reindented (AST-identical, pure whitespace), so the gate is green and locked.
- **pre-commit:** `.pre-commit-config.yaml` mirrors all three (ruff, 2-space, pyright) for local checks.

## Verification

- pyright `aneforge`: **0 errors**.
- ruff check: clean. pylint W0311/C0303 over `aneforge`+`tests`: **0**.
- golden-MIL: all representative graphs byte-identical (emit, hence device runtime, unchanged).
- full on-device suite (`--forked`, Apple Silicon): **563 passed**.

## Notes

- `examples/`/`bench/` got the C4 cleanups (ruff lints the repo) but are otherwise unchanged.
- No public-API, numerics, or logic changes.