### PR TITLE
Thin in-code prose; relocate design rationale to docs/developer/

### DIFF
--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -1,82 +1,15 @@
-"""aneforge - a clean graph->compile->run frontend for the Apple Neural Engine.
+"""aneforge - a graph->compile->run frontend for the Apple Neural Engine.
 
-Build a small tensor graph, `compile` it into ONE fused e5rt program, and run it
-on the ANE. Fusing is the point: the ANE penalises many tiny dispatches, so a whole
-subgraph becomes a single program. Weights pack automatically into one BLOBFILE -
-fp16, or per-channel int8 *streamed* (dequantised during the tile DMA) when
-`int8=True`.
+Build a tensor graph, `compile` it into one fused e5rt program (or a SegmentedModel
+when a netplist-bridge op cuts the graph), and run it on the ANE. fp16 compute with a
+wide reduction accumulator; weights pack into one BLOBFILE (fp16 / int8 / int4 /
+sparse). Wraps the unentitled Espresso `e5rt` runtime only - no CoreML, no entitlement.
 
-    import aneforge as af
-
-    x = af.input((1, 3, 32, 32))
-    h = af.conv(x, W1, pad=1).relu()
-    h = af.conv(h, W2, pad=1).relu()
-    y = h.mean((2, 3)).reshape(1, C) @ Wfc
-    net = af.compile(y, int8=True)      # one fused ANE program
-    net = af.compile(y, compress="int4")   # 4-bit LUT weights, accuracy-gated
-    out = net(image)                    # run on the ANE
-
-Op surface:
-  - linear algebra: conv, conv_transpose; matmul/linear via `@`; bmm
-  - dynamic_conv: conv with a RUNTIME-tensor weight (hypernetworks / per-sample kernels;
-    native ANE dynamic kernel, batch-1 only)
-  - activations: relu/silu/gelu/sigmoid/tanh/exp/log/sqrt/rsqrt/abs/square/
-    sin/cos/erf/softplus/relu6/elu/leaky_relu/clip
-  - arithmetic: add/sub/mul/div(`/`)/maximum/minimum/pow
-  - reductions/norms: mean/sum/amax/amin, softmax, l2_norm, rms_norm/layer_norm/
-    group_norm/batch_norm
-  - spatial/shape: max_pool/avg_pool, upsample, concat, reshape/transpose,
-    pixel_shuffle/pixel_unshuffle
-  - nn helpers: mha, cross_attention, geglu
-
-Two op routes. Most ops are FUSED e5rt-MIL: they lower to MIL and fuse into ONE
-program (no graph cut). A second family are NETPLIST-BRIDGE ops - native Path-A
-hardware layers Apple's MIL frontend never emits (sdpa, argmax/topk/sort,
-cross_product/cross_correlation/cost_volume, fps/radius_search, minmax_norm/lrn,
-the space/channel/batch rearranges, flatten/input_view/dynamic_slice/
-scaled_elementwise). Each bridge op CUTS the graph: surrounding regions run as
-e5rt programs, the bridge node runs as a separate native sub-program (sub-ms via
-the A2 persistent worker), and `compile` returns a SegmentedModel.
-
-Image input: `af.image_input(shape, scale=1/255, bias=0.0)` declares a uint8 input
-port and dequantises it on the engine (`cast -> scale -> bias`), so raw camera /
-decoded-video bytes feed the model directly (host skips the float-convert/repack);
-`scale`/`bias` are scalar or per-channel (length-C, broadcast over NCHW).
-
-Pretrained loaders: `af.load(".../all-MiniLM-L6-v2")` (sentence encoder),
-`af.load_resnet18()` (ImageNet classifier).
-
-Design rules: compute is fp16 only (fp32/int32/bf16
-rejected); reductions/matmuls use a WIDE (fp32-class) accumulator fed by radix-4
-fp16-rounded input tiles - representable sums are near-exact (a sum/dot of 16384 ones is
-bit-exact, where naive fp16 would stall at ~2048), and a +1 survives next to a 16000
-partial that an fp16 running sum would swallow. The fp16 limit is at the products and the
-I/O cast, not the running sum, so cancellation-heavy reductions still lose precision;
-`int8=True` streams weights at half the bytes. `compress=`
-chooses weight encoding: None (fp16, default), 'int8' (per-channel), 'int4'
-(LUT palettization, per-tensor, with an accuracy-gated fallback to int8/fp16 set by
-`compress_atol`), 'sparse' (unstructured bitmask, emitted when the weight is >=50%
-zeros, else fp16), or 'auto' (per-weight: sparse if sparse, else int4 if accurate,
-else int8, else fp16). `int8=True` is the alias for `compress='int8'`. Wraps the
-unentitled Espresso `e5rt` runtime only - no CoreML, no entitlement.
-
-aneforge also has a tiny reverse-mode autograd (`autograd.py`): `af.parameter` /
-`af.backward` / `af.mse` / `af.SGD` / `af.Trainer` train a small model with the
-forward and backward passes compiled and run on the ANE. It also does
-classification: `af.softmax_cross_entropy` (analytic fp16-stable on-ANE gradient) +
-`af.Adam` train a 784->128->10 MLP on MNIST to ~97% test accuracy.
-`Trainer(..., device_optimizer=True)` additionally runs the OPTIMIZER STEP on the
-ANE (SGD/Adam update as graph ops), so all training tensor-math is on the engine;
-the host only computes the scalar lr_t and shuttles state/grads (the host<->device
-state round-trip remains). See examples/train_mnist_mlp.py.
-
-Layout: graph.py (Tensor + ops), _compile.py (per-op emit registry + compile),
-_blob.py (weight packing), autograd.py (on-ANE autograd), models.py (pretrained loaders).
+See docs/developer/overview.md for the op surface, fused-vs-bridge routes, numerics,
+weight compression, image input, and on-ANE autograd.
 """
-# Tolerate a duplicate OpenMP runtime in one process: numpy/MKL and the ANE
-# runtime dylib each bring their own libomp, and without this the second to load
-# aborts the process. Set before any import that pulls in numpy so OpenMP sees it
-# at initialization; setdefault keeps it user-overridable.
+# Tolerate a duplicate OpenMP runtime (numpy/MKL and the ANE dylib each bring their
+# own libomp; without this the second to load aborts). Must precede any numpy import.
 import os as _os
 _os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 

--- a/aneforge/_blob.py
+++ b/aneforge/_blob.py
@@ -1,8 +1,6 @@
-"""Weight packing for aneforge: one BLOBFILE holding every constant the program
-needs (fp16, or per-channel int8 for streaming). The container is a 64-byte header
-followed, per blob, by a 64-byte descriptor (magic 0xDEADBEEF, dtype code, length,
-data offset) and the raw bytes. dtype codes: 1 = fp16, 4 = int8, 9 = uint1 (sparse
-mask), 11 = uint4 (LUT)."""
+"""BLOBFILE weight container: one file of every constant the program needs. 64-byte
+header, then per blob a 64-byte descriptor (magic 0xDEADBEEF, dtype code, length, data
+offset) and raw bytes. See docs/developer/compile-pipeline.md."""
 from __future__ import annotations
 
 import struct
@@ -11,12 +9,10 @@ import numpy as np
 
 _HEADER = 64
 _DESCRIPTOR = 64
+# BLOBFILE container dtype codes (distinct from the MIL-proto DataType enum).
 FP16, INT8 = 1, 4
-UINT1 = 9   # BLOBFILE container dtype code for the 1-bit sparse mask (Task 8 spike;
-            # distinct from the MIL-proto DataType enum). FP16=1, INT8=4, UINT4=11.
-UINT4 = 11  # BLOBFILE container dtype code for packed 4-bit LUT indices (Task 0 spike:
-            # read from CoreML's own weight.bin; distinct from the MIL-proto DataType
-            # enum). FP16=1, INT8=4 already exist.
+UINT1 = 9   # 1-bit sparse mask
+UINT4 = 11  # packed 4-bit LUT indices
 
 
 def fp16_bytes(a: np.ndarray) -> bytes:
@@ -33,11 +29,10 @@ def quantize_per_row(W: np.ndarray) -> tuple[bytes, bytes]:
 
 
 def palettize_lut4(W: np.ndarray) -> tuple[bytes, bytes]:
-  """Per-tensor 4-bit LUT palettization of an [OUT, IN] weight ->
-    (packed-index bytes, fp16 codebook bytes). 16 centroids via deterministic
-    Lloyd iterations seeded from quantiles (no RNG, so output is byte-stable).
-    Indices are packed two-per-byte, low nibble first; reconstruction is
-    `codebook[index]` (matches the on-device constexpr_lut_to_dense)."""
+  """Per-tensor 4-bit LUT palettization of [OUT, IN] -> (packed-index bytes, fp16 codebook
+    bytes). 16 centroids via deterministic (RNG-free, byte-stable) Lloyd iterations seeded
+    from quantiles; indices packed two-per-byte, low nibble first. Reconstruction
+    `codebook[index]` matches on-device constexpr_lut_to_dense."""
   flat = W.reshape(-1).astype(np.float32)
   edges = np.quantile(flat, np.linspace(0.0, 1.0, 17))
   centroids = ((edges[:-1] + edges[1:]) / 2.0).astype(np.float32)
@@ -55,15 +50,11 @@ def palettize_lut4(W: np.ndarray) -> tuple[bytes, bytes]:
 
 
 def quantize_blockwise(W: np.ndarray, block_size: int = 32) -> tuple[bytes, bytes, int]:
-  """Per-block symmetric int8 quant of [OUT, IN] -> (int8 data bytes, fp16 scale
-    bytes, nblocks). The inner dim splits into `nblocks` contiguous blocks of
-    `block_size` columns, each with its own scale; the layout the on-device
-    `constexpr_blockwise_shift_scale(data=.., scale=..)` reconstructs as
-    `data.reshape(OUT, nblocks, block_size) * scale[:, :, None]` (zero offset). The
-    scale tensor is [OUT, nblocks]. `block_size` is clamped to divide IN: if IN is
-    not a multiple, the largest divisor <= block_size is used (per-tensor when IN is
-    prime-ish). Finer blocks track local weight scale -> lower error than a single
-    per-tensor scale."""
+  """Per-block symmetric int8 quant of [OUT, IN] -> (int8 data, fp16 scale [OUT,nblocks],
+    nblocks). IN splits into nblocks contiguous `block_size`-column blocks, each with its
+    own scale; on-device constexpr_blockwise_shift_scale reconstructs as
+    `data.reshape(OUT, nblocks, block_size) * scale[:, :, None]`. `block_size` is clamped
+    to the largest divisor <= it that divides IN. Finer blocks -> lower error."""
   W = W.astype(np.float32)
   OUT, IN = W.shape
   bs = int(block_size)
@@ -76,11 +67,9 @@ def quantize_blockwise(W: np.ndarray, block_size: int = 32) -> tuple[bytes, byte
 
 
 def sparsify(W: np.ndarray) -> tuple[bytes, bytes]:
-  """Bitmask sparse encoding of [OUT, IN] -> (packed 1-bit mask bytes, fp16
-    nonzero-value bytes), row-major (C order). mask bit 1 = keep (nonzero),
-    LSB-first within each byte (element i -> bit i%8 of byte i//8). Reconstruction
-    scatters the nonzeros into the set positions (matches constexpr_sparse_to_dense).
-    Lossless for the kept values (fp16 rounding only)."""
+  """Bitmask sparse encoding of [OUT, IN] -> (packed 1-bit mask, fp16 nonzero values),
+    row-major. mask bit 1 = keep, LSB-first per byte. Reconstruction scatters nonzeros
+    into set positions (matches constexpr_sparse_to_dense); lossless but for fp16 rounding."""
   flat = W.reshape(-1)
   nz = flat != 0.0
   mask = np.packbits(nz.astype(np.uint8), bitorder="little")

--- a/aneforge/_bridges/_netplist.py
+++ b/aneforge/_bridges/_netplist.py
@@ -1,14 +1,6 @@
 #!/usr/bin/env python3
-"""Generate small ANEF net.plist programs without CoreML or MLCompute.
-
-The generated directory contains:
-  - net.plist
-  - weights.0
-  - weights.1 for convolution programs
-
-It can be loaded by ane_network_description_probe.m through
-_ANEInMemoryModelDescriptor modelWithNetworkDescription:weights:optionsPlist:.
-"""
+"""Shared netplist author for the Path-A bridges: generate net.plist + weights.*
+programs (no CoreML / MLCompute) and dispatch them. See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -23,20 +15,15 @@ _INVOKERS_DIR = Path(__file__).resolve().parents[1] / "_invokers"     # aneforge
 
 
 def bin_dir() -> Path:
-  """Per-machine compiled-invoker binary cache (sibling of the e5rt cache at
-    `~/.cache/aneforge/e5rt`), kept outside the package tree so the bridges work
-    when aneforge is installed into a read-only site-packages."""
+  """Per-machine compiled-invoker binary cache, outside the package tree so the
+    bridges work from a read-only site-packages install."""
   return Path.home() / ".cache" / "aneforge" / "bin"
 
 
 def ensure_invoker(name: str) -> Path:
-  """Compile `aneforge/_invokers/<name>.mm` -> `bin_dir()/<name>` on demand,
-    cached per machine (rebuilt when the source is newer). The invokers link only
-    system frameworks, so this works on any Apple Silicon Mac. Returns the binary path.
-
-    Several bridges share one invoker (e.g. `sdpa_invoker` is the generic netplist
-    invoker for the geometry / structural / rearrange ops), so the build is centralized
-    here, not duplicated per bridge."""
+  """Compile `_invokers/<name>.mm` -> `bin_dir()/<name>` on demand (rebuilt when
+    the source is newer); returns the binary path. `sdpa_invoker` is the generic
+    netplist invoker shared by the geometry/structural/rearrange ops."""
   src = _INVOKERS_DIR / f"{name}.mm"
   binp = bin_dir() / name
   if binp.exists() and src.exists() and binp.stat().st_mtime >= src.stat().st_mtime: return binp
@@ -50,16 +37,9 @@ def ensure_invoker(name: str) -> Path:
 
 
 def invoke_netplist(invoker, net_plist, *, weights=(), inputs=(), outputs=(), repeats=1, warmup=None, extra=()):
-  """Run a native-layer invoker over a netplist and return its parsed status.
-
-    Shared Path-A dispatch core for the netplist bridges: builds the invoker
-    command (`--net-plist` + per-weight `--weights` + per-input `--input name=path`
-    + per-output `--output name=path` + `--repeats` and optional `--warmup`), runs
-    it, and raises on a non-zero return code or a non-`ok` status. `inputs`/`outputs`
-    are `(name, path)` pairs; the caller writes the input files and reads the output
-    files (layouts differ per bridge). Returns the parsed last-line status dict (e.g.
-    timing info).
-    """
+  """Shared Path-A dispatch: build the invoker command and run it. `inputs`/
+    `outputs` are `(name, path)` pairs (caller writes inputs, reads outputs).
+    Raises on non-zero return or non-`ok` status; returns the status dict."""
   cmd = [str(invoker), "--net-plist", str(net_plist)]
   for w in weights: cmd += ["--weights", str(w)]
   for name, path in inputs: cmd += ["--input", f"{name}={path}"]
@@ -2386,43 +2366,18 @@ def build_sdpa(
 ) -> dict:
   """Build a single-op SDPA netplist mirroring the fused-hardware route.
 
-    The 4-input ANE fused-attention layer accepts Q, K, V, and Scale tensor
-    descriptors.  The validator (`_ANECValidateSDPALayer`) requires
-    `ANECTensorDesc.byte[0x39] bit 0` to be set on the Scale tensor (the
-    "Scale is expected to be constant" gate found by Agent #41).
-
-    The netplist spelling of that bit is undocumented; Apple's MIL->ANECIR
-    translator sets it implicitly via the `Constants` array.  This builder
-    supports several candidate spellings selected by `constant_flag_spelling`:
-
-      - "Constants_array"    : list Scale in the network's `Constants` array
-                               (the conventional Apple route - backed by
-                               weights.0).
-      - "IsConstant_unit"    : add `IsConstant: True` on the unit's input slot.
-      - "is_constant_unit"   : ditto, snake-case.
-      - "ConstantTensor_unit": `ConstantTensor: True` on the unit.
-      - "ScaleMutable_false" : analogue to other `*Mutable` Apple keys -
-                               `ScaleMutable: False` on the unit.
-      - "all"                : every variant simultaneously (probe mode).
-
-    The Scale value is folded into the constant weights blob; the
-    `scale` parameter defaults to `1/sqrt(dim)`.
-
-    `subtract_max` controls the `Params.SubtractMax` boolean.  Recovered from
-    ZinParseSDPAUnit + ANECDescToUnitInfo<ANECSDPALayerDesc>: the SDPA descriptor's
-    first field (`desc[0x00]`) is a CFBoolean the netplist parser sets from
-    `Params.SubtractMax`.  `ANECSDPALayerDescInitialize` defaults to `kCFBooleanFalse`
-    (no max-stabilization); numerically correct softmax requires `True`.  Apple's
-    MIL->ANECIR translator emits `SubtractMax=True` for
-    `scaled_dot_product_attention`.
+    The validator requires the Scale tensor be flagged constant; the netplist
+    spelling is undocumented, so `constant_flag_spelling` selects a candidate
+    ("Constants_array" is the Apple route and the only one that loads here;
+    "all" = probe mode). `subtract_max` -> `Params.SubtractMax` (default True;
+    the hardware default is no max-stabilization, which breaks softmax).
+    `scale` defaults to `1/sqrt(dim)`. See docs/developer/bridges.md.
     """
   if scale is None: scale = 1.0 / (float(dim) ** 0.5)
   unit_name = "sdpa-1"
   network_name = "network_sdpa-1"
 
-  # Inputs: Q, K, V are tensor inputs; Scale is a weight-backed constant.
-  # The Bottom array places Scale as the 4th input (index 3), matching
-  # Apple's __Z18ValidateLayer_Impl<ANECSDPALayerDesc, ...> 4-tensor layout.
+  # Q, K, V are tensor inputs; Scale is the 4th Bottom (weight-backed constant).
   params: dict[str, object] = {"SubtractMax": bool(subtract_max)}
   unit: dict[str, object] = {
     "Bottom": ["query", "key", "value", "scale"],
@@ -2430,17 +2385,11 @@ def build_sdpa(
     "Name": unit_name,
     "OutputChannels": channels,
     "OutputType": "Float16",
-    # `SubtractMax` is the only `Params` key the SDPA netplist parser
-    # (ZinParseSDPAUnit at 0x222ff4b1c) recognizes; it controls whether
-    # softmax subtracts the max before exp.  _ANECSDPALayerDescInitialize
-    # defaults desc[0x00]=kCFBooleanFalse (no stabilization) - the source of
-    # the original "Y depends on Q,K,V,scale but doesn't equal
-    # softmax(Q@K^T*s)@V" numerics gap.
+    # SubtractMax is the only Params key the SDPA parser reads (softmax max-sub).
     "Params": params,
     "Type": "SDPA",
   }
 
-  # Apply candidate constant-flag spellings on the unit dict.
   use_constants_array = constant_flag_spelling in {"Constants_array", "all"}
   if constant_flag_spelling in {"IsConstant_unit", "all"}: unit["IsConstant"] = [False, False, False, True]
   if constant_flag_spelling in {"is_constant_unit", "all"}: unit["is_constant"] = [False, False, False, True]
@@ -2462,17 +2411,14 @@ def build_sdpa(
   )
 
   if use_constants_array:
-    # Mark Scale as a 1-element fp16 weight-backed constant (the canonical
-    # Apple route for "tensor is constant" in netplist).
+    # Mark Scale a 1-element fp16 weight-backed constant (canonical Apple route).
     plist = attach_constant(
       plist,
       network_name,
       constant_entry("scale", "Float16", width=1, height=1, channels=1),
     )
   else:
-    # Even without the Constants array we need an "input" port for Scale;
-    # add a placeholder weight-backed constant if the spelling alone
-    # carries the flag, otherwise add Scale as a regular input.
+    # No Constants array: add Scale as a plain input port.
     plist["ProcedureList"][0]["InputList"].append(
       input_entry("scale", width=1, height=1, channels=1, entry_name=unit_name)
     )

--- a/aneforge/_bridges/ane_cost_volume_fused.py
+++ b/aneforge/_bridges/ane_cost_volume_fused.py
@@ -1,13 +1,5 @@
-"""Native ANE CostVolume (stereo/optical-flow matching cost) via a netplist.
-
-Entry point `cost_volume_fused(aux, ref, disparity_range)`.  Given single-channel
-rows `aux` (width `Wa`) and `ref` (width `Wr`, with `Wr >= Wa + R`), it computes
-the L1 matching cost for each disparity `d in [0, R]` and position `x in [0, Wa)`:
-
-    `cost[d, x] = | aux[x] - ref[x + d] |`
-
-returning `(R+1)` disparity planes each of width `Wa`.
-"""
+"""Native ANE CostVolume (L1 stereo/optical-flow matching cost) on Path A.
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -24,15 +16,8 @@ _ROOT = Path(__file__).resolve().parents[2]
 
 def cost_volume_fused(aux: np.ndarray, ref: np.ndarray,
                       disparity_range: int | np.integer[Any] = 1) -> np.ndarray:
-  """L1 cost volume of two single-channel rows.
-
-    Args:
-        aux:             `(Wa,)` fp16-castable row.
-        ref:             `(Wr,)` fp16-castable row, `Wr >= Wa + R`.
-        disparity_range: `R`; produces `R+1` disparity planes.
-    Returns:
-        `(R+1, Wa)` fp16 cost volume, `cost[d, x] = |aux[x] - ref[x+d]|`.
-    """
+  """L1 cost volume of two single-channel rows; returns `(R+1, Wa)` fp16,
+    `cost[d, x] = |aux[x] - ref[x+d]|`. `ref` must satisfy `Wr >= Wa + R`."""
   aux = np.asarray(aux, dtype=np.float16).reshape(-1)
   ref = np.asarray(ref, dtype=np.float16).reshape(-1)
   Wa, Wr = aux.size, ref.size

--- a/aneforge/_bridges/ane_cross_correlation_fused.py
+++ b/aneforge/_bridges/ane_cross_correlation_fused.py
@@ -1,10 +1,5 @@
 """Native ANE CrossCorrelation (template matching) on Path A.
-
-:func:`cross_correlation_fused` computes the valid (no-flip) cross-correlation
-of a single-channel `H x W` map `x` with a `Th x Tw` template on the ANE:
-`y[i, j] = sum_{u,v} x[i+u, j+v] * template[u, v]` over an
-`(H-Th+1) x (W-Tw+1)` output.
-"""
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -19,14 +14,8 @@ _ROOT = Path(__file__).resolve().parents[2]
 
 
 def cross_correlation_fused(x: np.ndarray, template: np.ndarray) -> np.ndarray:
-  """Valid cross-correlation of single-channel map `x` with `template`.
-
-    Args:
-        x:        `(H, W)` fp16-castable map.
-        template: `(Th, Tw)` fp16-castable template.
-    Returns:
-        `(H-Th+1, W-Tw+1)` fp16 correlation map.
-    """
+  """Valid (no-flip) cross-correlation of `(H,W)` map `x` with `(Th,Tw)`
+    `template`; returns the `(H-Th+1, W-Tw+1)` fp16 correlation map."""
   x = np.asarray(x, dtype=np.float16)
   template = np.asarray(template, dtype=np.float16)
   H, W = x.shape

--- a/aneforge/_bridges/ane_cross_product_fused.py
+++ b/aneforge/_bridges/ane_cross_product_fused.py
@@ -1,8 +1,5 @@
 """Native ANE 3-vector cross product on Path A.
-
-:func:`cross_product_fused` computes `cross(x, z)` for two length-3 fp16 vectors
-on the ANE (matches `numpy.cross(x, z)`).
-"""
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -17,13 +14,7 @@ _ROOT = Path(__file__).resolve().parents[2]
 
 
 def cross_product_fused(x: np.ndarray, z: np.ndarray) -> np.ndarray:
-  """Return `cross(x, z)` for two 3-vectors, computed on the ANE.
-
-    Args:
-        x, z: length-3 fp16-castable arrays.
-    Returns:
-        length-3 fp16 array equal to `numpy.cross(x, z)`.
-    """
+  """Return `cross(x, z)` (length-3 fp16) for two 3-vectors, on the ANE."""
   x = np.asarray(x, dtype=np.float16).reshape(3)
   z = np.asarray(z, dtype=np.float16).reshape(3)
   from ._netplist import write_model, ensure_invoker

--- a/aneforge/_bridges/ane_dynamic_slice_fused.py
+++ b/aneforge/_bridges/ane_dynamic_slice_fused.py
@@ -1,9 +1,5 @@
 """Native ANE `DynamicSlice` (runtime/parametric slice) on Path A.
-
-:func:`dynamic_slice_fused` extracts a window `x[start : start + slice_size]`
-along a tensor axis on the ANE, with `start` bound at runtime through a netplist
-constant rather than baked into the op.
-"""
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -18,13 +14,9 @@ _ROOT = Path(__file__).resolve().parents[2]
 
 
 def dynamic_slice_fused(x: np.ndarray, start: int, *, slice_size: int = 2) -> np.ndarray:
-  """Slice `x` (a length-W fp16 vector) to `x[start:start+slice_size]` on the ANE.
-
-    Uses the `dynamic_slice_const_u16` generator and overwrites the index constant
-    (weights.1) with `start` so the window is runtime-selectable.  The generator's
-    accepted variant fixes `SliceSize=2` and W=4; this function validates
-    `slice_size`/shape accordingly.
-    """
+  """Slice `x` (length-W fp16) to `x[start:start+slice_size]` on the ANE; `start`
+    is written into the index constant (weights.1) so the window is runtime-
+    selectable. Accepted variant fixes W=4, SliceSize=2."""
   from . import _netplist as g
 
   x = np.asarray(x, dtype=np.float16).reshape(-1)

--- a/aneforge/_bridges/ane_fps_fused.py
+++ b/aneforge/_bridges/ane_fps_fused.py
@@ -1,19 +1,6 @@
-"""Native ANE `FurthestPointSampling` (FPS) via a hand-authored ANECIR netplist.
-
-FPS is point-cloud downsampling: greedily pick `CentroidCount` points that are
-maximally far apart (seeded at index 0).  Entry point `fps_fused(points,
-centroid_count)`; `points` is `(N, 3)`, returns `(k, 3)` centroids.  The ANE uses
-L2 distance on this arch regardless of the `DistanceMetric` param.
-
-Schema (accepted unit dictionary)::
-
-    {"Type": "FurthestPointSampling",
-     "Bottom": ["points"],
-     "InputType": ["Float16"],
-     "OutputChannels": 3,
-     "OutputType": "Float16",
-     "Params": {"CentroidCount": k, "DistanceMetric": "L1" | "L2"}}
-"""
+"""Native ANE `FurthestPointSampling` (point-cloud downsampling) on Path A.
+The ANE uses L2 on this arch regardless of `DistanceMetric`.
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -53,11 +40,7 @@ def fps_fused(points: np.ndarray, centroid_count: int, *, metric: str = "L1") ->
 
 
 def numpy_reference(points: np.ndarray, centroid_count: int, metric: str = "L2") -> np.ndarray:
-  """Greedy FPS, seeded at index 0.
-
-    The ANE always uses L2 on this arch (see module docstring); the default
-    here is therefore L2, which matches the hardware exactly.
-    """
+  """Greedy FPS, seeded at index 0. Default L2 matches the hardware exactly."""
   P = np.asarray(points, dtype=np.float32)
   N = P.shape[0]
   sel = [0]

--- a/aneforge/_bridges/ane_input_view_fused.py
+++ b/aneforge/_bridges/ane_input_view_fused.py
@@ -1,9 +1,5 @@
 """Native ANE `InputView` (contiguous offset view) on Path A.
-
-:func:`input_view_fused` returns the ANE-computed view
-`x[offset : offset + size]` along a named axis, with no data movement beyond
-the view.
-"""
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 

--- a/aneforge/_bridges/ane_radius_search_fused.py
+++ b/aneforge/_bridges/ane_radius_search_fused.py
@@ -1,20 +1,5 @@
-"""Native ANE `RadiusSearch` via a hand-authored ANECIR netplist (Path A).
-
-RadiusSearch is point-cloud neighbor search: for each query centroid, find the
-input points within a given `Radius` (an L2 ball query).  Entry point
-`radius_search_fused(points, centroids, radius)` returns an
-`(N_points, N_centroids)` uint8 membership matrix (entry `[i, j]` is 1 iff
-`points[i]` is within L2 `radius` of `centroids[j]`).
-
-Schema (accepted unit dictionary)::
-
-    {"Type": "RadiusSearch",
-     "Bottom": ["centroids", "points"],
-     "InputType": ["Float16", "Float16"],
-     "OutputChannels": 1,
-     "OutputType": "Float16",
-     "Params": {"Radius": r}}
-"""
+"""Native ANE `RadiusSearch` (point-cloud L2 ball query) on Path A.
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -28,11 +13,8 @@ _ROOT = Path(__file__).resolve().parents[2]
 
 
 def radius_search_fused(points: np.ndarray, centroids: np.ndarray, radius: float) -> np.ndarray:
-  """Return an `(N_points, N_centroids)` uint8 membership matrix from the ANE.
-
-    Entry `[i, j]` is 1 iff `points[i]` is within L2 `radius` of
-    `centroids[j]`.
-    """
+  """`(N_points, N_centroids)` uint8 membership: `[i,j]` is 1 iff `points[i]`
+    is within L2 `radius` of `centroids[j]`."""
   from . import _netplist as g
 
   points = np.asarray(points, dtype=np.float16)

--- a/aneforge/_bridges/ane_rank_fused.py
+++ b/aneforge/_bridges/ane_rank_fused.py
@@ -1,23 +1,6 @@
-"""Native ANE rank-family layers via hand-authored ANECIR netplists.
-
-Four hardware-native fp16 rank layers - `Sort`, `TopK`, `ArgMinMax` and
-`GlobalArgMinMax` - running on the ANE via Path A.
-
-Per-layer `Params` schemas:
-
-  Sort             : Direction (Ascending|Descending), SortDimension,
-                     VectorDimension, SortIndices (key lane(s)),
-                     Indices (bool: output argsort instead of values).
-  TopK             : Type (Max|Min), K (int), SortDimension,
-                     VectorDimension, SortIndices, Indices (bool).
-  ArgMinMax        : Mode (SpatialArgMax|ChannelArgMax|SpatialArgMin|
-                     ChannelArgMin), KernelWidth, KernelHeight, Pad*.
-  GlobalArgMinMax  : Type (Max|Min), Dimension.
-
-Integer index outputs come back fp16-encoded in the ordinary Float16 output
-tensor; for the small index ranges these layers produce (< 2048), fp16 represents
-every integer exactly, so the indices are exact.
-"""
+"""Native ANE rank-family layers (Sort / TopK / ArgMinMax / GlobalArgMinMax)
+on Path A. Integer index outputs are fp16-encoded but exact (ranges < 2048).
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -54,7 +37,7 @@ def _ensure_invoker() -> Path:
   return _INVOKER_BIN
 
 
-# --- minimal netplist scaffolding (single op, single input x, output y) ----
+# Minimal netplist scaffolding: single op, single input x, output y.
 
 def _input_entry(unit, sym, *, width, height=1, channels=1):
   return {
@@ -101,8 +84,7 @@ def _build_plist(layer_type: str, params: dict, *, width, height, channels):
 def _run(layer_type: str, params: dict, x: np.ndarray, *,
          channels: int, width: int, height: int = 1,
          return_details: bool = False):
-  """Author netplist, run x (fp16, [channels, height, width]), return the output
-    decoded with the runtime-reported strides."""
+  """Run x ([C,H,W] fp16), decoding output with the runtime-reported strides."""
   invoker = _ensure_invoker()
   x = np.asarray(x, dtype=np.float16)
   with tempfile.TemporaryDirectory(prefix=f"ane_{layer_type.lower()}_") as ws:
@@ -139,16 +121,13 @@ def _run(layer_type: str, params: dict, x: np.ndarray, *,
     return out
 
 
-# --------------------------------------------------------------------------
-# Public per-layer entry points.  x is fp16 [channels, width] (height=1) for
-# Sort/TopK/GlobalArgMinMax, or [channels, height, width] for ArgMinMax.
-# --------------------------------------------------------------------------
+# Public per-layer entry points. x is fp16 [C, W] for Sort/TopK/GlobalArgMinMax,
+# or [C, H, W] for ArgMinMax.
 
 def sort(x: np.ndarray, *, descending: bool = False, key_lane: int = 0,
          return_indices: bool = False, **kw):
-  """Sort the Width axis of x ([channels, width]), permuting all channels
-    by the ordering of channel `key_lane` (SortIndices).  This is the ANE
-    Sort semantics: SortDimension=Width, VectorDimension=Channel."""
+  """Sort x ([C, W]) along Width, permuting all channels by channel `key_lane`
+    (SortDimension=Width, VectorDimension=Channel)."""
   x = np.atleast_2d(np.asarray(x, np.float16))
   ch, wd = x.shape
   params = {
@@ -162,8 +141,8 @@ def sort(x: np.ndarray, *, descending: bool = False, key_lane: int = 0,
 
 def topk(x: np.ndarray, k: int, *, largest: bool = True, key_lane: int = 0,
          return_indices: bool = False, **kw):
-  """Top-k along Width of x ([channels, width]) keyed by channel
-    `key_lane`.  NOTE: k in {3,4} is ARCH-GATED (ANECCompile fails)."""
+  """Top-k along Width of x ([C, W]) keyed by channel `key_lane`.
+    NOTE: k in {3,4} is ARCH-GATED (ANECCompile fails)."""
   x = np.atleast_2d(np.asarray(x, np.float16))
   ch, wd = x.shape
   params = {
@@ -176,11 +155,9 @@ def topk(x: np.ndarray, k: int, *, largest: bool = True, key_lane: int = 0,
 
 
 def argminmax(x: np.ndarray, mode: str, **kw):
-  """ArgMinMax over x ([channels, height, width]).
-
-    mode in {SpatialArgMax, SpatialArgMin, ChannelArgMax, ChannelArgMin}.
-    Spatial* -> one flattened-(H*W) index per channel.
-    Channel* -> one channel index per (h,w) spatial position."""
+  """ArgMinMax over x ([C, H, W]). mode in {Spatial,Channel}{ArgMax,ArgMin}:
+    Spatial* -> one flattened-(H*W) index per channel; Channel* -> one channel
+    index per (h, w)."""
   x = np.asarray(x, np.float16)
   if x.ndim == 2: x = x[:, None, :]   # [C, 1, W]
   ch, hh, wd = x.shape
@@ -191,8 +168,7 @@ def argminmax(x: np.ndarray, mode: str, **kw):
 
 def global_argminmax(x: np.ndarray, *, dimension: str = "Width",
                      largest: bool = True, **kw):
-  """GlobalArgMinMax: argmax/argmin index along `dimension`
-    (Width|Height|Channel) of x ([channels, width])."""
+  """GlobalArgMinMax: arg index along `dimension` (Width|Height|Channel)."""
   x = np.atleast_2d(np.asarray(x, np.float16))
   ch, wd = x.shape
   params = {"Type": "Max" if largest else "Min", "Dimension": dimension}

--- a/aneforge/_bridges/ane_rearrange_fused.py
+++ b/aneforge/_bridges/ane_rearrange_fused.py
@@ -1,18 +1,7 @@
-"""Native ANE spatial-rearrange layers via hand-authored ANECIR netplists.
-
-Six fp16 spatial-rearrange layers running natively on the ANE:
-
-    PixelShuffle    [N, C*fx*fy, H, W]  -> [N, C, H*fy, W*fx]   (depth->space)
-    PixelUnshuffle  [N, C, H*fy, W*fx]  -> [N, C*fx*fy, H, W]   (space->depth)
-    ChannelToSpace  depth->space, SAME shapes as PixelShuffle
-    SpaceToChannel  space->depth, SAME shapes as PixelUnshuffle
-    SpaceToBatch    [N, C, H, W]        -> [N*fx*fy, C, H/fy, W/fx]
-    BatchToSpace    [N*fx*fy, C, H, W]  -> [N, C, H*fy, W*fx]   (inverse of S2B)
-
-PixelShuffle / PixelUnshuffle use the PyTorch (channel-major) convention;
-ChannelToSpace / SpaceToChannel use the TensorFlow space_to_depth /
-depth_to_space (block-major) convention.  They coincide only when C==1.
-"""
+"""Native ANE spatial-rearrange layers (PixelShuffle/Unshuffle, Channel<->Space,
+Space<->Batch) on Path A. Pixel* use PyTorch (channel-major); Channel<->Space use
+TensorFlow (block-major) convention; they coincide only at C==1.
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -272,9 +261,7 @@ def ref_batch_to_space(x: np.ndarray, bh: int, bw: int) -> np.ndarray:
 if __name__ == "__main__":
   results = []
 
-  # Integer-valued fp16 inputs (exactly representable) so any mismatch is a true
-  # permutation error, not fp16 rounding noise.  C>1 exercises the channel-ordering
-  # convention.
+  # Integer fp16 inputs (exact) so any mismatch is a real permutation error.
   def iota(shape):
     return np.arange(int(np.prod(shape)), dtype=np.float16).reshape(shape)
 

--- a/aneforge/_bridges/ane_sdpa_fused.py
+++ b/aneforge/_bridges/ane_sdpa_fused.py
@@ -1,10 +1,6 @@
-"""Native ANE fused-attention via the 8-byte ANECSDPALayerDesc.
-
-:func:`sdpa_fused` runs SDPA end-to-end through a hand-authored ANECIR netplist
-with `Type=SDPA`, reaching the native fused-attention hardware layer instead of
-the HWX-level decomposition Apple's compiler emits.  A drop-in fused-attention
-path for `(B, heads, seq, d_head)`-layout Q/K/V at fp16.
-"""
+"""Native ANE fused-attention (`Type=SDPA`) on Path A, reaching the hardware
+fused-attention layer instead of Apple's HWX decomposition. Drop-in for
+`(B, heads, seq, d_head)` fp16 Q/K/V. See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
@@ -75,9 +71,7 @@ def _write_netplist(
 def _expected_shape(Q: np.ndarray, K: np.ndarray, V: np.ndarray) -> tuple[int, ...]:
   if Q.ndim != 4 or K.ndim != 4 or V.ndim != 4:
     raise ValueError("Q, K, V must each have shape [B, H, S, D]")
-  # K and V must share shape (same cached sequence); Q's SEQUENCE may differ from K/V's
-  # (the native SDPA validator requires only "Q,K same embedding (W)" and "K,V same seq (C)")
-  # - the KV-cache DECODE shape: seq_q query tokens attend to seq_kv cached K/V.
+  # K/V share shape; Q's seq may differ (KV-cache decode). See bridges.md.
   if K.shape != V.shape:
     raise ValueError(f"K and V must share shape (same cached sequence); got {K.shape}, {V.shape}")
   if Q.shape[0] != 1 or K.shape[0] != 1:
@@ -114,30 +108,12 @@ def sdpa_fused(
   subtract_max: bool = True,
   return_details: bool = False,
 ) -> np.ndarray | tuple[np.ndarray, dict[str, Any]]:
-  """Native ANE fused-attention via the 8-byte ANECSDPALayerDesc.
+  """Native ANE fused-attention over `[1, heads, seq, d_head]` fp16 Q/K/V;
+    returns Y in the same layout (or `(Y, info)` with timings if
+    `return_details`). `scale` defaults to `1/sqrt(d_head)`.
 
-    Compiles a netplist with SDPA + the constant-Scale bit set, dispatches via
-    _ANEInMemoryModel.  Bypasses Apple's MIL -> decomposition pipeline.
-
-    Args:
-        Q, K, V: fp16 arrays of shape `[1, heads, seq, d_head]`.
-        scale:   the softmax scale.  Defaults to `1 / sqrt(d_head)`.
-        repeats: number of evaluations to time (the function returns the
-                 output from the last one).
-        warmup:  number of warmup evals before timing.
-        constant_flag_spelling: which spelling of the constant-Scale
-                 flag the netplist should emit.  The default
-                 `"Constants_array"` is the only spelling that has
-                 been observed to compile + load on this host
-                 (other spellings raise `ANECCompile() FAILED`).
-        return_details: if True, also return a dict with timings and
-                 compile/load milliseconds.
-
-    Returns:
-        Y of shape `[1, heads, seq, d_head]` as fp16.
-        If `return_details=True`, returns `(Y, info)` where `info`
-        has keys `compile_ms`, `load_ms`, `eval_p10_us`,
-        `eval_p50_us`, `eval_p90_us`.
+    `constant_flag_spelling` default `"Constants_array"` is the only spelling
+    observed to compile + load on this host (others raise `ANECCompile() FAILED`).
     """
   Q = np.asarray(Q, dtype=np.float16)
   K = np.asarray(K, dtype=np.float16)
@@ -146,12 +122,8 @@ def sdpa_fused(
   Sq, Skv = Q.shape[2], K.shape[2]              # query seq vs cached K/V seq (decode: Sq < Skv)
   if scale is None: scale = 1.0 / math.sqrt(D)
 
-  # ANE's SDPA layer treats the C tensor dim as the sequence axis (the
-  # validator's "K and V must have same sequence length i.e C dim" string is
-  # literally true).  PyTorch / MIL convention puts heads in C and seq in H.
-  # Pre-transpose to swap them so the netplist sees seq-in-C, heads-in-H (the
-  # ANE-native layout).  Post-transpose to return Y in the caller's
-  # [B, heads, seq, d_head] order.
+  # ANE-native layout is seq-in-C, heads-in-H; PyTorch/MIL is the opposite, so
+  # pre-transpose here and post-transpose Y back. See bridges.md.
   Q_ane = np.ascontiguousarray(Q.transpose(0, 2, 1, 3))  # (B, S, H, D)
   K_ane = np.ascontiguousarray(K.transpose(0, 2, 1, 3))
   V_ane = np.ascontiguousarray(V.transpose(0, 2, 1, 3))
@@ -160,8 +132,7 @@ def sdpa_fused(
 
   with tempfile.TemporaryDirectory(prefix="ane_sdpa_") as workdir_str:
     workdir = Path(workdir_str)
-    # Note: `channels` is the ANE C dim (sequence after transpose),
-    # `sequence` here is the ANE H dim (heads after transpose).
+    # `channels`=ANE C dim (seq after transpose); `sequence`=ANE H dim (heads).
     netplist, weights = _write_netplist(
       workdir,
       channels=Skv,
@@ -179,11 +150,8 @@ def sdpa_fused(
               ("value", workdir / "in_value.f16")]
 
     if mask is not None or Sq != Skv:
-      # Edit the netplist for (a) the KV-cache DECODE shape - query seq Sq differs from
-      # cached K/V seq Skv, so query+output carry Sq channels while K/V carry Skv; and/or
-      # (b) the OPTIONAL additive MASK bottom ([C=S_q, H=1, W=S_kv], the validator's layout:
-      # "Mask Width axis must match K and V Channel axis or broadcastable"). Validated on M1:
-      # decode (Sq<Skv) cos ~1.0; causal mask cos 1.0 vs softmax(QKt*scale+mask)V.
+      # Patch the netplist for (a) decode shape (query carries Sq, K/V carry Skv)
+      # and/or (b) an additive mask bottom [C=Sq, H=1, W=Skv]. See bridges.md.
       pl = plistlib.loads(Path(netplist).read_bytes())
       il = pl["ProcedureList"][0]["InputList"]
       if Sq != Skv:
@@ -220,8 +188,7 @@ def sdpa_fused(
       repeats=repeats, warmup=warmup,
     )
 
-    # ANE output is (B, S, H, D) layout (its native C=seq, H=heads, W=d_head).
-    # Transpose back to the caller's (B, heads, seq, d_head) convention.
+    # ANE output is (B, S, H, D); transpose back to (B, heads, seq, d_head).
     Y_ane = np.frombuffer(
       (workdir / "out_y.f16").read_bytes(),
       dtype=np.float16,

--- a/aneforge/_bridges/ane_structural_fused.py
+++ b/aneforge/_bridges/ane_structural_fused.py
@@ -1,16 +1,6 @@
-"""Native ANE structural layers via direct ANECIR netplist authoring.
-
-Three structural layer kinds (`flatten` / `dropout` are public functions;
-`Broadcast` via the model generator):
-
-    * `Flatten`    -- NCHW identity reshape to a 1-D vector.
-    * `Dropout`    -- inference-time identity (rate must be 0).
-    * `Broadcast`  -- replicate a length-1 axis to `Size` along `Dimension`.
-
-Run as a script to self-verify::
-
-    python3 -m aneforge._bridges.ane_structural_fused
-"""
+"""Native ANE structural layers (Flatten / Dropout / Broadcast) on Path A.
+Run `python3 -m aneforge._bridges.ane_structural_fused` to self-verify.
+See docs/developer/bridges.md."""
 
 from __future__ import annotations
 

--- a/aneforge/_bridges/lrn_fused.py
+++ b/aneforge/_bridges/lrn_fused.py
@@ -1,22 +1,6 @@
-"""Native ANE local response normalization via a hand-authored ANECIR netplist.
-
-`LocalResponseNormalization` (classic vision cross-channel LRN) running natively
-on the ANE.
-
-Computes (Channel mode):
-    y[c] = x[c] / (K + alpha_eff * sum_{j in window} x[j]^2) ^ Beta
-
-Non-obvious conventions:
-    1. `Alpha` is a fp16 *bit pattern* (ZinParseFP16Token), NOT a float.
-       A float real int-truncates to ~0 -> identity output.
-    2. ANE divides the parsed alpha by KernelChannel internally, so the
-       effective alpha is  fp16(Alpha_bits) / KernelChannel.  For a desired
-       alpha, pass  Alpha = fp16_bits(desired_alpha * KernelChannel).
-    3. Only the first KernelChannel output channels are normalized; the rest
-       are identity-copied.  Use KernelChannel = C for full-tensor LRN; C must
-       exceed KernelChannel-as-window only spatially - empirically C ==
-       KernelChannel gives full coverage (C=5/KC=5).
-"""
+"""Native ANE `LocalResponseNormalization` (cross-channel LRN) on Path A.
+`Params.Alpha` is a fp16 bit pattern (not a float) and is divided by
+KernelChannel internally. See docs/developer/bridges.md for the conventions."""
 
 from __future__ import annotations
 

--- a/aneforge/_bridges/minmax_norm_fused.py
+++ b/aneforge/_bridges/minmax_norm_fused.py
@@ -1,17 +1,6 @@
-"""Native ANE min-max normalization via a hand-authored ANECIR netplist.
-
-`MinMaxNormalization` running natively on the ANE via Path A.
-
-Computes:   y = (x - min) / (max - min + eps)   over `Params.Dimension`.
-
-Supported reduction axes:
-    Dimension="Width"   -> per-row min/max over W
-    Dimension="Height"  -> per-column min/max over H
-    Dimension="Channel" -> ARCH-GATED (ANECCompile fails on this host).
-
-Epsilon convention: `Params.Epsilon` is a fp16 bit pattern, NOT a float
-real.  Pass `fp16_bits(desired_eps)`.
-"""
+"""Native ANE `MinMaxNormalization` on Path A: y = (x-min)/(max-min+eps) over
+`Params.Dimension` (Width|Height; Channel is ARCH-GATED). `Params.Epsilon` is a
+fp16 bit pattern. See docs/developer/bridges.md."""
 
 from __future__ import annotations
 

--- a/aneforge/_bridges/scaled_elementwise_fused.py
+++ b/aneforge/_bridges/scaled_elementwise_fused.py
@@ -1,10 +1,5 @@
-"""Native ANE scaled-elementwise op via a hand-authored ANECIR netplist.
-
-`ScaledElementWise` (ANECIR Type) fuses a binary elementwise op with a
-scalar scale factor:   y = scale * (x OP z).  `Params.Type` selects the
-elementwise op (Add / Mult / Sub / ...) and `Params.Scale` is a fp16 bit
-pattern (use `fp16_bits`).
-"""
+"""Native ANE `ScaledElementWise` on Path A: y = scale * (x OP z). `Params.Type`
+selects the op; `Params.Scale` is a fp16 bit pattern. See docs/developer/bridges.md."""
 
 from __future__ import annotations
 

--- a/aneforge/_capabilities.py
+++ b/aneforge/_capabilities.py
@@ -1,51 +1,11 @@
-"""The aneforge capability census - the single, closed, machine-checkable source of
-truth for *what ANE capability aneforge surfaces*.
+"""The aneforge capability census - the closed, machine-checkable source of truth for what
+ANE capability aneforge surfaces.
 
-Why this module exists: the authoritative runtime op sets are `_EMIT` (the fused
-e5rt-MIL emitters) and `NETPLIST_OPS` (the native Path-A bridge ops), both in
-`_compile.py`. The discovery evidence behind them - which layers were proven on
-silicon, which are genuine hardware walls, which are only predicted - is scattered
-across the reverse-engineering corpus. Nothing reconciled the two: a new op could
-appear unclassified, or a "surfaced" op could silently stop compiling unnoticed.
-
-`build_registry()` closes the loop. It introspects the live `_EMIT` /
-`NETPLIST_OPS` and merges them with curated, citation-carrying classification data
-for everything that *can't* be introspected (cracked-but-not-promoted layers, the
-arch-gated negatives, the predicted-but-unbuilt frontier). The result is a closed
-classification of every ANE capability aneforge knows about. `tests/
-test_routes.py` fails CI if the live runtime drifts from this registry either way.
-
-Discipline (this is a publication artifact): every entry is one of
-  - `fused`                - in `_EMIT`; lowers to e5rt-MIL, fuses into one program.
-  - `bridge`               - in `NETPLIST_OPS`; runs as a native Path-A sub-program (a graph cut).
-  - `cracked`              - reverse-engineered native layer PROVEN on silicon in
-                               the reverse-engineering corpus, but NOT yet promoted to the frontend.
-  - `reachable`            - the native MIL op compiles + runs correct on aneforge's own
-                               e5rt path (proven by the full-vocabulary sweep,
-                               `full_mil_vocabulary_sweep.json`), but is not yet
-                               promoted to a frontend `_EMIT` emitter or `af.` method.
-                               Reachable through the MIL door, not direct `Type=` netplist
-                               authoring, so it is not a cracked native layer and does not
-                               count toward the cracked-layer manifest.
-  - `arch-gated-negative`  - known NOT to work, carrying the SPECIFIC wall (an authored
-                               op/config that the ANE backend rejects or fails to lower).
-  - `not-authorable`       - control-flow / list / state ops (cond, while_loop, make_list,
-                               list_*, read_state, ...) with no single-op MIL form on the
-                               single-procedure feed-forward surface; recorded, not defeated
-                               (the recurrence/scan wall).
-  - `predicted`            - predicted crackable by the callable-`_ANECValidate*`
-                               heuristic, but NOT built and NOT verified.
-`fused`/`bridge` carry `verified="silicon"`; `cracked`/`reachable` carry it too
-(proven in the reverse-engineering corpus / the on-device sweep) - the distinction
-from fused/bridge is *promotion*, not evidence. `predicted` is explicitly
-`verified="no"`. Every `cracked` cites its bridge in the reverse-engineering corpus;
-every negative cites the finding that established the wall; every
-`reachable`/`not-authorable` cites the sweep matrix.
-
-Scope: the registry is exhaustive over the full 166-op MIL vocabulary swept in
-`full_mil_vocabulary_sweep.json` (116/166 reachable), not just the 50
-`_ANECValidate*Layer` validators. The validator-surface accounting (the cracked-layer
-manifest) is a strict subset, kept intact.
+`build_registry()` introspects the live `_EMIT` / `NETPLIST_OPS` and merges them with curated,
+citation-carrying classification of everything that can't be introspected. Each entry's status
+is one of STATUSES (fused/bridge/cracked/reachable/arch-gated-negative/not-authorable/predicted);
+exhaustive over the 166-op MIL vocabulary sweep. `tests/test_routes.py` fails CI on drift.
+See .superpowers/sdd/gold-core-heavy.md for the status taxonomy + evidence discipline.
 """
 from __future__ import annotations
 
@@ -62,11 +22,7 @@ STATUSES = ("fused", "bridge", "cracked", "reachable", "arch-gated-negative",
             "not-authorable", "predicted")
 
 
-# --------------------------------------------------------------------------- #
-# introspected: the frontend surface of each live runtime op                  #
-# --------------------------------------------------------------------------- #
-# runtime op name -> frontend spelling (Tensor method / af.* fn). Enriches
-# introspected entries; missing op reports frontend=None (still classified).
+# runtime op name -> frontend spelling (Tensor method / af.* fn); missing op -> frontend=None.
 _FRONTEND_SPELLING: dict[str, str] = {
     # fused unary activations
     "relu": "x.relu()", "silu": "x.silu()", "sigmoid": "x.sigmoid()", "tanh": "x.tanh()",
@@ -103,9 +59,7 @@ _FRONTEND_SPELLING: dict[str, str] = {
     "dynamic_slice": "af.dynamic_slice(x,start,size)", "scaled_elementwise": "af.scaled_elementwise(x,z,...)",
 }
 
-# The in-package bridge module each NETPLIST_OPS entry invokes (its evidence). Promoted
-# out of the reverse-engineering corpus into the self-contained aneforge/_bridges/ package
-# (the product no longer depends on the research corpus at runtime).
+# The in-package bridge module each NETPLIST_OPS entry invokes (its evidence).
 _BRIDGE_EVIDENCE: dict[str, str] = {
     "sdpa": "aneforge/_bridges/ane_sdpa_fused.py",
     "argmax": "aneforge/_bridges/ane_rank_fused.py", "topk": "aneforge/_bridges/ane_rank_fused.py",
@@ -149,13 +103,8 @@ def _introspect_bridge() -> list[dict[str, Any]]:
   } for name in sorted(_compile.NETPLIST_OPS)]
 
 
-# --------------------------------------------------------------------------- #
-# curated: classifications that can't be introspected from the runtime        #
-# --------------------------------------------------------------------------- #
-# (A) cracked - proven on silicon in the reverse-engineering corpus (a self-verifying
-#     *_fused.py), but not promoted into the frontend _EMIT / NETPLIST_OPS. Citations are
-#     the bridge files. (The promoted siblings - PixelShuffle, L2Norm, Sort/TopK/ArgMinMax,
-#     the space/channel/batch rearranges, Flatten, etc. - appear above as fused/bridge.)
+# (A) cracked - proven on silicon (a self-verifying *_fused.py), not promoted into the
+#     frontend _EMIT / NETPLIST_OPS. Citations are the bridge files.
 _CRACKED: list[dict[str, Any]] = [
     {
         "name": "Dropout",
@@ -217,16 +166,11 @@ _CRACKED: list[dict[str, Any]] = [
     },
 ]
 
-# (B) arch-gated negatives - known not to work on this M5, each with its specific wall.
-#     "Negative" means: rejected at compile, or the named configuration fails
-#     ANECCompile/HWX codegen even though the validator accepts the schema. The
-#     `probe` field is a tiny aneforge call the gate runs to confirm it still
-#     fails (raises) - None means manual-probe-only (too slow/risky for CI).
+# (B) arch-gated negatives - known not to work on this M5, each carrying its specific `wall`.
+#     `probe` is a tiny aneforge call the gate runs to confirm it still fails (None = manual-only).
 _NEGATIVES: list[dict[str, Any]] = [
-    # --- native MIL op unimplemented on the ANE backend ("Not implemented ... not
-    #     supported on any backend"). Key distinction (2026-05-31 calibration): the
-    #     native OP is unimplemented, but the CAPABILITY is reachable on the same e5rt
-    #     path via a decomposition. These are native-op gaps, not hardware walls. ---
+    # --- native MIL op unimplemented on the ANE backend; the CAPABILITY is often reachable
+    #     via a decomposition on the same e5rt path. Native-op gaps, not hardware walls. ---
     {
         "name": "reduce_prod",
         "wall": "the native MIL reduce_prod op is unimplemented on the ANE backend "
@@ -302,20 +246,9 @@ _NEGATIVES: list[dict[str, Any]] = [
         "evidence": "reference_unentitled_menu; capabilities.md (Datatypes)",
         "probe": None,  # numpy has no native bf16; no clean frontend probe
     },
-    # --- quantization: no walls remain (reconciled 2026-06-02) -----------------
-    # The former "blockwise_int8"/"int4_weight" negatives were a malformed probe: the
-    # empty-paren spelling `constexpr_blockwise_shift_scale()[data=..]` segfaults the
-    # e5rt compiler, but the named-arg form `constexpr_blockwise_shift_scale(data=..,
-    # scale=..)` compiles + runs correct (relerr ~3e-4) across multi-block + int4
-    # configs (same macOS 26 / M5). Ships as compress="blockwise". Caveat: the
-    # blockwise output is not matmul-routable, so it dequantizes in-program to dense
-    # fp16 (no weight-streaming win, unlike int8-affine / int4-LUT / sparse); exposed
-    # for the smaller artifact + finer scales, not throughput. Registered via the
-    # sweep-driven layer below.
-    # int8-affine (constexpr_affine_dequantize), int4-LUT (constexpr_lut_to_dense) and
-    # sparse (constexpr_sparse_to_dense) all run on the raw e5rt path and ship via
-    # compress="int8"/"int4"/"sparse" (test_compress.py). The "sparse segfaults" claim
-    # was likewise a malformed-MIL artifact. No quant wall remains.
+    # --- quantization: no walls remain (reconciled 2026-06-02) - the old blockwise/int4/
+    #     sparse "negatives" were malformed probes; all ship via compress= (test_compress.py).
+    #     See .superpowers/sdd/gold-core-heavy.md for the reconciliation detail. ---
     # --- layer/codegen walls (validator accepts schema, M5 HWX codegen fails) ---
     {
         "name": "conv_kernel_ge16",
@@ -408,13 +341,8 @@ _NEGATIVES: list[dict[str, Any]] = [
         "evidence": "finding_layer_crack_sweep; capabilities.md",
         "probe": None,
     },
-    # note (reconciled 2026-06-02): the former "NMS" arch-gated negative was flipped to
-    # reachable. The earlier wall was an over-cautious direct-NETPLIST probe (full Params
-    # recovered, compile failed). The MIL `non_maximum_suppression` op compiles + runs on the
-    # e5rt path (presence-only - not numerically validated against a reference, since NMS
-    # output ordering is selection-dependent), so it is `reachable` (sweep-proven on silicon,
-    # not promoted to a frontend primitive) via the sweep-driven layer below, not a negative.
-    # See full_mil_vocabulary_sweep.json (non_maximum_suppression, reachable).
+    # note: the former "NMS" negative was flipped to `reachable` (the MIL op compiles via the
+    # sweep-driven layer); see _SWEEP_NOTE["non_maximum_suppression"] and the gold file.
     {
         "name": "CropResize",
         "wall": "texture-family codegen gate: direct-netplist CropResize fails ANECCompile on M5 "
@@ -422,16 +350,8 @@ _NEGATIVES: list[dict[str, Any]] = [
         "evidence": "finding_layer_crack_sweep; the reverse-engineering corpus",
         "probe": None,
     },
-    # note (reconciled 2026-06-02): the former "AffineTransform" and "Resample_Bilinear"
-    # arch-gated negatives were flipped to reachable. The earlier walls came from over-
-    # cautious direct-NETPLIST (Type=AffineTransform / Type=Resample,Bilinear) probes that
-    # failed HWX codegen - scoped to the netplist door. The MIL ops compile + run correct on
-    # aneforge's own e5rt path (full_mil_vocabulary_sweep.json): `affine` (genuine warp,
-    # relerr 2.3e-3 at align_corners=True, not a no-op) and `resize_bilinear`/
-    # `upsample_bilinear` (exact bilinear, relerr 2e-4). All three now ship as fused _EMIT
-    # ops (af.affine / af.resize_bilinear / af.upsample_bilinear), so they appear in the
-    # census as `fused`, not negatives. Same macOS 26 / M5 (not an OS change). The remaining
-    # texture-family negative is CropResize (still walled below).
+    # note: the former AffineTransform / Resample_Bilinear negatives now ship as fused _EMIT
+    # ops (af.affine / af.resize_bilinear / af.upsample_bilinear); CropResize stays walled (above).
     {
         "name": "MATDECOMP_MATMULT_0x19",
         "wall": "internal-optimizer-gated (NOT schema-gated): the fused matrix-decomp-matmul "
@@ -481,12 +401,7 @@ _NEGATIVES: list[dict[str, Any]] = [
         "evidence": "capabilities.md (no hardware backing)",
         "probe": None,
     },
-    # note (reconciled 2026-06-02): the former "instance_norm" arch-gated negative was
-    # flipped to reachable. The earlier wall was scoped to the native InstanceNorm netplist
-    # LAYER (which failed ANECCompile); the MIL `instance_norm` op compiles + runs correct
-    # on the e5rt path (full_mil_vocabulary_sweep.json, reachable+correct) and now ships as
-    # a fused _EMIT op (x.instance_norm(...)), so it is `fused`, not a negative. The
-    # decomposition route (reduce_mean/sub/mul/rsqrt) remains available too.
+    # note: the former "instance_norm" negative now ships as a fused _EMIT op (x.instance_norm).
     {
         "name": "Reverse",
         "wall": "the native netplist Reverse LAYER is schema-UNREACHABLE: no exported "
@@ -513,9 +428,7 @@ _NEGATIVES: list[dict[str, Any]] = [
     },
 ]
 
-# (C) predicted - crackable by the callable-`_ANECValidate*` heuristic (a callable
-#     exported validator marks a schema-gated layer reachable by direct netplist
-#     authoring), but not built and not verified. Explicitly not-verified.
+# (C) predicted - crackable by the callable-`_ANECValidate*` heuristic, but not built / not verified.
 _PREDICTED: list[dict[str, Any]] = [
     {
         "name": "Pad",
@@ -535,34 +448,22 @@ _PREDICTED: list[dict[str, Any]] = [
 # --------------------------------------------------------------------------- #
 # (D) full-MIL-vocabulary sweep - the data-driven exhaustiveness layer          #
 # --------------------------------------------------------------------------- #
-# Makes the registry exhaustive over the full 166-op MIL vocabulary swept on-device
-# (full_mil_vocabulary_sweep.json). Every sweep op not already represented above
-# (by exact name in _EMIT / NETPLIST_OPS / the curated lists) gets a synthesized
-# entry, classified from its sweep `klass`:
-#   reachable+correct / reachable -> `reachable` (runs on the e5rt MIL path; not a
-#                                    promoted frontend primitive, so not a cracked
-#                                    native layer and not in the cracked-manifest count).
-#   not-implemented-on-ANE        -> `arch-gated-negative` (op unimplemented on backend).
-#   compile-walled                -> `not-authorable` for control-flow/list/state (no
-#                                    single-op MIL form), else `arch-gated-negative`.
-# Curated entries win over the sweep (exact-name match skipped), preserving the
-# hand-written walls/evidence/notes.
+# Synthesizes an entry for every swept op not already represented, classified from its
+# sweep `klass` (reachable -> `reachable`; not-implemented -> negative; compile-walled ->
+# not-authorable for control-flow else negative). Curated entries win (exact-name skipped).
 import os as _os
 _SWEEP_PATH = _os.path.join(_os.path.dirname(__file__),
                             "full_mil_vocabulary_sweep.json")
 
-# control-flow / list / state ops: walled because the single-procedure feed-forward
-# netplist surface has no loop/list/state construct (the recurrence/scan wall), not a
-# per-op codegen bug. Recorded as `not-authorable`, not arch-gated-negative.
+# control-flow / list / state ops: no loop/list/state construct on the feed-forward
+# netplist surface (the recurrence/scan wall), so `not-authorable`, not arch-gated-negative.
 _NOT_AUTHORABLE_OPS: frozenset[str] = frozenset({
     "cond", "while_loop", "classify",
     "make_list", "list_gather", "list_length", "list_read", "list_scatter", "list_write",
     "read_state", "gru", "lstm", "rnn",
 })
 
-# sweep ops that are the same capability as an op already surfaced under a different
-# name (a `reachable` entry pointing at its canonical surfaced sibling -
-# aliasing, no double-count of the capability as a distinct frontend primitive).
+# sweep ops aliasing an already-surfaced capability (a `reachable` entry -> its sibling; no double-count).
 _SWEEP_CAPABILITY_ALIAS: dict[str, str] = {
     "scaled_dot_product_attention": "sdpa (bridge) - same fused-attention capability",
     "linear": "matmul / linear_activation (fused) - same affine-projection capability",
@@ -666,23 +567,11 @@ def _introspect_sweep(already: set[str]) -> list[dict[str, Any]]:
   return out
 
 
-# --------------------------------------------------------------------------- #
-# EQUIVALENCE-route registry - the closed table of alternative lowerings        #
-# --------------------------------------------------------------------------- #
-# Every surfaced capability is either route-selectable (the autotuner picks its
-# cheapest equivalent lowering by measured cost) or single-route (one lowering, no
-# alternative). This table closes that over the bridge ops: each NETPLIST_OPS bridge op
-# records either an `alt` (a fused decomposition removing the graph cut, with loss-class
-# + on-device evidence) or `single_route=True` with the reason it has none. Only on-
-# device-validated alts appear (the builder lives in _rewrite._BRIDGE_DECOMPOSERS, keyed
-# identically; reconciled by tests/test_routes.py); a candidate that failed validation is
-# marked single-route with its failure evidence (e.g. rearranges hit the rank-5 wall).
-#
-# Loss class "lossless" = mathematically identical (bit-identical or within fp16
-# op-noise), chosen purely on measured speed. Fused ops are single-route by
-# construction and not listed; _routes_for() reports any op absent here as
-# single-route("only lowering"). The reduce_sum->@ones rewrite is on the precision
-# axis (tune_precision), documented there, not as a bridge alt.
+# Closed equivalence-route table over the bridge ops: each records an `alt` (a fused
+# decomposition removing the graph cut, with loss-class + on-device evidence) or
+# `single_route=True` with the reason. Only on-device-validated alts appear (builder in
+# _rewrite._BRIDGE_DECOMPOSERS; reconciled by tests/test_routes.py). Fused ops are
+# single-route by construction and not listed. See .superpowers/sdd/gold-core-heavy.md.
 _BRIDGE_ROUTES: dict[str, dict[str, Any]] = {
     # --- route-selectable: a validated fused decomposition removes the cut ---
     "sdpa": {
@@ -767,10 +656,7 @@ _BRIDGE_ROUTES: dict[str, dict[str, Any]] = {
 
 
 def _routes_for(name: str, status: str) -> dict[str, Any]:
-  """Route classification for one op: `{"route_class": "selectable"|"single", ...}`.
-    A bridge op in `_BRIDGE_ROUTES` with an `alt` is `selectable`; everything else
-    (single-route bridge, or any fused op - one lowering by construction) is `single`
-    with a reason."""
+  """Route class for one op: `selectable` (bridge with an `alt`) or `single` (with a reason)."""
   info = _BRIDGE_ROUTES.get(name)
   if info and "alt" in info:
     return {"route_class": "selectable", "alt_route": info["alt"],
@@ -790,11 +676,8 @@ def _routes_for(name: str, status: str) -> dict[str, Any]:
 
 
 def route_registry() -> dict[str, Any]:
-  """The closed equivalence-route registry over the BRIDGE ops: which are route-
-    selectable (with the validated alternative + loss class + evidence) and which are
-    single-route (with the reason). Driven off the live `NETPLIST_OPS` so it can never
-    silently omit a bridge op. Reconciled against `_rewrite._BRIDGE_DECOMPOSERS` and the
-    census by tests/test_routes.py."""
+  """The closed equivalence-route registry over the bridge ops (selectable vs single-route),
+    driven off the live `NETPLIST_OPS`. Reconciled by tests/test_routes.py."""
   selectable, single = [], []
   for name in sorted(_compile.NETPLIST_OPS):
     r = _routes_for(name, "bridge")
@@ -812,10 +695,7 @@ def route_registry() -> dict[str, Any]:
 # --------------------------------------------------------------------------- #
 # cracked-LAYER MANIFEST - the traceable artifact behind the "26 cracked"      #
 # --------------------------------------------------------------------------- #
-# `slice_by_index` (status=cracked) is the same hardware capability as the
-# `input_view` bridge op (Type=InputView) - the registry note already records it as
-# "not double-counted". The manifest folds it into `input_view` so the 26 are
-# distinct native layers, not 27 with an alias.
+# slice_by_index == input_view (both Type=InputView); folded in so the count is distinct layers.
 _CRACKED_DEDUPE_ALIAS: dict[str, str] = {"slice_by_index": "input_view"}
 
 _CRACKED_MANIFEST_DEFINITION = (
@@ -841,27 +721,10 @@ _CRACKED_MANIFEST_HISTORICAL_NOTE = (
 
 
 def cracked_manifest() -> list[dict[str, Any]]:
-  """The closed, machine-checkable manifest of the distinct cracked native hardware
-    layers behind the "26 cracked native hardware layers" count.
-
-    Membership rule (exact): a cracked native hardware layer is a registry entry whose
-    `status` is in `{"cracked", "bridge"}` - `bridge` ops are Path-A netplist sub-
-    programs authored directly, `cracked` ops are unpromoted direct-netplist cracks; both
-    are reached by the netplist-authoring method (author `Type=<Layer>` in the netplist)
-    and are not emitted by Apple's user-space MIL frontend.
-
-    Dedupe: `slice_by_index` (status=cracked) is the SAME hardware capability as the
-    `input_view` bridge op (both `Type=InputView`); it is folded into `input_view`
-    and not double-counted. So distinct cracked layers = (#cracked) + (#bridge) - 1.
-
-    `fused` ops are not cracks under this rule - they go through aneforge's MIL @op
-    emitter, not direct `Type=` authoring - even ones (PixelShuffle, L2Norm) historically
-    reached by the netplist-authoring method before promotion (see
-    `_CRACKED_MANIFEST_HISTORICAL_NOTE`).
-
-    Returns a list of `{name, status, route, evidence}` items, sorted by name. The
-    aliased member carries its fold-in via an `aliases` key.
-    """
+  """The closed manifest of distinct cracked native hardware layers (the "26 cracked" count).
+    Members = registry entries with status in {cracked, bridge}; slice_by_index folds into
+    input_view (distinct = #cracked + #bridge - 1). Returns {name, status, route, evidence}
+    items sorted by name. See `_CRACKED_MANIFEST_DEFINITION` for the exact membership rule."""
   reg = build_registry()
   by_name = {e["name"]: e for e in reg["entries"]}
 
@@ -925,13 +788,8 @@ def write_cracked_manifest(path: str = "cracked_manifest.json") -> str:
 
 
 def build_registry() -> dict[str, Any]:
-  """Build the closed capability registry: introspect the live `_EMIT` /
-    `NETPLIST_OPS` and merge with the curated cracked/negative/predicted entries.
-
-    Returns a dict with `entries` (list, sorted by (status-order, name)) and a
-    `summary` of per-status counts. This is the source of truth `write_json`
-    serialises and `tests/test_routes.py` reconciles against.
-    """
+  """Build the closed capability registry: introspect live `_EMIT` / `NETPLIST_OPS`, merge
+    the curated cracked/negative/predicted entries + sweep layer. Returns {entries, summary}."""
   entries: list[dict[str, Any]] = []
   entries += _introspect_fused()
   entries += _introspect_bridge()
@@ -947,10 +805,7 @@ def build_registry() -> dict[str, Any]:
                "verified": "no", "evidence": e["evidence"]}
               for e in _PREDICTED]
 
-  # (D) extend exhaustively over the full 166-op MIL vocabulary sweep: synthesize an
-  # entry for every swept op not already represented (curated entries win - same name
-  # is skipped so the hand-written walls/notes survive). Makes the registry exhaustive
-  # over the MIL vocabulary, not just the 50 validators / surfaced ops.
+  # (D) extend over the full MIL vocabulary sweep (curated entries win on name collision).
   already = {e["name"] for e in entries}
   entries += _introspect_sweep(already)
 
@@ -961,8 +816,7 @@ def build_registry() -> dict[str, Any]:
     if key in seen: raise ValueError(f"capability registry: duplicate entry {key}")
     seen.add(key)
 
-  # enrich fused/bridge entries with their equivalence-route classification (the
-  # source of truth for the optimizer's route choice - selectable vs single).
+  # enrich fused/bridge entries with their equivalence-route classification.
   for e in entries:
     if e["status"] in ("fused", "bridge"): e.update(_routes_for(e["name"], e["status"]))
 
@@ -971,8 +825,7 @@ def build_registry() -> dict[str, Any]:
 
   summary = {s: sum(1 for e in entries if e["status"] == s) for s in STATUSES}
   summary["total"] = len(entries)
-  # distinct cracked native hardware layers (cracked + bridge, minus the one alias);
-  # the traceable count behind the "26 cracked" figure (see cracked_manifest()).
+  # distinct cracked native layers = cracked + bridge - the one alias (see cracked_manifest()).
   summary["cracked_count"] = (
     summary["cracked"] + summary["bridge"] - len(_CRACKED_DEDUPE_ALIAS)
   )

--- a/aneforge/_circuit.py
+++ b/aneforge/_circuit.py
@@ -1,13 +1,6 @@
-"""Compile-failure backoff rate-limiter.
-
-After a compile FAILURE, ANEForge paces the next compile by a short interval (~15 s),
-a backstop for the one path that compiles many programs in a burst (the autotuner's
-variant sweep) should a compile fail mid-sweep. A successful compile clears the
-back-off; no failure-count cap is needed, pacing consecutive failures apart suffices.
-
-It rate-limits *consecutive compile failures*: a clean op-rejection and a harder
-failure both surface as a null handle, so the plain "failures" rate limiter is
-enough. Tunable / disablable via env:
+"""Compile-failure backoff rate-limiter: after a compile failure, pace the next compile
+by ~15s - a backstop for the autotuner's burst variant sweep. A success clears the
+back-off. See docs/developer/compile-pipeline.md. Env:
 
     ANEFORGE_COMPILE_BACKOFF             seconds to pace (default 15.0; 0 disables pacing)
     ANEFORGE_DISABLE_COMPILE_BREAKER=1   turn the guard off entirely
@@ -33,8 +26,7 @@ _last_failure_ts: float | None = None   # monotonic time of the last compile fai
 
 
 class CompileBackoffError(RuntimeError):
-  """Raised (in strict mode) when a compile is attempted within the backoff window
-    after a recent compile failure."""
+  """Raised (strict mode) when a compile is attempted within the backoff window."""
 
 
 def reset() -> None:
@@ -50,9 +42,8 @@ def note_compile_result(ok: bool) -> None:
 
 
 def guard_before_compile() -> None:
-  """Call immediately before a compile. If a compile failed within the last
-    `_BACKOFF_S` seconds, pace this one to keep consecutive failures a short interval
-    apart (default: sleep the remainder; strict mode: raise)."""
+  """Call before a compile. If one failed within `_BACKOFF_S`, pace this one (default:
+    sleep the remainder; strict mode: raise)."""
   if _DISABLED or _BACKOFF_S <= 0.0: return
   with _lock:
     if _last_failure_ts is None: return

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1,9 +1,6 @@
-"""Lower a graph into ONE fused e5rt program.
+"""Lower a graph into ONE fused e5rt program (one MIL op per node, weights in one BLOBFILE).
 
-`compile(out)` topologically orders the graph, emits a single MIL function (one op
-per graph node, weights packed into one BLOBFILE), and hands it to e5rt on the ANE.
-Each op's MIL is produced by a small handler registered with `@op(...)` - the
-registry doubles as the set of ops aneforge can reach on the device.
+See .superpowers/sdd/gold-core-heavy.md for the compile-pipeline design rationale.
 """
 from __future__ import annotations
 
@@ -29,8 +26,7 @@ _BUILD_INFO = (
 
 
 def _topo(out: Tensor) -> list[Tensor]:
-  # iterative post-order DFS (explicit stack) so deep unrolled graphs don't blow
-  # Python's recursion limit. Sources are appended before their consumers (valid topo).
+  # iterative post-order DFS so deep unrolled graphs don't hit the recursion limit.
   seen: set[int] = set()
   order: list[Tensor] = []
   stack: list = [(out, False)]
@@ -66,17 +62,14 @@ class _Emitter:
 
   def __init__(self, int8: bool, compress: str | None = None, compress_atol: float = 0.05,
         block_size: int = 32, family: int | None = None) -> None:
-    # `compress` is the unified knob: None (fp16), "int8", "int4", "sparse",
-    # "blockwise", or "auto". `int8=True` is the back-compat alias for compress="int8".
+    # `compress`: None (fp16), "int8", "int4", "sparse", "blockwise", "auto"; int8=True aliases "int8".
     self.compress = compress if compress is not None else ("int8" if int8 else None)
     self.int8 = self.compress == "int8"
     self.compress_atol = compress_atol
     self.block_size = block_size       # inner-dim block for compress="blockwise"
-    # compress="auto" is family-aware: only encodings that stream natively on the
-    # target family are auto candidates - a folding encoding costs accuracy for zero
-    # bandwidth win, so fp16 dominates it (h13/M1 streams int4-LUT + sparse; A14+ stream
-    # all four). family=None keeps every branch enabled (historical behavior);
-    # explicit single-mode knobs are never filtered - the user's call.
+    # compress="auto" is family-aware: only encodings that stream natively on the target
+    # family are candidates (folding ones cost accuracy for no bandwidth win). family=None
+    # keeps every branch enabled; explicit single-mode knobs are never filtered.
     if self.compress == "auto" and family is not None:
       from . import _targets as TG
       self._auto_streams = TG.native_streams(family)
@@ -103,7 +96,7 @@ class _Emitter:
     idx = np.empty(raw.size * 2, dtype=np.uint8)
     idx[0::2], idx[1::2] = raw & 0x0F, (raw >> 4) & 0x0F
     recon = cb[idx][: W2.size].reshape(W2.shape)
-    W2 = W2.astype(np.float32)   # norm in fp32: W2.dot(W2) overflows fp16 for large weights
+    W2 = W2.astype(np.float32)   # norm in fp32: it overflows fp16 for large weights
     return float(np.linalg.norm(recon - W2) / (np.linalg.norm(W2) + 1e-12))
 
   @staticmethod
@@ -112,33 +105,17 @@ class _Emitter:
     q = np.frombuffer(data, dtype=np.int8).astype(np.float32).reshape(OUT, nblocks, IN // nblocks)
     sc = np.frombuffer(scale, dtype=np.float16).astype(np.float32).reshape(OUT, nblocks)
     recon = (q * sc[:, :, None]).reshape(OUT, IN)
-    W2 = W2.astype(np.float32)   # norm in fp32: W2.dot(W2) overflows fp16 for large weights
+    W2 = W2.astype(np.float32)   # norm in fp32: it overflows fp16 for large weights
     return float(np.linalg.norm(recon - W2) / (np.linalg.norm(W2) + 1e-12))
 
   def weight(self, name: str, W: np.ndarray, allow_int8: bool,
        int8: bool | None = None, allow_int4: bool = False,
        allow_sparse: bool = False) -> str:
-    """Declare a constant weight `name`. Encoding precedence: sparse (when
-        compress='sparse', allowed, >=50% zeros) -> int4-LUT (when compress='int4',
-        allowed, inner dim even, within the accuracy budget) -> per-channel int8
-        (compress='int8'/int8 override, allowed) -> fp16. The int4 fallback chain is
-        int4 -> int8 (per-channel, where allowed) -> fp16: when int4-LUT is rejected
-        (gate miss or odd inner dim), the weight falls to int8 if allow_int8 (denser
-        than fp16, and the user opted into compression), else fp16. int4 is gated
-        by per-tensor relative-L2 reconstruction error vs self.compress_atol, falling
-        back rather than emitting a too-lossy weight. compress=None/opt=0 stays
-        byte-identical (the fp16 branch). Under compress='auto' each compressed branch
-        is additionally gated on the encoding streaming natively on the target family
-        (self._auto_streams): on h13/M1 that is int4-LUT + sparse, so auto streams those
-        (sparse for >=50%-zero weights) but skips int8/blockwise (they fold), and a rejected
-        int4 falls to fp16, not int8."""
+    """Declare a constant weight `name`. Encoding precedence: sparse -> int4-LUT (accuracy-
+        gated) -> per-channel int8 -> fp16; compress=None/opt=0 stays byte-identical (fp16).
+        See .superpowers/sdd/gold-core-heavy.md for the full fallback chain + auto gating."""
     path = '@model_path/weights.bin'
     W2 = W.reshape(W.shape[0], -1)
-    # Branch order is the "auto" precedence: sparse -> int4 -> int8 -> fp16.
-    # Single-mode knobs ("sparse"/"int4"/"int8") enable exactly their one compressed
-    # branch; "auto" enables the branches that stream natively on the target family
-    # and takes the most-aggressive that stays correct (sparse lossless, int4
-    # accuracy-gated, int8 the dense fallback).
     _auto = self.compress == "auto"
     if (self.compress == "sparse" or (_auto and "sparse" in self._auto_streams)) and allow_sparse:
       mask, vals = sparsify(W2)
@@ -159,11 +136,8 @@ class _Emitter:
       packed, lut = palettize_lut4(W2)
       if self._lut4_rel_error(W2, packed, lut) <= self.compress_atol:
         oi, ol = self.blob.add(packed, UINT4), self.blob.add(lut, FP16)
-        # Indices always have the same shape as the weight (lut rank = W.ndim + 2).
-        # For 2-D weights this is [1,1,16,1] exactly as before (byte-identical).
-        # For ND weights (e.g. conv) the lut is [1]*N+[16,1]; Espresso accepts any
-        # rank as long as lut.rank == indices.rank + 2.  A reshape of a constexpr_
-        # output is not routable on the ANE backend, so we must use ND indices.
+        # ND indices (lut.rank == indices.rank + 2): a reshape of a constexpr_ output is
+        # not routable on the ANE backend. 2-D case is [1,1,16,1] (byte-identical).
         ishp = list(W.shape)
         lut_shp = [1] * W.ndim + [16, 1]
         lut_shp_str = "[" + ", ".join(str(d) for d in lut_shp) + "]"
@@ -180,14 +154,9 @@ class _Emitter:
       data, scale, nblocks = quantize_blockwise(W2, self.block_size)
       if self._blockwise_rel_error(W2, data, scale, nblocks) <= self.compress_atol:
         od, osc = self.blob.add(data, INT8), self.blob.add(scale, FP16)
-        # data has the weight's shape; scale is [OUT, nblocks]. On-device
-        # constexpr_blockwise_shift_scale reconstructs data.reshape(OUT,nblocks,bs)
-        # * scale[:,:,None] (zero offset). Verified multi-block on M5 (relerr ~3e-4).
-        # wall: the constexpr output is not routable as a matmul/conv weight operand
-        # (Espresso "Not implemented"); it only feeds elementwise consumers, so we
-        # bridge it through a +0 add to a dense fp16 result that can back a
-        # matmul/conv. Net: dequantized in-program, not streamed as int8 (disk ~2x
-        # smaller, no bandwidth win - unlike int4-LUT/sparse).
+        # The constexpr output is not routable as a matmul/conv weight operand (Espresso
+        # "Not implemented"), so bridge it through a +0 add to a dense fp16 result that can.
+        # Net: dequantized in-program (disk ~2x smaller, no bandwidth win - unlike int4/sparse).
         shp = list(W.shape)
         self.line(f'tensor<int8, {shp}> {name}_d = const()[name = string("{name}_d"), '
              f'val = tensor<int8, {shp}>(BLOBFILE(path = string("{path}"), offset = uint64({od})))];')
@@ -275,10 +244,8 @@ def _e_act_alpha_beta(em, t, n, s):
 
 @op("square")
 def _e_square(em, t, n, s):
-  # emit mul(x,x) instead of the `square` opcode: the native square opcode fused
-  # with a following nonlinearity fails ANECCompile when (Width % 128) > 64
-  # (mapped in the reverse-engineering corpus); mul(x,x) is identical math and
-  # compiles everywhere.
+  # mul(x,x) not the `square` opcode: square fused with a following nonlinearity fails
+  # ANECCompile when (Width % 128) > 64; mul(x,x) is identical math and compiles everywhere.
   em.line(f'{em.ty(t.shape)} {n} = mul(x = {s[0]}, y = {s[0]})[name = string("{n}")];')
 
 
@@ -320,10 +287,7 @@ def _e_muls(em, t, n, s):
 
 @op("adds")
 def _e_adds(em, t, n, s):
-  # scalar add (x + k), the additive sibling of muls. A const fp16 broadcast-added
-  # to x - the only fused way to inject a scalar offset (e.g. a normalization eps),
-  # since _binary requires two graph Tensors. Bit-faithful: the const is fp16-rounded
-  # exactly as muls rounds its scalar.
+  # scalar add (x + k): a fp16 const broadcast-added to x (the fused way to inject a scalar offset).
   k = float(np.float16(t.attrs["k"])).hex()
   em.line(f'fp16 {n}_k = const()[name = string("{n}_k"), val = fp16({k})];')
   em.line(f'{em.ty(t.shape)} {n} = add(x = {s[0]}, y = {n}_k)[name = string("{n}")];')
@@ -331,8 +295,7 @@ def _e_adds(em, t, n, s):
 
 @op("cast")
 def _e_cast(em, t, n, s):
-  # dtype conversion (dequantises a uint8 image input to fp16): the source port's
-  # declared dtype is uint8; cast lifts it to the fp16 compute type.
+  # dtype conversion (e.g. lift a uint8 image input port to the fp16 compute type).
   dt = t.attrs.get("dtype", "fp16")
   em.line(f'string {n}_d = const()[name = string("{n}_d"), val = string("{dt}")];')
   em.line(f'{em.ty_dt(t.shape, dt)} {n} = cast(dtype = {n}_d, x = {s[0]})[name = string("{n}")];')
@@ -340,8 +303,7 @@ def _e_cast(em, t, n, s):
 
 @op("const_array")
 def _e_const_array(em, t, n, s):
-  # a small baked fp16 const tensor (e.g. per-channel image scale/bias), streamed
-  # from the weights blob like any other const.
+  # a small baked fp16 const tensor (e.g. per-channel image scale/bias) from the weights blob.
   W = np.asarray(t.attrs["value"], dtype=np.float16)
   path = '@model_path/weights.bin'
   o = em.blob.add(fp16_bytes(W), FP16)
@@ -351,8 +313,7 @@ def _e_const_array(em, t, n, s):
 
 @op("matmul")
 def _e_matmul(em, t, n, s):
-  # per-node int8 override (set by the rewriter) takes precedence over the global
-  # self.int8; None defers to the global flag (keeps opt=0 byte-identical).
+  # per-node int8 override (set by the rewriter) wins over global self.int8; None defers.
   w = em.weight(f"{n}_w", t.attrs["wt"], allow_int8=True, int8=t.attrs.get("int8"), allow_int4=True, allow_sparse=True)  # wt is [N, K]
   em.line(f'{em.ty(t.shape)} {n} = matmul(transpose_x = bool(false), transpose_y = bool(true), '
       f'x = {s[0]}, y = {w})[name = string("{n}")];')
@@ -371,14 +332,8 @@ def _e_bmm(em, t, n, s):
 @op("conv")
 def _e_conv(em, t, n, s):
   a = t.attrs
-  # per-channel int8 is routable as a conv weight on the ANE: constexpr_affine_dequantize
-  # feeds the conv weight operand directly (no +0 bridge - unlike constexpr_blockwise_
-  # shift_scale). Measured on h13/M1: int8 conv compiles+runs at cos~1.0 vs fp16,
-  # relerr ~0.6% vs fp32 ref (the expected per-channel int8 error), and ~halves the
-  # DRAM weight bytes (dequant-in-program at the MAC port). int4-LUT/sparse stay as
-  # higher-precedence branches (int4 streams natively 2.37x on M1; int8 folds/dequants
-  # but still halves bytes). The per-node `int8` attr (set by the auto-rewriter) overrides
-  # the global flag, like matmul; None defers (keeps opt=0 byte-identical).
+  # per-channel int8 is routable as a conv weight (constexpr_affine_dequantize feeds the
+  # conv operand directly, no +0 bridge); per-node `int8` attr overrides the global flag.
   w = em.weight(f"{n}_w", a["weight"], allow_int8=True, int8=a.get("int8"), allow_int4=True, allow_sparse=True)
   p, st, dl, g = a["pad"], a["stride"], a["dilation"], a["groups"]
   em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
@@ -396,9 +351,8 @@ def _e_conv(em, t, n, s):
 
 @op("dynamic_conv")
 def _e_dynamic_conv(em, t, n, s):
-  # native conv with a dynamic weight: the kernel is the second src (s[1]), a graph value,
-  # not a baked BLOBFILE const. Lowers to the ANE dynamic-kernel path. Batch is guaranteed 1
-  # by the graph builder (batch>=2 dynamic-weight conv is unsupported).
+  # conv with a dynamic weight (kernel is s[1], a graph value not a const). Batch is 1
+  # by construction (batch>=2 dynamic-weight conv is unsupported).
   a = t.attrs
   p, st, dl, g = a["pad"], a["stride"], a["dilation"], a["groups"]
   em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
@@ -438,7 +392,7 @@ def _e_avg_pool(em, t, n, s):
 @op("conv_transpose")
 def _e_conv_transpose(em, t, n, s):
   a = t.attrs
-  w = em.weight(f"{n}_w", a["weight"], allow_int8=False)         # [Cin, Cout, kH, kW]; int4-LUT unverified for conv_transpose -> fp16/int8
+  w = em.weight(f"{n}_w", a["weight"], allow_int8=False)         # [Cin, Cout, kH, kW]; int4 unverified here -> fp16
   p, st, dl, g = a["pad"], a["stride"], a["dilation"], a["groups"]
   em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
   em.line(f'tensor<int32, [2]> {n}_st = const()[name = string("{n}_st"), val = tensor<int32, [2]>([{st}, {st}])];')
@@ -504,9 +458,7 @@ def _e_softmax(em, t, n, s):
 
 @op("l2_norm")
 def _e_l2_norm(em, t, n, s):
-  # x / sqrt(sum(x^2, axis) + eps), built from reduce_l2_norm (verified on e5rt)
-  # over the requested axis. reduce_l2_norm computes sqrt(sum(x^2)); eps enters via
-  # a safe-divide guard (max with eps) to avoid div-by-zero.
+  # x / max(reduce_l2_norm(x), eps): reduce_l2_norm = sqrt(sum(x^2)); eps is a safe-divide floor.
   ax, eps = t.attrs["axis"], float(np.float16(t.attrs["eps"] ** 0.5)).hex()
   red_shape = tuple(1 if i == ax else d for i, d in enumerate(t.shape))
   em.line(f'tensor<int32,[1]> {n}_ax = const()[name=string("{n}_ax"), val=tensor<int32,[1]>([{ax}])];')
@@ -568,9 +520,7 @@ def _e_stack(em, t, n, s):
 
 @op("split")
 def _e_split(em, t, n, s):
-  # split emits N equal outputs once (keyed on which==0); later splits reuse the
-  # already-emitted multi-output statement by name (n0_<i>). Guard against re-emit
-  # via a per-source marker stored on the emitter.
+  # emit the N-output split statement once; later split nodes alias its ports by name.
   ns, ax, which = t.attrs["num_splits"], t.attrs["axis"], t.attrs["which"]
   src = s[0]
   key = f"_split_{src}_{ns}_{ax}"
@@ -689,16 +639,9 @@ def _e_affine(em, t, n, s):
 
 @op("rms_norm")
 def _e_rms_norm(em, t, n, s):
-  # RMS-norm via the fused `reduce_l2_norm` over the last axis - the same fast
-  # reduction `l2_norm` uses. The previous lowering reshaped to [M,D,1,1] and ran
-  # `reduce_sum` over the *channel* axis, which falls off the ANE's fast reduction
-  # tile past ~256 rows and ran ~48x slower than this path at [1024,1024]
-  # (e.g. 6882us -> 142us), and 16-27x slower than layer_norm despite RMS being
-  # structurally cheaper. Mathematically identical:
-  #     rms(x) = x / sqrt(mean(x^2)+eps) * g
-  #            = x * sqrt(D) / sqrt(sum(x^2)) * g        (reduce_l2_norm = sqrt(sum x^2))
-  # eps enters as a safe-divide floor on the norm (as in l2_norm); the sqrt(D)
-  # rescale is folded into the gamma weight so no extra op is emitted.
+  # RMS-norm via fused reduce_l2_norm over the last axis (the fast reduction l2_norm uses):
+  #   rms(x) = x*sqrt(D)/sqrt(sum(x^2))*g; the sqrt(D) rescale folds into gamma, eps is a
+  # safe-divide floor. The old channel-axis reduce_sum lowering ran ~48x slower at [1024,1024].
   D = t.shape[-1]
   ax = len(t.shape) - 1
   gw = (t.attrs["gamma"].reshape(1, D).astype(np.float32) * float(np.sqrt(D)))
@@ -740,9 +683,8 @@ def _e_layer_norm(em, t, n, s):
 
 @op("channel_layer_norm")
 def _e_channel_layer_norm(em, t, n, s):
-  # LayerNorm over the channel axis (axis 1) of a channels-first [N,C,1,S] tensor.
-  # Same reduction as layer_norm but with no reshape in/out: the ANE keeps the data in
-  # its native [N,C,1,S] layout, so the surrounding 1x1-conv projections stay efficient.
+  # LayerNorm over the channel axis of a channels-first [N,C,1,S] tensor, no reshape in/out
+  # (keeps the native layout so surrounding 1x1-conv projections stay efficient).
   N, C, _, S = t.shape
   ty = em.ty(t.shape)
   rty = f"tensor<fp16,[{N},1,1,{S}]>"
@@ -765,10 +707,8 @@ def _e_channel_layer_norm(em, t, n, s):
 
 @op("group_norm")
 def _e_group_norm(em, t, n, s):
-  # Rank-4 tiling: reshape to [1,G,C/G,H*W] and reduce over the trailing two axes
-  # (per-group, over C/G and H*W) rather than the flattened [1,G,(C/G)*H*W].
-  # Keeps every internal axis under the per-axis cap so big SD-1.5 maps (640@64,
-  # 512@128) compile, where the flat (C/G)*H*W extent overflowed.
+  # Rank-4 tiling: reshape to [1,G,C/G,H*W] and reduce the trailing two axes, keeping every
+  # internal axis under the per-axis cap (the flat [1,G,(C/G)*H*W] extent overflowed on big maps).
   _, C, H, W = t.shape
   G = t.attrs["groups"]; D = C // G; HW = H * W
   g4 = em.weight(f"{n}_g", t.attrs["gamma"].reshape(1, C, 1, 1), allow_int8=False)
@@ -780,7 +720,7 @@ def _e_group_norm(em, t, n, s):
   em.line(f'tensor<int32,[1]> {n}_a3 = const()[name=string("{n}_a3"), val=tensor<int32,[1]>([3])];')
   em.line(f'bool {n}_kd = const()[name=string("{n}_kd"), val=bool(true)];')
   em.line(f'tensor<fp16,[1,{G},{D},{HW}]> {n}_xg = reshape(shape={n}_gs, x={s[0]})[name=string("{n}_xg")];')
-  # mean = sum over both group axes * 1/(D*HW), via chained reduce_sum (D->1, then HW->1).
+  # mean = sum over both group axes * 1/(D*HW), via chained reduce_sum.
   em.line(f'tensor<fp16,[1,{G},{D},1]> {n}_s3 = reduce_sum(axes={n}_a3, keep_dims={n}_kd, x={n}_xg)[name=string("{n}_s3")];')
   em.line(f'tensor<fp16,[1,{G},1,1]> {n}_ss = reduce_sum(axes={n}_a2, keep_dims={n}_kd, x={n}_s3)[name=string("{n}_ss")];')
   em.line(f'fp16 {n}_id = const()[name=string("{n}_id"), val=fp16({invd})];')
@@ -804,16 +744,13 @@ def _e_group_norm(em, t, n, s):
 # --------------------------------------------------------------------------- #
 
 class Model:
-  """A compiled, fused ANE program. Call it with the input array(s), in the order
-    they were created with `af.input`."""
+  """A compiled, fused ANE program. Call it with the input array(s), in `af.input` order."""
 
   def __init__(self, prog, inputs: list[tuple[str, tuple]], out_name: str, out_shape, n_ops: int,
         input_tensors: list | None = None):
     self._prog = prog
     self._inputs = inputs
-    # The ordered input Tensor objects (same order as `inputs`); lets callers
-    # (e.g. autograd.Trainer) map each compiled input back to its source Tensor -
-    # trainable parameter vs provided data. Additive; no effect on inference.
+    # ordered input Tensor objects: lets autograd.Trainer map each input to its source Tensor.
     self._input_tensors = input_tensors if input_tensors is not None else []
     self._out_name, self._out_shape = out_name, out_shape
     self.n_ops = n_ops  # graph ops fused into this single program
@@ -834,23 +771,17 @@ class Model:
         feed[name] = a.astype(np.float16)
     return self._prog.eval(feed)[self._out_name].astype(np.float32)
 
-  # ---- zero-copy hot-loop API (skip the per-call host<->device memcpy) ----
-  # Pattern:  v = model.input_view(); ... write fp16 into v ...; model.execute();
-  #           out = model.output_view()   # fp16 view onto the result, no copy
-  # For tight inference/training loops; for one-off calls just use __call__.
+  # ---- zero-copy hot-loop API: input_view (write) / execute / output_view (read), no memcpy ----
   def input_view(self, name: str | None = None) -> np.ndarray:
-    """Writable fp16 view onto an input buffer (defaults to the sole input port).
-        See `Program.input_view`."""
+    """Writable fp16 view onto an input buffer (defaults to the sole input port)."""
     return self._prog.input_view(name or self._inputs[0][0])
 
   def output_view(self) -> np.ndarray:
-    """fp16 view onto the output buffer, valid after `execute()`. See
-        `Program.output_view`."""
+    """fp16 view onto the output buffer, valid after `execute()`."""
     return self._prog.output_view(self._out_name)
 
   def execute(self) -> None:
-    """Run once without binding inputs / reading outputs - pair with
-        `input_view`/`output_view` for a zero-copy loop."""
+    """Run once without binding inputs / reading outputs (pair with input_view/output_view)."""
     self._prog.execute()
 
   def release(self) -> None:
@@ -875,8 +806,7 @@ def _sig_ty(em, t: Tensor) -> str:
 
 
 def _emit_program_dir(em, inputs, out_var, out_shape, build_dir):
-  """Write one e5rt program (MIL + weights) for a set of input tensors to a dir; return
-    it. Shared by the device-compile path and the cross-target compile check."""
+  """Write one e5rt program (MIL + weights) to a dir; return it."""
   sig = ", ".join(f"{_sig_ty(em, t)} {t._name}" for t in inputs)
   mil = (f"program(1.3)\n{_BUILD_INFO}\n{{\n    func main<ios18>({sig}) {{\n"
      + "\n".join(em.lines) + f"\n    }} -> ({out_var});\n}}\n")
@@ -896,8 +826,7 @@ def _assemble_and_compile(em, inputs, out_var, out_shape, build_dir):
 
 
 def _lower_fused_to_dir(out: Tensor, build_dir=None, int8: bool = False):
-  """Lower a single-program fused graph to a MIL+weights dir WITHOUT compiling it.
-    Bridge/segmented graphs are out of scope for the cross-target check (raises)."""
+  """Lower a fused graph to a MIL+weights dir WITHOUT compiling it (bridge graphs raise)."""
   order = _topo(out)
   if any(t.op in NETPLIST_OPS for t in order):
     raise NotImplementedError("cross_compile_check: bridge/segmented graphs not supported")
@@ -912,30 +841,22 @@ def _lower_fused_to_dir(out: Tensor, build_dir=None, int8: bool = False):
 
 
 def cross_compile_check(out: Tensor, target, int8: bool = False) -> bool:
-  """Does the graph rooted at `out` compile for another ANE family, checked from this
-    host? `target` is a compiler arch string ('h13') or a family int. Returns True iff
-    the e5rt compiler produces a library for that TargetArchitecture - compile-level
-    validation only (it does not, and on a different-family host cannot, execute there).
-
-    The keystone of cross-chip CI: validate that the op corpus compiles for every chip
-    family on one box. Numeric correctness still needs the real silicon."""
+  """Does the graph compile for another ANE family, checked from this host? `target` is an
+    arch string ('h13') or family int. Compile-level validation only (cannot execute there).
+    The keystone of cross-chip CI; numeric correctness still needs the real silicon."""
   from . import _runtime
   from . import _targets as TG
   if isinstance(target, str):
     arch = target.strip().lower()
-    # The e5rt compiler silently falls back to the host target on an unrecognized
-    # TargetArchitecture string (measured: 'zzz' compiles fine), turning a typo into
-    # a false cross-target pass. Gate on the known-target table first.
+    # e5rt silently falls back to the host target on an unrecognized TargetArchitecture
+    # string (a typo -> a false pass), so gate on the known-target table first.
     if arch not in TG._ARCH_FAMILY:
       raise ValueError(f"unknown ANE target arch {target!r}; known: " f"{sorted(TG._ARCH_FAMILY)}")
   else:
     arch = TG.arch_for_family(int(target))
-  # Static pre-gate: a target's per-family caps (conv kernel width, max tensor dim, ops
-  # below their MinimumFamily floor) are HAL-data gated, and the host cross-compiler does
-  # not reliably enforce a different family's caps when emitting for its TargetArchitecture
-  # - so a cap violation would compile here and only fail on the real silicon, a false CI
-  # pass. preflight() answers the same question statically and family-aware (it is what
-  # compile(target=) gates on), so reject up front and skip the compiler entirely.
+  # Static pre-gate via preflight(): the host cross-compiler does not reliably enforce a
+  # different family's caps, so a cap violation would compile here and fail only on real
+  # silicon (a false CI pass). preflight() answers family-aware, so reject up front.
   fam = TG.family_of_arch(arch)
   rep = TG.preflight(out, fam)
   if not rep.ok:
@@ -947,8 +868,7 @@ def cross_compile_check(out: Tensor, target, int8: bool = False) -> bool:
       f"({arch}): {bad}. Rejected statically (preflight); the compiler was not run.",
       stacklevel=2)
     return False
-  # Annotate cross-chip fp16 divergence risk (Direction B) before compiling: warn-only,
-  # so a typo'd/unreachable graph still surfaces its compile error.
+  # Annotate cross-chip fp16 divergence risk (Direction B) before compiling: warn-only.
   try:
     _warn_fp16_cross_chip(out, TG.detect_family(), fam)
   except Exception as e:
@@ -963,20 +883,15 @@ def cross_compile_check(out: Tensor, target, int8: bool = False) -> bool:
 
 
 class MultiModel:
-  """A compiled fused program with N named outputs (e.g. a resident training
-    step: `(x, y, lr, w, m, v, ...) -> (w', m', v', ...)`). Unlike `Model` it
-    keeps the ordered input/output Tensors and exposes the raw `Program` so
-    callers (autograd.Trainer's resident path) can alias state outputs onto their
-    inputs via `share_buffer` and drive the resident loop. `__call__` evals
-    once and returns the outputs by name (for verification / non-resident use)."""
+  """A compiled fused program with N named outputs (e.g. a resident training step). Unlike
+    `Model` it keeps the ordered input/output Tensors and exposes the raw `Program` so the
+    resident path can alias state outputs onto inputs via `share_buffer`."""
 
   def __init__(self, prog, inputs: list, outputs: list):
     self.prog = prog
     self.input_tensors = list(inputs)
     self.output_tensors = list(outputs)
-    # Port names are snapshotted here (like Model): compile()/compile_multi()
-    # reassign t._name on shared Tensor objects, so a later compile of another
-    # graph sharing these tensors must not break this model's feed/read names.
+    # snapshot port names: a later compile of a graph sharing these Tensors reassigns t._name.
     self.input_ports = [(t, t._name) for t in inputs]
     self.output_ports = [(t, t._name) for t in outputs]
 
@@ -996,10 +911,8 @@ class MultiModel:
 
 
 def compile_multi(outs, build_dir=None) -> MultiModel:
-  """Lower a graph with multiple output Tensors into one fused ANE program with
-    N named output ports (the multi-output analogue of `compile`). Used for the
-    resident training step, where each state tensor needs its own output port to
-    alias back onto its input. fp16 only; no opt/compress/segmented path."""
+  """Lower a multi-output graph into one fused program with N named output ports (the
+    multi-output `compile`, for the resident training step). fp16 only; no opt/compress."""
   seen: set[int] = set()
   order: list[Tensor] = []
   stack: list = [(o, False) for o in reversed(outs)]    # iterative post-order (deep-graph safe)
@@ -1041,25 +954,16 @@ def compile_multi(outs, build_dir=None) -> MultiModel:
 
 
 class PrecisionWarning(UserWarning):
-  """Emitted by `compile` when a graph has fp16-cancellation-risk nodes whose
-    results may be inaccurate. Silence with
-    `warnings.filterwarnings('ignore', category=aneforge.PrecisionWarning)`."""
+  """Emitted by `compile` when a graph has fp16-cancellation-risk nodes (results may be inaccurate)."""
 
 
 class DispatchFloorWarning(UserWarning):
-  """Emitted by `compile` when a program is dispatch-floor-bound: its predicted ANE
-    time is dominated by the fixed per-call dispatch + firmware round-trip, so each call
-    costs about the same however small the work is. Dispatch is single-in-flight, so
-    threads/concurrency do not amortize it - only larger batches or more ops per program do.
-    Silence with `warnings.filterwarnings('ignore', category=aneforge.DispatchFloorWarning)`."""
+  """Emitted by `compile` when a program is dispatch-floor-bound (predicted time dominated by the
+    fixed per-call dispatch + firmware round-trip; threads/concurrency do not amortize it)."""
 
 
 def _dispatch_floor_signal(out: Tensor) -> None:
-  """Warn once if the program is dispatch-floor-bound, so a caller looping per-sample
-    isn't silently paying the full fixed per-call cost every time. The ANE per-call latency
-    is a fixed dispatch + firmware round-trip (~0.2 ms on M1-class parts) that batching and
-    op-chaining amortize but concurrency does not. Cheap: a structural estimate, no device
-    work; fires only when the predicted cost is dominated by the dispatch floor."""
+  """Warn once if the program is dispatch-floor-bound (predicted cost ~= the fixed per-call floor)."""
   try:
     from ._cost import estimate, _constants
     pred = float(estimate(out))
@@ -1084,10 +988,7 @@ def _dispatch_floor_signal(out: Tensor) -> None:
 
 
 def _precision_signal(out: Tensor, strict: bool) -> None:
-  """Run the structural fp16-precision-risk check and tell the user. Warns (or, with
-    `strict`/`validate=True`, raises) when the graph has cancellation / narrow-reduce
-    hotspots, so an unstable computation can never run silently. Cheap: a static pass
-    over the graph, no device work. See `precision_risk` for the (heuristic) model."""
+  """Warn (or, with strict, raise) on the graph's fp16 cancellation / narrow-reduce hotspots."""
   from ._cost import precision_risk
   risk = precision_risk(out)
   if not risk["hotspots"]: return
@@ -1106,23 +1007,9 @@ def _precision_signal(out: Tensor, strict: bool) -> None:
 
 
 def _warn_h13_slice_saturation(out: Tensor, family: int) -> None:
-  """Pre-A16 ANE quirk on nonzero-width (last-axis) `slice_by_size` offsets, which
-    lower through a Q.4 fixed-point crop-DMA (an implied x16 scale). Two distinct,
-    silicon-pinned failure modes:
-
-      (1) wrong elements when multiple width-offset slices are concatenated - confirmed
-          on A14 (the gather axis-1 bug) and A13, at any magnitude. A single width-offset
-          slice selects the correct elements (a 180-config bare-slice sweep is numpy-exact
-          on A14), so this mode is specific to the concat-of-width-slices pattern.
-      (2) saturation: a sliced element with |value| > 4094 (= 65504/16) clamps to +/-inf,
-          magnitude-driven, on a single width-offset slice. Silicon-confirmed on A13 (conv
-          weight-grad) and A14 (M2 probe: 4094 finite -> 4100 inf, bit-exact); A15 pending
-          M3 data.
-
-    A zero last-axis begin, or an offset on any non-last axis, avoids the path and is
-    exact; A16/M5 is unaffected. `gather` and the conv im2col backward already route off
-    the last axis, so this is a safety net for any remaining hand-written occurrence.
-    """
+  """Pre-A16 quirk: last-axis-offset slice_by_size lowers through a Q.4 crop-DMA (x16 scale).
+    Mode (1) concat of >=2 width-offset slices -> wrong elements; mode (2) |value|>4094 -> +/-inf.
+    See .superpowers/sdd/gold-core-heavy.md for the silicon evidence per family."""
   import warnings
 
   from . import _targets as TG
@@ -1130,8 +1017,7 @@ def _warn_h13_slice_saturation(out: Tensor, family: int) -> None:
     return
   sat_family = int(family) <= int(TG.Family.A14)   # saturation measured on A13 + A14
   for t in _topo(out):
-    # Mode (1): a concat of >= 2 nonzero-width-offset slices (the gather / im2col
-    # pattern) - wrong elements on any pre-A16 family.
+    # Mode (1): a concat of >= 2 nonzero-width-offset slices -> wrong elements (pre-A16).
     if t.op == "concat":
       n_w = sum(1 for s in t.srcs if s.op == "slice_by_size" and (s.attrs.get("begin") or [0])[-1] > 0)
       if n_w >= 2:
@@ -1152,16 +1038,12 @@ def _warn_h13_slice_saturation(out: Tensor, family: int) -> None:
 
 
 class CrossChipFP16Warning(UserWarning):
-  """Emitted by `cross_compile_check` when a graph compiles for a different-family
-    target but carries an op whose fp16 VALUE can diverge from the host's on that chip
-    (per the Direction B HAL-field predictor). The compile is still valid - this is a
-    numeric heads-up, not a rejection. Silence with
-    `warnings.filterwarnings('ignore', category=aneforge.CrossChipFP16Warning)`."""
+  """Emitted by `cross_compile_check` when a graph compiles for a different-family target but
+    carries an op whose fp16 value can diverge on that chip (Direction B). A heads-up, not a rejection."""
 
 
 def _node_max_abs(t: Tensor):
-  """Best-effort static bound on a node's value magnitude (for the slice saturation
-    gate): a baked const's actual max, else unknown (None = treat as possibly-large)."""
+  """Static bound on a node's value magnitude: a baked const's max, else None (possibly-large)."""
   v = t.attrs.get("value")
   if v is not None:
     try:
@@ -1173,14 +1055,11 @@ def _node_max_abs(t: Tensor):
 
 
 def _fp16_risk_kind(t: Tensor) -> str:
-  """Map a graph node to the predictor's op-kind string: 'slice', 'reduce_square'
-    (a reduce feeding a square/mul = variance/L2/RMS), 'reduce' (any reduction/softmax/
-    norm), or '' (no fp16-route axis)."""
+  """Predictor op-kind: 'slice', 'reduce_square' (reduce->square/mul), 'reduce', or ''."""
   op = t.op
   if op == "slice_by_size": return "slice"
   if op in ("square", "mul"):
-    # reduce -> square/mul: the 0x494 fuse axis. Flag only when a source is a reduction
-    # (variance/L2/RMSNorm shape), not every elementwise square.
+    # reduce -> square/mul (the 0x494 fuse axis): flag only when a source is a reduction.
     if any(s.op.startswith("reduce") or s.op in ("l2_norm", "rms_norm") for s in t.srcs): return "reduce_square"
     return ""
   if op.startswith("reduce") or op in ("softmax", "l2_norm", "rms_norm", "layer_norm", "group_norm", "instance_norm"):
@@ -1189,9 +1068,7 @@ def _fp16_risk_kind(t: Tensor) -> str:
 
 
 def _warn_fp16_cross_chip(out: Tensor, host_family: int, target_family: int) -> None:
-  """Annotate, as warnings, which ops in the graph carry a cross-chip fp16 divergence
-    risk when validating for a different-family target (Direction B predictor). Groups by
-    risk class so the message is one line per (op, class). Never rejects."""
+  """Warn which ops carry cross-chip fp16 divergence risk for a different-family target. Never rejects."""
   import warnings
 
   from . import _targets as TG
@@ -1229,11 +1106,9 @@ def _resolve_family(target) -> int:
 
 
 def _retarget_for(out: Tensor, target) -> Tensor:
-  """Gate the graph for a target ANE family before lowering. Raises a clear
-    compile-time error on the H13+ hard floor, on an unreachable op, or on a tensor
-    exceeding the family's limits; substitutes below-floor ops that have an in-graph
-    decomposition (sin/cos -> aneforge.special). Returns the (possibly rewritten) graph.
-    On the host family with an all-native graph this is a no-op fast path (returns out)."""
+  """Gate the graph for a target family before lowering: raises on the H13+ floor, an unreachable
+    op, or an oversized tensor; substitutes below-floor ops with an in-graph decomposition
+    (sin/cos -> aneforge.special). No-op fast path on the host family with an all-native graph."""
   from . import _targets as TG
   from . import special
   fam = _resolve_family(target)
@@ -1277,45 +1152,15 @@ def compile(out: Tensor, int8: bool = False, build_dir=None, opt: "str | int | N
       compress: str | None = None, compress_atol: float = 0.05,
       block_size: int = 32, validate: bool = False, target=None,
       _check_precision: bool = True):
-  """Lower the graph rooted at `out` into ONE fused ANE program (or, if it
-    contains `af.sdpa` nodes, a segmented plan: e5rt programs split around each
-    native-SDPA sub-program).
+  """Lower `out` into ONE fused ANE program (or a segmented plan if it has `af.sdpa` nodes).
 
-    `opt` selects the graph optimizer (default `'routes'`):
-      - `opt='routes'` (default) : the lossless route pass - cost-model-driven, per
-                      shape, choosing for each route-bearing bridge node (sdpa,
-                      minmax_norm, flatten, lrn) between the native bridge (a graph
-                      cut) and the proven-equivalent fused decomposition (cut removed),
-                      without on-device measurement. The route registry is lossless
-                      (cos 1.0), so this never changes numerics; a cut-free graph
-                      compiles to exactly the `opt=0` program (no regression). For
-                      `sdpa` the cost model keeps native where it wins (long
-                      sequences), so the default never blindly removes a cut that
-                      helps.
-      - `opt=0`   : no optimization - the historical, byte-identical path
-                      (`int8` honored as given). Use this for byte-identity tests.
-      - `opt=1`   : cost-model pick over the full variant set (route swaps and the
-                      lossy whole-graph int8 variant), without measuring on-device.
-      - `opt=2` / `opt='max'` : autotune - measure the legal proven-safe variants
-                      on the ANE, validate each vs the opt=0 baseline, return the
-                      fastest correct one (cached; instant on a cache hit).
-
-    `compress` selects weight encoding: None (fp16, default, byte-identical at
-    `opt=0`), 'int8' (per-channel), 'int4' (LUT, accuracy-gated), 'sparse' (bitmask,
-    when the weight is >=50% zeros), 'blockwise' (per-inner-block int8 via
-    `constexpr_blockwise_shift_scale`, `block_size` columns per scale,
-    accuracy-gated -> int8 -> fp16), or 'auto' (per-weight: sparse if sparse, else int4
-    if accurate, else int8, else fp16 - the most aggressive encoding that stays
-    correct). 'auto' is family-aware: only encodings that stream natively on the
-    `target` family (host-detected when `target=None`) are candidates - on h13/M1
-    that is int4-LUT + sparse, so auto streams those (sparse for >=50%-zero weights) but
-    skips int8/blockwise (they fold to dense fp16: accuracy cost, no bandwidth win) and a
-    rejected int4 falls to fp16. Explicit single-mode knobs are never filtered.
-    `compress_atol` is the int4/blockwise fallback budget (relative L2);
-    `block_size` is the inner-dim block width for 'blockwise'. Compressed weights
-    stay on the byte-identical (opt=0) lowering: passing `compress` with an explicit
-    `opt>=1` is rejected, and the default route pass is skipped for compressed
-    compiles (they take the no-op path).
+    `opt`: 'routes' (default, lossless cost-model route pass), 0 (byte-identical, no opt),
+    1 (cost-model variant pick, no measurement), 2/'max' (autotune on-device).
+    `compress`: weight encoding - None (fp16), 'int8', 'int4', 'sparse', 'blockwise', or
+    family-aware 'auto'. `compress_atol` is the int4/blockwise fallback budget (relative L2);
+    `block_size` is the 'blockwise' inner-dim width. Compressed weights take the opt=0
+    lowering (compress with explicit opt>=1 is rejected).
+    See .superpowers/sdd/gold-core-heavy.md for the full opt/compress semantics.
     """
   if _check_precision:                 # once per user compile (internal re-entries pass False)
     _precision_signal(out, strict=validate)
@@ -1354,12 +1199,10 @@ def compile(out: Tensor, int8: bool = False, build_dir=None, opt: "str | int | N
 
 
 def _compile_opt(out: Tensor, int8: bool, opt):
-  """opt=1/2/'max' dispatch (lazy-imported so aneforge stays importable without the
-    optimizer/cost-model present)."""
+  """opt=1/2/'max' dispatch (lazy-imported so aneforge imports without the optimizer)."""
   from . import _optimize
   if opt in (1,):
-    # cost-model pick: no measurement, just the cheaper-predicted variant (this
-    # now spans route swaps too, since _estimate_variant costs the rewritten DAG).
+    # cost-model pick: cheaper-predicted variant (spans route swaps), no measurement.
     cfgs = _optimize._variants(out)
     best = min(cfgs, key=lambda c: _optimize._estimate_variant(out, c))
     return _optimize.build_variant(out, best)
@@ -1371,9 +1214,7 @@ def _compile_opt(out: Tensor, int8: bool, opt):
 # segmented compile: native-SDPA graph cuts                                   #
 # --------------------------------------------------------------------------- #
 def _import_bridge(module: str, attr: str, op_name: str, filename: str):
-  """Lazily import `attr` from the in-package `aneforge._bridges.<module>` bridge
-    (keeps aneforge self-contained: the netplist-bridge closure lives inside the
-    package, with no runtime dependency on the reverse-engineering corpus)."""
+  """Lazily import `attr` from the in-package `aneforge._bridges.<module>` bridge."""
   import importlib
   try:
     mod = importlib.import_module(f"{__package__}._bridges.{module}")
@@ -1389,24 +1230,20 @@ def _sdpa_fused(*args, **kwargs):
 
 
 # --------------------------------------------------------------------------- #
-# netplist-bridge ops: graph nodes that run as a native-ANE Path-A sub-program #
-# (a graph cut), like af.sdpa. Each entry maps an op name to a runner that,     #
-# given the materialized fp16 inputs + the node attrs, returns the fp16 output. #
-# Adding an op here makes it a legal cut point in the segmented plan (see        #
-# _compile_segmented). The fused e5rt-MIL emitters above are always preferred;   #
-# these are for ops the ANE backend doesn't expose through MIL.                  #
+# netplist-bridge ops: graph nodes that run as a native-ANE Path-A sub-program  #
+# (a graph cut), for ops the ANE backend doesn't expose through MIL. Each entry  #
+# in NETPLIST_OPS is a legal cut point in the segmented plan (_compile_segmented)#
 # --------------------------------------------------------------------------- #
 
 def _run_sdpa(srcs, attrs):
   q, k, v = srcs[0], srcs[1], srcs[2]
   mask = None
   if attrs.get("causal"):
-    # additive causal mask [S_q, S_k]: 0 on/below the diagonal, -inf above (fed as the
-    # native SDPA layer's optional 5th "mask" bottom). q is [B, H, S, D].
+    # additive causal mask [S,S]: 0 on/below diagonal, -inf above (native SDPA's 5th input).
     S = q.shape[2]
     mask = np.triu(np.full((S, S), -1e4, np.float32), k=1)
   elif attrs.get("masked"):
-    # runtime attn_mask (4th src): a [1,1,Sq|1,Skv] additive bias -> [Sq, Skv] for the bridge.
+    # runtime attn_mask (4th src): [1,1,Sq|1,Skv] additive bias -> [Sq, Skv].
     mask = np.asarray(srcs[3], np.float32).reshape(q.shape[2], k.shape[2])
   return _sdpa_fused(q, k, v, scale=attrs["scale"], mask=mask).astype(np.float16)
 
@@ -1417,7 +1254,6 @@ def _run_argmax(srcs, attrs):
   # GlobalArgMinMax over Width (last axis) or Channel (axis 0); x is [C, W] fp16.
   dim = "Width" if attrs["axis"] == 1 else "Channel"
   out = np.asarray(fn(x, dimension=dim, largest=True), dtype=np.float16)
-  # bridge returns a vector (one index per surviving position); reshape to keepdims
   C, W = x.shape
   return out.reshape((C, 1) if attrs["axis"] == 1 else (1, W))
 
@@ -1426,9 +1262,8 @@ def _run_topk(srcs, attrs):
   fn = _import_bridge("ane_rank_fused", "topk", "topk", "ane_rank_fused.py")
   (x,) = srcs
   k, largest = attrs["k"], attrs["largest"]
-  # The native TopK sorts Width keyed by one channel lane and permutes all
-  # channels by that single order. For PyTorch's per-row top-k (each row
-  # ranked independently) we dispatch each row as its own 1-channel tile.
+  # native TopK ranks Width keyed by one channel lane; dispatch each row as a 1-channel
+  # tile for per-row-independent ranking.
   rows = [np.asarray(fn(x[c:c + 1], k, largest=largest), dtype=np.float16).reshape(k) for c in range(x.shape[0])]
   return np.stack(rows, axis=0)
 
@@ -1438,9 +1273,8 @@ def _run_sort(srcs, attrs):
   (x,) = srcs
   W = x.shape[1]
   desc, idx = attrs["descending"], attrs["return_indices"]
-  # Like TopK, the native Sort orders Width keyed by one channel lane and
-  # permutes all channels by that single order. For a per-row independent sort
-  # (numpy-like) we dispatch each row as its own 1-channel tile.
+  # like TopK: native Sort orders Width keyed by one channel lane; dispatch each row
+  # as a 1-channel tile for a per-row-independent (numpy-like) sort.
   rows = [np.asarray(fn(x[c:c + 1], descending=desc, return_indices=idx),
            dtype=np.float16).reshape(W)
       for c in range(x.shape[0])]
@@ -1497,9 +1331,7 @@ def _run_lrn(srcs, attrs):
 
 
 def _run_rearrange(layer_fn, *index_keys):
-  """Build a runner for an ane_rearrange_fused.py op. `layer_fn` is the bridge
-    function name; `index_keys` are the attr names whose values are passed
-    positionally after the input array (e.g. ('r',) or ('bh','bw'))."""
+  """Build a runner for an ane_rearrange_fused.py op (`index_keys` -> positional args after x)."""
   def run(srcs, attrs):
     fn = _import_bridge("ane_rearrange_fused", layer_fn, layer_fn, "ane_rearrange_fused.py")
     (x,) = srcs
@@ -1579,10 +1411,8 @@ def _subgraph(target, source_ids):
 
 
 class SegmentedModel:
-  """A compiled plan: e5rt program segments interleaved with native-ANE
-    sub-program calls (sdpa / argmax / topk - see NETPLIST_OPS). Tensors thread
-    between segments as host fp16 arrays (correctness-first; a persistent IOSurface
-    worker is the throughput follow-up)."""
+  """A compiled plan: e5rt program segments interleaved with native-ANE sub-program calls
+    (NETPLIST_OPS). Tensors thread between segments as host fp16 arrays (correctness-first)."""
 
   def __init__(self, stages, inputs, out_id, out_shape, n_ops, n_netplist):
     self._stages = stages
@@ -1591,10 +1421,8 @@ class SegmentedModel:
     self.n_ops = n_ops
     # count of native sub-programs; kept as `n_sdpa` for backward compat
     self.n_netplist = self.n_sdpa = n_netplist
-    # A2: persistent Path-A workers, one per netplist stage with a worker
-    # route. Built lazily on first call (keyed by the stage), reused for the
-    # rest of this model's lifetime, released in release(). Set
-    # ANEFORGE_NETPLIST_WORKER=0 to force the A1 (subprocess-per-call) path.
+    # A2: persistent Path-A workers, one per netplist stage with a worker route, built
+    # lazily and cached for this model's lifetime. ANEFORGE_NETPLIST_WORKER=0 forces A1.
     self._workers: dict[int, "_Worker"] = {}
     self._worker_runs: dict[int, Callable[..., Any]] = {}
     self._worker_warned: set[str] = set()
@@ -1617,15 +1445,12 @@ class SegmentedModel:
     return env[self._out_id].astype(np.float32)
 
   def _netplist_runner(self, st) -> Callable[..., Any]:
-    """Resolve the runner for a netplist stage. Prefer a persistent Path-A worker
-        (load-once-eval-many), built lazily on first use and cached for this model's
-        lifetime. Fall back to the subprocess-per-call bridge when no worker route
-        exists for the op or when the worker is disabled / fails to start."""
+    """Resolve a netplist stage's runner: prefer a persistent Path-A worker (load-once-
+        eval-many), fall back to the subprocess-per-call bridge when none exists / it fails."""
     import os
     if os.environ.get("ANEFORGE_NETPLIST_WORKER", "1") == "0": return NETPLIST_OPS[st["op"]][0]
-    # Causal SDPA needs the per-call additive-mask injection, which lives on the
-    # subprocess bridge path (_run_sdpa); the persistent Path-A worker pre-builds a
-    # mask-less netplist, so route masked SDPA to the bridge (correctness over the worker).
+    # masked/causal SDPA needs per-call mask injection (subprocess _run_sdpa); the worker
+    # pre-builds a mask-less netplist, so route it to the bridge (correctness over the worker).
     if st["op"] == "sdpa" and (st["attrs"].get("causal") or st["attrs"].get("masked")): return NETPLIST_OPS[st["op"]][0]
     sid = st["tid"]
     run = self._worker_runs.get(sid)
@@ -1633,8 +1458,7 @@ class SegmentedModel:
     try:
       from . import _netplist_worker as nw
       if not nw.has_worker(st["op"]):
-        # No worker route exists for this op - the subprocess bridge IS the
-        # normal path, not a degradation; stay silent.
+        # no worker route - the subprocess bridge is the normal path; stay silent.
         run = NETPLIST_OPS[st["op"]][0]
         self._worker_runs[sid] = run
         return run
@@ -1643,9 +1467,8 @@ class SegmentedModel:
       self._worker_runs[sid] = run
       return run
     except Exception as e:
-      # Genuine worker failure -> fall back to the verified subprocess-bridge path
-      # (correctness-preserving, slower per call) and remember it so we don't
-      # retry the worker every call. Signal once per op.
+      # worker failure -> fall back to the subprocess bridge (slower, correctness-preserving)
+      # and remember it so we don't retry the worker every call. Signal once per op.
       if st["op"] not in self._worker_warned:
         self._worker_warned.add(st["op"])
         import warnings

--- a/aneforge/_cost.py
+++ b/aneforge/_cost.py
@@ -1,28 +1,8 @@
-"""Op-agnostic structural cost model for aneforge graphs - the optimizer's PRUNER.
+"""Op-agnostic structural cost model - the optimizer's PRUNER (orders variants; does not select).
 
-`estimate(out) -> microseconds` gives a fast, structural roofline estimate of a
-compiled program's latency WITHOUT touching the device. It is deliberately simple
-and op-agnostic: every node's cost is a roofline of `max(floor, bytes/BW,
-flops/COMPUTE)`, where
-
-  - `bytes` is derived GENERICALLY from shapes - (sum of input elems + output
-    elems + weight elems) * 2 (fp16). No per-op byte table; this works for ANY op.
-  - `flops` is only known for the few ops with a closed-form (matmul/linear/bmm/
-    conv/conv_transpose); every other op contributes 0 flops (it is then bytes- or
-    floor-bound, which matches the calibration: the cheap fused ops all sit at the
-    dispatch floor).
-
-Composition mirrors `_compile`'s segmentation exactly: the graph is one fused
-program unless it contains a netplist-bridge op (NETPLIST_OPS), in which case it is
-cut into fused regions interleaved with native sub-programs. A fused region costs
-`floor + sum(max(0, node_cost - floor))` (the fusion discount: one dispatch floor
-for the whole region, plus only the above-floor work of each node). Each cut adds a
-`cut_penalty` and the bridge node's own roofline.
-
-A PRUNER, not ground truth. Its job is to ORDER variants so the autotuner can skip
-measuring ones predicted far worse than the current best. Real selection is always
-by on-device measurement (see _optimize.measure). Calibrated constants load from the
-bundled aneforge/ane_cost_model.json when present; else the documented defaults below.
+`estimate(out) -> microseconds` is a structural roofline (max(floor, bytes/BW, flops/COMPUTE)
+per node, fusion-discounted per region) that never touches the device. Real selection is by
+on-device measurement (_optimize.measure). See .superpowers/sdd/gold-core-heavy.md for the model.
 """
 from __future__ import annotations
 
@@ -35,16 +15,10 @@ import numpy as np
 from ._compile import NETPLIST_OPS, _topo
 
 # --------------------------------------------------------------------------- #
-# calibrated constants (load from the cost-model JSON; else documented defaults) #
+# calibrated constants (load from the cost-model JSON; else defaults below)      #
 # --------------------------------------------------------------------------- #
-# Defaults are read off ane_cost_model.json's calibration:
-#   - FLOOR_US  ~ the per-call dispatch floor (smallest fused-op min latency).
-#   - CUT_US    ~ the per-cut penalty (a native sub-program + host round-trip; the
-#                 composition probe measured ~150-300us; 200 is the documented mid).
-#   - BW_BPUS   ~ effective fp16 streaming bandwidth, bytes/us. From the matmul
-#                 sweep: K=4096 streams 32 MiB in ~293us -> ~114 GB/s ~ 1.1e5 B/us.
-#   - FLOPS_PUS ~ effective fp16 compute, flops/us. From conv C=512: 4.83 GFLOP in
-#                 ~334us -> ~14.5 TFLOP/s ~ 1.45e7 flop/us.
+# Defaults from ane_cost_model.json's calibration (floor/cut/BW/FLOPS); see
+# .superpowers/sdd/gold-core-heavy.md for how each was measured.
 _DEFAULTS = {
   "floor_us": 70.0,
   "cut_us": 200.0,
@@ -63,17 +37,14 @@ def _constants() -> dict:
       model = j.get("model", {})
       floor = model.get("dispatch_floor_us")
       if floor: c["floor_us"] = float(floor)
-      # derive BW / COMPUTE from the matmul + conv scaling fits when present
+      # derive BW / COMPUTE from the matmul + conv scaling fits when present (us/flop -> flop/us)
       mm = model.get("matmul", {})
       if mm.get("slope_us_per_unit"):
-        # us per flop -> flop per us. (matmul has bytes==flops here, but the
-        # fit captures the compute-or-stream slope either way.)
         c["flops_per_us"] = 1.0 / float(mm["slope_us_per_unit"])
       cv = model.get("conv_channels", {})
       if cv.get("slope_us_per_unit"):
         c["flops_per_us"] = max(c["flops_per_us"], 1.0 / float(cv["slope_us_per_unit"]))
-      # cut penalty: a native bridge sub-program's floor sits ~90-110us above
-      # nothing; use the smallest bridge min as the marginal cut cost when present.
+      # cut penalty: the smallest measured bridge min as the marginal cut cost.
       bridge = model.get("bridge_ops", {})
       mins = [float(v["min_us"]) for v in bridge.values()
               if isinstance(v, dict) and v.get("min_us") and v["min_us"] < 1000]
@@ -95,37 +66,17 @@ def _cost_model_path():
 # --------------------------------------------------------------------------- #
 # the measurement-free ANALYTIC per-chip cost model (Direction A)              #
 # --------------------------------------------------------------------------- #
-# The compiler carries its own analytic cycles->roofline->wall-time model
-# (ZinNEPerf, non-SIP). It was decompiled and the per-chip HAL perf fields +
-# freq/efficiency curves walked live for all 28 targets -> the bundled
-# costmodel_curves.json (ANEForge reverse-engineering). The model is
-#   t = overhead + max( flops/peak , bytes/bw )          [per fused program]
-# anchored to silicon-measured chips (_ANCHORS: M1/h13 + M5/h17s) and scaled to any
-# other chip from its family's anchor by {cores (BW), clock (floor), cores*eff (peak)}.
-# The M1 anchors, both from measurement:
-#   * latency-roofline FIT (reproduces the 5 measured M1 convs within +/-17%):
-#       peak 3.25 TFLOP/s, BW 9.0 GB/s, dispatch overhead 0.22 ms.
-#   * headline fp16 PEAK (measured): 1.8 TFLOP/s -> project_peak().
-# The M5 anchor is the 2026-06-05 loop-closure re-fit (BW 57 GB/s, floor 110 us,
-# peak 8.9 TFLOP/s) - see _ANCHORS below for why BW is core-scaled, not clock-scaled.
-# Cross-chip throughput scales by cores*eff_freq(0.8*fmax) relative to M1 (the
-# eff_freq is the second column of eff_map_0x7a8: the engine's effective frequency,
-# already derated for the high-clock MAC-rate falloff on A14+).
+# Decompiled from the compiler's own ZinNEPerf model; per-chip HAL fields + freq/eff
+# curves -> bundled costmodel_curves.json. Model: t = overhead + max(flops/peak, bytes/bw)
+# per fused program, anchored to measured chips (_ANCHORS) and scaled by {cores (BW),
+# clock (floor), cores*eff (peak)}. See .superpowers/sdd/gold-core-heavy.md for the anchors.
 _M1_FIT_PEAK_FLOPS = 3.25e12        # latency roofline compute ceiling (fit on M1 convs)
-_M1_FIT_BW_BYTES = 9.0e9            # effective streaming BW (dispatch-bound; ~= measured 10 GB/s).
-#   (2026-06-09): a broad estimate-vs-measured sweep found this over-predicts EXTREME
-#   bandwidth-bound shapes ~4-5x (m1 1x4096x4096: pred ~3700us vs measured ~800us -> ~42 GB/s
-#   effective). But it is jointly calibrated with peak/overhead into the +/-17% 5-conv fit
-#   (test_cost_model_analytic pins it), so it can't be bumped alone without regressing that
-#   fit -- a proper re-anchor needs a joint roofline re-fit over a broader measured set.
+_M1_FIT_BW_BYTES = 9.0e9            # effective streaming BW (jointly fit; over-predicts extreme BW-bound shapes ~4-5x)
 _M1_FIT_OVERHEAD_US = 220.0         # additive per-program dispatch overhead (0.22 ms)
 _M1_MEASURED_PEAK_TFLOPS = 1.8      # headline fp16 peak (the project_peak absolute anchor)
 _CLOCK_FRACTION = 0.8              # operating clock ~= 0.8 * fmax (DAT_2241e37f8)
 
-# arch string (aneforge lowercase, e.g. 'h13'/'h17s') -> a per-family fallback curve
-# key for chips without their own entry in costmodel_curves.json. The curves cover the
-# distinct cost profiles; an arch missing one (h14g, h16c, h17a, h18, ...) folds to its
-# family's representative die (matching _targets._ARCH_FAMILY tiers).
+# arch -> per-family fallback curve key for chips without their own costmodel_curves.json entry.
 _FAMILY_CURVE = {2: "H13", 3: "H14", 4: "H15", 5: "H16s"}
 
 
@@ -176,9 +127,8 @@ def _interp(x: float, xs, ys) -> float:
 
 
 def _eff_freq_at_op(curve: dict) -> tuple[float, float]:
-  """(operating_freq, effective_freq) at the operating clock f = 0.8*fmax for a chip.
-    effective_freq is eff_map_0x7a8's second column interpolated at f - the engine's
-    derated throughput frequency (M1=1.0*f; A14+ derates ~0.84)."""
+  """(operating_freq, effective_freq) at f = 0.8*fmax. effective_freq = eff_map_0x7a8 col 2
+    interpolated at f (the engine's derated throughput freq; M1=1.0*f, A14+ ~0.84)."""
   freqs = curve["freq_0x760"]
   f = _CLOCK_FRACTION * max(freqs)
   em = curve["eff_map_0x7a8"]                    # [[freq, eff_freq], ...]
@@ -187,8 +137,7 @@ def _eff_freq_at_op(curve: dict) -> tuple[float, float]:
 
 
 def _compute_scale(arch: str) -> float:
-  """Compute-throughput multiplier of `arch` relative to M1 (H13): the ratio of
-    cores * effective_freq(0.8*fmax). This is the cross-chip peak-throughput scaler."""
+  """Compute-throughput multiplier of `arch` vs M1 (H13): ratio of cores*effective_freq."""
   c = _curve_for_arch(arch)
   _, ce = _eff_freq_at_op(c)
   m1 = _curve_for_arch("h13")
@@ -197,9 +146,8 @@ def _compute_scale(arch: str) -> float:
 
 
 def project_peak(arch: str) -> dict:
-  """Measurement-free fp16 peak-throughput projection for any ANE target, anchored to
-    the measured M1 point (1.8 TFLOP/s). Returns {tflops, rel_m1, cores, ghz} - the
-    generational-scaling table (M5 ~5.5x, H17d ~22x, M11 ~0.1x) needs no silicon beyond M1."""
+  """Measurement-free fp16 peak projection for any ANE target, anchored to measured M1
+    (1.8 TFLOP/s). Returns {tflops, rel_m1, cores, ghz}; needs no silicon beyond M1."""
   scale = _compute_scale(arch)
   c = _curve_for_arch(arch)
   return {
@@ -210,30 +158,20 @@ def project_peak(arch: str) -> dict:
   }
 
 
-# Silicon-measured roofline anchors, one per measured chip. h13 is the M1 latency fit
-# (the +/-17% 5-conv validation); h17s is the M5 LOOP-CLOSURE re-fit (m5_bw_floor.py /
-# m5_weight_stream.py): BW 57 GB/s measured, dispatch floor ~110 us, peak 8.9 TFLOP/s
-# (= project_peak('h17s'), validated by the re-fit landing the quoted convs within ~13%).
-# The earlier single-anchor model scaled M1's BW by CLOCK and over-predicted M5 ~2x
-# (mean |err| 99%): effective BW tracks CORE COUNT (16/4 -> 5.5x), not clock (x1.66) -
-# a faster clock does not widen the DMA path, more cores do.
+# Silicon-measured roofline anchors, one per measured chip (h13=M1, h14=M2 Pro, h17s=M5).
+# Effective BW tracks CORE COUNT, not clock (clock-scaling over-predicted M5 ~2x); `util` is
+# h14's mid-utilization compute ramp. See .superpowers/sdd/gold-core-heavy.md for the fits.
 _ANCHORS = {
   "h13": {"bw": _M1_FIT_BW_BYTES, "floor_us": _M1_FIT_OVERHEAD_US, "peak": _M1_FIT_PEAK_FLOPS},
-  # M2 Pro silicon (A14), measured. `util` = a mid-utilization compute ramp fit to the 25-point
-  # h14 grid (papers H14_CALIBRATION_GRID.md): effective compute throughput is far below peak for
-  # mid-size ops (a 768^3 GEMM sustains ~1.5 of the 7.24 TFLOP/s), ramping with per-op FLOPs.
-  # eff_peak = peak * min(1, (flops/F)^q): a CAPPED power law that returns to full peak for large
-  # ops (the cap matters - a 2048^3 GEMM already hits peak and must not be slowed). Fit (F=1.8e10
-  # FLOP, q=0.38) cuts the grid's mean error 1.61x -> 1.16x with the peak points recovered.
+  # eff_peak = peak * min(1, (flops/F)^q): a CAPPED power law (large ops return to full peak).
   "h14": {"bw": 48.0e9, "floor_us": 100.0, "peak": 7.3e12, "util": (1.80e10, 0.38)},
   "h17s": {"bw": 57.0e9, "floor_us": 110.0, "peak": 8.9e12},
 }
 
 
 def _anchor_for_arch(arch: str) -> str:
-  """The measured anchor chip for `arch`: its own entry when silicon-measured, else the
-    nearest measured generation. Three measured anchors now: A13/h13 (M1), A14/h14 (M2 Pro),
-    A16/h17s (M5). A15 (no M3 silicon yet) uses the A14 anchor as the nearest below it."""
+  """The measured anchor for `arch`: its own when silicon-measured, else the nearest
+    measured generation (anchors: A13/h13, A14/h14, A16/h17s; A15 -> A14)."""
   key = arch.strip().lower()
   if key in _ANCHORS: return key
   from . import _targets as _TG
@@ -245,18 +183,8 @@ def _anchor_for_arch(arch: str) -> str:
 
 def estimate_provenance(target: str) -> dict:
   """Is `estimate(out, target=...)` silicon-anchored or extrapolated for `target`?
-
-    Three chips were measured and fit a roofline anchor (`_ANCHORS`): A13/h13 (M1),
-    A14/h14 (M2 Pro), A16/h17s (M5). A target whose capability family OWNS one of those
-    anchors is silicon-measured (the A16 tier folds H16/H17* into the h17s point); every
-    other target is extrapolated from the nearest measured anchor by its {cores, clock,
-    efficiency} curve. Surfaces that distinction so a caller knows whether a per-chip
-    estimate rests on measured silicon or a generational projection.
-
-    Returns `{'target', 'anchor', 'measured': bool, 'basis': str}` where `anchor` is
-    the silicon point the estimate is built on, `measured` is True iff `target`'s family
-    has its own anchor, and `basis` is `'silicon'` or `'extrapolated-from-<anchor>'`.
-    Raises `ValueError` on an unknown arch (mirrors `cross_compile_check`)."""
+    Returns {target, anchor, measured: bool, basis} (basis = 'silicon' or
+    'extrapolated-from-<anchor>'). Raises ValueError on an unknown arch."""
   from . import _targets as _TG
   key = target.strip().lower()
   if key not in _TG._ARCH_FAMILY:
@@ -274,13 +202,9 @@ def estimate_provenance(target: str) -> dict:
 
 
 def _analytic_constants(arch: str) -> dict:
-  """The {floor_us, cut_us, bw_bytes_per_us, flops_per_us} for `arch`'s ANALYTIC
-    roofline, taken from the nearest silicon-measured anchor (_ANCHORS) and scaled:
-    effective streaming BW by CORE-COUNT ratio (the verified M5 loop-closure mechanism,
-    NOT clock), the dispatch floor by operating-clock ratio (setup runs at engine clock),
-    and the compute peak by the relative cores*eff_freq scale. A measured chip gets its
-    anchor exactly. cut_us (a host round-trip for a netplist bridge) is host-side, so
-    chip-independent."""
+  """The {floor_us, cut_us, bw_bytes_per_us, flops_per_us} for `arch`'s analytic roofline,
+    scaled from the nearest anchor: BW by cores, floor by clock, peak by cores*eff_freq;
+    cut_us is host-side (chip-independent)."""
   a_key = _anchor_for_arch(arch)
   a = _ANCHORS[a_key]
   c, ac = _curve_for_arch(arch), _curve_for_arch(a_key)
@@ -303,31 +227,14 @@ def _analytic_constants(arch: str) -> dict:
 # --------------------------------------------------------------------------- #
 # measured per-bridge-op cost model                                            #
 # --------------------------------------------------------------------------- #
-# The 19 NETPLIST bridge ops (sdpa, argmax, topk, sort, ...) have no closed-form
-# flops, so node_cost() would cost them at the generic dispatch floor. But
-# ane_cost_model.json's `model.bridge_ops` holds measured per-config min latencies
-# (keyed by a size string like "sdpa H=8 S=128 D=64", tagged with a `family`).
-# _bridge_model() parses these into per-family points so bridge_cost() uses the
-# measured value, not the floor.
-#
-# Key format -> size params (parsed by family):
-#   bridge_sdpa    "sdpa H=<H> S=<S> D=<D>"   -> (H, S, D)
-#   bridge_argmax  "argmax [<C>,<W>]"         -> (C, W)
-#   bridge_topk    "topk k=<k> [<C>,<W>]"     -> (C, W)   (k fixed 5 in the sweep)
-#   bridge_sort    "sort [<C>,<W>]"           -> (C, W)
-#
-# Interpolation (approximate): the grid is sparse (2-6 points/family). Per family
-# we pick a work scalar w(size) (see _BRIDGE_WORK), anchor to the nearest measured
-# point by it, and scale min_us by the work ratio, clamped to the dispatch floor.
-# Captures the right magnitude and ordering (all the pruner needs), not a per-shape
-# fit. Families with no data fall back to the roofline node_cost().
+# Bridge ops have no closed-form flops; ane_cost_model.json's `model.bridge_ops` holds
+# measured per-config min latencies (keyed by a size string + a `family`). bridge_cost()
+# nearest-neighbour anchors by a per-family work scalar (_BRIDGE_WORK) and scales by the
+# work ratio, clamped to the floor. Approximate ordering, not a per-shape fit; families with
+# no data fall back to the roofline. See .superpowers/sdd/gold-core-heavy.md for key formats.
 import re
 
-# op name -> bridge family in the JSON. All 19 NETPLIST bridge ops are measured by
-# the cost sweeps (sdpa/argmax/topk/sort by ane_cost_model_sweep.py's `bridge`
-# group; the remaining 15 by bridge_cost_sweep.py), so every bridge node maps to a
-# measured family here. (An op missing from this table, or whose family has no rows
-# in the JSON, still falls back to the roofline in bridge_cost().)
+# op name -> bridge family in the JSON (all 19 bridge ops are measured by the cost sweeps).
 _OP_TO_FAMILY = {
   "sdpa": "bridge_sdpa",
   "argmax": "bridge_argmax",
@@ -350,18 +257,10 @@ _OP_TO_FAMILY = {
   "scaled_elementwise": "bridge_scaled_elementwise",
 }
 
-# per-family "work scalar": a monotone proxy for the op's per-call cost, used as the
-# nearest-neighbour key + the proportional-scaling ratio. Defensible choices:
-#   sdpa  ~ attention MACs = H * S^2 * D  (QK^T + AV both scale this way)
-#   argmax/topk/sort ~ elements scanned = C * W  (a full pass over the row-major map)
-#
-# The 15 native-bridge ops below run via the A1 subprocess-per-call path (no A2
-# persistent worker exists for them - see _netplist_worker._WORKER_BUILDERS), so
-# their measured per-call cost is DISPATCH-FLOOR DOMINATED (~30-60ms subprocess
-# spawn + ANECCompile load), nearly flat in size. The work scalar is still the
-# right element/MAC proxy so the nearest-neighbour anchor + ordering is sensible;
-# the proportional scaling barely moves since the measured points are ~flat.
-# fps is the exception - it scales ~N*k (seconds/call).
+# per-family "work scalar": a monotone proxy for per-call cost (nearest-neighbour key +
+# scaling ratio). e.g. sdpa ~ H*S^2*D (attention MACs); argmax/topk/sort ~ C*W (scan).
+# The 15 subprocess-per-call ops are dispatch-floor-dominated (~flat in size); the scalar
+# still gives sensible ordering. fps is the exception (scales ~N*k).
 _BRIDGE_WORK = {
   "bridge_sdpa":   lambda p: float(p[0]) * float(p[1]) ** 2 * float(p[2]),  # H*S^2*D
   "bridge_argmax": lambda p: float(p[0]) * float(p[1]),                     # C*W
@@ -503,17 +402,10 @@ def _node_size(fam: str, t):
 
 
 def bridge_cost(t):
-  """Measured per-call cost (microseconds) for a NETPLIST bridge node, or None if
-    the node's family has no measured data (caller falls back to roofline node_cost).
-
-    Maps the node's op -> family, extracts its size parameters from the graph node
-    (sdpa: srcs[0]=[1,H,S,D]; argmax/topk/sort: srcs[0]=[C,W]), then nearest-neighbour
-    anchors to the measured point with the closest work scalar and scales by the work
-    ratio (see the module note above for the interpolation's approximate scope)."""
+  """Measured per-call cost (us) for a bridge node, or None if its family has no data
+    (caller falls back to roofline node_cost). Nearest-neighbour by work scalar, scaled."""
   fam = _OP_TO_FAMILY.get(t.op)
   if fam is None: return None
-  # extract this node's size parameters from its shape/srcs/attrs, in the same
-  # tuple convention _parse_bridge_key produces for this family.
   size = _node_size(fam, t)
   if size is None: return None
   work_fn = _BRIDGE_WORK[fam]
@@ -521,10 +413,7 @@ def bridge_cost(t):
   floor = _constants()["floor_us"]
   pts = _bridge_model().get(fam)
   if not pts:
-    # No measured points for this family in the shipped cost model (e.g. sdpa is not in the
-    # bridge sweep, so af.estimate used to return None for attention). Fall back to an
-    # analytic roofline on the family's work scalar (~2 flops per MAC), clamped at the
-    # dispatch floor - an order-of-magnitude estimate beats none.
+    # no measured points (e.g. sdpa): analytic roofline on the work scalar (~2 flops/MAC).
     return max(floor, 2.0 * q / _constants()["flops_per_us"])
   # nearest measured point by work scalar (in log space so ratios are symmetric)
   log_q = np.log(max(q, 1e-9))
@@ -623,19 +512,11 @@ def _estimate_analytic(out, arch: str, int8: bool) -> float:
 # composition: replicate _compile's fused-region vs netplist-cut segmentation   #
 # --------------------------------------------------------------------------- #
 def estimate(out, int8: bool = False, target: str | None = None) -> float:
-  """Estimate the compiled latency (microseconds) of the graph rooted at `out`.
+  """Estimate the compiled latency (us) of the graph rooted at `out`.
 
-    int8 scales streamed weight bytes by ~0.5 (per-channel int8 streams half the
-    bytes; activations stay fp16). This is the only dtype lever the model needs to
-    rank int8 vs fp16; everything else is structural.
-
-    `target` (an ANE arch string, e.g. 'h13'/'h17s') switches to the measurement-free
-    ANALYTIC per-chip model (Direction A) - a roofline taken from the nearest
-    silicon-measured anchor (M1/h13 or M5/h17s) and scaled to that chip's {cores, clock,
-    efficiency} curve, valid for all 28 chips with no on-device measurement (+/-17% on
-    the measured M1 convs; the M5 anchor lands the loop-closure convs within ~15% on the
-    quoted set). `target=None` (the default) uses the precise M5-measured heuristic below,
-    unchanged.
+    int8 scales streamed weight bytes by ~0.5 (the only dtype lever; everything else is
+    structural). `target` (an arch string) switches to the analytic per-chip model
+    (Direction A); `target=None` uses the M5-measured heuristic below.
     """
   if target is not None: return _estimate_analytic(out, target, int8)
   c = _constants()
@@ -656,12 +537,8 @@ def estimate(out, int8: bool = False, target: str | None = None) -> float:
       return max(floor, bytes_moved / c["bw_bytes_per_us"], flops / c["flops_per_us"])
     return node_cost(t)
 
-  # int8 tie-breaker: even when a graph is floor-bound (so the roofline ties int8
-  # and fp16 at the dispatch floor), int8 always streams <= fp16 bytes, never more.
-  # Encode that as a tiny weight-byte-proportional discount so the model is DECISIVE
-  # and directionally correct (int8 predicted <= fp16) instead of an arbitrary tie.
-  # Scaled well below a floor's worth so it never reorders variants with a real cost
-  # difference.
+  # int8 tie-breaker: a tiny weight-byte-proportional discount so a floor-bound graph
+  # predicts int8 <= fp16 (decisive, not an arbitrary tie); kept below a floor's worth.
   int8_discount = 0.0
   if int8:
     saved_bytes = sum(_weight_elems(t) for t in region_nodes if t.op == "matmul")
@@ -672,11 +549,8 @@ def estimate(out, int8: bool = False, target: str | None = None) -> float:
     region = sum(max(0.0, _ncost(t) - floor) for t in region_nodes)
     return floor + region - int8_discount
 
-  # segmented: fused regions (each pays one floor) interleaved with cuts.
-  # Mirror _compile_segmented: a region is built per cut-source and for the final
-  # output. Approximate region count as the number of distinct fused-program segments
-  # - at most (n_cuts + 1) - and charge each a floor; the cheap nodes spread across
-  # them, so keep the global above-floor sum and add (n_regions) floors plus the cuts.
+  # segmented: fused regions (each pays one floor) interleaved with cuts. Approximate
+  # region count as (n_cuts + 1); keep the global above-floor sum, add the floors + cuts.
   n_cuts = len(cut_nodes)
   n_regions = (n_cuts + 1) if region_nodes else 0
   region_work = sum(max(0.0, _ncost(t) - floor) for t in region_nodes)
@@ -692,32 +566,21 @@ def estimate(out, int8: bool = False, target: str | None = None) -> float:
 # --------------------------------------------------------------------------- #
 # precision / fp16-cancellation risk MODEL  (the optimizer's numerics pruner)  #
 # --------------------------------------------------------------------------- #
-# Companion to estimate(): a cheap structural pattern-matcher (not an error bound)
-# over the three characterized fp16 failure modes (fp16_envelope.py):
-#   (a) reduce_sum over signed terms, long contraction -> the narrow fp16 reduce
-#       accumulator re-injects per-add rounding the wide matmul avoids. Fixable by
-#       the reduce_sum->matmul rewrite (>= accuracy).
-#   (b) subtract of two large, structurally-small-result quantities -> CFG-style
-#       cancellation. Not detectable structurally (data-dependent), so every
-#       elementwise sub/add-of-negation is flagged as a *candidate*. Fixable only
-#       if operands carry sub-ulp bits (paired-fp16, regime B).
-#   (c) group_norm / large-feature-map compile cliffs ((W%128)>64 squared, large
-#       group_norm map): avoid/flag, not a rewrite target.
-# Each flagged node gets an order-of-magnitude error proxy in [0,1]; the per-graph
-# signal is the max over nodes. (b) is a candidate flag only; the tuner's vs-fp32
-# gate confirms the real gain.
+# Cheap structural pattern-matcher (not an error bound) over three fp16 failure modes:
+# (a) signed long-contraction reduce_sum (narrow accumulator; fix reduce_sum->matmul),
+# (b) sub of two live tensors (candidate CFG cancellation; fix paired-fp16),
+# (c) group_norm per-axis cliff (avoid/flag). Per-graph signal = max node error proxy.
+# See .superpowers/sdd/gold-core-heavy.md for the full failure-mode notes.
 
-# fp16 has ~3-4 decimal digits; a clean fused op sits at ~1e-3 relerr (the corpus
-# median). These are order-of-magnitude error proxies, deliberately coarse.
+# order-of-magnitude error proxies, deliberately coarse (clean fp16 op ~1e-3 relerr).
 _FP16_CLEAN = 1e-3            # a clean fp16 op's relative error (corpus-calibrated)
 _NARROW_SUM_FLOOR = 256      # contraction length above which a signed reduce_sum
                              # starts to lose digits to the narrow accumulator
 
 
 def _is_signed_producer(t) -> bool:
-  """True if `t` can produce signed values (so a sum over it can cancel). A
-    square/abs/relu/sigmoid/exp/softplus output is non-negative -> a sum over it does
-    NOT cancel; everything else is conservatively treated as possibly-signed."""
+  """True if `t` can produce signed values (a sum over it can cancel); non-negative
+    outputs (square/abs/relu/sigmoid/exp/softplus) are excluded, else conservatively signed."""
   return t.op not in ("square", "abs", "relu", "relu6", "sigmoid", "exp",
                       "softplus", "softmax")
 
@@ -754,8 +617,7 @@ def precision_risk(out, verbose: bool = False) -> dict:
       K = _reduce_len(t)
       signed = (not t.srcs) or _is_signed_producer(t.srcs[0])
       if signed and K >= _NARROW_SUM_FLOOR:
-        # error grows ~ sqrt(K) * fp16_eps under the narrow accumulator;
-        # cap at 1.0. This is an order-of-magnitude proxy, not a bound.
+        # error grows ~ sqrt(K) under the narrow accumulator (proxy, not a bound), cap 1.0.
         est = min(1.0, _FP16_CLEAN * (K ** 0.5))
         nodes.append({"idx": i, "op": t.op, "kind": "narrow_sum",
                       "est_error": est, "fixable": "reduce_sum->matmul",
@@ -773,10 +635,7 @@ def precision_risk(out, verbose: bool = False) -> dict:
                       "reason": "subtract of two live tensors (CANDIDATE catastrophic "
                                 "cancellation - confirm with data; fix is upstream paired-fp16)"})
       continue
-    # (c) group_norm at the per-axis wall. The rank-4 tiled lowering reduces over
-    #     [1,G,C/groups,H*W], so the cliff is max(C/groups, H*W) > 65536 (aligned to
-    #     af.group_norm's construction guard) - NOT the flattened (C/groups)*H*W,
-    #     which the tiling now keeps under the cap (640@64, 512@128 run fine in fp16).
+    # (c) group_norm per-axis wall: the rank-4 tiling makes the cliff max(C/groups, H*W) > 65536.
     if t.op == "group_norm" and len(t.shape) == 4:
       _, C, H, W = t.shape
       groups = int(t.attrs.get("groups", 1)) or 1
@@ -787,13 +646,9 @@ def precision_risk(out, verbose: bool = False) -> dict:
                                 "AVOID - exceeds the ANE per-axis bound"})
       continue
 
-  # Default hotspots = only the RELIABLE, structurally-determinable signals: a narrow
-  # reduce_sum whose estimated error exceeds the fp16-clean floor, and the group_norm
-  # per-axis wall. cancel_sub is SPECULATIVE - a subtract of two live tensors is a
-  # *candidate* for cancellation, but most (residuals, losses, differences) are benign
-  # and unconfirmable without data. Flagging every such subtract trained users to ignore
-  # the warning, so cancel_sub is now informational-only: it stays in `nodes` (surfaced
-  # by precision_risk(verbose=True)) but does not raise the default warning.
+  # Default hotspots = only the reliable structural signals (narrow reduce_sum over the
+  # floor + the group_norm wall). cancel_sub is speculative/unconfirmable -> informational
+  # only (in `nodes` for verbose, not a default warning).
   hotspots = [n["idx"] for n in nodes if n["est_error"] > _FP16_CLEAN
               or n["kind"] == "groupnorm_cliff"]
   graph_error = max([_FP16_CLEAN] + [n["est_error"] for n in nodes])

--- a/aneforge/_netplist_worker.py
+++ b/aneforge/_netplist_worker.py
@@ -1,27 +1,12 @@
 """A2: a persistent Path-A worker for aneforge's netplist-bridge ops.
 
-The correctness-first path (A1) spawns a one-shot ObjC probe per `af.sdpa` /
-`af.argmax` / `af.topk` call: that probe pays the full
-descriptor -> compileWithQoS -> loadWithQoS -> mapIOSurfaces tax (hundreds of
-ms), evaluates once, and exits.  For repeated calls of a *fixed-shape* netplist
-program (the common decode-loop case) that startup tax dominates.
+The one-shot path (A1) pays the full descriptor->compile->load->mapIOSurfaces tax per call;
+for repeated fixed-shape calls (the decode loop) that startup dominates. A2 keeps a
+long-lived helper process that pays compile/load/map ONCE, then services many evals over a
+pipe (steady-state: host<->IOSurface memcpy + evaluateWithQoS). Import-lazy; authors the
+netplist with the SAME A1 bridge generators (only the dispatch differs).
 
-A2 keeps a long-lived helper process (`~/.cache/aneforge/bin/persistent_worker`)
-that pays compile/load/map ONCE at startup, then services many evals over a
-pipe.  Steady-state per call is just host<->IOSurface memcpy + evaluateWithQoS.
-
-This module is import-lazy: `aneforge` stays standalone-importable; the worker
-is built/spawned only the first time a netplist-bridge op runs.  It authors the
-netplist with the SAME in-package bridge generators A1 uses
-(`ane_rank_fused._build_plist` / `ane_sdpa_fused._write_netplist`) - we never
-duplicate the netplist layout, only swap the *dispatch* (load-once-eval-many vs
-one-shot).
-
-Supported ops: `sdpa` (GOAL #3 shape), `argmax` (GlobalArgMinMax over Width or
-Channel) and `topk` (native TopK, per-row tiled).  `topk`'s per-row tiling (the
-native op keys all channels by one lane, so per-row top-k runs each row as its
-own 1-channel program) is reproduced by loading ONE 1-channel program and
-eval-ing it C times, matching the A1 result bit-for-bit.
+Supported: sdpa, argmax (GlobalArgMinMax), topk (per-row tiled). See docs/developer/bridges.md.
 """
 from __future__ import annotations
 
@@ -42,8 +27,8 @@ _INVOKER_BIN_NAME = "persistent_worker"
 
 
 def _ensure_worker_built() -> Path:
-  """Build the persistent-worker invoker once if missing/stale (UNIQUE path so
-    it never clobbers the one-shot invokers)."""
+  """Build the persistent-worker invoker once if missing/stale (unique path, never
+    clobbers the one-shot invokers)."""
   binp = bin_dir() / _INVOKER_BIN_NAME
   src = Path(__file__).resolve().parent / "_invokers" / "persistent_worker.mm"
   if binp.exists() and src.exists() and binp.stat().st_mtime >= src.stat().st_mtime: return binp
@@ -62,12 +47,10 @@ def _ensure_worker_built() -> Path:
 class _Worker:
   """Owns one spawned worker process holding ONE compiled+loaded netplist.
 
-    The wire protocol is batched: per request we write a 4-byte little-endian
-    uint32 count `N` followed by `N` input sets packed back-to-back as raw fp16
-    bytes (each set in the spawn symbol order), and read back `N` output sets
-    packed the same way.  `self.in_elems` / `self.out_elems` (from the worker's
-    "ready" line) give the per-set framing.  `eval` is the N=1 case; `eval_batch`
-    packs many input sets into ONE round-trip (the per-row-tiled topk/sort win).
+    Batched wire protocol: per request, a LE uint32 count N then N input sets packed
+    back-to-back as raw fp16 (spawn symbol order); read back N output sets the same way.
+    `in_elems`/`out_elems` (from the "ready" line) give the per-set framing. `eval` is the
+    N=1 case; `eval_batch` packs many sets into ONE round-trip.
     """
 
   def __init__(self, netplist: Path, weights: list[Path], in_syms: list[str],
@@ -106,16 +89,12 @@ class _Worker:
     self._out_bytes = 2 * sum(self.out_elems)
 
   def eval(self, inputs: list[np.ndarray]) -> list[np.ndarray]:
-    """One eval. `inputs` are contiguous fp16 arrays in spawn symbol order;
-        returns the output tensors as flat fp16 arrays in spawn symbol order."""
+    """One eval. fp16 arrays in spawn symbol order in and out."""
     return self.eval_batch([inputs])[0]
 
   def eval_batch(self, input_sets: list[list[np.ndarray]]) -> list[list[np.ndarray]]:
-    """Run `N = len(input_sets)` evals in ONE pipe round-trip.  Each entry of
-        `input_sets` is a full input set (one array per spawn symbol, in order).
-        Returns N output sets (one flat fp16 array per output symbol).  Bit-identical
-        to calling `eval` N times, but pays a single request/reply instead of N --
-        the per-row-tiled topk/sort win."""
+    """Run N evals in ONE pipe round-trip. Bit-identical to N `eval` calls but pays a
+        single request/reply (the per-row-tiled topk/sort win)."""
     if self._proc.poll() is not None: raise RuntimeError("persistent worker has exited")
     n = len(input_sets)
     if n == 0: return []
@@ -184,16 +163,13 @@ class _Worker:
       pass
 
 
-# --------------------------------------------------------------------------- #
-# per-op worker builders: author the netplist with the A1 bridge generator,    #
-# then hand it to a persistent _Worker.  Each returns a callable               #
-# (src_arrays, attrs) -> output fp16 array matching the A1 runner's contract.  #
-# --------------------------------------------------------------------------- #
+# per-op worker builders: author the netplist with the A1 bridge generator, then hand it
+# to a persistent _Worker. Each returns a callable (src_arrays, attrs) -> fp16 output
+# matching the A1 runner's contract.
 
 def _build_sdpa_worker(shape, attrs):
-  """Persistent SDPA. `shape` is the Q/K/V shape [1, H, S, D]; `attrs` has `scale`.
-    Mirrors ane_sdpa_fused.sdpa_fused's ANE layout: pre/post transpose Q,K,V
-    (heads<->seq) so the netplist sees seq-in-C, heads-in-H."""
+  """Persistent SDPA. `shape` = Q/K/V [1,H,S,D], `attrs` has `scale`. Pre/post transpose
+    Q,K,V (heads<->seq) so the netplist sees seq-in-C, heads-in-H."""
   from ._bridges import ane_sdpa_fused as af  # the A1 bridge = the netplist author
 
   B, H, S, D = shape
@@ -227,9 +203,8 @@ def _build_sdpa_worker(shape, attrs):
 
 def _write_rank_netplist(wd: Path, layer_type: str, params: dict, *,
              channels: int, width: int, height: int = 1):
-  """Author a single-op rank netplist (Sort/TopK/ArgMinMax/GlobalArgMinMax) into
-    `wd` via the A1 bridge's own generator (`ane_rank_fused._build_plist`) so the
-    worker sees byte-identical layout.  Returns (netplist_path, [weight])."""
+  """Author a single-op rank netplist (Sort/TopK/ArgMinMax/GlobalArgMinMax) into `wd`
+    via the A1 bridge generator (byte-identical layout). Returns (netplist_path, [weight])."""
   import plistlib
   from ._bridges import ane_rank_fused as rf  # the A1 bridge = the netplist author
   plist = rf._build_plist(layer_type, params, width=width, height=height,
@@ -243,10 +218,8 @@ def _write_rank_netplist(wd: Path, layer_type: str, params: dict, *,
 
 
 def _build_argmax_worker(shape, attrs):
-  """Persistent GlobalArgMinMax (argmax).  `shape` is the input `[C, W]`; `attrs`
-    has `axis` (1=Width, 0=Channel).  One loaded program, one eval per call.  Output
-    matches the A1 `_run_argmax` contract: keepdims `[C,1]` for axis=1 (Width) or
-    `[1,W]` for axis=0 (Channel)."""
+  """Persistent GlobalArgMinMax (argmax). `shape` = input [C,W], `attrs` has `axis`
+    (1=Width, 0=Channel). Output keepdims [C,1] for axis=1 or [1,W] for axis=0."""
   C, W = shape
   axis = attrs["axis"]
   dim = "Width" if axis == 1 else "Channel"
@@ -269,11 +242,10 @@ def _build_argmax_worker(shape, attrs):
 
 
 def _build_topk_worker(shape, attrs):
-  """Persistent per-row TopK.  `shape` is the input `[C, W]`; `attrs` has `k` and
-    `largest`.  The native TopK keys *all* channels by ONE lane's order, so
-    PyTorch-style per-row top-k requires each row run as its own 1-channel program.
-    We load ONE 1-channel (channels=1, width=W, K=k) program and eval it C times (one
-    row per eval), reproducing the A1 stack exactly.  Output is `[C, k]` values."""
+  """Persistent per-row TopK. `shape` = input [C,W], `attrs` has `k`, `largest`. Native
+    TopK keys ALL channels by one lane's order, so per-row top-k runs each row as its own
+    1-channel program: load ONE 1-channel (width=W, K=k) program, eval it C times. Output
+    [C,k] values."""
   C, W = shape
   k, largest = attrs["k"], attrs["largest"]
   params = {
@@ -291,16 +263,9 @@ def _build_topk_worker(shape, attrs):
   def run(srcs, attrs2):
     (x,) = srcs
     xa = np.ascontiguousarray(np.asarray(x, np.float16).reshape(C, W))
-    # note: the C row-tiles dispatch as C separate eval() round-trips, not one
-    # eval_batch(). Measured on M5 Pro, topk's per-call floor is set by the C
-    # sequential ANE evaluateWithQoS dispatches (~0.08 ms each), not by pipe
-    # round-trips (a single trip+eval is ~0.083 ms; the worker blocks on read and
-    # replies immediately, so the trip is ~free). Packing all C rows into one
-    # round-trip removes only the ~free trips and regresses the median (per-eval
-    # cost rose 0.079->0.28 ms at N=16) because the worker's back-to-back eval
-    # loop loses the pipe pacing that keeps the ANE warm. So we keep the per-call
-    # dispatch; eval_batch stays available (and bit-identical) when the round-trip
-    # truly dominates.
+    # C separate eval() round-trips, NOT one eval_batch: measured (M5 Pro), the floor is
+    # the C sequential ANE dispatches, not the pipe trips (~free). Batching loses the pipe
+    # pacing that keeps the ANE warm and regressed the median, so keep per-call dispatch.
     rows = [worker.eval([xa[c]])[0].reshape(k) for c in range(C)]
     return np.stack(rows, axis=0)
 
@@ -321,6 +286,5 @@ def has_worker(op: str) -> bool:
 
 
 def build_worker(op: str, shape, attrs):
-  """Return `(worker, run_fn)` for `op` at `shape`/`attrs`.  Raises
-    KeyError if no worker route exists for `op`."""
+  """Return `(worker, run_fn)` for `op`. Raises KeyError if no worker route exists."""
   return _WORKER_BUILDERS[op](shape, attrs)

--- a/aneforge/_op_catalog.py
+++ b/aneforge/_op_catalog.py
@@ -1,19 +1,10 @@
-"""Complete ANE operation catalog - every MIL op the ANECompiler exposes, with its
-category, per-device availability (M1..M5), MIL kernel class, and notes.
+"""Complete ANE op catalog - every MIL op the ANECompiler exposes, with category,
+per-device availability (M1..M5), MIL kernel class, and notes. The single source of truth
+for the native MIL vocabulary; aneforge's higher-level ops are composites that lower to it.
 
-Auto-generated from the ANEForge reverse-engineering (the 187-op x device matrix +
-the symbol-resolution op map), grounded in the HAL extraction and live M1 silicon probes.
-Device columns map to ANE capability families (verified SoC->arch ladder):
-    m1 = A13 (family 2)   m2 = A14 (family 3)   m3 = A15 (family 4)   m4_m5 = A16/A17 (family 5)
-Each device cell is one of: 'native' (runs on-engine), 'bridge' (needs a netplist-bridge
-or host/graph decomposition), 'walled' (no path - decompose on host).
-
-This is the NATIVE MIL op vocabulary the ANE emits. aneforge's higher-level ops
-(rms_norm, group_norm, channel_layer_norm, mha, sdpa, einsum, the fft/linalg/special
-submodules) are COMPOSITES that lower to these - query their constituent ops here.
-
-This dict is the single source of truth. The deeper per-op argument, shape, dtype,
-and per-chip capability write-ups live in the project's companion reference guide.
+Device keys -> capability families: m1=A13 (fam 2), m2=A14 (3), m3=A15 (4), m4_m5=A16/A17 (5).
+Each cell: 'native' (on-engine), 'bridge' (netplist/host decomposition), 'walled' (host only).
+See docs/developer/capabilities-and-targets.md.
 """
 from __future__ import annotations
 

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -1,31 +1,12 @@
 """aneforge graph autotuner: a deterministic measurement-cache search over the
 metamorphic-proven-safe variant space, validated to never change results.
 
-The premise (see tests/fuzz_metamorphic.py): the optimizer is a rewrite engine whose
-correctness rule is that a semantics-preserving rewrite never changes the output. So
-the only variants this tuner enumerates are ones the metamorphic fuzzer proved safe
-within tolerance:
-
-  PRIMARY  - int8 weight selection: compile(int8=True) streams per-channel int8
-             weights at half the bytes; fp16_vs_int8 is a proven-safe (PRECISION-
-             class) rewrite. Global today; the per-weight hook is designed in.
-  SECONDARY- sdpa<->decomposed route: an af.sdpa node can be substituted by the
-             proven-equivalent decomposed attention (mha_vs_sdpa). v1 ships the
-             cost-model route hint (estimate() picks by sequence length) and the
-             detection/plumbing hook; the in-place graph rewrite is the next hook
-             (documented below) since it requires rebuilding the graph, which the
-             tune() API does not own (it receives an already-built `out` tensor).
-
-SEARCH: enumerate the small legal variant set, prune with estimate() (skip any variant
-the cost model predicts much worse than the current best), measure the rest on the ANE
-(compile + warmup + MIN over reps), validate each variant's output against the opt=0
-baseline within tol (a variant that breaks accuracy scores inf and is never chosen),
-pick the fastest correct one, and cache the decision keyed by a deterministic
-(structure-hash, shapes, dtype, variant-config) tuple.
-
-Determinism is what makes the cache valid across runs: the same graph structure +
-input shapes always hashes the same, so a cached decision is reusable. `tune` is
-instant on a cache hit.
+Variant axes: int8 weight selection (lossy, accuracy-gated), lossless route swaps
+(sdpa/minmax_norm/flatten/lrn native-bridge vs fused decomposition), reduce_sum->matmul,
+scalar/const folds. Search: enumerate the legal set, prune with estimate(), measure
+survivors on the ANE, validate vs the opt=0 baseline within tol, pick the fastest correct
+one, cache by a deterministic (structure-hash, shapes, config) key (instant on a hit). See
+docs/developer/optimizer-and-cost.md.
 """
 from __future__ import annotations
 
@@ -42,19 +23,12 @@ from ._compile import compile as _raw_compile, _topo
 from ._cost import estimate, precision_risk
 from .graph import Tensor
 
-# --------------------------------------------------------------------------- #
-# tolerance for variant correctness (vs the opt=0 baseline)                    #
-# --------------------------------------------------------------------------- #
-# DEFAULT is accuracy-preserving (~fp16 noise): a variant must reproduce the baseline
-# this closely or it is rejected. At this default a lossy rewrite like int8 (~1-2%
-# quantization error, well above fp16 noise) is rejected, so tune() never silently
-# trades accuracy - it returns the lossless baseline. int8 is opt-in: pass
-# tune(out, atol=0.1) to admit it within a stated accuracy budget. (0.12 was the
-# metamorphic fp16_vs_int8 precision tol - right to PASS for an explicit int8 budget,
-# wrong as a DEFAULT.)
-_ACCURACY_TOL = 5e-3        # default: fp16-noise - lossless rewrites pass, int8 fails
-# A lossy variant must beat the baseline by at least this factor to be chosen, so a
-# measurement-noise "win" (CV ~10-20%) never costs accuracy for no real speedup.
+# Variant-correctness tolerance vs the opt=0 baseline. The default is fp16-noise: lossless
+# rewrites pass, lossy int8 (~1-2% error) is rejected, so default tune never trades accuracy.
+# int8 is opt-in via a looser atol.
+_ACCURACY_TOL = 5e-3
+# A lossy variant must beat the baseline by this factor to be chosen, so a measurement-noise
+# "win" never costs accuracy for no real speedup.
 _MIN_LOSSY_SPEEDUP = 1.10
 
 
@@ -62,10 +36,9 @@ _MIN_LOSSY_SPEEDUP = 1.10
 # deterministic graph-structure hash                                          #
 # --------------------------------------------------------------------------- #
 def _graph_key(out, input_shapes) -> str:
-  """A deterministic hash of the graph STRUCTURE + input shapes. Walks the graph in
-    topo order, hashing each node's op, shape, source positions, and the shapes/dtypes of
-    any constant-weight attrs (not their values - structure, not data). Same structure +
-    shapes -> same key across runs (the cache validity premise)."""
+  """Deterministic hash of the graph STRUCTURE + input shapes (op, shape, source positions,
+    constant-weight attr shapes/dtypes - not values). Same structure -> same key across runs
+    (the cache validity premise)."""
   order = _topo(out)
   pos = {id(t): i for i, t in enumerate(order)}
   h = hashlib.sha256()
@@ -126,11 +99,9 @@ def _save_cache(cache: dict) -> None:
 # --------------------------------------------------------------------------- #
 # attention query-tile autotune                                                #
 # --------------------------------------------------------------------------- #
-# The query-tile count in mha/sdpa/cross_attention sets how the [H, S, T] score is
-# fissioned. The S-based heuristic (max(1,(S+256)//512)) avoids the un-tiled wall but is
-# not the per-shape optimum, and the optimum is bound by L2 residency / pipelining, so it
-# shifts with head count and chip. This measures the best count ONCE per (chip, S, T,
-# heads, head_dim) and caches it; the heuristic is the default until a tuned value exists.
+# The query-tile count sets how the [H,S,T] score is fissioned. The S-based heuristic avoids
+# the un-tiled wall but is not the per-shape optimum (bound by L2 residency/pipelining, shifts
+# with head count and chip). Measure the best count once per (chip,S,T,heads,head_dim), cache it.
 _TILE_MEMO: dict = {}
 _TILE_CANDIDATES = (1, 2, 3, 4, 5, 6, 8)
 
@@ -172,12 +143,10 @@ def _time_attention_core(S: int, T: int, n_heads: int, dh: int, n_tiles: int, re
 
 def attention_tiles(S: int, n_heads: int, dh: int, T: int | None = None,
                     tune: bool = False, candidates=_TILE_CANDIDATES) -> int:
-  """Query-tile count for an [n_heads, S, dh] x [n_heads, dh, T] attention score.
-
-    Returns a chip+shape-cached tuned value if one exists, else the S-based heuristic.
-    With `tune=True` (or env ANEFORGE_TUNE_ATTENTION=1) it measures the candidate counts
-    once on the engine, caches the fastest (persisted in autotune.json, keyed by chip),
-    and returns it. Exact either way - the tile count only changes how the score fissions."""
+  """Query-tile count for an [n_heads, S, dh] x [n_heads, dh, T] attention score. Returns a
+    chip+shape-cached tuned value, else the S-based heuristic. `tune=True` (or env
+    ANEFORGE_TUNE_ATTENTION=1) measures the candidates once and caches the fastest. Exact
+    either way (the tile count only changes how the score fissions)."""
   T = S if T is None else T
   from ._targets import _cpu_brand
   key = f"attn_tiles:{_cpu_brand() or 'unknown'}:{S}:{T}:{n_heads}:{dh}"
@@ -205,9 +174,8 @@ def tune_attention(S: int, n_heads: int, dh: int, T: int | None = None,
 # variant space (legal == metamorphic-proven-safe)                            #
 # --------------------------------------------------------------------------- #
 def _has_weights(out) -> bool:
-  """True if the graph carries any int8-eligible weight: a matmul/linear streamed `wt`
-    or a conv baked `weight` (per-channel int8 routes as a conv weight on the ANE). int8
-    is a no-op otherwise, so we don't enumerate it."""
+  """True if the graph carries any int8-eligible weight (matmul `wt` or conv `weight`).
+    int8 is a no-op otherwise, so we don't enumerate it."""
   for t in _topo(out):
     if t.op == "matmul" and isinstance(t.attrs.get("wt"), np.ndarray): return True
     if t.op == "conv" and isinstance(t.attrs.get("weight"), np.ndarray): return True
@@ -215,15 +183,9 @@ def _has_weights(out) -> bool:
 
 
 def _int8_candidates(out):
-  """Per-weight int8 candidate nodes: the topo indices of weight-bearing nodes, paired
-    with the weight's element count (the int8 benefit proxy - int8 halves these bytes, so
-    a bigger weight is a bigger bandwidth win). Candidates are matmul nodes (streamed
-    `wt`) AND conv nodes (baked `weight`): per-channel int8 routes as a conv weight on
-    the ANE (constexpr_affine_dequantize, ~halves the conv DRAM bytes, cos~1.0 vs fp16).
-
-    Returns a list of (topo_index, weight_elems) sorted by weight_elems DESCENDING
-    (largest weight first) - the order greedy adds candidates, so the budget is spent
-    where int8 helps most."""
+  """Per-weight int8 candidates: (topo_index, weight_elems) for each weight-bearing
+    matmul/conv node, sorted by weight_elems DESCENDING (largest weight = biggest bandwidth
+    win). The order greedy adds candidates, so the budget is spent where int8 helps most."""
   order = _topo(out)
   cands = []
   for i, t in enumerate(order):
@@ -242,50 +204,38 @@ def _sdpa_ids(out):
 
 
 def _route_ids(out):
-  """Topo indices of every ROUTE-BEARING node - a bridge node whose op has a validated
-    equivalent fused lowering in the closed route registry (sdpa, minmax_norm,
-    flatten, ...). These are the axes the optimizer flips between the native bridge (a
-    graph cut) and the fused decomposition (cut removed). Single-route bridge ops
-    (argmax/sort/fps/the rearranges/...) are not here - they have no alternative, so the
-    tuner never tries to flip them. Deterministic (topo order) so the cache key is
-    stable."""
+  """Topo indices of every ROUTE-BEARING node (a bridge op with a validated equivalent
+    fused lowering: sdpa/minmax_norm/flatten/...) - the axes the optimizer flips between
+    native bridge and fused decomposition. Single-route bridge ops are excluded."""
   from ._rewrite import _BRIDGE_DECOMPOSERS
   order = _topo(out)
-  # A causal sdpa must NOT be route-flipped to the fused decomposition: that
-  # decomposition drops the native layer's additive mask (the route registry's decomposed
-  # attention is unmasked), so a routed causal sdpa would silently return unmasked
-  # attention. Keep it on the native bridge route (where _run_sdpa feeds the causal mask
-  # via the 5th SDPA bottom).
+  # A causal sdpa must NOT be route-flipped: the fused decomposition is unmasked, so a routed
+  # causal sdpa would silently return unmasked attention. Keep it on the native bridge route.
   return [i for i, t in enumerate(order)
           if t.op in _BRIDGE_DECOMPOSERS
           and not (t.op == "sdpa" and (t.attrs.get("causal") or t.attrs.get("masked")))]
 
 
 def _constfold_candidates(out):
-  """Topo indices of nodes whose whole source cone is constant (foldable to one
-    const_array). Excludes the const/input leaves themselves."""
+  """Topo indices of nodes whose whole source cone is constant (foldable to one const_array).
+    Excludes const/input leaves."""
   from ._rewrite import _const_subgraph
   return [i for i, t in enumerate(_topo(out))
           if t.op not in ("const_array", "input") and _const_subgraph(t) is not None]
 
 
 def _scalarchain_candidates(out):
-  """Topo indices of muls/adds chain heads (a muls whose src is a muls, or adds
-    over adds) - the nodes a scalar-chain fold collapses."""
+  """Topo indices of muls/adds chain heads (muls-over-muls, adds-over-adds) - the nodes a
+    scalar-chain fold collapses."""
   return [i for i, t in enumerate(_topo(out))
           if t.op in ("muls", "adds") and t.srcs[0].op == t.op]
 
 
 def _apply_variant(out, cfg):
-  """Materialize the rewritten DAG for a variant `cfg` in ONE graph_rewrite pass.
-    Every axis composes over the ORIGINAL graph (indices resolved to original ids up
-    front), so there is no chained-rewrite index drift. The compile-time global int8
-    flag is returned separately (a compiler arg, not a graph rewrite).
-
-    cfg axes: `decomp` (bridge topo-indices -> fused decomposition), `int8_nodes`
-    (matmul/conv topo-indices -> per-node int8 tag), `rs_matmul` (reduce_sum
-    topo-indices -> @ones contraction), `scalarfold` (muls/adds chain-head indices),
-    `constfold` (constant-cone indices -> one const_array)."""
+  """Materialize the rewritten DAG for a variant `cfg` in ONE graph_rewrite pass. Every axis
+    composes over the ORIGINAL graph (ids resolved up front -> no chained-rewrite index
+    drift). The global int8 flag is returned separately (a compiler arg, not a rewrite).
+    cfg axes: decomp, int8_nodes, rs_matmul, scalarfold, constfold."""
   from ._rewrite import (Rule, graph_rewrite, _BRIDGE_DECOMPOSERS, _reduce_sum_as_matmul,
                          _b_fold_muls, _b_fold_adds, _b_const_fold)
   order = _topo(out)
@@ -332,31 +282,17 @@ def _apply_variant(out, cfg):
 
 
 def _variants(out):
-  """Return the legal variant configs for this graph as a list of dicts. Each is a
-    compile-config the tuner can build, measure, and cache.
-
-    Variant axes (separable -> coordinate-descent-ready):
-      - GLOBAL int8 (legacy whole-graph): {False, True}. LOSSY (accuracy-gated).
-      - ROUTE per route-bearing bridge node: {native bridge, fused decomposition}.
-        Generalized over EVERY op in the closed route registry that has a validated
-        equivalent lowering (sdpa, minmax_norm, flatten, ...), not just sdpa. Each
-        route is LOSSLESS (bit-identical or fp16-op-noise, the metamorphic proof
-        class), so it is always eligible and chosen purely by measured speed.
-        Enumerated by COORDINATE DESCENT over the route-bearing nodes: the all-native
-        baseline + each single node flipped to its fused decomposition + the all-
-        decomposed config. That is K single-flips + (all-decomposed when K>1) = at most
-        K+1 route variants on top of baseline - linear, NOT 2^K. (Single-route bridge ops
-        are not in the route-id set, so the tuner never tries to flip them.)
+  """Legal variant configs (each a buildable/cacheable compile-config). Axes:
+      - GLOBAL int8: {False, True}, LOSSY (accuracy-gated).
+      - ROUTE per route-bearing node: {native bridge, fused decomposition}, LOSSLESS.
+        Enumerated by COORDINATE DESCENT: baseline + each single flip + all-decomposed =
+        K+1 variants, linear NOT 2^K.
     """
-  # config values are JSON-friendly (lists, not tuples) so a cached config compares
-  # equal to a freshly-enumerated one after a JSON round-trip (the cache premise).
+  # config values are JSON-friendly lists (a cached config must compare equal after a JSON
+  # round-trip - the cache premise).
   routes = _route_ids(out)
   configs = [{"int8": False, "decomp": [], "lossy": False}]   # opt=0 baseline (all native)
   if routes:
-    # coordinate descent over the route axis: each single route-bearing node flipped
-    # to its fused decomposition, plus the all-decomposed config. (Typical 1-bridge
-    # graph is just {native, decomposed}; K nodes is K single-flips + all-decomposed =
-    # K+1 route variants on top of baseline - linear.)
     for i in routes:
       configs.append({"int8": False, "decomp": [i], "lossy": False})
     if len(routes) > 1:
@@ -373,16 +309,11 @@ def _variants(out):
 
 
 def _route_variants(out):
-  """The LOSSLESS-ONLY variant set for the DEFAULT route pass: the all-native baseline
-    plus the route-bearing bridge nodes flipped to their fused decomposition
-    (sdpa/minmax_norm/flatten/lrn). No int8/lossy variant is ever included - every config
-    here is cos-1.0 equivalent to opt=0, so the default pass can never change numerics.
-    Same coordinate-descent shape as `_variants` (linear in #route nodes: each single flip
-    + the all-decomposed config), minus the lossy int8 branch.
-
-    (Shape-dependent equivalence is handled upstream: `af.sdpa` itself decomposes above
-    the native layer's accuracy limit, so a routable native `sdpa` node only exists where
-    native and decomposed actually agree - the route stays lossless.)"""
+  """The LOSSLESS-ONLY variant set for the DEFAULT route pass: baseline + route-bearing
+    flips, no int8/lossy. Every config is cos-1.0 vs opt=0, so the default pass never changes
+    numerics. (Shape-dependent equivalence is handled upstream: af.sdpa decomposes above the
+    native accuracy limit, so a routable native sdpa node only exists where the route is
+    lossless.)"""
   routes = _route_ids(out)
   configs = [{"int8": False, "decomp": [], "lossy": False}]      # all-native baseline
   for i in routes:
@@ -393,27 +324,13 @@ def _route_variants(out):
 
 
 def _compile_routes(out, int8: bool, build_dir=None):
-  """The DEFAULT compile pass: a cost-model-driven, lossless route optimization.
-
-    For each route-bearing bridge node (sdpa/minmax_norm/flatten/lrn) it picks per SHAPE
-    between the native bridge (a graph cut) and the fused decomposition (cut removed),
-    choosing whichever `estimate()` predicts cheaper - without any on-device measurement
-    (no compile-time cost beyond costing the DAGs). The route registry is lossless-only,
-    so this never changes numerics (cos 1.0 vs opt=0).
-
-    The A/B in the reverse-engineering corpus validates this: across the routable shapes,
-    the cost model's argmin matches the fastest CORRECT route every time, so measurement
-    would add compile cost without changing the pick. (Shape-dependent equivalence is
-    handled in the frontend: `af.sdpa` decomposes above the native layer's accuracy limit,
-    so a routable native sdpa node only exists where the route is genuinely lossless.)
-
-    If the graph has NO route-bearing node (the common case), the only variant is the
-    all-native baseline, so this returns exactly the same single program `opt=0` would -
-    it never regresses a cut-free model. `int8` is threaded through to the eventual
-    `_raw_compile` so the legacy whole-graph int8 flag is still honored."""
+  """The DEFAULT compile pass: cost-model-driven, lossless route optimization. Per
+    route-bearing node, pick native-bridge vs fused decomposition by whichever estimate()
+    predicts cheaper (no on-device measurement; the cost model's argmin matches the fastest
+    correct route, validated). Lossless-only -> never changes numerics. A cut-free graph
+    returns exactly the opt=0 program. `int8` is threaded to _raw_compile."""
   cfgs = _route_variants(out)
-  if len(cfgs) == 1:
-    # no removable cut: identical to the byte-identical opt=0 path.
+  if len(cfgs) == 1:                                          # no removable cut: opt=0 path
     return _raw_compile(out, int8=int8, build_dir=build_dir, opt=0, _check_precision=False)
   best = min(cfgs, key=lambda c: _estimate_variant(out, c))
   variant_out, _ = _apply_variant(out, best)
@@ -434,12 +351,9 @@ def _config_label(cfg: dict) -> str:
 # --------------------------------------------------------------------------- #
 def measure(out, inputs, cfg, baseline_out=None, reps: int = 20, warmup: int = 5,
             tol: float = _ACCURACY_TOL):
-  """Compile the graph under `cfg`, validate vs `baseline_out` (the opt=0 output)
-    within tol, and return MIN latency over `reps` (microseconds).
-
-    Returns `inf` if the variant is incorrect (so it is never selected) or fails to
-    compile/run. Also returns the variant's own baseline output array when `baseline_out`
-    is None (so the caller can use the first variant as the reference)."""
+  """Compile under `cfg`, validate vs `baseline_out` within tol, return MIN latency over
+    `reps` (us). `inf` if incorrect or fails. Also returns the variant's own output when
+    `baseline_out` is None (so the first variant becomes the reference)."""
   arrs = [np.asarray(a, np.float16) for a in inputs]
   try:
     variant_out, int8 = _apply_variant(out, cfg)
@@ -475,22 +389,11 @@ def measure(out, inputs, cfg, baseline_out=None, reps: int = 20, warmup: int = 5
 # --------------------------------------------------------------------------- #
 def _greedy_int8(out, inputs, baseline_out, baseline_us, *, reps, atol,
                  min_lossy_speedup, budget, verbose=False):
-  """Greedily grow the per-weight int8 set, one weight at a time.
-
-    Start from the all-fp16 baseline (empty int8 set). Walk the candidate matmul weights
-    ordered by predicted benefit (largest weight first - int8 halves its bytes). For each
-    candidate, tentatively add it to the int8 set and MEASURE the resulting graph: keep
-    the weight int8 only if (a) accuracy stays within `atol` vs the opt=0 baseline AND
-    (b) it improves measured speed over the current best config. Continue until no
-    remaining candidate helps or the budget is spent. Returns `(int8_nodes_tuple, best_us,
-    n_measured)` - the chosen per-weight config and its measured latency. The set is built
-    on the all-native route (decomp empty); the route axis is separable and handled by the
-    lossless track.
-
-    O(#candidates^2) measurements worst-case (each pass re-scans remaining candidates), but
-    capped by `budget`; the largest-weight-first order front-loads the wins so the budget
-    is well spent.
-    """
+  """Greedily grow the per-weight int8 set, one weight at a time (coordinate descent, not
+    2^K). From the all-fp16 baseline, walk candidates largest-weight-first; tentatively add
+    each, MEASURE, and keep it only if accuracy stays within `atol` AND measured speed
+    improves. Returns (int8_nodes_tuple, best_us, n_measured). O(#candidates^2) worst-case,
+    capped by `budget`."""
   cands = _int8_candidates(out)
   if not cands: return (), float("inf"), 0
   chosen: list[int] = []
@@ -539,8 +442,8 @@ def _greedy_int8(out, inputs, baseline_out, baseline_us, *, reps, atol,
 # tune                                                                        #
 # --------------------------------------------------------------------------- #
 def _gen_inputs(input_shapes):
-  """Deterministic synthetic inputs for measurement/validation (fp16 ~N(0,1),
-    nudged off zero so divides/rsqrt don't blow up - same recipe as the fuzzer)."""
+  """Deterministic synthetic inputs (fp16 ~N(0,1), nudged off zero so divides/rsqrt don't
+    blow up)."""
   rng = np.random.default_rng(0xA9E)
   def _make(sh):
     a = rng.standard_normal(tuple(sh)).astype(np.float32)
@@ -554,10 +457,9 @@ def _input_shapes(out):
 
 
 def _estimate_variant(out, cfg):
-  """Cost-model estimate for a variant: apply its graph rewrite (route/per-weight),
-    then cost the resulting DAG under the global int8 flag. This is how the route decision
-    (native vs decomposed) is predicted before measuring - the decomposed DAG has no
-    native-SDPA cut, so estimate() costs it as one fused program."""
+  """Cost-model estimate for a variant: apply its rewrite, then cost the DAG. Predicts the
+    route decision before measuring - the decomposed DAG has no native-SDPA cut, so estimate()
+    costs it as one fused program."""
   variant_out, int8 = _apply_variant(out, cfg)
   return estimate(variant_out, int8=int8)
 
@@ -572,27 +474,15 @@ def tune(out, budget: int = 8, inputs=None, prune_factor: float = 1.5,
          reps: int = 20, atol: float = _ACCURACY_TOL,
          min_lossy_speedup: float = _MIN_LOSSY_SPEEDUP, verbose: bool = False,
          target_error: float | None = None):
-  """Return the fastest CORRECT compiled Model for the graph rooted at `out`.
+  """Return the fastest CORRECT compiled Model for the graph rooted at `out`: enumerate the
+    legal variant space, prune with the cost model, measure survivors, validate vs the opt=0
+    baseline, pick the fastest correct one, cache it (instant on a hit).
 
-    Enumerates the legal (proven-safe) variant space, prunes with the cost model, measures
-    the survivors on the ANE, validates each against the opt=0 baseline, picks the fastest
-    correct one, and caches the decision (instant on a cache hit).
-
-    PRECISION axis: pass `target_error=E` to switch to the precision-aware path
-    (`tune_precision`) - the optimizer then selects the numerics-aware rewrite set
-    (reduce_sum->matmul, +/- int8) that meets the error budget E (measured vs an fp32
-    reference, or vs the fp16 baseline's output when no fp32 emulation exists for the
-    graph) at minimum cost, and can IMPROVE accuracy over the fp16 baseline. With no
-    `target_error` the behavior is unchanged (speed tune; accuracy-preserving).
-
-    Accuracy contract: by default (`atol` = fp16 noise) tune is accuracy-PRESERVING - a
-    lossy rewrite (int8) is rejected, so the result matches opt=0 within fp16 noise. To
-    trade accuracy for speed, pass an explicit budget, e.g. `tune(out, atol=0.1)`; even
-    then a lossy variant must beat the baseline by `min_lossy_speedup` (default 1.10) to
-    be chosen, so a measurement-noise "win" never costs accuracy for no real gain.
-
-    `budget` caps the number of on-device measurements. `prune_factor`: skip any variant
-    whose estimate() is > prune_factor x the best estimate so far.
+    `target_error=E` switches to the precision-aware path (`tune_precision`), selecting the
+    numerics-aware rewrite that meets E at minimum cost (can IMPROVE accuracy). Default (no
+    target_error) is accuracy-PRESERVING: with `atol` at fp16 noise, lossy int8 is rejected;
+    pass a looser `atol` to admit it (it must still beat the baseline by `min_lossy_speedup`).
+    `budget` caps on-device measurements; `prune_factor` skips variants > that x the best estimate.
     """
   if target_error is not None:
     model, _report = tune_precision(out, target_error=target_error, inputs=inputs,
@@ -605,10 +495,8 @@ def tune(out, budget: int = 8, inputs=None, prune_factor: float = 1.5,
 
   configs = _variants(out)
 
-  # cache hit: rebuild the cached winner directly (no measurement). The winner is
-  # either an enumerated variant (route/global-int8) or a greedy per-weight int8 config
-  # (carrying `int8_nodes`, not in the static variant set but still buildable from the
-  # same graph since the cache key pins the structure).
+  # cache hit: rebuild the cached winner directly (no measurement). It may be an enumerated
+  # variant or a greedy per-weight int8 config (buildable since the key pins the structure).
   if key in cache and cache[key].get("config") is not None:
     cfg = cache[key]["config"]
     if cfg in configs or cfg.get("int8_nodes"):
@@ -678,13 +566,9 @@ def tune(out, budget: int = 8, inputs=None, prune_factor: float = 1.5,
       "successfully), so lossy variants were skipped - without a lossless "
       "reference their accuracy cannot be validated.")
 
-  # greedy per-weight int8 (coordinate descent). int8 is lossy, so only enumerate it
-  # when the user has opted into a loose accuracy budget (atol > the fp16-noise default).
-  # At the tight default it fails the accuracy gate anyway - skip it so the budget is not
-  # wasted and default tune stays the lossless baseline (byte-identical decision). The
-  # result competes with GLOBAL int8 already in the variant set: greedy wins when only
-  # SOME weights tolerate int8, global when all do (greedy then selects every candidate
-  # and ties global).
+  # greedy per-weight int8: only when atol is loosened past the fp16-noise default (at the
+  # tight default it fails the gate anyway, so default tune stays the lossless baseline).
+  # Competes with global int8: greedy wins when only SOME weights tolerate int8.
   if (atol > _ACCURACY_TOL and _has_weights(out) and baseline_out is not None
       and n_measured < budget):
     i8_nodes, i8_us, i8_n = _greedy_int8(
@@ -714,9 +598,8 @@ def tune(out, budget: int = 8, inputs=None, prune_factor: float = 1.5,
 
 
 def tune_report(out, budget: int = 8, inputs=None, reps: int = 20):
-  """Like tune() but returns a structured report dict instead of a Model - used by the
-    validator to report per-program speedup and cost-model ranking accuracy. Does not
-    consult/write the cache (always measures), so the report is fresh."""
+  """Like tune() but returns a structured report dict (per-program speedup, cost-model
+    ranking) instead of a Model. Never touches the cache (always measures)."""
   input_shapes = _input_shapes(out)
   if inputs is None: inputs = _gen_inputs(input_shapes)
   configs = _variants(out)
@@ -744,22 +627,18 @@ def tune_report(out, budget: int = 8, inputs=None, reps: int = 20):
 
 
 # =========================================================================== #
-# precision-aware tune  -  the synthesis of the cost model with the fp16        #
-# envelope. Speed is no longer the only axis: given an EXPLICIT error budget,    #
-# the optimizer selects the numerics-aware rewrite set (reduce_sum->matmul,      #
-# paired-fp16, +/- int8) that MEETS the budget at minimum predicted cost - or    #
-# minimizes error within a cost budget. Accuracy is measured vs an fp32          #
-# reference where one can be emulated (else the fp16 baseline's own output), so   #
-# a rewrite can be selected for improving accuracy, which speed-only tune()       #
-# cannot do.                                                                      #
+# precision-aware tune: given an EXPLICIT error budget, select the numerics-aware #
+# rewrite set (reduce_sum->matmul, paired-fp16, +/- int8) that MEETS it at minimum #
+# predicted cost (or minimizes error within a cost budget). Accuracy is measured   #
+# vs an fp32 reference where emulable (else the fp16 baseline), so a rewrite can be #
+# selected to IMPROVE accuracy. See docs/developer/optimizer-and-cost.md.          #
 # =========================================================================== #
-def _f16(x):  # fp16 rounding of operands/products (the ANE storage), wide accum
+def _f16(x):  # fp16 rounding of operands/products (ANE storage), wide accum
   return np.asarray(x, np.float16).astype(np.float64)
 
 
-# op -> numpy evaluator for the fp32-faithful reference. Each takes the node's
-# fp16-rounded source values `s` and the node `t`. Built once (module scope), not
-# per-node. An op absent here has no faithful reference (the graph falls back).
+# op -> numpy evaluator for the fp32-faithful reference (fp16-rounded sources `s`, node `t`).
+# An op absent here has no faithful reference (the graph falls back).
 _FP32_EVAL = {
   "add":         lambda s, t: _f16(s[0]) + _f16(s[1]),
   "sub":         lambda s, t: _f16(s[0]) - _f16(s[1]),
@@ -782,13 +661,10 @@ _FP32_EVAL = {
 
 
 def _fp32_reference(out, inputs):
-  """Compute a fp64/fp32-faithful reference for the graph on numpy, so accuracy can be
-    measured as IMPROVEMENT (not just preservation). Uses the same wide-accumulator
-    semantics the ANE matmul offers (products fp16-rounded, accumulation wide) so the
-    reference is the achievable target, not an unreachable fp64 ideal.
-
-    Returns the reference array (fp64) or None if any op lacks a numpy evaluator (then
-    precision tune falls back to measuring vs the fp16 baseline, like speed tune)."""
+  """fp64/fp32-faithful reference on numpy, using the ANE matmul's wide-accumulator
+    semantics (products fp16-rounded, accumulation wide) so it is the achievable target, not
+    an unreachable fp64 ideal. None if any op lacks a numpy evaluator (then precision tune
+    falls back to the fp16 baseline)."""
   order = _topo(out)
   vals: dict[int, np.ndarray] = {}
   ins = [np.asarray(a, np.float16).astype(np.float64) for a in inputs]
@@ -812,9 +688,8 @@ def _fp32_reference(out, inputs):
 
 
 def _measure_with_ref(out, inputs, cfg, ref, reps, warmup=5):
-  """Compile a variant, run it, and return (latency_us, relerr_vs_ref, out_arr).
-    `relerr_vs_ref` is max-abs relative error vs the fp32 reference (the accuracy
-    metric the budget is stated in). inf latency / 1.0 relerr on failure."""
+  """Compile/run a variant -> (latency_us, relerr_vs_ref, out_arr). relerr is max-abs
+    relative error vs the reference; inf / 1.0 on failure."""
   arrs = [np.asarray(a, np.float16) for a in inputs]
   try:
     variant_out, int8 = _apply_variant(out, cfg)
@@ -843,19 +718,15 @@ def _measure_with_ref(out, inputs, cfg, ref, reps, warmup=5):
 
 
 def _precision_variants(out, want_int8=True):
-  """The numerics-aware variant configs for precision tune, in increasing op-cost
-    order: fp16 baseline, then reduce_sum->matmul on the flagged narrow sums, then
-    (optionally) int8 (a LOSSY speed lever the budget may still admit). paired-fp16 is a
-    region rewrite (it changes the dataflow type), so it is not auto-enumerated here - it
-    is an explicit opt-in (see precision_rewrite / the demo); automatic cancel-sub
-    detection is a CANDIDATE flag only (data-dependent)."""
+  """Numerics-aware variant configs in increasing op-cost order: fp16 baseline,
+    reduce_sum->matmul on flagged narrow sums, then optionally int8 (lossy). paired-fp16 is
+    a region rewrite (changes the dataflow type), so it is opt-in, not auto-enumerated."""
   risk = precision_risk(out)
   rs_hot = [n["idx"] for n in risk["nodes"] if n["kind"] == "narrow_sum"]
   configs = [{"label_kind": "fp16-baseline", "rs_matmul": [], "lossy": False,
               "cost_rank": 0}]
   if rs_hot:
-    # the flagship safe rewrite: rewrite all flagged narrow sums to matmul. A tiny
-    # extra op cost (one matmul vs one reduce), accuracy strictly >= baseline.
+    # rewrite all flagged narrow sums to matmul: tiny extra op cost, accuracy >= baseline.
     configs.append({"label_kind": "reduce_sum->matmul", "rs_matmul": list(rs_hot),
                     "lossy": False, "cost_rank": 1})
   if want_int8 and _has_weights(out):
@@ -866,36 +737,19 @@ def _precision_variants(out, want_int8=True):
 
 def tune_precision(out, target_error: float | None = None, cost_budget_us: float | None = None,
                    inputs=None, reps: int = 20, verbose: bool = False):
-  """PRECISION-AWARE tune: select the numerics-aware rewrite set under an explicit
-    ERROR BUDGET (or a cost budget), measuring accuracy vs an fp32 reference.
+  """PRECISION-AWARE tune: select the numerics-aware rewrite set under an explicit error
+    budget (or cost budget), measuring accuracy vs an fp32 reference. Modes (give one):
+      * `target_error=E`   : min predicted cost among variants with relerr <= E.
+      * `cost_budget_us=C`  : min measured error among variants with cost <= C.
+    Default (neither): minimize error at any cost. Unlike speed-tune(), a variant can be
+    chosen to IMPROVE accuracy over the fp16 baseline.
 
-    Two modes (give one):
-      * `target_error=E`    : among variants whose measured relerr-vs-reference <= E,
-                                pick the one with MINIMUM predicted cost. (A tight E
-                                forces the accurate rewrites; a loose E lets a cheaper/
-                                lossy variant in.)
-      * `cost_budget_us=C`  : among variants whose predicted cost <= C, pick the one
-                                with MINIMUM measured error. (Best accuracy you can buy.)
-
-    Default (neither given) == minimize error at any cost (the most-accurate variant).
-
-    Returns `(model, report)` where report carries the per-variant (cost, error) table,
-    the precision-risk flags, and the chosen config - so a caller can SEE the accuracy/cost
-    frontier, not just the winner. Unlike speed-tune(), a variant here can be chosen for
-    IMPROVING accuracy over the fp16 baseline.
-
-    SCOPE: automatic hotspot detection covers the reduce_sum->matmul case
-    (structurally detectable). The CFG-style paired-fp16 fix is opt-in (use
-    `precision_rewrite` / pass a marked region) because near-equal cancellation is
-    data-dependent and cannot be confirmed at graph-build time.
-
-    REFERENCE: `_fp32_reference` emulates only the simple elementwise/matmul ops; a graph
-    it cannot evaluate (conv/softmax/norms/...) falls back to the fp16 baseline's own
-    measured output as the reference - `target_error` then bounds divergence FROM the fp16
-    baseline (which has relerr 0.0 by definition). The report's `ref_kind` ("fp32" |
-    "fp16-baseline" | None) records which reference was used; None means no reference of
-    any kind existed (the baseline failed too), in which case the budget is NOT enforced
-    and a warning is emitted."""
+    Returns `(model, report)`; report carries the per-variant (cost, error) table, risk
+    flags, and chosen config. Automatic detection covers reduce_sum->matmul; paired-fp16 is
+    opt-in (cancellation is data-dependent). REFERENCE: _fp32_reference emulates only simple
+    ops; a graph it cannot evaluate falls back to the fp16 baseline's output (then
+    target_error bounds divergence FROM it). `report.ref_kind` ("fp32"|"fp16-baseline"|None)
+    records which; None means no reference (budget NOT enforced, warning emitted)."""
   input_shapes = _input_shapes(out)
   if inputs is None: inputs = _gen_inputs(input_shapes)
   ref = _fp32_reference(out, inputs)
@@ -907,10 +761,8 @@ def tune_precision(out, target_error: float | None = None, cost_budget_us: float
     est = _estimate_variant(out, cfg)
     us, relerr, out_arr = _measure_with_ref(out, inputs, cfg, ref, reps=reps)
     if ref_kind is None and cfg["label_kind"] == "fp16-baseline" and out_arr is not None:
-      # no fp32-faithful emulation for this graph: the fp16 baseline's own measured
-      # output becomes the reference (the docstring contract), so remaining variants
-      # are gated on divergence from it. The baseline is the reference: relerr 0.0 by
-      # definition, not NaN.
+      # no fp32 emulation: the fp16 baseline's own output becomes the reference (relerr 0.0
+      # by definition); remaining variants are gated on divergence from it.
       ref = np.asarray(out_arr, np.float64)
       ref_kind = "fp16-baseline"
       relerr = 0.0
@@ -929,10 +781,8 @@ def tune_precision(out, target_error: float | None = None, cost_budget_us: float
                    "ref_available": ref is not None, "ref_kind": ref_kind}
 
   if ref_kind is None:
-    # NO reference of any kind: fp32 emulation is unsupported for this graph AND the
-    # fp16 baseline failed, so no variant's error was measured. Error-based selection
-    # would be meaningless - prefer the cheapest LOSSLESS variant and say so rather than
-    # silently pretending the budget was enforced.
+    # NO reference (fp32 unsupported AND fp16 baseline failed): error-based selection is
+    # meaningless, so prefer the cheapest LOSSLESS variant rather than fake-enforce the budget.
     pool = [r for r in usable if not r["config"].get("lossy")] or usable
     chosen = min(pool, key=lambda r: r["est_us"])
     reason = ("NO accuracy reference (fp32 emulation unsupported for this graph; "

--- a/aneforge/_paired.py
+++ b/aneforge/_paired.py
@@ -1,52 +1,10 @@
-"""Paired-fp16 ("double-fp16") arithmetic for aneforge - extended precision with
-NO fp32 anywhere in the compute path.
+"""Paired-fp16 ("double-fp16") extended precision with NO fp32 in the compute path.
 
-A value is carried as an *unevaluated pair* `(hi, lo)` with `hi = fp16(x)` and
-`lo = fp16(x - hi)`, so the pair represents `hi + lo` to ~2x the fp16
-significand (~22 effective bits). Both `hi` and `lo` are ordinary aneforge
-Tensors, so every Paired operation builds a pure-fp16 graph that compiles to fp16
-MIL and runs on the ANE.
-
-The arithmetic is the classic *error-free transforms*, every intermediate rounded
-to fp16 (validated first in numpy then on-silicon in the reverse-engineering
-corpus; this module reuses those exact algorithms):
-
-  * TwoSum (Knuth)      - add/sub: `a+b = s + e` exactly, s = fl(a+b), all fp16.
-  * TwoProduct (Dekker) - mul: `a*b = p + e` exactly via a Veltkamp split, all fp16.
-  * compensated dot     - TwoProduct each element, then accumulate the product AND
-                          the error streams. CRUCIAL: accumulate via `@ ones`
-                          (matmul, whose ANE accumulator is WIDE >= fp32), never via
-                          `reduce_sum` (whose ANE accumulator is NARROW fp16 and
-                          re-injects the error the compensation just removed).
-
-Why this beats plain fp16: the wall is *catastrophic cancellation* - a tiny result
-formed from large nearly-equal quantities, where the fp16 rounding of the operands
-and products (not the accumulation) swamps the signal. The lo terms capture exactly
-that rounding, so carrying (hi, lo) recovers it.
-
-COMPILER CAVEAT (verified): an aggressive algebraic simplifier could collapse
-`hi + lo` back to `hi` (since `lo` is, in exact arithmetic, "just the rounding
-of hi"), defeating the trick. On this ANE / e5rt it does NOT happen - the on-device
-Paired results match the numpy-fp16 proof bit-for-bit-close (validation in
-`examples/paired_fp16.py`). The transforms are opaque fp16 add/sub/mul chains with
-no fp32 island for the compiler to "see through", and e5rt preserves them. If a
-future toolchain fuses them away, the tell is the on-device relerr jumping back to
-the plain-fp16 value; the demo asserts against that.
-
-Op cost (fp16 ops/element, matching the envelope finding):
-  * TwoSum / compensated add-sub : ~6 fp16 ops/elem
-  * TwoProduct / compensated mul : ~17 fp16 ops/elem
-  * compensated dot of length K  : ~17 fp16 ops/elem + 2 matmul-accumulates
-
-API::
-
-    import aneforge as af
-    a = af.paired(af.input((1, D)))          # split an fp16 Tensor -> Paired (lo=0)
-    a = af.paired(hi_tensor, lo_tensor)      # or supply (hi, lo) carrying sub-ulp bits
-    d = (a - b).to_tensor()                  # compensated subtract, best-fp16 result
-    s = (a + b)                              # Paired
-    p = (a * b)                              # Paired (TwoProduct)
-    dot = a.dot(b)                           # compensated contraction -> Paired
+A value is an unevaluated pair `(hi, lo)`, hi=fp16(x), lo=fp16(x-hi), so hi+lo carries
+~2x the fp16 significand. Both limbs are ordinary Tensors -> pure-fp16 graph on the ANE.
+Uses the classic error-free transforms (TwoSum/TwoProduct), every intermediate fp16; the
+compensated dot accumulates through `@ ones` (the WIDE matmul accumulator), never
+reduce_sum. See docs/developer/numerics.md.
 """
 from __future__ import annotations
 
@@ -55,13 +13,11 @@ import numpy as np
 from .graph import Tensor
 
 # Dekker/Veltkamp split constant for fp16 (11-bit significand): 2^ceil(11/2)+1.
-# Same constant the numpy proof uses; fed as a scalar multiply (graph `muls`).
 _SPLIT = float(np.float16(2 ** 6 + 1))
 
 
 def _two_sum(a: Tensor, b: Tensor):
-  """Knuth TwoSum on aneforge Tensors: returns (s, e) with s = fl(a+b) and, in
-    exact arithmetic, a + b = s + e. Pure fp16 ops (~6 adds/subs)."""
+  """Knuth TwoSum: (s, e) with s = fl(a+b), a+b = s+e exactly. Pure fp16."""
   s = a + b
   bb = s - a
   e = (a - (s - bb)) + (b - bb)
@@ -69,8 +25,7 @@ def _two_sum(a: Tensor, b: Tensor):
 
 
 def _split(t: Tensor):
-  """Veltkamp split of an fp16 Tensor into hi + lo (each ~half the significand).
-    Pure fp16 (one scalar mul + two subs)."""
+  """Veltkamp split into hi + lo (each ~half the significand). Pure fp16."""
   c = t * _SPLIT
   hi = c - (c - t)
   lo = t - hi
@@ -78,8 +33,7 @@ def _split(t: Tensor):
 
 
 def _two_prod(a: Tensor, b: Tensor):
-  """Dekker TwoProduct (no FMA) on aneforge Tensors: returns (p, e) with p = fl(a*b)
-    and, in exact arithmetic, a*b = p + e. Pure fp16 ops (~17)."""
+  """Dekker TwoProduct (no FMA): (p, e) with p = fl(a*b), a*b = p+e exactly. Pure fp16."""
   p = a * b
   ah, al = _split(a)
   bh, bl = _split(b)
@@ -88,19 +42,15 @@ def _two_prod(a: Tensor, b: Tensor):
 
 
 def _renorm(s: Tensor, e: Tensor):
-  """Renormalize an overlapping (s, e) into a non-overlapping pair (hi, lo) so the
-    Paired invariant hi = fl(hi+lo) holds. Pure fp16 (fast-two-sum)."""
+  """Renormalize (s, e) into a non-overlapping (hi, lo) so hi = fl(hi+lo). Pure fp16."""
   hi = s + e
   lo = e - (hi - s)
   return hi, lo
 
 
 class Paired:
-  """A value carried as an unevaluated fp16 pair `hi + lo` (double-fp16).
-
-    `hi` and `lo` are aneforge `Tensor` graph nodes of the same shape; every
-    operation builds more fp16 graph. Construct via :func:`paired` (the public
-    `af.paired`), not directly, unless you hold matched (hi, lo) tensors."""
+  """A value carried as an unevaluated fp16 pair `hi + lo` (double-fp16). Construct
+    via :func:`paired` (`af.paired`) unless you hold matched (hi, lo) Tensors."""
 
   __slots__ = ("hi", "lo")
 
@@ -131,9 +81,8 @@ class Paired:
   def __mul__(self, o) -> "Paired":
     if isinstance(o, (int, float)): return Paired(self.hi * float(o), self.lo * float(o))  # scalar: scale both limbs
     o = _as_paired(o)
-    p, e = _two_prod(self.hi, o.hi)        # exact hi*hi product + its rounding
-    # cross terms hi*lo + lo*hi captured in fp16 (lo*lo dropped - below fp16 ulp)
-    e = e + (self.hi * o.lo + self.lo * o.hi)
+    p, e = _two_prod(self.hi, o.hi)
+    e = e + (self.hi * o.lo + self.lo * o.hi)  # cross terms (lo*lo dropped, below ulp)
     return Paired(*_renorm(p, e))
   __rmul__ = __mul__
 
@@ -141,43 +90,34 @@ class Paired:
     return Paired(self.hi * -1.0, self.lo * -1.0)
 
   def dot(self, o: "Paired", axis: int = -1) -> "Paired":
-    """Compensated dot / contraction over `axis` (the down_proj / accurate-sum
-        case). TwoProduct each element, then accumulate the product AND error streams
-        through `@ ones` - the WIDE matmul accumulator - never reduce_sum.
-
-        Returns a Paired reduced along `axis` (keepdims). Pure fp16."""
+    """Compensated dot/contraction over `axis`: TwoProduct each element, then accumulate
+        products AND error streams through `@ ones` (WIDE matmul accumulator), never
+        reduce_sum. Returns a Paired reduced along `axis` (keepdims). Pure fp16."""
     o = _as_paired(o)
     if self.shape != o.shape: raise ValueError(f"dot: shape mismatch {self.shape} vs {o.shape}")
     ax = axis % len(self.shape)
     K = self.shape[ax]
 
-    # full TwoProduct of the two pairs, element-wise (products + captured error)
     p, e = _two_prod(self.hi, o.hi)
     e = e + (self.hi * o.lo + self.lo * o.hi)
 
-    # accumulate via matmul (wide accumulator): move `axis` to last, contract it
-    # with a [K,1] ones weight, then restore.
+    # accumulate via matmul (wide accumulator): move `axis` to last, contract with [K,1] ones.
     def _accum(t: Tensor) -> Tensor:
       perm = [i for i in range(len(t.shape)) if i != ax] + [ax]
       tp = t.transpose(perm) if perm != list(range(len(t.shape))) else t
       ones = np.ones((K, 1), dtype=np.float16)
-      acc = tp @ ones                    # [..., 1]  wide accumulate
-      return acc                          # leading dims preserved, last dim == 1
+      acc = tp @ ones
+      return acc
 
     sp, se = _accum(p), _accum(e)
-    # the matmul itself rounds its fp16 output; recover that with one more TwoSum
-    s, e2 = _two_sum(sp, se)
+    s, e2 = _two_sum(sp, se)   # recover the matmul's own fp16 output rounding
     return Paired(*_renorm(s, e2))
 
   # -- conversions ------------------------------------------------------- #
   def to_tensor(self) -> Tensor:
-    """Collapse the pair to its best single-fp16 approximation.
-
-        That value is `hi` (the pair invariant is hi = fl(hi+lo), so fl(hi+lo)==hi).
-        We return `hi + lo` - identical in fp16 to `hi` for a normalized pair, but
-        written as an explicit add so the compiler must MATERIALIZE lo into the result
-        (a guard against a dead-code pass dropping the lo computation; if elided the
-        on-device error would regress to plain fp16)."""
+    """Best single-fp16 value. Returns `hi + lo` (== hi for a normalized pair) as an
+        explicit add so the compiler MATERIALIZES lo - guards against a dead-code pass
+        dropping the lo computation (which would regress on-device error to plain fp16)."""
     return self.hi + self.lo
 
   combine = to_tensor
@@ -195,22 +135,15 @@ def _as_paired(o) -> Paired:
 def paired(hi: Tensor, lo: Tensor | None = None) -> Paired:
   """Public constructor for a :class:`Paired` (double-fp16) value.
 
-    `af.paired(x)`       - split an fp16 Tensor `x` into a pair (lo = 0). A genuine
-                             fp16 input has no sub-ulp bits to carry, so the win comes
-                             from the compensated *ops* capturing each operation's
-                             rounding.
-    `af.paired(hi, lo)`  - wrap an already-split pair (hi, lo) that carries sub-ulp
-                             information (e.g. a residual or a value produced upstream
-                             in higher working precision). The regime where paired-fp16
-                             recovers the most (the CFG/regime-B case).
-
-    Pure fp16: the split is `hi = x`, `lo = x - x` ( == 0 ) built as graph ops,
-    so the result stays a live fp16 dataflow with no fp32 cast."""
+    `af.paired(x)`      - split a Tensor into a pair (lo = 0); the win is the compensated
+                          ops capturing each operation's rounding.
+    `af.paired(hi, lo)` - wrap an already-split pair carrying sub-ulp info (regime B, where
+                          paired-fp16 recovers the most). See docs/developer/numerics.md."""
   if not isinstance(hi, Tensor):
     raise TypeError("af.paired(hi[, lo]) expects an aneforge Tensor for hi")
   if lo is None:
-    # lo = x - x: structurally zero, but emitted as ops so hi/lo share a shape and
-    # the pair is a real two-limb dataflow (no Python-side fp32 collapse).
+    # lo = x - x: structurally zero, but emitted as ops so the pair is a real two-limb
+    # dataflow (no Python-side fp32 collapse).
     lo = hi - hi
   elif not isinstance(lo, Tensor): raise TypeError("af.paired(hi, lo): lo must be an aneforge Tensor")
   elif hi.shape != lo.shape: raise ValueError(f"af.paired: hi shape {hi.shape} != lo shape {lo.shape}")

--- a/aneforge/_rewrite.py
+++ b/aneforge/_rewrite.py
@@ -1,29 +1,10 @@
-"""Graph-rewrite infrastructure for the aneforge optimizer.
+"""Graph-rewrite engine for the aneforge optimizer.
 
-Tensors are immutable/pure (op + srcs + attrs), so a "rewrite" is not in-place
-mutation - it RE-DERIVES the output DAG, substituting new nodes at match sites
-and rebuilding every node on the path from a match up to `out`. Shared subgraphs
-are cloned once (memoized by node identity) so a diamond stays a diamond, not two
-copies.
-
-The public entry point is `rewrite(out, rule)`: `rule(t) -> Tensor | None` is a
-node-local rewrite (return a replacement Tensor for `t`, or None to leave it). It
-is applied bottom-up: a node's sources are rewritten first, then the node itself is
-rebuilt on the (possibly new) sources, then `rule` is offered the rebuilt node.
-
-On top of that, two concrete rewrites the optimizer uses:
-
-  - `sdpa_to_decomposed` : replace one (or all) native-`sdpa` node(s) with the
-    metamorphic-PROVEN bit-identical decomposed form
-    `((q @ k^T) * scale).softmax(-1) @ v` - built from aneforge ops (bmm/muls/
-    softmax), which fuse into ONE e5rt program (no native-SDPA graph cut). Being
-    bit-identical (see the reverse-engineering corpus + tests/fuzz_metamorphic
-    `mha_vs_sdpa`), it is LOSSLESS: the optimizer picks native-vs-decomposed
-    purely by speed.
-
-  - `set_node_int8` : tag a specific weight-bearing node with an `int8` attr so
-    the compiler streams just that node's weight as int8 (a per-weight, LOSSY
-    rewrite - opt-in, accuracy-gated by the tuner).
+Tensors are immutable/pure, so a "rewrite" re-derives the output DAG: new nodes at match
+sites, every node on the path up to `out` rebuilt; shared subgraphs cloned once (memoized
+by identity). Rules apply bottom-up. Concrete rewrites: lossless route decompositions
+(sdpa/minmax_norm/flatten/lrn), per-node int8 (lossy, tuner-gated), reduce_sum->matmul,
+canon/numeric folds. See docs/developer/compile-pipeline.md.
 """
 from __future__ import annotations
 
@@ -38,25 +19,22 @@ from .graph import Tensor
 
 @dataclass(frozen=True)
 class Rule:
-  """One graph-rewrite rule. `match`/`build` both see the REBUILT node (sources
-  already rewritten); identity-based selection is delegated to graph_rewrite's
-  `select`. `kind` is "lossless" (always-on canon) or "numeric" (tuner-gated)."""
+  """One graph-rewrite rule. `match`/`build` see the REBUILT node (sources already
+  rewritten). `kind` is "lossless" (always-on canon) or "numeric" (tuner-gated)."""
   name: str; kind: str
   match: Callable[[Tensor], bool]; build: Callable[[Tensor], Tensor]
 
 
 def graph_rewrite(out: Tensor, rules: list["Rule"], select: set[int] | None = None) -> Tensor:
-  """Return a new output DAG, rules applied bottom-up in ONE memoized pass.
-
-  Sources are rewritten first; the node is rebuilt on the (possibly new) sources;
-  then the first rule whose `match` accepts the rebuilt node fires (its `build`
-  replaces it). `select` (original-node id()s) gates eligibility; None = all
-  eligible. A node with no applied rule and unchanged sources is returned
-  unchanged (same object), so a no-op rule-set yields the SAME object."""
-  from ._compile import _topo                 # iterative post-order (sources before consumers);
-  memo: dict[int, Tensor] = {}                 # a forward pass over it is stack-safe on deep unrolled graphs
+  """Return a new output DAG, rules applied bottom-up in ONE memoized pass. First rule
+  whose `match` accepts a rebuilt node fires. `select` (original-node id()s) gates
+  eligibility; None = all. A node with no rule and unchanged sources is returned
+  unchanged (same object), so a no-op rule-set yields the SAME object (keeps opt=0
+  byte-identical)."""
+  from ._compile import _topo                 # iterative post-order: stack-safe on deep graphs
+  memo: dict[int, Tensor] = {}
   for t in _topo(out):
-    new_srcs = [memo[id(s)] for s in t.srcs]   # every src precedes t in _topo, so it is already in memo
+    new_srcs = [memo[id(s)] for s in t.srcs]   # every src precedes t in _topo
     rebuilt = t if all(a is b for a, b in zip(new_srcs, t.srcs)) else Tensor(t.shape, t.op, new_srcs, dict(t.attrs))
     res = rebuilt
     if select is None or id(t) in select:
@@ -67,34 +45,20 @@ def graph_rewrite(out: Tensor, rules: list["Rule"], select: set[int] | None = No
 
 
 def rewrite(out: Tensor, rule: Callable[[Tensor], Optional[Tensor]]) -> Tensor:
-  """Return a NEW output DAG with `rule` applied bottom-up to every node.
-
-    `rule(node) -> Tensor | None`: a replacement for `node` (already built on the
-    rewritten sources), or None to keep the rebuilt node as-is. The clone is memoized
-    by source-node identity, so shared subgraphs are rewritten exactly once and stay
-    shared. Inputs (and any node `rule` leaves unchanged with unchanged sources) are
-    returned unchanged, so a no-op rule yields the SAME object - the optimizer relies
-    on that to keep opt=0 byte-identical.
-    """
-  # `rule` must be a pure node-local transform: it is called once in `match` and
-  # again in `build`, so a stateful/non-deterministic rule would be unsafe. The
-  # match-guard ensures `build` fires only when `rule` returns a Tensor (not None),
-  # which is why the build-lambda's None-able return is type-ignored as safe.
-  # cast: the match-guard (`rule(t) is not None`) guarantees build is only called
-  # when rule returns a Tensor, so the None-able return type is safe to narrow here.
+  """Return a NEW output DAG with `rule(node) -> Tensor | None` applied bottom-up.
+    A no-op rule yields the SAME object (opt=0 byte-identical)."""
+  # `rule` must be a pure node-local transform: it is called in both `match` and `build`.
+  # The match-guard guarantees build only fires when rule returned a Tensor, so the
+  # None-able return is safe to narrow (cast).
   r = Rule("adhoc", "lossless", lambda t: rule(t) is not None,
        cast(Callable[[Tensor], Tensor], lambda t: rule(t)))
   return graph_rewrite(out, [r])
 
 
 def _decompose_sdpa(node: Tensor) -> Tensor:
-  """Build the decomposed equivalent of an `sdpa` node from aneforge ops.
-
-    Matches the reverse-engineering corpus's `dec` exactly:
-        scores = (q @ k.transpose([0,1,3,2])) * scale
-        a      = scores.softmax(-1)
-        out    = a @ v
-    q/k/v are [1, H, S, D]; the result is [1, H, S, D]. Pure fused MIL - no cut."""
+  """Decomposed equivalent of an `sdpa` node: ((q @ k^T) * scale).softmax(-1) @ v.
+    q/k/v are [1,H,S,D]; result [1,H,S,D]. Pure fused MIL - no cut. Bit-identical to
+    native sdpa (lossless route)."""
   q, k, v = node.srcs
   scale = node.attrs["scale"]
   scores = (q @ k.transpose([0, 1, 3, 2])) * float(scale)
@@ -103,11 +67,8 @@ def _decompose_sdpa(node: Tensor) -> Tensor:
 
 
 def sdpa_to_decomposed(out: Tensor, only_id: Optional[int] = None) -> Tensor:
-  """Rewrite native `sdpa` node(s) to the decomposed (fused-MIL) form.
-
-    `only_id` (an `id()` of a node in the ORIGINAL graph) rewrites just that one
-    sdpa node; None rewrites every sdpa node. Returns a new output DAG (the same
-    object if there was nothing to rewrite)."""
+  """Rewrite native `sdpa` node(s) to the decomposed (fused-MIL) form. `only_id` (an
+    ORIGINAL-graph node id) targets one; None rewrites all. Returns a new output DAG."""
   sel = None if only_id is None else {only_id}
   r = Rule("sdpa", "lossless", lambda t: t.op == "sdpa", _decompose_sdpa)
   return graph_rewrite(out, [r], select=sel)
@@ -120,9 +81,8 @@ def list_sdpa_nodes(out: Tensor) -> list[Tensor]:
 
 
 def set_node_int8(out: Tensor, node_ids: set[int]) -> Tensor:
-  """Return a new DAG where each weight-bearing node whose `id()` is in
-    `node_ids` carries an `int8=True` attr (per-weight int8 override). The
-    compiler's `weight()` honors `t.attrs['int8']` over the global flag."""
+  """Tag each weight-bearing node in `node_ids` with `int8=True` (per-weight override;
+    the compiler honors `t.attrs['int8']` over the global flag). Returns a new DAG."""
   if not node_ids: return out
   r = Rule("int8", "numeric", lambda t: t.op in ("matmul", "conv"),
        lambda t: Tensor(t.shape, t.op, t.srcs, {**t.attrs, "int8": True}))
@@ -130,9 +90,8 @@ def set_node_int8(out: Tensor, node_ids: set[int]) -> Tensor:
 
 
 def list_weight_nodes(out: Tensor) -> list[Tensor]:
-  """Weight-bearing (int8-eligible) nodes in topo order: matmul (streamed `wt`) and
-    conv (baked `weight`). Both honor per-channel int8 (constexpr_affine_dequantize)
-    as a routable weight operand on the ANE."""
+  """Weight-bearing (int8-eligible) nodes in topo order: matmul (`wt`) and conv
+    (`weight`). Both honor per-channel int8 (constexpr_affine_dequantize) on the ANE."""
   from ._compile import _topo
   return [t for t in _topo(out)
       if (t.op == "matmul" and isinstance(t.attrs.get("wt"), np.ndarray))
@@ -143,16 +102,10 @@ def list_weight_nodes(out: Tensor) -> list[Tensor]:
 # NUMERICS-aware rewrites (accuracy-improving, each validated vs fp32)          #
 # --------------------------------------------------------------------------- #
 def _reduce_sum_as_matmul(t: Tensor) -> Tensor:
-  """Rebuild a single `reduce_sum` node as a contraction against a ones-vector,
-    so the sum runs through the WIDE matmul accumulator instead of the NARROW
-    reduce_sum accumulator. Mathematically identical (sum_k x_k == x @ 1), strictly
-    >= accuracy under cancellation (fp16_envelope: comp_mm beats comp_rsum).
-
-    Only the single-axis, last-axis case is rewritten here (the contraction matmul
-    expresses directly): `x[..., K].sum(-1, keepdims) == x @ ones[K,1]`. For a
-    non-last single axis we transpose the axis to the end, contract, and transpose
-    back. Multi-axis sums are left to reduce_sum (the rewrite would need a reshape
-    chain; not worth it, and the optimizer won't offer it)."""
+  """Rebuild a single `reduce_sum` as `x @ ones[K,1]`, routing the sum through the WIDE
+    matmul accumulator instead of the NARROW reduce_sum accumulator. Identical math,
+    >= accuracy under cancellation. Single-axis only; a non-last axis is transposed to
+    the end and back. See docs/developer/numerics.md."""
   src = t.srcs[0]
   axes = tuple(t.attrs.get("axes", ()))
   if len(axes) != 1:
@@ -164,23 +117,20 @@ def _reduce_sum_as_matmul(t: Tensor) -> Tensor:
   ones = np.ones((K, 1), dtype=np.float16)
 
   if ax == rank - 1:
-    # x[..., K] @ ones[K, 1] -> [..., 1]   (keepdims, matches reduce_sum keep_dims)
     return src @ ones
-  # move `ax` to the last position, contract, move the resulting size-1 dim back.
+  # move `ax` last, contract, move the size-1 dim back.
   perm = [i for i in range(rank) if i != ax] + [ax]
   inv = [0] * rank
   for new_pos, old in enumerate(perm):
     inv[old] = new_pos
-  contracted = src.transpose(perm) @ ones          # [..., 1] with ax-data last
-  return contracted.transpose(inv)                  # restore original axis order
+  contracted = src.transpose(perm) @ ones
+  return contracted.transpose(inv)
 
 
 def reduce_sum_to_matmul(out: Tensor, only_idx: set[int] | None = None) -> Tensor:
-  """Rewrite single-axis `reduce_sum` node(s) to a `@ ones` matmul contraction
-    (the WIDE-accumulator sum). LOSSLESS-or-better: identical math, >= accuracy under
-    cancellation. `only_idx` selects nodes by topo index in the ORIGINAL graph;
-    None rewrites every eligible reduce_sum. Returns a new output DAG (same object if
-    nothing matched)."""
+  """Rewrite single-axis `reduce_sum` node(s) to a `@ ones` contraction (WIDE-accumulator
+    sum, lossless-or-better). `only_idx` selects by ORIGINAL-graph topo index; None = all.
+    Returns a new output DAG."""
   from ._compile import _topo
   order = _topo(out)
   elig = lambda t: t.op == "reduce_sum" and len(t.attrs.get("axes", ())) == 1
@@ -192,20 +142,14 @@ def reduce_sum_to_matmul(out: Tensor, only_idx: set[int] | None = None) -> Tenso
 
 
 # --------------------------------------------------------------------------- #
-# BRIDGE-ELIMINATION rewrites (replace a native netplist cut with a fused        #
-# decomposition built from _EMIT ops). Each is lossless - validated on-device     #
-# to agree with the bridge within fp16 op-noise (tests/test_routes.py), same       #
-# proof class as sdpa<->decomposed. Removing the cut lets the region fuse into     #
-# one e5rt program (estimate() costs it cheaper accordingly).                       #
+# BRIDGE-ELIMINATION rewrites: replace a native netplist cut with a fused        #
+# decomposition. Each is lossless (validated on-device vs the bridge within fp16  #
+# op-noise, tests/test_routes.py); removing the cut lets the region fuse into one #
+# e5rt program. See docs/developer/compile-pipeline.md.                           #
 # --------------------------------------------------------------------------- #
 def _decompose_minmax_norm(node: Tensor) -> Tensor:
-  """Build the fused equivalent of a `minmax_norm` node from _EMIT ops:
-        y = (x - amin(x, dim)) / (amax(x, dim) - amin(x, dim) + eps)
-    over the reduction axis (Width=-1, Height=-2). reduce_min/reduce_max/sub/
-    real_div are all fused; the `+ eps` is the scalar-add `adds` op. The native
-    layer is bit-faithful to this formula (aneforge/_bridges/minmax_norm_fused.py header), so
-    the rewrite is LOSSLESS: the two agree within fp16 op-noise (test_routes.py), and
-    the degenerate max==min row yields 0/eps==0 on BOTH sides (no NaN divergence)."""
+  """Fused minmax_norm: y = (x - amin) / (amax - amin + eps) over the reduction axis.
+    Lossless; max==min row -> 0/eps==0 on both sides (no NaN divergence)."""
   (x,) = node.srcs
   ax = -1 if node.attrs["dimension"] == "Width" else -2
   eps = float(node.attrs["eps"])
@@ -215,26 +159,17 @@ def _decompose_minmax_norm(node: Tensor) -> Tensor:
 
 
 def _flatten_to_reshape(node: Tensor) -> Tensor:
-  """Rebuild a `flatten` node (native Flatten bridge, [C,H,W] -> [prod]) as a plain
-    fused `reshape` to the same 1-D shape. BIT-IDENTICAL (both are a contiguous
-    row-major collapse - test_routes.py measures relerr 0.0), so it is LOSSLESS and
-    removes the netplist cut entirely."""
+  """Rebuild a `flatten` (Flatten bridge) as a fused `reshape`. Bit-identical (both a
+    contiguous row-major collapse); removes the netplist cut."""
   (x,) = node.srcs
   return x.reshape(node.shape)
 
 
 def _decompose_lrn(node: Tensor) -> Tensor:
-  """Rebuild an `lrn` node (native LocalResponseNormalization bridge, a graph cut)
-    as the fused MIL `local_response_norm` op (one program, no cut). BIT-EQUIVALENT
-    (test_routes.py measures cos 1.000000 / relerr 0.0 across C/alpha/beta/k): the
-    bridge fixes the layer's channel window to N = C and divides the window sum by
-    KernelChannel internally, so the fused op reproduces it with `size=C` and `alpha`
-    pre-scaled by C (the fused op uses `alpha/size`; size=C cancels the C, recovering
-    the bridge's TRUE effective alpha):
-        lrn(alpha, beta, k)  ==  local_response_norm(size=C, alpha=alpha*C, beta, k)
-    where C = x.shape[1]. LOSSLESS, so the optimizer picks native-vs-fused purely by
-    speed - and the fused route removes the cut (~1250x faster on a conv->lrn->relu
-    block). The fused op also drops the C<16 cap the bridge carries."""
+  """Rebuild an `lrn` (LocalResponseNormalization bridge) as fused local_response_norm.
+    The bridge fixes the channel window to N=C; the fused op uses alpha/size, so size=C
+    cancels the C: lrn(alpha,beta,k) == local_response_norm(size=C, alpha=alpha*C, beta, k),
+    C = x.shape[1]. Bit-equivalent; removes the cut. See docs/developer/compile-pipeline.md."""
   (x,) = node.srcs
   C = node.shape[1]
   a = node.attrs
@@ -242,10 +177,8 @@ def _decompose_lrn(node: Tensor) -> Tensor:
   return local_response_norm(x, size=C, alpha=a["alpha"] * C, beta=a["beta"], k=a["k"])
 
 
-# rewrite op-name -> (matched bridge op, decomposition builder). The route registry
-# in _capabilities.py is the single source OF truth for *which* bridge ops are route-
-# selectable; this table is just the executable builders, keyed identically.
-# Reconciled by tests/test_routes.py.
+# op-name -> decomposition builder. The route registry in _capabilities.py is the source
+# of truth for WHICH bridge ops are route-selectable; this is just the executable builders.
 _BRIDGE_DECOMPOSERS = {
   "sdpa": _decompose_sdpa,
   "minmax_norm": _decompose_minmax_norm,
@@ -256,9 +189,8 @@ _BRIDGE_DECOMPOSERS = {
 
 def decompose_bridge(out: Tensor, decomp_idx: set[int]) -> Tensor:
   """Rewrite the bridge nodes at the given ORIGINAL-graph topo indices to their fused
-    decomposition (sdpa/minmax_norm/flatten/lrn - see `_BRIDGE_DECOMPOSERS`). Walks the
-    original graph so the indices are stable, rebuilding bottom-up. A node whose op has
-    no registered decomposer is left as-is (single-route). Returns a new output DAG."""
+    decomposition (see `_BRIDGE_DECOMPOSERS`). Nodes with no decomposer are left as-is.
+    Returns a new output DAG."""
   from ._compile import _topo
   order = _topo(out)
   sel = {id(order[i]) for i in decomp_idx
@@ -270,17 +202,9 @@ def decompose_bridge(out: Tensor, decomp_idx: set[int]) -> Tensor:
 
 
 def paired_subtract(a, b):
-  """Carry a single `a - b` through paired-fp16 (compensated TwoSum), returning a
-    plain fp16 Tensor whose value is the best-fp16 result of the compensated subtract.
-
-    This is the CFG-style cancellation fix from fp16_envelope: the compensated
-    subtract captures the subtract's own rounding (and, in regime B, the carried lo of
-    paired inputs). `a` / `b` may each be a plain Tensor or a `Paired` (pass a Paired
-    to exploit regime B, the recovering case). Higher op cost (~6 fp16 ops/elem) -> the
-    optimizer gates this behind the error budget.
-
-    Returns a Tensor (`.to_tensor()` of the Paired difference) so it drops straight
-    into an existing fp16 graph at the hotspot."""
+  """Carry `a - b` through paired-fp16 (compensated TwoSum), returning a plain fp16 Tensor
+    - the cancellation fix that captures the subtract's own rounding. `a`/`b` may each be a
+    Tensor or a `Paired` (pass Paired to exploit regime B). See docs/developer/numerics.md."""
   from ._paired import Paired, paired as _mk_paired
   pa = a if isinstance(a, Paired) else _mk_paired(a)
   pb = b if isinstance(b, Paired) else _mk_paired(b)
@@ -320,9 +244,8 @@ CANON_RULES: list[Rule] = [
 ]
 
 def canonicalize(out: Tensor) -> Tensor:
-  """Apply the lossless CANON_RULES to a fixed point (a rule may expose a fresh
-  redundancy for the next pass). Returns the SAME object when nothing matches, so
-  a clean graph is unchanged."""
+  """Apply the lossless CANON_RULES to a fixed point. Returns the SAME object when
+  nothing matches (a clean graph is unchanged)."""
   while (nxt := graph_rewrite(out, CANON_RULES)) is not out: out = nxt
   return out
 
@@ -346,8 +269,8 @@ NUMERIC_RULES: list[Rule] = [
   Rule("adds_chain", "numeric", lambda t: t.op == "adds" and t.srcs[0].op == "adds", _b_fold_adds),
 ]
 
-# fp16 NumPy kernels for the foldable ops. Compute reproduces device fp16 where it can,
-# but is NEVER assumed bit-identical to the engine -> const_fold is gated (NUMERIC).
+# fp16 NumPy kernels for the foldable ops; not assumed bit-identical to the engine, so
+# const_fold is gated (NUMERIC).
 def _f16(x: "np.ndarray") -> "np.ndarray": return np.asarray(x, np.float16)
 _EvalFn = Callable[["list[np.ndarray]", "dict[str, Any]", "tuple[int, ...]"], "np.ndarray"]
 _EVAL: dict[str, _EvalFn] = {
@@ -362,8 +285,8 @@ _EVAL: dict[str, _EvalFn] = {
 }
 
 def _const_subgraph(t: Tensor, max_elems: int = 1 << 16) -> "np.ndarray | None":
-  """fp16 value of `t` if its entire source cone is constant (const_array leaves,
-  no `input`) and the op set is foldable and the size is bounded; else None."""
+  """fp16 value of `t` if its whole source cone is constant, foldable, and size-bounded;
+  else None."""
   if math.prod(t.shape) > max_elems: return None
   memo: dict[int, "np.ndarray | None"] = {}
   def ev(n: Tensor) -> "np.ndarray | None":

--- a/aneforge/_runtime.py
+++ b/aneforge/_runtime.py
@@ -1,10 +1,7 @@
-"""aneforge's device runtime - a lean ctypes wrapper over libane_e5rt_dispatch.dylib.
-
-The *only* low-level dependency of the aneforge package. Exposes exactly what the
-compiler needs: compile a MIL program, eval it (bind fp16 inputs, run, read fp16
-outputs), release it. The full experimental e5rt surface (multi-op, async,
-pipelining, chaining, multi-shape, CPU/GPU masks) lives separately in the
-reverse-engineering corpus; aneforge deliberately does not depend on it.
+"""aneforge's device runtime - a lean ctypes wrapper over libane_e5rt_dispatch.dylib, the
+only low-level dependency. Exposes just what the compiler needs: compile a MIL program,
+eval it (bind fp16 inputs, run, read fp16 outputs), release it. See
+docs/developer/compile-pipeline.md.
 """
 from __future__ import annotations
 
@@ -27,13 +24,10 @@ _DYLIB = "libane_e5rt_dispatch.dylib"
 def _find_dylib() -> Path:
   """Locate libane_e5rt_dispatch.dylib, building it on first use if needed.
 
-    Lookup order: an explicit ``ANEFORGE_DYLIB`` override, the package's own
-    `aneforge/_lib/` copy (the canonical location, built by `aneforge/_lib/build.sh`
-    or on demand), a legacy out-of-tree `<repo>/ane_build/lib/` build, then the
-    per-version build cache. If none exists and we are on macOS, the dylib is
-    compiled from the packaged source and cached, so a plain `pip install aneforge`
-    works on first dispatch. Set ``ANEFORGE_NO_AUTOBUILD=1`` to require an explicit
-    build (`python -m aneforge.build`) instead."""
+    Order: ``ANEFORGE_DYLIB`` override, the package's `aneforge/_lib/` copy (canonical),
+    a legacy `<repo>/ane_build/lib/` build, then the per-version build cache; else compile
+    from packaged source and cache (so `pip install aneforge` works on first dispatch).
+    ``ANEFORGE_NO_AUTOBUILD=1`` requires an explicit `python -m aneforge.build`."""
   override = os.environ.get("ANEFORGE_DYLIB")
   if override and Path(override).expanduser().exists(): return Path(override).expanduser()
   here = Path(__file__).resolve()
@@ -54,14 +48,9 @@ def _find_dylib() -> Path:
 
 
 class _Dylib:
-  """Lazy ctypes proxy for the e5rt dispatch dylib.
-
-    The library is loaded and its ABI signatures configured on first attribute
-    access; every call then delegates to it. This keeps `import aneforge` (and the
-    off-device tooling: cost model, op catalog, target table) working without the
-    built dylib; building it (`aneforge/_lib/build.sh`) is required only to compile
-    or dispatch to the ANE.
-    """
+  """Lazy ctypes proxy for the e5rt dispatch dylib: loaded and ABI-bound on first
+    attribute access. Keeps `import aneforge` (and off-device tooling) working without the
+    built dylib; the dylib is needed only to compile or dispatch to the ANE."""
 
   def __init__(self) -> None:
     self._lib = None
@@ -95,8 +84,8 @@ class _Dylib:
       ctypes.c_void_p, ctypes.c_char_p, ctypes.POINTER(ctypes.c_uint16), ctypes.c_size_t]
     lib.ane_e5rt_program_execute.restype = ctypes.c_int
     lib.ane_e5rt_program_execute.argtypes = [ctypes.c_void_p]
-    # Zero-copy: hand back the persistent CPU+ANE-visible buffer for a port so the host can
-    # read/write it directly and skip the per-call set_input/get_output memcpy.
+    # Zero-copy: hand back the persistent CPU+ANE-visible buffer for a port (skip the
+    # per-call set_input/get_output memcpy).
     for _fn in ("ane_e5rt_program_input_buffer", "ane_e5rt_program_output_buffer"):
       getattr(lib, _fn).restype = ctypes.c_int
       getattr(lib, _fn).argtypes = [
@@ -104,16 +93,14 @@ class _Dylib:
         ctypes.POINTER(ctypes.c_void_p), ctypes.POINTER(ctypes.c_size_t)]
     lib.ane_e5rt_program_release.restype = None
     lib.ane_e5rt_program_release.argtypes = [ctypes.c_void_p]
-    # Resident-state support: rebind an input port to read another port's output
-    # buffer (within one program). Aliasing an op's own output onto its own input
-    # makes that tensor persist on-device across executes - the basis for resident
-    # optimizer state during training (see autograd.Trainer resident path).
+    # Resident-state support: rebind an input port to read another port's output buffer.
+    # Aliasing an op's own output onto its own input makes that tensor persist on-device
+    # across executes - the basis for resident optimizer state during training.
     lib.ane_e5rt_program_share_buffer.restype = ctypes.c_int
     lib.ane_e5rt_program_share_buffer.argtypes = [
       ctypes.c_void_p, ctypes.c_size_t, ctypes.c_char_p, ctypes.c_size_t, ctypes.c_char_p]
-    # Compile-only cross-target check: compile a MIL for a TargetArchitecture WITHOUT the
-    # device-bound op, validating that a graph compiles for another ANE family (e.g. h13)
-    # from this host. Returns 0 if a library was produced for the target, nonzero otherwise.
+    # Compile-only cross-target check: compile a MIL for a TargetArchitecture without the
+    # device op, validating a graph compiles for another ANE family from this host.
     lib.ane_e5rt_compile_check.restype = ctypes.c_int
     lib.ane_e5rt_compile_check.argtypes = [
       ctypes.c_char_p, ctypes.c_char_p, ctypes.c_uint64, ctypes.c_char_p]
@@ -126,9 +113,8 @@ _lib = _Dylib()
 
 
 def compile_check(mil_path, cache_dir, custom_ane_options=None, device_mask=ANE_MASK) -> int:
-  """Compile `mil_path` for the given `custom_ane_options` (e.g.
-    `'TargetArchitecture=h13'`) without creating the device operation. Returns the
-    dispatch return code: 0 = a library was produced (compiles for that target)."""
+  """Compile `mil_path` for `custom_ane_options` (e.g. `'TargetArchitecture=h13'`) without
+    creating the device op. Returns the dispatch rc: 0 = a library was produced."""
   opt = custom_ane_options.encode() if custom_ane_options else None
   return _lib.ane_e5rt_compile_check(
     str(mil_path).encode(), str(cache_dir).encode(), device_mask, opt)
@@ -144,14 +130,14 @@ def _fp16_bytes(shape: tuple[int, ...]) -> int:
   return _numel(shape) * 2
 
 
-# bytes-per-element of the supported input dtypes (compute is fp16; uint8 image
-# inputs are dequantised in-graph, so only their port size/feed differs).
+# bytes-per-element of supported input dtypes (compute is fp16; uint8 image inputs are
+# dequantised in-graph, so only their port size/feed differs).
 _DT_BYTES = {"fp16": 2, "uint8": 1}
 
 
 def _port_bytes(shape: tuple[int, ...], dtype: str) -> int:
-  """Byte size of an input port. uint8 ports round up to even so `_feed`'s
-    padded uint16 view always fits (set_input copies in 2-byte units)."""
+  """Byte size of an input port. uint8 ports round up to even (set_input copies in
+    2-byte units, so `_feed`'s padded uint16 view must fit)."""
   n = _numel(shape) * _DT_BYTES[dtype]
   return n + (n % 2)
 
@@ -167,8 +153,8 @@ def _ptr(view: np.ndarray):
 
 
 class Program:
-  """A compiled, dispatch-ready ANE program. Output buffers are allocated once
-    and reused across `eval` calls (copy them if you need to retain results)."""
+  """A compiled, dispatch-ready ANE program. Output buffers are allocated once and reused
+    across `eval` calls (copy them to retain results)."""
 
   def __init__(self, handle: int, inputs: dict, outputs: dict, device_mask: int,
                input_dtypes: dict | None = None) -> None:
@@ -176,15 +162,14 @@ class Program:
     self._inputs = dict(inputs)
     self._outputs = dict(outputs)
     self._device_mask = device_mask
-    # per-port input dtype ("fp16" default, or "uint8" for image inputs); only the
-    # feed (byte count / no fp16 cast) differs; the in-graph cast does the dequant.
+    # per-port input dtype ("fp16" default, "uint8" for image inputs): only the feed
+    # differs; the in-graph cast does the dequant.
     self._input_dtypes = dict(input_dtypes or {})
     self._out_buffers = {name: np.zeros(shape, np.float16) for name, shape in outputs.items()}
 
   def _feed(self, name: str, arr: np.ndarray) -> None:
-    """Copy `arr` into input port `name`. fp16 ports take a fp16 view; uint8
-        image ports take the raw bytes (set_input_fp16 copies count*2 bytes, so we
-        pass ceil(nbytes/2) over a uint16 view of the byte buffer)."""
+    """Copy `arr` into input port `name`. fp16 ports take a fp16 view; uint8 image ports
+        take raw bytes via a uint16 view (set_input_fp16 copies in 2-byte units)."""
     if self._input_dtypes.get(name, "fp16") == "uint8":
       b = np.ascontiguousarray(np.asarray(arr, dtype=np.uint8)).reshape(-1)
       if b.size % 2:                                   # pad odd byte count for the uint16 view
@@ -210,15 +195,14 @@ class Program:
     return self._out_buffers
 
   # ---- resident-state primitives (granular set / execute / read + alias) ----
-  # `eval` binds all inputs and reads all outputs every call. For resident
-  # training we seed state ports once, alias each state output onto its input,
-  # then per step feed only the data ports and execute - no state copy.
+  # `eval` binds all inputs and reads all outputs every call. For resident training we
+  # seed state ports once, alias each state output onto its input, then per step feed only
+  # the data ports and execute - no state copy.
 
   def share_buffer(self, src_op_idx: int, src_out_port: str,
                    dst_op_idx: int, dst_in_port: str) -> None:
-    """Rebind `dst`'s input port to read `src`'s output buffer. With
-        `src_op_idx == dst_op_idx == 0` and a state tensor's own output->input,
-        the tensor stays resident on-device across `execute` calls."""
+    """Rebind `dst`'s input port to read `src`'s output buffer. Aliasing a state tensor's
+        own output->input keeps it resident on-device across `execute` calls."""
     rc = _lib.ane_e5rt_program_share_buffer(
       self._handle, ctypes.c_size_t(src_op_idx), src_out_port.encode(),
       ctypes.c_size_t(dst_op_idx), dst_in_port.encode())
@@ -259,19 +243,16 @@ class Program:
     return raw.view(np.float16).reshape(shape)            # writable view onto ANE memory
 
   def input_view(self, name: str) -> np.ndarray:
-    """Writable fp16 view onto the persistent ANE-visible INPUT buffer for `name`.
-        Write your input into it in place (or `np.copyto`), then call `execute()`: this
-        skips the per-call host->device copy that `eval`/`set_input` do, the only host
-        overhead aneforge can remove (the ~fixed firmware round-trip dominates; see
-        DispatchFloorWarning). Valid only while the Program is alive; don't retain past
-        `release()`. Don't overwrite a resident-state port bound via `share_buffer`."""
+    """Writable fp16 view onto the persistent ANE-visible INPUT buffer. Write in place then
+        `execute()`: skips the per-call host->device copy (the only host overhead aneforge
+        can remove; the firmware round-trip dominates). Valid only while the Program is
+        alive; don't overwrite a `share_buffer`-bound resident-state port."""
     if name not in self._inputs: raise KeyError(f"unknown input port: {name!r}")
     return self._buffer_view(name, self._inputs[name], _lib.ane_e5rt_program_input_buffer)
 
   def output_view(self, name: str) -> np.ndarray:
-    """fp16 view onto the persistent ANE-visible OUTPUT buffer for `name`, valid after
-        `execute()`. Read it directly (no copy); `.copy()` it if you must retain the
-        result across the next `execute()`. Valid only while the Program is alive."""
+    """fp16 view onto the persistent ANE-visible OUTPUT buffer, valid after `execute()`.
+        Read directly (no copy); `.copy()` to retain across the next `execute()`."""
     if name not in self._outputs: raise KeyError(f"unknown output port: {name!r}")
     return self._buffer_view(name, self._outputs[name], _lib.ane_e5rt_program_output_buffer)
 
@@ -294,8 +275,8 @@ class Program:
 
 
 class E5RT:
-  """Compiles a MIL program into a ready-to-run :class:`Program`. Stateless -
-    each `compile` is independent (no shared global compiler)."""
+  """Compiles a MIL program into a ready-to-run :class:`Program`. Stateless (each
+    `compile` is independent)."""
 
   @staticmethod
   def compile(mil_path, *, cache_dir=os.path.join(os.path.expanduser("~"), ".cache", "aneforge", "e5rt"),
@@ -311,8 +292,7 @@ class E5RT:
       *[_port_bytes(inputs[n], input_dtypes.get(n, "fp16")) for n in in_names])
     out_n = (ctypes.c_char_p * len(out_names))(*[n.encode() for n in out_names])
     out_s = (ctypes.c_size_t * len(out_names))(*[_fp16_bytes(outputs[n]) for n in out_names])
-    # Pace consecutive compile failures: a backstop so the autotuner's burst of
-    # variant compiles can't pile up after a failure.
+    # Pace consecutive compile failures (backstop for the autotuner's variant burst).
     from . import _circuit
     _circuit.guard_before_compile()
     handle = _lib.ane_e5rt_program_compile(

--- a/aneforge/_targets.py
+++ b/aneforge/_targets.py
@@ -1,36 +1,18 @@
-"""Per-chip ANE target capabilities - the host-independent core of aneforge's
-cross-chip support.
+"""Per-chip ANE target capabilities - the host-independent core of cross-chip support.
 
-Apple's ANE compiler (ANECompiler 9.509) is byte-identical across chips; everything
-that varies between an M1 and an M5 is the per-chip HAL/target DATA the identical code
-reads, plus the `MinimumFamily<N>` op-trait floors. So portability is a data problem:
-this module holds the measured per-family capability table and answers, for a given
-target family, whether each op is native / must be decomposed / is unreachable, plus the
-numeric limits a graph must respect.
+Apple's ANE compiler is byte-identical across chips; what varies M1->M5 is the per-chip
+HAL/target DATA plus the `MinimumFamily<N>` op floors, so portability is a data problem.
+This module holds the measured per-family capability table and answers, per target family,
+whether each op is native/decompose/reject, plus the numeric limits a graph must respect.
 
-The compiler enumerates 28 HAL targets in 5 capability families. A17 (H17*) and A18
-(H18) targets exist but add no op capabilities over A16 - they scale NE-core count only
-(suffix decoder: base=4, g=8, s=16, c=32, d=64) - so the A16 tier is the capability
-ceiling:
+28 HAL targets in 5 capability families (A16 is the ceiling; A17/A18 scale core count only):
 
-    family 1  older   H11, H12, M9, T0                       A11 / A12  (no MIL path)
-    family 2  A13     H13, H13g, T1                          A13 (M1)
-    family 3  A14     H14, H14g, H14c                        A14
-    family 4  A15     H15, H15g, H15c                        A15  (also ~= M11, see below)
-    family 5  A16     H16, H16g, H16c, H16s,                 A16
-                      H17, H17a, H17g, H17s, H17c, H17d,     A17 (M5 == H17s)
-                      H18                                    A18
+    family 1 older  A11/A12  (no MIL path)    family 4 A15  M3 (~= M11)
+    family 2 A13    M1                         family 5 A16  M4, M5 (== H17s)
+    family 3 A14    M2
 
-(U1/U2/U3 are compiler-internal reference targets, not silicon; M11 is a 1-core
-efficiency ANE with A16 features but A13-sized dims - capability-wise the A15 tier.)
-
-Physically measured anchors, both via the compiled bundle's directory name: M1 == H13
-(`H13C.bundle`) and M5 == H17s (`H17S.bundle`). M-series == H(generation+12) follows
-from the two anchors; intermediate chips are still detected at runtime, never assumed.
-
-Sources (ANEForge reverse-engineering): op floors from the per-family code-generation
-analysis; numeric limits from the measured `hal_extraction/named_hal.json`; the "MIL is
-only supported for H13+ ANE architectures" hard floor from `ANE_constraint_strings.txt`.
+Measured anchors: M1 == H13, M5 == H17s; M-series == H(gen+12). See
+docs/developer/capabilities-and-targets.md.
 """
 import os
 import re
@@ -54,9 +36,8 @@ class Family(IntEnum):
   A16 = 5     # M5
 
 
-# The e5rt/MIL path aneforge dispatches through carries the hard assert
-# "MIL is only supported for H13+ ANE architectures" - family >= 2 required
-# regardless of any per-op floor.
+# The e5rt/MIL path carries the hard "MIL is only supported for H13+ ANE architectures"
+# assert: family >= 2 required regardless of any per-op floor.
 MIN_FAMILY = int(Family.A13)
 
 
@@ -65,10 +46,8 @@ def supports_mil(family: int) -> bool:
   return int(family) >= MIN_FAMILY
 
 
-# Compiler arch string -> capability family index. All 28 compiler HAL targets are
-# valid TargetArchitecture strings (verified on-device 2026-06-05); the generation digit
-# gives the capability family, with H17*/H18 folding into the A16 tier (core-count
-# scaling only).
+# Compiler arch string -> capability family. All 28 are valid TargetArchitecture strings;
+# H17*/H18 fold into the A16 tier (core-count scaling only).
 _ARCH_FAMILY = {
   "h11": Family.OLDER, "h12": Family.OLDER, "m9": Family.OLDER, "t0": Family.OLDER,
   "h13": Family.A13, "h13g": Family.A13, "t1": Family.A13,
@@ -78,22 +57,19 @@ _ARCH_FAMILY = {
   "h17": Family.A16, "h17a": Family.A16, "h17g": Family.A16, "h17s": Family.A16,
   "h17c": Family.A16, "h17d": Family.A16,
   "h18": Family.A16,
-  # M11: A16 op features but A13-sized dims (16384) -- the A15 tier is the exact
-  # capability match (every A15 op native, 16384 dims). U1/U2/U3 are reference
-  # targets, not silicon, deliberately not mapped.
+  # M11: A16 op features but A13-sized dims -> the A15 tier is the exact match.
+  # U1/U2/U3 are reference targets, not silicon, deliberately not mapped.
   "m11": Family.A15,
 }
 
 
 def family_of_arch(arch: str) -> int:
-  """Resolve an ANE arch string (OS or compiler-internal, e.g. 'h13' or 'h17s') to a
-    compiler family index. Raises KeyError on an unrecognized arch."""
+  """Resolve an ANE arch string ('h13'/'h17s') to a compiler family. KeyError if unknown."""
   return int(_ARCH_FAMILY[arch.strip().lower()])
 
 
-# A representative arch string per capability family, for the TargetArchitecture
-# compile option. h16s stands in for the whole A16 tier: h17*/h18 compile too but are
-# capability-identical, so one representative keeps the cross-compile matrix small.
+# A representative arch string per family for the TargetArchitecture compile option (h16s
+# stands in for the whole A16 tier, keeping the cross-compile matrix small).
 _FAMILY_ARCH = {Family.A13: "h13", Family.A14: "h14", Family.A15: "h15", Family.A16: "h16s"}
 
 
@@ -103,49 +79,28 @@ def arch_for_family(family: int) -> str:
 
 
 # --- per-family native weight-streaming formats ------------------------------------------
-# Which compressed-weight encodings the per-family lowering keeps as a native streaming
-# kernel (DRAM bandwidth win) vs folds to a dense fp16 const (no win). The kernel-streaming
-# master gate (HAL +0x48f) turns on at A13, but the per-format gates (the +0x520-0x539
-# cluster) are 0 on h13: only the palette/LUT path streams there (its +0x529 gate is
-# A13-on). Silicon-measured endpoints: A13/M1 = int4-LUT (2.37x) AND sparse (~1.6x); A14/M2
-# = int4 + int8 + sparse all stream, blockwise folds (measured 0.985x, no win); A16/M5 = the
-# broad set streams. (The earlier "A14 streams all four" was an inferred HAL guess, refuted
-# by M2 silicon - blockwise never gets a native stream.) papers M2_SILICON_FINDINGS.md +
-# per-family compressed-weight streaming.
-#
-# Sparse on A13/M1 is a round-9 correction: compress="sparse" lowers to MIL
-# `constexpr_sparse_to_dense` (a 1-bit mask + packed-fp16 DMA that decompresses on-chip),
-# a different path from the HAL kernel-format sparse gate (the +0x520-0x539 cluster that is
-# 0 on h13). On genuinely-sparse weights (>=50% zeros) it streams: live-measured ~1.55-1.64x
-# (0.43x dense bytes, cos=1.0) on a conv1x1 - the native-stream fingerprint. The old "no win"
-# reading came from running sparse mode on dense-random weights (all-ones mask, 0 bytes saved).
-# See the reverse-engineering corpus
+# Which compressed-weight encodings stream natively (DRAM-bandwidth win) vs fold to dense
+# fp16 (no win). Silicon-measured: A13/M1 = int4-LUT + sparse; A14/M2 = int4+int8+sparse
+# (blockwise folds, no win); A16/M5 = broad set. See docs/developer/capabilities-and-targets.md.
 _ALL_FORMATS = frozenset({"int4", "int8", "sparse", "blockwise"})
 _NATIVE_STREAMS = {
-  int(Family.A13): frozenset({"int4", "sparse"}),           # M1-measured: int4-LUT + sparse stream
+  int(Family.A13): frozenset({"int4", "sparse"}),           # M1-measured
   int(Family.A14): frozenset({"int4", "int8", "sparse"}),   # M2-measured; blockwise folds
 }
 
 
 def native_streams(family: int) -> frozenset:
-  """The compressed-weight encodings that stream natively (a bandwidth win) on
-    `family`. Encodings outside the set still compile and stay correct, but the on-device
-    compiler folds them to dense fp16 - an accuracy cost for zero win."""
+  """Compressed-weight encodings that stream natively (a bandwidth win) on `family`. Others
+    still compile correctly but fold to dense fp16 (accuracy cost, zero win)."""
   return _NATIVE_STREAMS.get(int(family), _ALL_FORMATS)
 
 
 # --- runtime host-chip detection -------------------------------------------------------
-# The chip -> ANE-family map. M1 (H13) and M5 (H17s) are physically measured anchors (via
-# their H13C/H17S bundles); M2/M3/M4 are resolved by the verified M-series == H(gen+12)
-# rule (Apple's own +[_ANEDeviceInfo aneArchitectureType] boardType ladder, disassembled
-# and live-validated on M1 Max = h13g; VideoProcessing's cnn_frame_enhancer ships exactly
-# {H13..H17} = M1..M5). So M2=H14/A14, M3=H15/A15, M4=H16/A16 are ground-truth capability
-# families (only absolute power/watt still needs each chip's rail). The model identifier
-# stays a trap (MacBookPro17,1 is an M1, Mac17,8 an M5), so we match the M-generation off
-# the clean CPU brand string ("Apple M5 Pro"); the Pro/Max/Ultra ('g') variant changes core
-# count, not capability family. Chips beyond this map (a future M6+) fall back to MIN_FAMILY
-# - a family-2 program runs on every H13+ chip (higher families are strict op/shape/fp16
-# supersets), so under-claiming stays correct.
+# Chip -> ANE-family. M1/M5 are measured anchors; M2/M3/M4 by the verified M-series ==
+# H(gen+12) rule. Matched off the clean CPU brand string ("Apple M5 Pro") - the model
+# identifier is a trap (MacBookPro17,1 is M1); Pro/Max/Ultra changes core count, not family.
+# A future M6+ falls back to MIN_FAMILY (a family-2 program runs on every H13+ chip, since
+# higher families are strict supersets - under-claiming stays correct).
 _BRAND_FAMILY = {
   1: Family.A13,   # M1  - measured H13
   2: Family.A14,   # M2  - verified H14 (M-series ladder)
@@ -195,9 +150,8 @@ def detect_family() -> int:
 
 
 # --- op floors -------------------------------------------------------------------------
-# Minimum native family per op. Anything not listed defaults to family 2 (the F0/F2
-# vocabulary: conv/matmul/pooling/elementwise/activations/softmax/norms/reductions/
-# sqrt/rsqrt/erf/exp2/log2/SDPA/resize/tile/space<->channel/atan - all native on M1+).
+# Minimum native family per op. Unlisted ops default to family 2 (the F0/F2 vocabulary,
+# all native on M1+). See docs/developer/capabilities-and-targets.md.
 _OP_FLOOR = {
   # F4 trig (A15+) - the one genuinely family-gated trig pair in this MIL vocabulary.
   "sin": Family.A15, "cos": Family.A15,
@@ -214,10 +168,8 @@ _OP_FLOOR = {
   "topk": Family.A14, "sort": Family.A14, "dynamic_slice": Family.A14,
 }
 
-# Below-floor ops for which aneforge has a working substitution. sin/cos -> special.py
-# Horner; dropout/random -> host-side RNG. The texture-engine and bridge-codegen ops have
-# no substitution wired, so below their floor they hard-reject (a clear compile-time
-# error) instead of crashing at dispatch.
+# Below-floor ops with a working substitution (sin/cos -> Horner; dropout/random -> host
+# RNG). Texture-engine and bridge-codegen ops have none, so they hard-reject below floor.
 _DECOMPOSABLE = {"sin", "cos", "dropout", "random"}
 
 
@@ -235,28 +187,16 @@ def has_texture_engine(family: int) -> bool:
   return int(family) >= int(Family.A14)
 
 
-# Per-family numeric limits. Values keyed by the lowest family at which they take effect;
-# _limit_for() picks the value for the highest threshold <= the queried family.
+# Per-family numeric limits, keyed by the lowest family at which a value takes effect;
+# limit() picks the highest threshold <= the queried family. Caps are generation-monotone
+# (A13 == A14 <= A16) and ride the op's LOWERING, not the tensor. Measured per family. See
+# docs/developer/capabilities-and-targets.md.
 _LIMITS = {
-  # Per-op-class extents (A14 measured exact by binary search + run-at-cap, M2 measurement
-  # A14_MAXDIM_CAPS.md; A16 row measured the same way on the M5 dev box). Three distinct
-  # caps, riding the op's LOWERING, not the tensor:
-  #   spatial/contraction (H, W, matmul-K, conv spatial)  A14 16384  ->  A16 65536
-  #   channel (C; elementwise and conv Cin)               A14 65536  ==  A16 65536
-  #   transpose extent (an offset-field width)            A14 2^23-1 ->  A16 >=2^24-1
-  # A13 row now measured on the live M1: W/H 16384 (16385 rejects), C 65536 (65537
-  # rejects) -- exactly A14. So the caps are generation-monotone (A13 == A14 <= A16); the
-  # old "M1 ran a 262144-wide relu" was a red herring (a direct compile probe rejects
-  # 16385). The conservative A13 = A14 pin was correct; no inversion.
-  "max_tensor_dim": {Family.A13: 16384, Family.A16: 65536},     # spatial/contraction (compat name)
-  "channel_extent": {Family.A13: 65536},
-  "transpose_extent": {Family.A13: 8388607, Family.A16: 16777215},
-  # conv kernel WIDTH (fp16): A13 measured kW<=13 (14 rejects); A16 measured kW<=15 (16
-  # rejects -> route via space_to_depth). Monotone A13<=A16. A14/A15 inherit 13 (unmeasured;
-  # conservative). kH is not a fixed cap (rejects only when taller than the input).
-  # graph.conv() also hard-guards the family ceiling kW>15 at build.
+  "max_tensor_dim": {Family.A13: 16384, Family.A16: 65536},     # spatial/contraction (H,W,matmul-K)
+  "channel_extent": {Family.A13: 65536},                        # C (elementwise, conv Cin)
+  "transpose_extent": {Family.A13: 8388607, Family.A16: 16777215},  # offset-field width
+  # conv kernel WIDTH (fp16): A13 kW<=13, A16 kW<=15 (graph.conv() also guards kW>15 at build).
   "conv_kw_max": {Family.A13: 13, Family.A16: 15},
-  # reduction->transpose threshold: 192 on A13/A14, raised to 384 at A15.
   "reduction_transpose_extent": {Family.A13: 192, Family.A15: 384},
 }
 
@@ -270,27 +210,21 @@ def limit(name: str, family: int) -> int:
 
 
 # --- cross-chip fp16 divergence predictor (Direction B) --------------------------------
-# The MAC accumulator width and the compiler __TEXT are uniform across chips, so cross-chip
-# fp16 VALUE divergence can only come from HAL-data-selected codegen routes that reorder (or
-# saturate) fp16 ops - predictable by comparing a small set of per-family HAL fields. Each
-# field below is keyed by the lowest family at which it takes its value; _field_for()
-# resolves the value for a queried family (highest threshold <= family). Source: ANEForge
-# reverse-engineering (field offsets cited per row).
+# The MAC accumulator width and compiler __TEXT are uniform across chips, so cross-chip
+# fp16 VALUE divergence can only come from HAL-data-selected codegen routes that reorder or
+# saturate fp16 ops - predictable from a few per-family HAL fields (keyed by lowest family;
+# _field_for resolves highest threshold <= family). See docs/developer/capabilities-and-targets.md.
 
 # fp16 max / 16 = 65504/16: the slice-x16 Q.4 crop-DMA saturation threshold (finite->inf).
 FP16_SLICE_SAT = 4094.0
 
 _HAL_FIELDS = {
-  # 0x494 bit0: reduce->square fusion. Silicon-measured no-op: A13, A14 (M2), and A16 (M5)
-  # all compute fp16(sum)^2 (the "unfused" value) -- a non-tied reduce->square probe gives
-  # 62624 on all three, not the fused 62656. Consistent with the fp16 reduce OUTPUT (the
-  # reduce result is cast to fp16 before the square, so a fuse has no extra precision to
-  # preserve). The earlier HAL-inferred flip {A13:0, A14:1} was wrong; kept uniform 0 so the
-  # predictor never flags a (nonexistent) reduce->square divergence.
+  # 0x494 reduce->square fusion: silicon-measured no-op (A13/A14/A16 all compute fp16(sum)^2,
+  # since the reduce output is fp16 before the square). Kept uniform 0 so the predictor never
+  # flags a nonexistent divergence.
   "reduce_square_fuse": {Family.A13: 0},
-  # 0x3f0: reduction->transpose route threshold (= reduction_transpose_extent). 192 on
-  # A13/A14, 384 on A15+. Empirically a no-op (block accumulation absorbs it), but a
-  # differing value still flags a <=1-ULP reorder risk for the reduced extent.
+  # 0x3f0 reduction->transpose route threshold (192 A13/A14, 384 A15+). Empirically a no-op,
+  # but a differing value still flags a <=1-ULP reorder risk.
   "reduce_route_thresh": {Family.A13: 192, Family.A15: 384},
 }
 
@@ -300,43 +234,33 @@ def _field_for(name: str, family: int) -> int | None:
   return next((table[t] for t in sorted(table, reverse=True) if int(family) >= int(t)), None)
 
 
-# Op-kind classes the predictor recognizes, mapped to the divergence axis they ride.
-# A graph node's `op` is matched against these (substring/exact) by the compile-side
-# wiring; the predictor takes the resolved kind string.
+# Op-kind classes the predictor recognizes, mapped to the divergence axis they ride
+# (matched substring/exact against the resolved kind string).
 _REDUCE_OPS = ("reduce", "softmax", "norm", "mean", "sum", "variance", "rms")
 _SLICE_OPS = ("slice_by_size", "slice", "crop")
 
 
 def predict_fp16_divergence(kind: str, shape, target_a: int, target_b: int,
                             begin=None, max_abs: float | None = None) -> str:
-  """Statically predict whether an op's fp16 VALUE can diverge between two target ANE
-    families, from the HAL fields that select its codegen route. Returns one verdict:
+  """Statically predict whether an op's fp16 VALUE can diverge between two ANE families,
+    from the HAL fields that select its codegen route. Verdicts (strongest wins):
 
-      `"saturation"` - a slice with a nonzero last-axis/width begin-offset, where one
-          target is A13 (family 2): A13 routes the offset through a Q.4 x16 crop-DMA that
-          clamps any |value| > 4094 (=fp16max/16) to +/-inf, while A14+ takes a clean
-          route. Magnitude-gated: flagged only when values can exceed 4094 (`max_abs`
-          None = unknown, treated as possible; a finite `max_abs` <= 4094 downgrades it).
-      `"round1"` - a reduce immediately followed by a square/mul (variance, L2-norm,
-          RMSNorm) where the 0x494 reduce->square fusion bit differs. Currently never
-          returned: A13/A14/A16 silicon all compute fp16(sum)^2 (the field is uniform, a
-          measured no-op given the fp16 reduce output); kept for completeness.
-      `"ulp1"` - a reduction / softmax / norm whose 0x3f0 route threshold differs (192
-          A13/A14 vs 384 A15+) for the reduced extent: a partial-sum reorder, <=1 ULP.
-      `"none"` - no HAL field selects a differing route for this op/shape pair.
+      `"saturation"` - a slice with a nonzero last-axis begin-offset where one target is
+          A13: A13's Q.4 x16 crop-DMA clamps |value| > 4094 to +/-inf. Magnitude-gated by
+          `max_abs` (None = unknown = possible).
+      `"round1"`     - reduce-then-square (variance/L2/RMSNorm) where the 0x494 fuse bit
+          differs. Never currently returned (the field is a measured no-op); kept for completeness.
+      `"ulp1"`       - reduction/softmax/norm whose 0x3f0 route threshold differs (<=1-ULP reorder).
+      `"none"`       - no differing route.
 
-    `kind` is an op-kind string (the node `op`, or a coarse class like 'slice' /
-    'reduce' / 'reduce_square'); `shape` is the op's output shape; `begin` is the slice
-    begin-offset tuple (for slice kinds); `max_abs` bounds the op's value magnitude.
-    The strongest verdict wins (saturation > round1 > ulp1 > none)."""
+    `kind` is the node op or a coarse class; `begin` is the slice offset tuple; `max_abs`
+    bounds the value magnitude. See docs/developer/capabilities-and-targets.md."""
   fa, fb = int(target_a), int(target_b)
   k = kind.lower()
 
-  # 1. slice with nonzero last-axis/width begin-offset -> Q.4 x16 crop-DMA saturation.
-  # The quirk is present on A13 AND A14 (M2 silicon: 4094 finite -> 4100 inf, bit-exact,
-  # same as M1), absent on A16; A15 pending M3 data. Flag a divergence when exactly one
-  # target is affected (family <= A14) and the other is not -- both-affected and both-clean
-  # pairs match.
+  # 1. slice with nonzero last-axis begin-offset -> Q.4 x16 crop-DMA saturation. The quirk
+  # is present on A13 AND A14 (measured), absent on A16; A15 pending. Flag when exactly one
+  # target is affected (family <= A14).
   if any(s in k for s in _SLICE_OPS):
     last_off = bool(begin) and len(begin) > 0 and int(begin[-1]) > 0
     sat_a, sat_b = fa <= int(Family.A14), fb <= int(Family.A14)
@@ -366,9 +290,8 @@ class OpReport:
 
 @dataclass
 class Preflight:
-  """Result of walking a graph for a target family. `ok` iff nothing hard-blocks
-    compilation: no rejected ops and no oversize tensors. `decompose` ops are
-    recoverable (route through the host/special.py substitution) and do not clear ok."""
+  """Result of walking a graph for a target family. `ok` iff nothing hard-blocks: no
+    rejected ops, no oversize tensors. `decompose` ops are recoverable and keep ok True."""
   family: int
   native: list = field(default_factory=list)
   decompose: list = field(default_factory=list)
@@ -380,11 +303,9 @@ class Preflight:
 
 
 def _internal_axis_oversize(t, max_dim: int) -> bool:
-  """Some ops reshape to a larger per-axis extent INSIDE their MIL lowering than any
-    node shape shows. group_norm's rank-4 tiled lowering reshapes to [1,G,C/groups,H*W],
-    so its largest internal axis is max(C/groups, H*W); this can exceed the family's max
-    dimension even when [1,C,H,W] does not (e.g. C512@128 -> H*W=16384, at the A13 cap).
-    Catch these so preflight predicts the compiler instead of missing the overflow."""
+  """Some ops reshape to a larger per-axis extent INSIDE their MIL lowering than any node
+    shape shows. group_norm's rank-4 lowering reshapes to [1,G,C/groups,H*W], so its largest
+    internal axis is max(C/groups, H*W) - can exceed the cap even when [1,C,H,W] does not."""
   if t.op == "group_norm" and len(t.shape) == 4:
     _, c, h, w = t.shape
     g = int(t.attrs.get("groups", 1)) or 1
@@ -393,19 +314,15 @@ def _internal_axis_oversize(t, max_dim: int) -> bool:
 
 
 def preflight(out, family: int) -> Preflight:
-  """Walk the graph feeding `out` and report, for the given target family, which ops
-    are native / need decomposition / are unreachable, plus any tensor whose dimensions
-    (or known internal-reshape extents) exceed the family's limits. Pure static analysis -
-    no compile, no hardware. `out` is an aneforge `Tensor` (anything with
-    `.op`/`.shape`/`.srcs`)."""
+  """Walk the graph feeding `out` and report, per target family, which ops are
+    native/decompose/reject, plus any tensor exceeding the family's limits. Pure static
+    analysis (no compile, no hardware)."""
   rep = Preflight(family=int(family))
   seen: set = set()
 
   if not supports_mil(family):
-    # Below the H13+ MIL floor (Family.OLDER): the e5rt/MIL path carries the hard
-    # "MIL is only supported for H13+ ANE architectures" assert, so NOTHING runs.
-    # Report every op as rejected (not ok) without querying the per-family limits,
-    # which are only defined at or above the floor — limit() raises below it.
+    # Below the H13+ MIL floor: NOTHING runs (hard assert). Report every op rejected
+    # without querying limits (limit() is undefined below the floor).
     walk = [out]
     while walk:
       t = walk.pop()
@@ -419,7 +336,7 @@ def preflight(out, family: int) -> Preflight:
   chan_dim = limit("channel_extent", family)
   tr_dim = limit("transpose_extent", family)
   # nodes whose extent rides the WIDE transpose lowering: transposes and their direct
-  # inputs (the measured (N,2)->(2,N) silicon cap covers both sides of the op).
+  # inputs (the cap covers both sides of the op).
   nodes, walk = [], [out]
   tr_wide: set = set()
   while walk:
@@ -432,9 +349,9 @@ def preflight(out, family: int) -> Preflight:
       tr_wide.add(id(t))
       tr_wide.update(id(s) for s in t.srcs if s.op == "input")
   for t in nodes:
-    # per-axis caps ride the op's lowering (A14_MAXDIM_CAPS.md): transpose ops take
-    # the wide offset-field extent on every axis; rank-4 tensors get the channel cap on
-    # axis 1 and the spatial cap elsewhere; other ranks are spatial-capped.
+    # per-axis caps ride the op's lowering: transposes take the wide offset-field extent on
+    # every axis; rank-4 tensors get the channel cap on axis 1 and spatial elsewhere; other
+    # ranks are spatial-capped.
     if id(t) in tr_wide:
       over = any(int(d) > tr_dim for d in t.shape)
     elif len(t.shape) == 4:
@@ -442,10 +359,8 @@ def preflight(out, family: int) -> Preflight:
     else:
       over = any(int(d) > max_dim for d in t.shape)
     over = over or _internal_axis_oversize(t, max_dim)
-    # conv kernel width is a per-family cap (A13<=13, A16<=15) below the build-time
-    # ceiling guard (kW>15) - catch the family-specific case statically. conv_transpose
-    # shares the cap; its weight is [Cin,Cout,kH,kW], so kW is the last axis for both
-    # layouts.
+    # conv kernel width is a per-family cap (A13<=13, A16<=15). conv_transpose shares it;
+    # kW is the last weight axis for both layouts.
     if t.op in ("conv", "conv_transpose") and "weight" in getattr(t, "attrs", {}):
       over = over or int(t.attrs["weight"].shape[-1]) > limit("conv_kw_max", family)
     status = op_status(t.op, family)

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -1063,17 +1063,8 @@ class UnrolledTrainer:
   """Train with `K` Adam steps UNROLLED into ONE fused ANE program: each `step()`
     runs K forward->backward->update steps in a single dispatch. Bounded-K
     fully-on-engine analogue of `Trainer`, enabled by the stop-gradient frontier in
-    `backward` (each step treats current weights as leaves). See docs/developer/autograd.md.
-
-    Args:
-      params: trainable leaves (`af.parameter` / `af.conv_param`).
-      forward: `forward(P, x) -> output` building the model from current-step weight
-        tensors `P` and data input `x`; used per step and for `predict`.
-      kind: `"ce"` (logits + softmax-cross-entropy) or `"mse"`.
-      x_inputs, t_inputs: K data / target input placeholders, one per step.
-      dataset: `(X, Y)` arrays; `Y` one-hot [N, C] for `"ce"`.
-      resident: if True (default) optimizer state stays RESIDENT on-device across
-        dispatches (aliased via `share_buffer`); host feeds only minibatches + lr.
+    `backward` (each step treats current weights as leaves). `resident=True` keeps
+    optimizer state on-device across dispatches. See docs/developer/autograd.md.
     """
   def __init__(self, params, forward, kind, x_inputs, t_inputs, dataset, lr,
                loss_scale: float = 1.0, betas=(0.9, 0.999), eps: float = 1e-8,

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -1,6 +1,5 @@
-"""A tiny reverse-mode autograd over the aneforge graph: forward and backward
-both run on the ANE. Trainable `parameter`s are graph inputs (fed each step,
-updated host-side, no recompile)."""
+"""Reverse-mode autograd over the aneforge graph; forward and backward both run
+on the ANE. See docs/developer/autograd.md."""
 from __future__ import annotations
 
 import math
@@ -25,8 +24,7 @@ def vjp(*names: str):
 
 def parameter(init) -> Tensor:
   """A trainable leaf: a graph input tagged trainable, holding an fp32 master
-    value in attrs['value']. Used like any input; fed its current value each
-    eval and updated by the optimizer."""
+    value in attrs['value']; fed each eval and updated by the optimizer."""
   init = np.asarray(init, dtype=np.float32)
   t = graph.input(init.shape)
   t.attrs["trainable"] = True
@@ -53,14 +51,9 @@ def _topo(out: Tensor, stop: set | None = None) -> list[Tensor]:
 
 
 def _const_like(t: Tensor, c: float) -> Tensor:
-  """A tensor of constant value `c` shaped like `t`, built from existing ops
-    (aneforge has no const-tensor op). Uses `(t - t).adds(c)` rather than the
-    obvious `(t * 0.0).adds(c)` because `mul(reduce_output, 0.0)` trips an
-    ANECCompile fusion wall: a `reduce_sum`/`reduce_mean` result times ZERO
-    fails (characterized in the reverse-engineering corpus). Only that
-    combination fails: `reduce * nonzero` compiles, and mul-by-zero without a
-    preceding reduce compiles. `t - t` is an exact-zero `sub` (not a
-    mul-by-zero), so it sidesteps the wall for any finite `t`."""
+  """Constant `c` shaped like `t`, built from existing ops (no const-tensor op).
+    `(t - t)` not `(t * 0.0)`: mul-by-zero on a reduce output trips an ANECCompile
+    fusion wall; an exact-zero sub sidesteps it. See docs/developer/autograd.md."""
   return (t - t).adds(float(c))
 
 
@@ -70,9 +63,8 @@ def _ones_like(t: Tensor) -> Tensor:
 
 
 def _reverse(order, g, params, stop: set | None = None):
-  """Core reverse-accumulation over a precomputed topo `order`, seeded grads `g`
-    (dict id->Tensor). Returns {param: grad_Tensor}. Tensors in `stop` accumulate a
-    gradient but don't propagate it to their sources (stop-gradient / detach)."""
+  """Reverse-accumulate over topo `order` from seeded grads `g` (id->Tensor) ->
+    {param: grad}. Tensors in `stop` accumulate but don't propagate (detach)."""
   stop = stop or set()
   for t in reversed(order):
     gt = g.get(id(t))
@@ -87,16 +79,9 @@ def _reverse(order, g, params, stop: set | None = None):
 
 
 def backward(loss: Tensor, params, loss_scale: float = 1.0, stop=None) -> dict:
-  """Reverse-mode grads of scalar `loss` wrt each Tensor in `params`. Returns
-    {param: grad_Tensor}. The seed dL/dloss = loss_scale (folded into the seed's
-    additive constant, avoiding a muls on the reduced loss output).
-
-    `stop` is the stop-gradient (detach) frontier: gradient reaches these tensors
-    but does not propagate past them. Defaults to `params` - a no-op when the
-    params are true graph leaves (the usual case), but it matters when an UNROLLED
-    training step threads one step's updated-weight TENSORS into the next step's
-    forward: there each step's gradient must treat the current weights as leaves
-    (plain SGD), not differentiate through the previous update (second-order)."""
+  """Reverse-mode grads of scalar `loss` wrt each Tensor in `params` ->
+    {param: grad}. `stop` is the stop-gradient (detach) frontier (defaults to
+    `params`); it matters for unrolled training. See docs/developer/autograd.md."""
   stop_ids = {id(t) for t in (params if stop is None else stop)}
   order = _topo(loss, stop_ids)
   return _reverse(order, {id(loss): _const_like(loss, float(loss_scale))}, params, stop_ids)
@@ -104,8 +89,7 @@ def backward(loss: Tensor, params, loss_scale: float = 1.0, stop=None) -> dict:
 
 def backward_from(grad_root, root, params, stop=None) -> dict:
   """Reverse-mode from an explicit gradient `grad_root` at `root` (e.g. logits),
-    rather than from a scalar loss + ones-seed. `stop` is the stop-gradient frontier
-    (defaults to `params`); see `backward` - it matters for unrolled training."""
+    not from a scalar loss + ones-seed. `stop` as in `backward`."""
   stop_ids = {id(t) for t in (params if stop is None else stop)}
   return _reverse(_topo(root, stop_ids), {id(root): grad_root}, params, stop_ids)
 
@@ -117,17 +101,14 @@ def _vjp_muls(t, g):
 
 @vjp("reduce_sum")
 def _vjp_reduce_sum(t, g):
-  # broadcast g (keepdims shape) back to the source shape
   x = t.srcs[0]
-  return [g * _ones_like(x)]
+  return [g * _ones_like(x)]                   # broadcast g back to the source shape
 
 
 def _unbroadcast(g, shape):
-  """Sum g down to `shape` (reverse of numpy broadcasting), reducing the
-    broadcast axes. Assumes g.shape broadcasts from shape."""
+  """Sum g down to `shape` (reverse of numpy broadcasting)."""
   shape = tuple(shape)
-  # sum leading extra dims
-  while len(g.shape) > len(shape):
+  while len(g.shape) > len(shape):             # sum leading extra dims
     g = g.sum((0,))            # reduce axis 0 (keepdims -> shape[0]=1)
     g = g.reshape(g.shape[1:])
   axes = tuple(i for i, (d, s) in enumerate(zip(g.shape, shape)) if s == 1 and d != 1)
@@ -174,11 +155,8 @@ def _T(t):
 
 @vjp("bmm")
 def _vjp_bmm(t, g):
-  # y = a @ b ; ga = g @ b^T ; gb = a^T @ g. When a or b broadcast over the batch
-  # dim(s) (e.g. patches[N,L,K] @ W[1,K,Cout] in the trainable conv), the raw
-  # products carry the full (max) batch and `_unbroadcast` sums them back to each
-  # operand's own shape. For equal-batch bmm it's a no-op, so the MLP/attention
-  # path is unchanged.
+  # ga = g @ b^T ; gb = a^T @ g. _unbroadcast handles a/b broadcasting over the
+  # batch dim (trainable conv); a no-op for equal-batch bmm (MLP/attention).
   a, b = t.srcs
   ga = g @ _T(b)
   gb = _T(a) @ g
@@ -187,19 +165,15 @@ def _vjp_bmm(t, g):
 
 @vjp("matmul")
 def _vjp_matmul(t, g):
-  # frozen baked weight (attrs['wt']=W^T stored [N,K]); only the activation input
-  # gets a grad. y = x @ W ; gx = g @ W^T = g @ wt (wt is [N,K]); baked matmul.
+  # baked weight (attrs['wt']=W^T [N,K]); only the activation gets a grad: gx = g @ wt.
   wt = t.attrs["wt"]
-  gx = g @ wt              # Tensor @ numpy -> baked matmul = g @ wt = gx
+  gx = g @ wt
   return [gx]
 
 
 @vjp("reduce_mean")
 def _vjp_reduce_mean(t, g):
-  # tensor*tensor `g * _const_like(x, 1/n)` broadcasts g to x and scales by 1/n in
-  # one op. (1/n is nonzero so a plain `muls` would also compile; only mul-by-zero
-  # fails on a reduce output - see reduce_muls_fusion_probe.py. The tensor*tensor
-  # form is kept as the uniform, wall-proof pattern.)
+  # tensor*tensor broadcasts g to x and scales by 1/n in one wall-proof op.
   x = t.srcs[0]
   n = math.prod(x.shape[a] for a in t.attrs["axes"])
   return [g * _const_like(x, 1.0 / n)]
@@ -246,13 +220,8 @@ def _vjp_silu(t, g):
   return [g * dz]
 
 
-# --------------------------------------------------------------------------- #
-# normalization vjps (rms_norm / layer_norm) - unlock transformer / LLM / CNN  #
-# training. gamma (a per-channel constant, not a graph Tensor) is re-injected   #
-# as a fed value-input (no const-tensor op; the trainer feeds any input         #
-# carrying attrs['value']). Both reduce over the LAST dim; closed-form grad_x    #
-# is exact.                                                                      #
-# --------------------------------------------------------------------------- #
+# normalization vjps: gamma (a per-channel const) is re-injected as a fed
+# value-input; closed-form grad_x. See docs/developer/autograd.md.
 def _gamma_input(t):
   """gamma from a norm node's attrs, shaped [1,...,1,D] as a fed value-input."""
   gamma = np.asarray(t.attrs["gamma"], np.float32)
@@ -297,12 +266,8 @@ def _vjp_channel_layer_norm(t, g):
   return [grad * rstd]
 
 
-# --------------------------------------------------------------------------- #
-# unary math / activation vjps - surfaced by the gradient audit (each forward   #
-# op already runs natively; these make them trainable). Closed-form derivatives  #
-# from existing ops; the forward output `t` is reused where it IS the derivative #
-# term (exp/inverse/rsqrt), else recomputed from t.srcs[0].                       #
-# --------------------------------------------------------------------------- #
+# unary math / activation vjps: closed-form derivatives from existing ops; the
+# forward output `t` is reused where it IS the derivative term (exp/inverse/rsqrt).
 @vjp("exp")
 def _vjp_exp(t, g):
   return [g * t]                                   # exp'(x) = exp(x) = t
@@ -442,18 +407,12 @@ def _vjp_group_norm(t, g):
   return [(grad * rstd).reshape(N, C, H, W)]
 
 
-# --------------------------------------------------------------------------- #
-# structural vjps (transpose / reshape) - unlock transformer (af.mha) training  #
-# --------------------------------------------------------------------------- #
-# af.mha is linear/bmm/softmax/muls (vjps above) + transpose + reshape. Adding
-# these two structural rules makes a whole transformer block differentiable end
-# to end on the ANE. Both are pure index re-arrangements, so the gradient is the
-# exact inverse re-arrangement of g (no numerics, fp16-exact).
+# structural vjps (transpose / reshape): pure index re-arrangements, fp16-exact;
+# unlock transformer (af.mha) training. See docs/developer/autograd.md.
 
 @vjp("transpose")
 def _vjp_transpose(t, g):
-  """y = transpose(x, perm); the cotangent flows back through the INVERSE
-    permutation: dx = transpose(g, argsort(perm))."""
+  """dx = transpose(g, inverse-perm)."""
   perm = t.attrs["perm"]
   inv = [0] * len(perm)
   for i, p in enumerate(perm): inv[p] = i
@@ -462,26 +421,22 @@ def _vjp_transpose(t, g):
 
 @vjp("reshape")
 def _vjp_reshape(t, g):
-  """y = reshape(x, out_shape); dx = reshape(g, x.shape) (reshape is a no-op on
-    the values, so the gradient reshapes straight back to the source shape)."""
+  """dx = reshape(g, x.shape)."""
   x = t.srcs[0]
   return [g.reshape(x.shape)]
 
 
 @vjp("flatten2d")
 def _vjp_flatten2d(t, g):
-  """Native flatten2d is a reshape; the gradient reshapes back to the source."""
+  """flatten2d is a reshape; dx reshapes back to the source."""
   x = t.srcs[0]
   return [g.reshape(x.shape)]
 
 
 @vjp("slice_by_size")
 def _vjp_slice_by_size(t, g):
-  """y = x[begin : begin+size] (per axis); dx scatters g back into a zeros-like-x
-    at the same offset. The scatter is built on-ANE by concatenating zero-slices
-    (carved from a zero tensor shaped like x) before/after g along each axis. The
-    overlapping slices an im2col emits accumulate through `_reverse`'s grad
-    summation. Verified cos 1.0 vs a numpy scatter reference."""
+  """dx scatters g back into a zeros-like-x at the slice offset, built on-ANE by
+    concatenating zero-slices around g (no scatter op). See docs/developer/autograd.md."""
   x = t.srcs[0]
   begin, size, full = t.attrs["begin"], t.attrs["size"], x.shape
   z = _const_like(x, 0.0)                          # zeros shaped like x
@@ -504,8 +459,7 @@ def _vjp_slice_by_size(t, g):
 
 @vjp("concat")
 def _vjp_concat(t, g):
-  """y = concat(srcs, axis); each source receives the slice of g spanning its
-    own extent along the concat axis (a static slice_by_size, on-ANE)."""
+  """Each source receives the slice of g spanning its own extent along the axis."""
   axis = t.attrs["axis"]
   outs, off = [], 0
   for src in t.srcs:
@@ -518,37 +472,18 @@ def _vjp_concat(t, g):
   return outs
 
 
-# --------------------------------------------------------------------------- #
-# relu vjp - previously deferred; now expressible via the exposed comparison +   #
-# select ops: dx = select(x > 0, g, 0).                                          #
-# --------------------------------------------------------------------------- #
-
 @vjp("relu")
 def _vjp_relu(t, g):
-  """dx = g where x > 0 else 0. Built as select(x > 0, g, zeros) via the
-    `greater` (-> bool cond) and `select` ops. `x.greater(z)` needs a Tensor rhs,
-    so compare against an exact-zero tensor (x - x)."""
+  """dx = select(x > 0, g, 0). `greater` needs a Tensor rhs, so compare vs (x - x)."""
   x = t.srcs[0]
   zero = _const_like(x, 0.0)
   cond = x.greater(zero)
   return [graph.select(cond, g, _const_like(g, 0.0))]
 
 
-# --------------------------------------------------------------------------- #
-# spatial vjps - conv (grad wrt input) and avg_pool (uniform spread)             #
-# --------------------------------------------------------------------------- #
-# The native ANE conv/conv_transpose require a CONST (baked) weight: a runtime
-# tensor-weight conv is rejected by Espresso ("Not implemented ... not supported
-# on any backend") - verified by probe. So a native `conv` node's weight is not
-# a graph input and the autograd never asks for its gradient; only the gradient
-# wrt the conv INPUT is defined here, as the standard transposed-conv backward:
-#   grad_input = conv_transpose(grad_out, W) with the forward stride/pad/dilation.
-# The conv weight [Cout,Cin,kH,kW] is passed AS-IS to conv_transpose (whose weight
-# layout [Cin_ct,Cout_ct,kH,kW] matches because the transposed conv's input
-# channels are the forward conv's OUTPUT channels). Verified cos 1.0 vs torch for
-# stride=1 (pad 0/1). stride>1 needs an output_padding the op lacks and is
-# rejected. For a trainable conv (weight gradient), use `conv_trainable` below,
-# which builds the conv from primitives so the weight is a real graph parameter.
+# spatial vjps. Native conv needs a baked weight, so only the conv INPUT grad is
+# defined here (transposed-conv backward, stride=1); for a trainable conv weight
+# use conv2d below. See docs/developer/autograd.md.
 
 @vjp("conv")
 def _vjp_conv(t, g):
@@ -571,9 +506,8 @@ def _vjp_conv(t, g):
 
 @vjp("avg_pool")
 def _vjp_avg_pool(t, g):
-  """Uniform spread of the cotangent over each pooling window. For the
-    non-overlapping case (stride == k, the demo's config) the backward is exactly
-    nearest-neighbour upsample by k, scaled by 1/k^2. Verified cos 1.0 vs torch."""
+  """Uniform spread over each window: nearest-neighbour upsample by k, scaled 1/k^2
+    (non-overlapping case, stride == k)."""
   k, st = t.attrs["k"], t.attrs["stride"]
   if st != k or t.attrs["pad"] != 0:
     raise NotImplementedError(
@@ -584,22 +518,10 @@ def _vjp_avg_pool(t, g):
 
 @vjp("max_pool")
 def _vjp_max_pool(t, g):
-  """Route the cotangent only to the max element of each pooling window, built
-    WITHOUT gather/scatter (both walled). For the non-overlapping, unpadded case
-    (stride == k, pad == 0) the pooled output `y` upsampled by `k` (nearest)
-    repeats each window's max over its k*k cells, so `y_up` aligns cell-for-cell
-    with the input `x`. The argmax mask is then `mask = (x == y_up)`, expressed
-    with the exposed comparison + select: since `y_up >= x` everywhere (it is the
-    window max), `x == y_up` is exactly `NOT (y_up > x)`, i.e.
-    `select(y_up.greater(x), 0, 1)`. The gradient is
-    `grad_x = upsample(grad_y, k) * mask`.
-
-    Tie handling: when several cells in a window share the max, the mask is 1 for
-    all of them, over-routing the gradient (torch routes to exactly one). On random
-    continuous fp16 inputs exact ties are rare, so this matches torch within the
-    fp16 band (cos > 0.99). The tie approximation is left documented rather than
-    normalized to keep the rule simple (normalization would need a per-window
-    reduce + broadcast)."""
+  """Route g only to each window's max (no gather/scatter): grad_x =
+    upsample(g, k) * mask, mask = select(y_up.greater(x), 0, 1) with y_up the
+    upsampled window max. Ties over-route (1 per tied cell) vs torch's one; rare
+    on continuous fp16. Non-overlapping, unpadded only. See docs/developer/autograd.md."""
   x = t.srcs[0]
   k, st = t.attrs["k"], t.attrs["stride"]
   if st != k or t.attrs["pad"] != 0:
@@ -611,23 +533,14 @@ def _vjp_max_pool(t, g):
   return [g.upsample(k) * is_max]
 
 
-# --------------------------------------------------------------------------- #
-# trainable conv - a conv whose weight is a real graph parameter                #
-# --------------------------------------------------------------------------- #
-# The native ANE conv requires a baked (const) weight, so its weight can never be
-# a trainable graph input. To train a conv on the engine we build it from
-# primitives: an im2col (static slice_by_size + concat, not the walled
-# KernelRasterizer) into patches, then a broadcast batched-matmul (bmm) by the
-# weight parameter. Every op has a vjp (slice_by_size/concat/transpose/reshape/
-# bmm), so both the input and weight gradients are produced automatically and run
-# on the ANE. Verified cos 1.0 vs torch for the forward and both gradients
-# (stride=1, pad=0). Downsampling is done by avg_pool, not stride.
+# trainable conv (weight is a real graph parameter): native conv needs a baked
+# weight, so build the conv from primitives (im2col via slice_by_size + concat,
+# then broadcast bmm) where every op has a vjp. See docs/developer/autograd.md.
 
 def conv_param(weight_init) -> Tensor:
   """A trainable conv weight parameter. `weight_init` is [Cout, Cin, kH, kW]
-    (PyTorch conv layout); stored internally as the flat patch matrix
-    [Cin*kH*kW, Cout] that `conv2d` consumes. The patch (row) order is
-    `ci*(kH*kW) + (u*kW + v)`, matching the im2col built in `conv2d`."""
+    (PyTorch layout), stored as the flat patch matrix [Cin*kH*kW, Cout] that
+    `conv2d` consumes (row order ci*(kH*kW) + (u*kW + v))."""
   W = np.asarray(weight_init, dtype=np.float32)
   Cout, Cin, kH, kW = W.shape
   flat = W.reshape(Cout, Cin * kH * kW).T.copy()        # [Cin*kH*kW, Cout]
@@ -638,19 +551,12 @@ def conv_param(weight_init) -> Tensor:
 
 def conv2d(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0) -> Tensor:
   """A trainable stride-1 2-D conv built from primitives so `weight` is a real
-    graph parameter (see `conv_param`). `x` is [N, Cin, H, W]; `weight` is a
-    `conv_param` (flat [Cin*kH*kW, Cout], carrying `conv_shape`). Returns
-    [N, Cout, Hout, Wout]. `stride` must be 1 (strided slicing is unavailable);
-    `pad` >= 0 zero-pads H and W IN-GRAPH (a zero-border `concat` before the
-    im2col), so a 'same' conv stays inside one fused program and the padding
-    differentiates through the existing concat VJP. With `pad=0` the behaviour is
-    byte-for-byte the previous implementation.
+    graph parameter (see `conv_param`). `x` is [N, Cin, H, W]; `weight` a
+    `conv_param`; returns [N, Cout, Hout, Wout]. `stride` must be 1; `pad` >= 0
+    zero-pads in-graph (concat before im2col, differentiated through concat's VJP).
 
-    COMPILE SCALES WITH BATCH N: the im2col materialises [N, Cin*kH*kW, Hout*Wout]
-    tensors, so the *compile* (tiling/partition) time grows with N - on M1/h13 a
-    very large full batch (e.g. N~1000 over 28x28) can take minutes or hang the
-    compiler (M5 compiles it fine). Train large datasets in MINI-BATCHES (a modest
-    N, e.g. <=128, fed per step) rather than one full-batch graph."""
+    Compile time grows with batch N (the im2col materialises [N, Cin*kH*kW,
+    Hout*Wout]); train in MINI-BATCHES (N <= ~128). See docs/developer/autograd.md."""
   if stride != 1:
     raise NotImplementedError("conv2d (trainable) supports stride=1 only; "
                               "downsample with avg_pool/max_pool.")
@@ -663,10 +569,8 @@ def conv2d(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0) -> Tensor:
   if Cin_w != Cin:
     raise ValueError(f"conv2d: weight Cin {Cin_w} != input Cin {Cin}")
   if pad:
-    # In-graph zero padding: concat zero-constant borders onto H (axis 2) then W
-    # (axis 3). The constant is a non-trainable input leaf; concat's VJP emits a
-    # grad slice for it but it's discarded (not a parameter), adding no
-    # trainable VJP.
+    # In-graph zero padding: concat zero-constant borders onto H then W (the
+    # constant is a non-trainable leaf; its grad slice is discarded).
     zh = graph.input((N, Cin, pad, W)); zh.attrs["value"] = np.zeros((N, Cin, pad, W), np.float32)
     x = graph.concat([zh, x, zh], axis=2)            # [N, Cin, H+2pad, W]
     H = H + 2 * pad
@@ -678,13 +582,9 @@ def conv2d(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0) -> Tensor:
   parts = []
   for u in range(kH):
     for v in range(kW):
-      # patch index goes on axis 2 (NOT the last axis): the concat's backward is a
-      # slice along that axis, and the h13 x16 crop-DMA saturation (>4094 -> +/-inf) fires
-      # ONLY on a nonzero begin-offset of the LAST (width) axis. With the patches on a
-      # non-last axis, the large loss-scaled input-gradient never transits the saturating
-      # slice, so multi-layer conv training is numerically correct on M1 at any loss_scale.
-      # (The forward x-slice still carries the small input; the transpose below moves K to
-      # the last axis, and transpose's backward is a pure permute with no slice.)
+      # patch index on axis 2 (not last): A13's x16 crop-DMA saturation (>4094)
+      # fires only on a nonzero last-axis slice offset, so keeping the large
+      # loss-scaled grad off the width axis keeps M1 conv training correct.
       parts.append(x.slice_by_size([0, 0, u, v], [N, Cin, Hout, Wout]).reshape(N, Cin, 1, L))
   patches = graph.concat(parts, axis=2).transpose([0, 3, 1, 2]).reshape(N, L, K)   # [N,L,K]
   y = patches @ weight.reshape(1, K, Cout)                  # broadcast bmm -> [N,L,Cout]
@@ -696,10 +596,9 @@ def conv2d(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0) -> Tensor:
 # --------------------------------------------------------------------------- #
 
 class CEHandle:
-  """A softmax-cross-entropy training objective: carries the logits and the
-    one-hot target (a graph input). The gradient at the logits is the analytic
-    fused form (softmax(logits) - target)/N, which is fp16-stable (no log). The
-    loss VALUE + accuracy are computed host-side in fp32 by the Trainer."""
+  """A softmax-cross-entropy objective carrying the logits and one-hot target.
+    The logit gradient is the analytic fused form (softmax(logits) - target)/N,
+    fp16-stable (no log); the loss value + accuracy are host-side fp32."""
   def __init__(self, logits: Tensor, target: Tensor):
     if len(logits.shape) != 2 or logits.shape != target.shape:
       raise ValueError(f"softmax_cross_entropy expects 2-D logits/target [N,K]; "
@@ -721,14 +620,9 @@ def mse(y: Tensor, target: Tensor) -> Tensor:
   return diff.square().mean(tuple(range(len(y.shape))))
 
 
-# --------------------------------------------------------------------------- #
-# on-ANE optimizer update graph builders                                       #
-# --------------------------------------------------------------------------- #
-# These build the optimizer update as aneforge graph ops, so the update
-# ARITHMETIC runs on the ANE (not the host). `lr_t` is a fed [1,1] input
-# (broadcast tensor-mul over the param), not a baked `muls`, so per-step bias
-# correction / loss-scale folding varies correctly each step. Verified on-device
-# (cosine 1.0 vs numpy).
+# on-ANE optimizer update graph builders: the update arithmetic runs as graph
+# ops. `lr_t` is a fed [1,1] input (broadcast tensor-mul, not a baked `muls`) so
+# per-step bias correction / loss-scale folding varies each step.
 
 def _sgd_update(w: Tensor, g: Tensor, lr_t: Tensor) -> Tensor:
   """w' = w - lr_t * g  (lr_t a fed [1,1] input, broadcast tensor-mul)."""
@@ -737,12 +631,8 @@ def _sgd_update(w: Tensor, g: Tensor, lr_t: Tensor) -> Tensor:
 
 def _adam_update(w: Tensor, m: Tensor, v: Tensor, g: Tensor, lr_t: Tensor,
                  b1: float = 0.9, b2: float = 0.999, eps: float = 1e-8):
-  """Adam update as ANE ops; b1/b2/eps baked, lr_t fed (bias correction folded
-    into lr_t host-side). Returns (w', m', v').
-
-    `lr_t * m2` is a tensor-`mul` broadcasting the fed [1,1] over the param shape
-    (not a baked `muls`). `m*b1`, `g*(1-b1)`, `.adds(eps)` are baked scalars -
-    fine, since none is mul-by-zero on a reduce output (the only `muls` wall)."""
+  """Adam update as ANE ops; b1/b2/eps baked, lr_t fed (bias correction folded in
+    host-side). Returns (w', m', v')."""
   m2 = (m * float(b1)) + (g * float(1 - b1))
   v2 = (v * float(b2)) + (g.square() * float(1 - b2))
   w2 = w - ((lr_t * m2) / (v2.sqrt().adds(float(eps))))
@@ -750,11 +640,10 @@ def _adam_update(w: Tensor, m: Tensor, v: Tensor, g: Tensor, lr_t: Tensor,
 
 
 def adam_step(params, m, v, grads: dict, lr_t, betas=(0.9, 0.999), eps: float = 1e-8):
-  """One Adam update as graph ops over lists `params`/`m`/`v` (grads keyed by
-    param), returning the new (params, m, v) TENSOR lists. Used to UNROLL K training
-    steps into one program: thread the returned lists into the next step's forward.
-    Propagates a `conv_param` weight's `conv_shape` onto the updated tensor so an
-    advanced conv weight still works as a `conv2d` weight in the next unrolled step."""
+  """One Adam update as graph ops over lists `params`/`m`/`v`, returning the new
+    (params, m, v) tensor lists. Used to UNROLL K steps into one program (thread the
+    returned lists into the next step's forward); `conv_shape` is propagated so a
+    conv weight still works as a `conv2d` weight next step."""
   b1, b2 = betas
   nP, nM, nV = [], [], []
   for p, mi, vi in zip(params, m, v):
@@ -765,18 +654,10 @@ def adam_step(params, m, v, grads: dict, lr_t, betas=(0.9, 0.999), eps: float = 
 
 
 def _stack3(w: Tensor, m: Tensor, v: Tensor) -> Tensor:
-  """STACK the three same-shape update outputs into ONE output by concatenating
-    along axis 0 in their NATURAL row width: `concat([w,m,v], axis=0)` ->
-    [3*rows, cols] for a [rows, cols] param. This makes a 3-output Adam update
-    compile as a SINGLE-output program (no _compile.py change needed); the host
-    splits it back row-block-wise via `_split3`.
-
-    The natural-width axis-0 stack is load-bearing: reshaping each output to a wide
-    [1, prod(shape)] row and concatenating those trips the ANECCompile wide-row
-    wall once prod(shape) is large (e.g. a 784x128 = 100352-wide row segfaults;
-    verified). Keeping the column width and stacking rows stays inside the verified
-    2-D envelope and matches numpy on-device at every param shape here. Params are
-    flattened to 2-D first so `cols` is well defined."""
+  """Concat (w, m, v) along axis 0 in their natural row width -> [3*rows, cols],
+    so a 3-output Adam update compiles as a SINGLE-output program (split host-side
+    via `_split3`). Natural-width axis-0 is load-bearing: reshaping to a wide row
+    first trips the ANECCompile wide-row wall. See docs/developer/autograd.md."""
   w2 = w.reshape(1, int(np.prod(w.shape))) if len(w.shape) == 1 else w
   m2 = m.reshape(1, int(np.prod(m.shape))) if len(m.shape) == 1 else m
   v2 = v.reshape(1, int(np.prod(v.shape))) if len(v.shape) == 1 else v
@@ -784,8 +665,7 @@ def _stack3(w: Tensor, m: Tensor, v: Tensor) -> Tensor:
 
 
 def _split3(out, shape):
-  """Split a [3*rows, cols] stacked-update result back into (w', m', v') in
-    `shape` (inverse of `_stack3`'s natural-width axis-0 stack)."""
+  """Inverse of `_stack3`: split [3*rows, cols] back into (w', m', v') in `shape`."""
   out = np.asarray(out)
   rows = shape[0] if len(shape) >= 2 else 1
   return (out[0 * rows:1 * rows].reshape(shape),
@@ -794,11 +674,9 @@ def _split3(out, shape):
 
 
 def _check_finite_grads(opt, grads) -> bool:
-  """True iff every gradient is finite (one np.isfinite reduction per array).
-    Otherwise bump the optimizer's consecutive-skip counter and warn (on the
-    first skip, then every 100th) so the caller skips the ENTIRE step - the
-    standard loss-scaling overflow idiom: a skipped step leaves the fp32 masters
-    (and Adam's t/moments) untouched, so a later finite step is unaffected."""
+  """True iff every gradient is finite. Otherwise bump the skip counter, warn
+    (1st skip then every 100th), and skip the whole step (loss-scaling overflow
+    idiom: masters + Adam state stay untouched)."""
   bad = [i for i, g in enumerate(grads) if not np.isfinite(np.asarray(g)).all()]
   if not bad:
     opt._nonfinite_skips = 0
@@ -817,8 +695,8 @@ def _check_finite_grads(opt, grads) -> bool:
 
 
 class SGD:
-  """Host fp32 SGD over the parameters' master values. `Trainer` applies loss
-    scaling (grads come in scaled; divide before the step)."""
+  """Host fp32 SGD over the parameters' master values (loss-scaled grads divided
+    out before the step)."""
   def __init__(self, params, lr: float, loss_scale: float = 1.0):
     self.params, self.lr, self.scale = list(params), float(lr), float(loss_scale)
     self._nonfinite_skips = 0
@@ -830,9 +708,8 @@ class SGD:
 
 
 class Adam:
-  """Host fp32 Adam over the parameters' master values. Loss-scaled grads are
-    divided by `loss_scale` before the moment update; fp16 written back into the
-    fed param value (sibling to SGD)."""
+  """Host fp32 Adam over the parameters' master values (loss-scaled grads divided
+    out before the moment update; sibling to SGD)."""
   def __init__(self, params, lr: float = 1e-3, betas=(0.9, 0.999),
                eps: float = 1e-8, loss_scale: float = 1.0):
     self.params = list(params)
@@ -854,22 +731,16 @@ class Adam:
       p.attrs["value"] = p.attrs["value"] - self.lr * mhat / (np.sqrt(vhat) + self.eps)
 
 
-# A13 (M1) conv weight-grad saturation ceiling: the trainable conv builds im2col from
-# width-offset slices (conv2d's `for u,v` slice_by_size, v>0), and on A13 a nonzero
-# last-axis/width slice offset routes through a Q.4 x16 crop-DMA that clamps any
-# |value| > 4094 (=fp16max/16) to +/-inf. The weight-grad runs loss-scaled backward
-# activations through those slices, so `loss_scale x |backward activation|` must stay
-# under 4094. The synthetic repro breaks at loss_scale >= 512, but end-to-end a real
-# normalized CNN trains identically at loss_scale 128/1024/65536 on M1 (the repro's
-# 0.5*sum(y^2) loss + random inputs push magnitudes a real net never reaches), so this
-# is a WARN, never an auto-cap. M5/A16: clean route.
+# A13 (M1) conv weight-grad saturation ceiling: a nonzero width-axis im2col slice
+# offset routes through A13's Q.4 x16 crop-DMA, clamping |value| > 4094 to +/-inf,
+# so loss_scale x |backward activation| must stay under 4094. Real normalized CNNs
+# clear it; a WARN, never an auto-cap (M5/A16 unaffected). See docs/developer/autograd.md.
 _A13_CONV_WGRAD_LOSS_SCALE_MAX = 512.0
 
 
 def _has_conv_wgrad(params, objective) -> bool:
-  """Does training this objective produce a conv WEIGHT-grad through the width-offset
-    im2col slices? True iff a param is a trainable conv weight with kW>1 (a kW=1 conv has
-    no width-offset slice, so never hits the A13 saturation path)."""
+  """True iff a param is a trainable conv weight with kW>1 (only those hit the
+    A13 width-offset saturation path)."""
   for p in params:
     cs = p.attrs.get("conv_shape")
     if cs is not None and int(cs[3]) > 1: return True   # conv_shape = (Cout, Cin, kH, kW)
@@ -877,13 +748,9 @@ def _has_conv_wgrad(params, objective) -> bool:
 
 
 def _guard_a13_conv_loss_scale(params, objective, loss_scale: float) -> float:
-  """If the compile target is A13-class (M1) and the graph trains a conv weight, warn
-    when loss_scale could push loss-scaled backward activations past 4094, where the
-    width-offset im2col slices saturate to +/-inf (corrupt weight-grad). WARN ONLY - a
-    real normalized CNN trains correctly at any loss_scale on M1 (the cap worry was
-    refuted end-to-end); saturation needs unusually large backward magnitudes. Returns
-    loss_scale unchanged. Target resolves via the same detect_family() path as compile
-    (honors ANEFORGE_TARGET); other families are unaffected."""
+  """On A13/M1 with a trainable conv weight, warn when loss_scale could push
+    backward activations past 4094 (width-offset im2col saturation). WARN only;
+    returns loss_scale unchanged. Other families unaffected."""
   from . import _targets as TG
   try:
     fam = TG.detect_family()
@@ -906,41 +773,25 @@ def _guard_a13_conv_loss_scale(params, objective, loss_scale: float) -> float:
 
 
 class Trainer:
-  """Compiles a forward program ONCE plus one backward program PER PARAMETER
-    (each emitting that param's gradient in its natural 2-D shape); `step` evals
-    the backward programs on the ANE and applies the optimizer (params update
-    host-side, fed back next eval - no recompile). One program per param avoids an
-    ANECCompile wall hit by reshaping a large weight grad into a wide row and
-    concatenating it with a differently-sized row (the math is unchanged).
+  """Compiles a forward program ONCE plus one backward program PER PARAMETER (each
+    emitting that param's grad in natural shape); `step` evals them and applies the
+    optimizer host-side (no recompile). Per-param programs avoid an ANECCompile
+    wide-row wall.
 
-    Accepts either:
-      * a scalar `loss` Tensor (regression): forward program outputs the loss
-        scalar; `loss()` reads it; backward seeds from a ones-seed at the loss.
-      * a `CEHandle` (classification): forward program outputs the logits;
-        backward seeds from the analytic on-ANE gradient
-        `(softmax(logits) - target) * (loss_scale / N)` at the logits.
-        Host-side `loss()` (fp32 cross-entropy) and `accuracy(X, y_labels)`
-        (argmax) read the logits program.
+    Accepts a scalar `loss` Tensor (regression; ones-seed) or a `CEHandle`
+    (classification; analytic on-ANE logit seed, host-side fp32 `loss()`/`accuracy`).
+    `optimizer="sgd"|"adam"`.
 
-    `optimizer="sgd"|"adam"` selects the optimizer.
-
-    `device_optimizer=True` runs the OPTIMIZER STEP on the ANE: alongside the
-    per-param backward programs (-> grads), a per-param UPDATE program computes the
-    new state with ANE graph ops, so no training tensor-math runs on the host. The
-    host only computes the scalar `lr_t`, shuttles state/grads in-out (the deferred
-    host<->device round-trip), samples minibatch indices, and prints. The Adam
-    moments `m`/`v` are held host-side as fp16 arrays, fed each step and read back.
-    `device_optimizer=False` (default) keeps the host fp32 optimizer path
-    byte-for-byte unchanged (the regression guard + the 98% baseline)."""
+    `device_optimizer=True` runs the optimizer step on the ANE (per-param UPDATE
+    programs); Adam moments held host-side as fp16, fed/read each step. Default
+    False keeps the host fp32 path byte-for-byte. See docs/developer/autograd.md."""
   def __init__(self, objective, params, lr: float, loss_scale: float = 1.0,
                data_inputs: dict | None = None, optimizer: str = "sgd",
                betas=(0.9, 0.999), eps: float = 1e-8, device_optimizer: bool = False,
                resident_state: bool = False):
     from . import _compile as _c
     self.params = list(params)
-    # A13/M1 conv weight-grad saturation guard: warn if loss_scale could push the
-    # width-offset im2col backward slices past the x16 crop-DMA threshold (no-op off A13
-    # or for non-conv graphs). Done before scale is consumed by the optimizer/seed.
+    # A13/M1 conv weight-grad saturation guard (before scale is consumed).
     loss_scale = _guard_a13_conv_loss_scale(self.params, objective, float(loss_scale))
     self.data = dict(data_inputs or {})       # {input Tensor: numpy value}
     self.scale = float(loss_scale)
@@ -948,8 +799,7 @@ class Trainer:
     self.b1, self.b2 = float(betas[0]), float(betas[1])
     self.eps = float(eps)
     self.optimizer = optimizer
-    # resident_state implies the optimizer runs on-device (it IS the on-device
-    # update, with state held resident); device_optimizer is forced on.
+    # resident_state forces device_optimizer on (it IS the on-device update).
     self.resident_state = bool(resident_state)
     self.device_optimizer = bool(device_optimizer) or self.resident_state
     self.opt = (Adam(self.params, lr, betas, eps=eps, loss_scale=loss_scale)
@@ -962,35 +812,21 @@ class Trainer:
       self.ce = None
       grads = backward(objective, self.params, loss_scale=loss_scale)
       fwd_out = objective                        # forward program -> loss scalar
-    # Backward: ONE e5rt program per parameter, each emitting that param's grad
-    # in its NATURAL shape. Concatenating all grads into a single wide row trips
-    # an ANECCompile wall when a large weight grad (e.g. 784x128) is reshaped to a
-    # 100k-wide row and concatenated with a differently-sized row (verified: the
-    # reshape-to-wide-row-into-concat is the trigger, not the matmul). Per-param
-    # programs stay inside the verified 2-D matmul envelope, and the optimizer
-    # consumes the grads in param shape anyway.
-    # aneforge's own training kernels (forward loss, per-param backward, optimizer
-    # update) contain structural subtracts - the loss pred-target, gradient axpys,
-    # the w-lr*g update - that trip the generic cancel_sub precision heuristic. These
-    # are vouched, accuracy-tested kernels (the MNIST baselines + the corpus), not
-    # user-data modeling choices, so they skip the user-facing precision check.
+    # ONE backward program per param, in natural shape: concatenating all grads
+    # into one wide row trips an ANECCompile wide-row wall. _check_precision is off
+    # because the training kernels' structural subtracts (loss/axpy/update) are
+    # vouched, not user-data choices. See docs/developer/autograd.md.
     self._fwd = _c.compile(fwd_out, _check_precision=False)
     if self.resident_state:
-      # The whole step (forward + backward + per-param update) is ONE fused
-      # multi-output program; state tensors stay resident on-device across
-      # steps (no host round-trip). _fwd is kept only for checkpoint accuracy.
-      self._build_resident(_c, grads)
+      self._build_resident(_c, grads)            # _fwd kept only for checkpoint accuracy
     else:
       self._bwd = [_c.compile(grads[p], _check_precision=False) for p in self.params]
       if self.device_optimizer: self._build_device_optimizer(_c)
 
   def _build_device_optimizer(self, _c):
-    """Compile a per-param UPDATE program so the optimizer arithmetic runs on
-        the ANE. SGD: `(w_p, g_p, lr_t) -> w_p'` (single output). Adam:
-        `(w_p, m_p, v_p, g_p, lr_t) -> stack(w_p', m_p', v_p')` via `_stack3` (the
-        single-output STACK path), split host-side. `g_p`/`m_p`/`v_p`/`lr_t` are
-        plain (non-trainable) leaves fed each step; `w_p` is the param leaf itself
-        (its master value is fed, the new value written back)."""
+    """Compile a per-param UPDATE program so optimizer arithmetic runs on the ANE.
+        SGD: (w, g, lr_t) -> w'. Adam: -> stack(w', m', v') via `_stack3`, split
+        host-side. g/m/v/lr_t are fed leaves; w is the param leaf itself."""
     self._upd, self._upd_g, self._upd_lr = [], [], []
     if self.optimizer == "adam":
       self._m = [np.zeros(p.shape, np.float16) for p in self.params]
@@ -1011,15 +847,12 @@ class Trainer:
       self._upd.append(_c.compile(out, _check_precision=False))
 
   def _build_resident(self, _c, grads):
-    """Assemble the whole training step as ONE fused multi-output program with
-        optimizer state RESIDENT on-device. Each param `p` (and, for Adam, its
-        moments `m_p`/`v_p`) is a graph input whose updated value is a program
-        OUTPUT aliased back onto that input port via `share_buffer` - so state
-        lives on the engine across steps and the host feeds only the minibatch
-        (x, target) + the scalar `lr_t`, reading state back at checkpoints. The
-        forward and the update share the same resident param buffer: within one
-        execute the stream's FIFO ordering has the forward read the pre-step param
-        and the update overwrite it last (the next step reads the advanced value)."""
+    """Assemble the whole step as ONE fused multi-output program with optimizer
+        state RESIDENT on-device: each updated-state output is aliased back onto its
+        input port via `share_buffer`, so state lives on the engine across steps and
+        the host feeds only the minibatch + lr_t. Within one execute, FIFO ordering
+        has the forward read the pre-step param and the update overwrite it last.
+        See docs/developer/autograd.md."""
     lr_in = graph.input((1, 1))
     self._res_lr = lr_in
     self._t = 0
@@ -1045,8 +878,7 @@ class Trainer:
     prog = mm.prog
     self._res_in_name = dict(mm.input_ports)
     self._res_out_name = dict(mm.output_ports)
-    # alias each updated-state output onto its own input port (resident), then
-    # seed the (now shared) buffers once - params to their masters, moments to 0.
+    # alias each updated-state output onto its input port, then seed once.
     for out_t, in_t in alias:
       prog.share_buffer(0, self._res_out_name[out_t], 0, self._res_in_name[in_t])
     for entry in self._res_state:
@@ -1066,9 +898,8 @@ class Trainer:
     self._res_dirty = False
 
   def _resident_step(self) -> None:
-    """One resident step: feed ONLY the minibatch + lr_t, execute. State ports
-        are never written (they live on-device); the host does no tensor math and
-        no state copy."""
+    """One resident step: feed ONLY the minibatch + lr_t, execute (state stays
+        on-device; no host tensor math or state copy)."""
     if getattr(self, "_ds", None) is not None:
       xin, X, tin, Y = self._ds
       idx = self._next_batch()
@@ -1086,8 +917,8 @@ class Trainer:
     self._res_dirty = True
 
   def _sync_params_from_device(self) -> None:
-    """Checkpoint read: copy the resident params off the device into the host
-        masters (for accuracy/loss via the forward program). Moments stay resident."""
+    """Checkpoint read: copy resident params off-device into the host masters (for
+        accuracy/loss via the forward program); moments stay resident."""
     prog = self._res.prog
     for i, entry in enumerate(self._res_state):
       w = prog.read_output(self._res_out_name[entry["w_out"]]).astype(np.float32)
@@ -1103,11 +934,9 @@ class Trainer:
     self._res_dirty = False
 
   def _feed(self, model, override: dict | None = None):
-    """Map each compiled input Tensor to a fp16 array: trainable -> current
-        master value; present in `override` -> override[t] (used by the device
-        optimizer to inject grads/lr); otherwise a baked value-input carrying
-        attrs['value'] (e.g. the gamma a norm VJP re-injects).
-        `model._input_tensors` is the ordered input list stored by compile."""
+    """Map each compiled input Tensor to a fp16 array: trainable -> master value;
+        in `override` -> override[t] (device optimizer grads/lr); else the baked
+        value-input attrs['value'] (e.g. a norm VJP's re-injected gamma)."""
     lk = self.data if override is None else override
     return [
       t.attrs["value"].astype(np.float16) if t.attrs.get("trainable")
@@ -1116,8 +945,7 @@ class Trainer:
     ]
 
   def _feed_update(self, net, p, extra):
-    """Feed a per-param update program; delegates to _feed with the `extra`
-        override dict (grad/lr inputs keyed by their Tensor leaves)."""
+    """Feed a per-param update program (delegates to _feed with `extra`)."""
     return self._feed(net, extra)
 
   def set_dataset(self, x_input, X_full, target_input, Y_onehot, seed: int = 0):
@@ -1152,9 +980,7 @@ class Trainer:
     if not self.device_optimizer:
       self.opt.step(grads)
       return
-    # On-ANE optimizer: the update arithmetic runs as graph ops. The host only
-    # computes the scalar lr_t (folding loss-scale + Adam bias correction) and
-    # shuttles state/grads in-out - no host tensor math.
+    # On-ANE optimizer: update arithmetic runs as graph ops; host only computes lr_t.
     if self.optimizer == "adam":
       self._device_adam_step(grads)
     else:
@@ -1171,13 +997,9 @@ class Trainer:
 
   def _device_adam_step(self, grads):
     self._t += 1
-    # Host scalar lr_t = lr * sqrt(1-b2^t)/(1-b1^t) (bias correction folded in).
-    # The loss-scale is not divided out here: Adam's update is the ratio
-    # m/sqrt(v), and with the scaled grad g'=scale*g the moments scale as
-    # m'=scale*m, v'=scale^2*v, so m'/sqrt(v') = m/sqrt(v) - the loss-scale
-    # cancels in the ratio. Dividing lr_t by scale (a naive SGD-style unscale)
-    # double-unscales and collapses the step. (eps is the only scale-sensitive
-    # term and is negligible vs scale*sqrt(v).)
+    # lr_t = lr * sqrt(1-b2^t)/(1-b1^t). Loss-scale is NOT divided out: it cancels
+    # in Adam's m/sqrt(v) ratio (m'=scale*m, v'=scale^2*v); unscaling would
+    # double-unscale and collapse the step. See docs/developer/autograd.md.
     lr_t = self.lr * math.sqrt(1.0 - self.b2 ** self._t) / (1.0 - self.b1 ** self._t)
     lr_arr = np.full((1, 1), lr_t, np.float16)
     for i, p in enumerate(self.params):
@@ -1237,40 +1059,21 @@ class Trainer:
     for net in getattr(self, "_upd", []): net.release()
 
 
-# --------------------------------------------------------------------------- #
-# UnrolledTrainer - K Adam steps as ONE fused program, fully on the ANE        #
-# --------------------------------------------------------------------------- #
-
 class UnrolledTrainer:
-  """Train with `K` Adam steps UNROLLED into ONE fused ANE program, so the whole
-    forward -> backward -> optimizer-update recurrence runs on the engine with NO
-    per-step host loop. Each `step()` runs K steps in a SINGLE dispatch: the host
-    feeds K minibatches plus the K per-step learning rates and shuttles the (params,
-    m, v) arrays in and out between K-step blocks. That shuttle is an array move, not
-    tensor math, and there's no per-step host<->device round-trip inside the block.
-
-    The bounded-K, fully-on-engine analogue of `Trainer` (whose `step()` dispatches
-    once per step). Enabled by the stop-gradient frontier in
-    `backward`/`backward_from`: threading one step's updated-weight tensors into the
-    next step's forward needs each step's gradient to treat the current weights as
-    leaves (plain SGD/Adam), not differentiate through the previous update.
+  """Train with `K` Adam steps UNROLLED into ONE fused ANE program: each `step()`
+    runs K forward->backward->update steps in a single dispatch. Bounded-K
+    fully-on-engine analogue of `Trainer`, enabled by the stop-gradient frontier in
+    `backward` (each step treats current weights as leaves). See docs/developer/autograd.md.
 
     Args:
-      params (list): trainable leaves (`af.parameter` / `af.conv_param`).
-      forward (callable): `forward(P, x) -> output` building the model from the
-        current-step weight tensors `P` (a list aligned with `params`) and a data
-        input tensor `x`. Used both per unrolled step and for `predict`.
-      kind (str): `"ce"` (output = logits, softmax-cross-entropy) or `"mse"`.
-      x_inputs (list): list of K data input placeholders (`af.input`), one per step.
-      t_inputs (list): list of K target input placeholders, one per step.
-      dataset (tuple): `(X, Y)` numpy arrays; `X` already shaped like `x_inputs[k]`
-        per sample (leading axis = sample), `Y` one-hot ([N, C]) for `"ce"`.
-      resident (bool): if True (default) the optimizer state (params, m, v) stays
-        RESIDENT on-device across dispatches - each updated-state output is aliased
-        (`share_buffer`) onto its own input port, seeded once. The host then feeds
-        ONLY the K minibatches + per-step lr and reads weights at checkpoints;
-        nothing is shuttled in/out between dispatches. The end-to-end fully-on-
-        engine path (no per-step loop AND no state move).
+      params: trainable leaves (`af.parameter` / `af.conv_param`).
+      forward: `forward(P, x) -> output` building the model from current-step weight
+        tensors `P` and data input `x`; used per step and for `predict`.
+      kind: `"ce"` (logits + softmax-cross-entropy) or `"mse"`.
+      x_inputs, t_inputs: K data / target input placeholders, one per step.
+      dataset: `(X, Y)` arrays; `Y` one-hot [N, C] for `"ce"`.
+      resident: if True (default) optimizer state stays RESIDENT on-device across
+        dispatches (aliased via `share_buffer`); host feeds only minibatches + lr.
     """
   def __init__(self, params, forward, kind, x_inputs, t_inputs, dataset, lr,
                loss_scale: float = 1.0, betas=(0.9, 0.999), eps: float = 1e-8,
@@ -1315,10 +1118,9 @@ class UnrolledTrainer:
       self._data_map[id(x_inputs[k])] = (k, "x")
       self._data_map[id(t_inputs[k])] = (k, "t")
 
-    # a separate single-batch forward program for checkpoint predict (on the ANE).
-    # It uses its OWN weight-input leaves (fed the masters), NOT the trainable
-    # params: compile mutates each Tensor's internal name, so sharing the param
-    # objects between the two programs would clobber the training program's ports.
+    # separate single-batch forward program for checkpoint predict, with its OWN
+    # weight leaves: compile mutates Tensor names, so sharing params would clobber
+    # the training program's ports.
     ev_w = [graph.input(p.shape) for p in self.params]
     for ew, p in zip(ev_w, self.params):
       if "conv_shape" in p.attrs: ew.attrs["conv_shape"] = p.attrs["conv_shape"]

--- a/aneforge/build.py
+++ b/aneforge/build.py
@@ -1,11 +1,8 @@
 """Build-on-demand for the e5rt dispatch dylib.
 
-The package ships the dispatch shim SOURCE (`aneforge/_lib/ane_e5rt_dispatch.mm`),
-not a binary: the dylib links Apple's private frameworks, so it is compiled
-per-machine. This module compiles it the first time aneforge dispatches to the ANE
-(or eagerly via `python -m aneforge.build`) and caches the result, so a plain
-`pip install aneforge` works on an Apple Silicon Mac with the Xcode command-line
-tools. Set ANEFORGE_NO_AUTOBUILD=1 to require an explicit build instead.
+The package ships the dispatch shim SOURCE (links Apple's private frameworks, so it is
+compiled per-machine), built on first ANE dispatch (or `python -m aneforge.build`) and
+cached. ANEFORGE_NO_AUTOBUILD=1 requires an explicit build. See docs/developer/compile-pipeline.md.
 """
 from __future__ import annotations
 

--- a/aneforge/dsp.py
+++ b/aneforge/dsp.py
@@ -1,41 +1,11 @@
-"""aneforge.dsp - a digital-signal-processing toolkit on the Apple Neural Engine.
+"""aneforge.dsp - a DSP toolkit on the Apple Neural Engine, composed from real
+CONVOLUTION (the conv layer) and the MATMUL-FFT from `aneforge.fft`.
 
-Built on the two things the ANE is genuinely good at: REAL CONVOLUTION (the conv
-layer) and the MATMUL-FFT from `aneforge.fft` (the DFT factored into matmul stages,
-complex carried as real/imag PAIRS). This submodule composes them into the everyday
-DSP kit:
-
-    from aneforge.dsp import (fir_filter, fft_convolve, freq_filter,
-                             stft, spectrogram, hann, hamming, blackman,
-                             correlate, autocorrelate)
-
-WHAT FITS THE ANE:
-  * FIR filtering  - a finite impulse response IS a convolution. Short kernels run
-    on the native conv layer (1xK, arch-capped at K<=15 on this M5, verified);
-    longer ones fall back to FFT convolution. Feed-forward, no recurrence: a clean fit.
-  * FFT-domain DSP - fft_convolve / freq_filter / stft / spectrogram are all
-    (windowed) FFTs + elementwise spectral ops + iFFT, every stage a matmul or an
-    elementwise map (real/imag pairs via aneforge.fft). A clean fit.
-  * Correlation   - cross/auto-correlation is convolution without the kernel flip,
-    exactly what the ANE conv and the native CrossCorrelation bridge already do.
-
-WHAT DOES NOT FIT (arch limit):
-  * IIR / recursive filters (Butterworth, biquads, any `y[n] = ... + a*y[n-1]`).
-    A direct-form IIR is a DATA-DEPENDENT RECURRENCE over samples - the scan/cumsum
-    wall the ANE lacks (no in-graph loop, no scalar feedback). No streaming IIR
-    here. `iir_filter` is ONLY a FIXED-LENGTH UNROLL: the recurrence becomes its
-    truncated FIR impulse response of a chosen length, run as an FIR. Exact only up
-    to the truncation, and the unroll is fixed at build time - it does NOT scale to
-    arbitrary-length streaming IIR. Exposed tagged, with the relerr-vs-untruncated
-    cost reported, rather than faking a recurrent filter.
-
-CONVENTIONS (inherited):
-  * The ANE conv is a CROSS-CORRELATION (no kernel flip), matching
-    `np.correlate(x, h, 'valid')`. True convolution (np.convolve / scipy lfilter)
-    flips the kernel - fir_filter handles the flip + causal zero-pad internally.
-  * Complex is (re, im) real-tensor pairs; spectra come back as separate real arrays.
-  * Everything is fp16 on-device; the matmul accumulator is wide (>=fp32), so the
-    error floor is fp16 INPUT/twiddle rounding (~few e-4), flat in length.
+FIR filtering, FFT convolution, frequency-domain filtering, STFT/spectrogram, and
+correlation all FIT the ANE (feed-forward, every stage a matmul/conv/elementwise map).
+IIR / recursive filters do NOT (data-dependent sample recurrence = the scan/cumsum
+wall); `iir_filter` is only a fixed-length FIR unroll of the truncated impulse response.
+The ANE conv is a CROSS-correlation (no kernel flip). See docs/developer/applied-math.md.
 
     PYTHONPATH=. python3 aneforge/dsp.py
 """
@@ -56,13 +26,7 @@ import aneforge as af  # noqa: E402
 from aneforge.fft import fft, ifft, fft_plan, ifft_plan  # noqa: E402
 
 
-# --------------------------------------------------------------------------- #
-# windows (host-side numpy: tiny, data-independent coefficient vectors)        #
-# --------------------------------------------------------------------------- #
-# Windows are short constant vectors multiplied into framed signals. Computed on
-# the host (numpy) - no gain from a length-W cosine table on the ANE - and applied
-# as fp16 elementwise multiplies on-device (in stft) or on the host (when the caller
-# just wants the coefficients).
+# windows: short constant vectors, computed host-side (numpy), applied as fp16 muls.
 
 def hann(M: int, sym: bool = False) -> np.ndarray:
   """Hann window (raised cosine). `sym=False` gives the periodic/DFT window
@@ -109,34 +73,17 @@ def get_window(window, M: int) -> np.ndarray:
   return w
 
 
-# --------------------------------------------------------------------------- #
-# FIR filtering - convolution (the ANE's home turf)                            #
-# --------------------------------------------------------------------------- #
-
-# The native 1xK conv backend is arch-capped at K<=15 on this M5 (verified: K=16
-# fails "Some ops are not supported on any of the specified backends"). Longer FIR
-# kernels are routed through fft_convolve instead (same linear-convolution result).
+# FIR filtering - convolution. The native 1xK conv backend is arch-capped at K<=15 on
+# this M5 (K=16 fails backend support); longer kernels route through fft_convolve.
 _MAX_CONV_TAPS = 15
 
 
 def fir_filter(x, taps, mode: str = "same"):
-  """FIR filter `y = x * taps` (true convolution), on the ANE.
-
-    A finite impulse response is a convolution. The ANE conv is a CROSS-correlation
-    (no kernel flip), so we flip the taps and zero-pad to realize a genuine
-    convolution / causal FIR:
-
-      * mode='full'  -> length L+K-1   (== np.convolve(x, taps))
-      * mode='same'  -> length L, centered (== np.convolve(..., 'same'))
-      * mode='valid' -> length L-K+1   (== np.convolve(..., 'valid'))
-      * mode='lfilter' -> length L, causal (== scipy.signal.lfilter(taps, [1.0], x))
-
-    Short kernels (K<=15) run on the native conv layer in ONE fused program; longer
-    kernels fall back to FFT convolution (aneforge.fft) automatically - same result.
-
-    cost: COMPUTE (a real conv) for short taps; FFT-domain for long taps.
-    fit:  GOOD - feed-forward, no recurrence.
-    """
+  """FIR filter `y = x * taps` (true convolution), on the ANE. The ANE conv is a
+    cross-correlation, so taps are flipped and zero-padded to realize a genuine
+    convolution / causal FIR. `mode` in full/same/valid/lfilter (matching np.convolve /
+    scipy.signal.lfilter). Short kernels (K<=15) use the native conv; longer ones fall
+    back to FFT convolution automatically."""
   x = np.asarray(x, np.float32).ravel()
   taps = np.asarray(taps, np.float32).ravel()
   L, K = x.shape[0], taps.shape[0]
@@ -190,18 +137,9 @@ def _next_fft_size(n: int) -> int:
 
 
 def fft_convolve(x, h, block: int | None = None):
-  """Linear convolution `y = x * h` via the FFT (aneforge.fft), length L+K-1.
-
-    Equivalent to `np.convolve(x, h)` but computed as FFT(x)*FFT(h) -> iFFT, so
-    every stage is a matmul or an elementwise spectral product (ANE-native). For a
-    short kernel against a long signal we use OVERLAP-ADD: split the signal into
-    blocks, multiply each block-FFT by the (cached) kernel spectrum, inverse-
-    transform, and sum the overlapping tails. A single block is used when the whole
-    thing fits one transform.
-
-    cost: COMPUTE/FUSION - staged matmul-FFTs + spectral multiply.
-    fit:  GOOD.
-    """
+  """Linear convolution `y = x * h` via the FFT (aneforge.fft), length L+K-1 (==
+    np.convolve) computed as FFT(x)*FFT(h) -> iFFT. A short kernel against a long signal
+    uses OVERLAP-ADD (block FFTs against the cached kernel spectrum); one block otherwise."""
   x = np.asarray(x, np.float32).ravel()
   h = np.asarray(h, np.float32).ravel()
   L, K = x.shape[0], h.shape[0]
@@ -233,14 +171,9 @@ def fft_convolve(x, h, block: int | None = None):
 
 
 def _ifft_real_scaled(Yr: np.ndarray, Yi: np.ndarray, N: int, iplan=None) -> np.ndarray:
-  """Inverse-FFT a spectrum to a real signal, guarding fp16 dynamic range.
-
-    aneforge's iFFT accumulates the length-N inverse-DFT sum BEFORE the 1/N scale, so
-    the on-device intermediate peaks at ~max_k sum_n |Y_n|. For convolution/correlation
-    spectra (products of two transforms) that peak can exceed fp16's 65504 ceiling and
-    SATURATE, corrupting the result (the FFT module's fp16 dynamic-range wall, not a
-    precision issue). We pre-scale `Y` so the unscaled sum stays well within range, run
-    the (linear) iFFT, then undo the scale on the host."""
+  """Inverse-FFT a spectrum to a real signal, guarding fp16 dynamic range: the iFFT sums
+    BEFORE the 1/N scale, so convolution/correlation spectra can overflow fp16 (65504) and
+    saturate. Pre-scale Y into range, run the linear iFFT, undo on the host. See numerics.md."""
   peak = float(np.sum(np.sqrt(Yr.astype(np.float64) ** 2 + Yi.astype(np.float64) ** 2)))
   s = 1.0
   if peak > 1.0:
@@ -266,17 +199,10 @@ def _fft_conv_block(x: np.ndarray, h: np.ndarray, N: int) -> np.ndarray:
 # --------------------------------------------------------------------------- #
 
 def freq_filter(x, kind: str, cutoff, fs: float = 2.0):
-  """Frequency-domain filter: FFT the (real) signal, zero out the rejected bins,
-    inverse-FFT. A brick-wall ideal filter in the DFT domain.
-
-    `kind` in {'lowpass','highpass','bandpass','bandstop'}. `cutoff` is a scalar
-    (low/high) or a (lo, hi) pair (band). `fs` is the sample rate (default 2.0 so a
-    bare `cutoff` reads as a normalized frequency in [0,1] == fraction of
-    Nyquist). Returns the real filtered signal (length L), on the ANE.
-
-    The mask is applied to BOTH the bin and its conjugate mirror so the output stays
-    real. cost: COMPUTE/FUSION (FFT + elementwise mask + iFFT). fit: GOOD.
-    """
+  """Brick-wall frequency-domain filter: FFT, zero the rejected bins, inverse-FFT.
+    `kind` in lowpass/highpass/bandpass/bandstop; `cutoff` a scalar or (lo, hi) pair;
+    `fs` the sample rate (default 2.0 so a bare cutoff is a fraction of Nyquist). The
+    mask hits both the bin and its conjugate mirror, so the output stays real."""
   x = np.asarray(x, np.float32).ravel()
   L = x.shape[0]
   N = _next_fft_size(L)
@@ -316,17 +242,10 @@ def _frame(x: np.ndarray, win_len: int, hop: int) -> np.ndarray:
 
 
 def stft(x, win=256, hop=None, window: str = "hann"):
-  """Short-time Fourier transform: window each frame, FFT it (aneforge.fft), stack.
-
-    `win` is the frame length (int) or an explicit window-coefficient array; `hop`
-    the step between frames (default win//4 like scipy); `window` the named window
-    when `win` is an int. Returns (Zr, Zi), each [n_freq, n_frames] with
-    n_freq = win//2 + 1 (the non-redundant rfft half), matching scipy.signal.stft's
-    bin layout (NOT its 1/sum(win) scaling - see spectrogram for magnitudes).
-
-    Each frame is one matmul-FFT. The frames are independent (no recurrence), a
-    clean ANE fit; we batch them through the cached FFT plan. fit: GOOD.
-    """
+  """Short-time Fourier transform: window each frame, FFT it, stack. `win` is the frame
+    length (int) or a window array; `hop` defaults to win//4. Returns (Zr, Zi), each
+    [n_freq, n_frames] with n_freq = win//2 + 1, matching scipy.signal.stft's bin layout
+    (NOT its 1/sum(win) scaling). Each frame is one matmul-FFT through the cached plan."""
   x = np.asarray(x, np.float32).ravel()
   if isinstance(win, (int, np.integer)):
     win_len = int(win)
@@ -365,17 +284,10 @@ def spectrogram(x, win=256, hop=None, window: str = "hann", mode: str = "magnitu
 # --------------------------------------------------------------------------- #
 
 def correlate(a, b, mode: str = "valid"):
-  """Cross-correlation `r[k] = sum_n a[n+k] * b[n]` on the ANE.
-
-    For a short template (Lb<=15) uses the native CrossCorrelation bridge (a path
-    Apple's MIL frontend rejects): a length-La row and a smaller length-Lb template ->
-    'valid' correlation of length La-Lb+1, matching `np.correlate(a, b, 'valid')`.
-    A wider template (Lb>=16, the same 1xK conv-width arch wall as fir_filter) falls
-    back to FFT correlation (correlation = convolution with `b` reversed). Other
-    modes zero-pad the map before the valid correlation.
-
-    cost: MIXED (cut) for the bridge; COMPUTE/FFT for the fallback. fit: GOOD.
-    """
+  """Cross-correlation `r[k] = sum_n a[n+k] * b[n]` on the ANE. A short template (Lb<=15)
+    uses the native CrossCorrelation bridge; a wider one (Lb>=16, the 1xK conv-width wall)
+    falls back to FFT correlation (convolution with `b` reversed). `mode` in valid/full/same.
+    See docs/developer/applied-math.md."""
   a = np.asarray(a, np.float32).ravel()
   b = np.asarray(b, np.float32).ravel()
   La, Lb = a.shape[0], b.shape[0]
@@ -391,9 +303,7 @@ def correlate(a, b, mode: str = "valid"):
   else:
     raise ValueError(f"correlate: mode must be valid/full/same; got {mode!r}")
 
-  # wide template: the CrossCorrelation bridge lowers to a 1xLb conv, capped at
-  # Lb<=15 on this ANE (Lb>=16 fails ANECCompile). Fall back to FFT correlation:
-  # correlate(ap, b) 'valid' == full-convolve(ap, reverse(b)) sliced to valid lags.
+  # wide template -> FFT: correlate(ap,b) 'valid' == full-convolve(ap, reverse(b)) sliced.
   if Lb > _MAX_CONV_TAPS:
     full = fft_convolve(ap, b[::-1])                 # length len(ap)+Lb-1
     return full[Lb - 1:ap.shape[0]].astype(np.float32)
@@ -405,13 +315,9 @@ def correlate(a, b, mode: str = "valid"):
 
 
 def autocorrelate(x, max_lag: int | None = None):
-  """Autocorrelation `r[k] = sum_n x[n] x[n+k]` for lags k=0..max_lag, on the ANE.
-
-    Built as a correlation of the signal against its own leading `window` via the
-    CrossCorrelation bridge. `max_lag` defaults to len(x)//4 (the template length is
-    len(x)-max_lag, kept < len(x)). Returns r[0..max_lag] (the non-negative lags),
-    matching the tail of `np.correlate(x, x, 'full')`. fit: GOOD.
-    """
+  """Autocorrelation `r[k]` for lags k=0..max_lag, on the ANE: a correlation of the signal
+    against its own leading prefix. `max_lag` defaults to len(x)//4. Returns the
+    non-negative lags, matching the tail of np.correlate(x, x, 'full')."""
   x = np.asarray(x, np.float32).ravel()
   L = x.shape[0]
   if max_lag is None: max_lag = L // 4
@@ -428,23 +334,11 @@ def autocorrelate(x, max_lag: int | None = None):
 # --------------------------------------------------------------------------- #
 
 def iir_filter(x, b, a, n_taps: int = 256):
-  """ARCH-LIMITED IIR via a FIXED-LENGTH FIR unroll.
-
-    A direct-form IIR `a[0] y[n] = sum_i b[i] x[n-i] - sum_{j>=1} a[j] y[n-j]` is a
-    DATA-DEPENDENT RECURRENCE over samples - each output depends on previous OUTPUTS.
-    The ANE is feed-forward: no in-graph loop, no scalar feedback, no scan/cumsum.
-    There is NO streaming IIR on this hardware.
-
-    The ONLY realization is to TRUNCATE the IIR's infinite impulse response to
-    `n_taps` and run it as an FIR (via fir_filter / fft_convolve). Exact only up to
-    the truncation tail, with the tap count fixed at build time - it does NOT scale
-    to arbitrary streaming IIR. Use it for stable filters whose impulse response has
-    decayed within `n_taps` samples; the residual is the truncated tail energy.
-
-    Returns the FIR-approximated, causal (lfilter-style) output (length L), plus prints
-    nothing - the caller-facing tag is in the module docstring. fit: ARCH-LIMITED
-    (fixed unroll only).
-    """
+  """ARCH-LIMITED IIR via a FIXED-LENGTH FIR unroll. A direct-form IIR is a
+    data-dependent sample recurrence (each output depends on previous outputs) - the
+    scan/cumsum wall the ANE lacks. The only realization is to truncate the IIR's
+    impulse response to `n_taps` and run it as an FIR: exact up to the truncation tail,
+    tap count fixed at build time, does NOT scale to streaming IIR."""
   import scipy.signal as ss
   b = np.asarray(b, np.float64).ravel()
   a = np.asarray(a, np.float64).ravel()

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -1,48 +1,14 @@
-"""aneforge.einsum - a general `einsum(equation, *operands) -> Tensor` that
-decomposes a numpy-style subscript equation into a sequence of aneforge graph ops
-(transpose / reshape / matmul-bmm / broadcast-mul / reduce-sum) so the whole
-contraction runs as ONE fused e5rt program on the Apple Neural Engine.
+"""aneforge.einsum - `einsum(equation, *operands) -> Tensor`, decomposing a numpy-style
+subscript equation into aneforge graph ops (transpose / reshape / matmul-bmm /
+broadcast-mul / reduce-sum) so the whole contraction runs as ONE fused ANE program.
 
-    import aneforge as af
-
-    a = af.input((32, 64)); b = af.input((64, 16))
     c = af.einsum("ij,jk->ik", a, b)     # a plain matmul, on the ANE
-    net = af.compile(c); out = net(A, B)
 
-`af.einsum` IS this function (the package rebinds the name to it), so it is
-callable directly; `from aneforge.einsum import einsum` works identically.
+`af.einsum` IS this function. The decomposition partitions a two-operand contraction
+into batch/contract/keep-A/keep-B index classes and routes it through a batched matmul;
+diagonal/trace (repeated index in one operand) is a gather and is rejected, never
+miscomputed. See docs/developer/applied-math.md.
 
-WHY THIS IS POSSIBLE (and where it stops)
------------------------------------------
-A two-operand einsum `A,B->C` partitions its indices into four classes:
-  * BATCH  (B): appear in A, B and C        -> kept as outer/batch dims
-  * CONTRACT (K): appear in A and B, not C  -> summed over (the dot dimension)
-  * KEEP-A (M): appear in A and C, not B    -> rows of the output
-  * KEEP-B (N): appear in B and C, not A    -> cols of the output
-Align each operand to `[B..., M..., K...]` / `[B..., K..., N...]` by
-transpose, collapse each group to a single axis by reshape, then a batched
-matmul `[B,M,K] @ [B,K,N] -> [B,M,N]` does the contract-and-sum in ONE op
-(the ANE matmul accumulator is wide, >=fp32, so the K-sum is clean). Reshape the
-result back to the named output dims, then transpose to the requested order.
-
-Indices in ONE operand but NOT in the output are summed FIRST with a reduce
-(`af.sum`); output-only indices absent from the inputs are unsupported (einsum
-cannot invent a dimension). For >2 operands we left-fold: contract the running
-result with the next operand pairwise.
-
-REDUCTION-ONLY and OUTER products are handled directly:
-  * `ij->i` / `ij->` : pure reduce (sum over the dropped axes).
-  * `i,j->ij`          : broadcast-mul (no contraction), an outer product.
-
-WHAT IS *NOT* SUPPORTED (rejected with a clear error, never wrong results)
--------------------------------------------------------------------------
-Any equation with a REPEATED index inside a single operand - diagonal / trace
-extraction (`ii->i`, `ii->`, `...ii->...`). Reading a tensor's diagonal is a
-GATHER, unsupported on the ANE (per the op-conformance finding), with no
-matmul/reduce decomposition. These raise `EinsumUnsupported`. Ellipsis (`...`)
-is also not implemented (v1).
-
-Run the self-test (validates a battery vs `numpy.einsum` on the ANE):
     PYTHONPATH=. python3 aneforge/einsum.py
 """
 from __future__ import annotations
@@ -58,8 +24,8 @@ from aneforge.graph import Tensor
 
 
 class EinsumUnsupported(NotImplementedError):
-  """Raised for einsum equations that cannot be lowered to ANE matmul/reduce ops
-    (diagonal/trace via repeated indices, ellipsis, invented output dims)."""
+  """Raised for equations not lowerable to ANE matmul/reduce ops (diagonal/trace via
+    repeated indices, ellipsis, invented output dims)."""
 
 
 # --------------------------------------------------------------------------- #

--- a/aneforge/fft.py
+++ b/aneforge/fft.py
@@ -1,69 +1,13 @@
-"""aneforge.fft - a real FFT for the Apple Neural Engine, built as Cooley-Tukey
-factored into MATMUL STAGES.
+"""aneforge.fft - a real FFT on the Apple Neural Engine, Cooley-Tukey factored into
+MATMUL STAGES (the ANE has no complex dtype, so complex is carried as (re, im) pairs).
 
-The ANE has NO complex dtype (compute is fp16 real only) and no in-graph loop or
-gather, but it is a *matmul machine*. A previous probe (tests/test_spectral_sci.py,
-examples/spectral_analysis.py) showed the DFT-as-a-twiddle-matrix-matmul is fp16-CLEAN to
-N=2048 because the matmul accumulator is wide (>=fp32) - but that is the naive O(N^2)
-DFT (one dense [N,N] twiddle matrix). This module keeps the "every stage is a matmul"
-property while cutting the op count to ~O(N*(N1+N2+...)) via the Cooley-Tukey
-factorization.
+N is split into <=3 balanced groups; the signal stays a fully-split rank-4 tensor for
+the whole computation (each group is one dense-DFT matmul stage), cutting cost from
+O(N^2) to ~O(N*sum(groups)). The complex-as-real-pairs twiddle scheme, the rank-4 cap,
+and the transpose-chain mis-fusion wall are documented in docs/developer/applied-math.md
+and docs/developer/numerics.md.
 
-THE IDEA (Cooley-Tukey, one split N = N1 * N2):
-    Index n = n1*N2 + n2  (n1 in [0,N1), n2 in [0,N2));  k = k2*N1 + k1.
-    X[k1 + N1*k2] = sum_{n2} [ exp(-2pi i n2 k1 / N)
-                               * ( sum_{n1} x[n1*N2 + n2] * exp(-2pi i n1 k1 / N1) ) ]
-                             * exp(-2pi i n2 k2 / N2)
-    => reshape x to [N1, N2];
-       (1) N1-point DFT down each column  (matmul by the [N1,N1] twiddle Wn1),
-       (2) multiply by the CROSS twiddles  T[k1,n2] = exp(-2pi i k1 n2 / N),
-       (3) N2-point DFT along each row     (matmul by the [N2,N2] twiddle Wn2),
-       (4) transpose to put the output in order  X[k1, k2] -> X[k2*N1 + k1].
-
-WHAT THIS MODULE BUILDS (and why). N is factored into AT MOST 3 balanced GROUPS,
-N = g0*g1*g2, and the signal is reshaped ONCE to a 4-D tensor [1, g0, g1, g2] that
-stays fully split for the whole computation. Each group is one dense-DFT matmul stage
-along its own axis (a single transpose to bring the axis last, the complex matmul, a
-single transpose back), with cross-twiddle multiplies between stages and ONE final
-axis-reversal transpose. Cost = N*(g0+g1+g2) MACs vs the dense DFT's N^2 - sub-quadratic,
-e.g. 32x fewer at N=1024, 51x at N=2048; every stage is a matmul (ANE-native).
-
-TWO HARD ANE WALLS shape this (both found empirically on M5, see _factor / _axis_dft):
-  - The ANE caps transpose+matmul at RANK-4 tensors (rank>=5 fails ANECCompile), so the
-    fully-split tensor carries at most 3 factor groups -> a 3-stage FFT, not a full
-    log-depth radix-2 cascade.
-  - Chaining the recursive transpose->reshape->transpose COLLAPSE mis-fuses on this ANE
-    (correct VALUES, permuted ORDER). Keeping the tensor fully split with ONE isolated
-    transpose per stage sidesteps it. (A single transpose, or a transpose separated by a
-    matmul, is reliable - verified.)
-
-COMPLEX AS REAL PAIRS. Every value is a (re, im) Tensor pair. A complex matmul
-C = A @ B is four real matmuls:
-    Cre = Are@Bre - Aim@Bim
-    Cim = Are@Bim + Aim@Bre
-(Straight 4-matmul form, not Karatsuba: on the ANE matmul is cheap and the wide
-accumulator keeps the straight form cleanest - Karatsuba's (a+b)(c+d) sums lose a bit
-of fp16 headroom for no real op savings here.) The twiddle matrices are small fp16
-CONSTANTS folded into the graph (matmul against a numpy array is a streamed weight,
-see graph.Tensor.__matmul__).
-
-This is a submodule over the PUBLIC aneforge ops only (`@` matmul, reshape, transpose,
-add/sub/mul, concat, square, sqrt, af.input, af.compile). It does not touch graph.py,
-_compile.py, __init__.py, _optimize.py, _paired.py or linalg.py.
-
-API
-    fft(x_re, x_im, N)        -> (X_re, X_im)        complex -> complex
-    ifft(X_re, X_im, N)       -> (x_re, x_im)        inverse (1/N scaled)
-    rfft(x_real, N)           -> (X_re, X_im)        real input (imag = 0)
-    fft2(x_re, x_im)          -> (X_re, X_im)        2-D transform of an [M,N] field
-    ifft2(X_re, X_im)         -> (x_re, x_im)        inverse (1/(M*N) scaled)
-    magnitude(X_re, X_im)     -> |X|                 sqrt(re^2 + im^2)
-    power(X_re, X_im)         -> |X|^2
-
-Each returns numpy arrays; internally it builds an aneforge graph, compiles it to
-ONE fused e5rt program, and runs it on the ANE. A `Plan` object (fft_plan / rfft_plan)
-compiles once and runs many times.
-
+    fft / ifft / rfft, fft2 / ifft2, magnitude, power. Plans compile once, run many.
     PYTHONPATH=. python3 aneforge/fft.py
 """
 from __future__ import annotations
@@ -82,41 +26,28 @@ import aneforge as af  # noqa: E402
 from aneforge.graph import Tensor  # noqa: E402
 
 
-# --------------------------------------------------------------------------- #
-# complex-as-real-pairs algebra on graph Tensors                              #
-# --------------------------------------------------------------------------- #
-# A "cplx" is just a (re, im) tuple of aneforge Tensors with identical shape.
+# complex-as-real-pairs algebra: a value is a (re, im) tuple of Tensors.
 
 def _cmatmul_const(re: Tensor, im: Tensor, Wr: np.ndarray, Wi: np.ndarray):
-  """Complex matmul (re+im*i) @ (Wr+Wi*i) where W is a fp16 constant matrix.
-    Four real matmuls against streamed twiddle constants:
-        Cre = re@Wr - im@Wi ;  Cim = re@Wi + im@Wr
-    """
+  """Complex matmul (re+im*i) @ (Wr+Wi*i), W a fp16 constant: four real matmuls
+    Cre = re@Wr - im@Wi, Cim = re@Wi + im@Wr."""
   Wr = Wr.astype(np.float16); Wi = Wi.astype(np.float16)
   Cre = (re @ Wr) - (im @ Wi)
   Cim = (re @ Wi) + (im @ Wr)
   return Cre, Cim
 
 
-# note on cross twiddles. They are data-shaped [N1,restlen] constants. The public
-# frontend has no free constant-tensor op (only matmul/conv weights fold into the blob;
-# elementwise add/mul require two graph Tensors). So the cross twiddles ride in as graph
-# INPUTS - an input IS a graph Tensor - and the Plan threads the constant arrays in
-# automatically on every call (see _Builder._cross / Plan.__call__). They are fed in
-# creation order, exactly the order aneforge.compile assigns input slots.
+# Cross twiddles ([N1,restlen] constants) ride in as graph INPUTS, not folded weights:
+# the public frontend folds only matmul/conv weights, while elementwise mul needs two
+# graph Tensors. The Plan threads the arrays in on every call, in input-slot order.
 
-
-# --------------------------------------------------------------------------- #
-# twiddle factories                                                           #
-# --------------------------------------------------------------------------- #
 
 def _dft_matrix(M: int):
-  """The [M,M] DFT twiddle W[k,n] = exp(-2pi i k n / M), split into (Wr, Wi).
-    Used as a streamed fp16 weight: y = x @ W  (x is [.., M], W is [M, M])."""
+  """The [M,M] DFT twiddle W[k,n] = exp(-2pi i k n / M), split into (Wr, Wi). Used as a
+    streamed fp16 weight y = x @ W^T (folding W^T so x@Wt gives X[k])."""
   n = np.arange(M)
   k = n.reshape(-1, 1)
   W = np.exp(-2j * np.pi * k * n / M).astype(np.complex128)   # W[k,n]
-  # we compute X[k] = sum_n x[n] W[k,n] = x @ W^T ; fold W^T as the weight.
   Wt = W.T                                   # [n, k] so x@Wt gives X[k]
   Wt_re = Wt.real
   Wt_im = Wt.imag
@@ -136,11 +67,8 @@ def _idft_matrix(M: int):
            np.ascontiguousarray(Wt_im).astype(np.float16)
 
 
-# The ANE caps transpose+matmul at rank-4 (4D) tensors (verified on-device: rank>=5
-# fails ANECCompile). A fully-split FFT tensor is [1, g0, g1, ..., g_{m-1}], so the
-# split is limited to AT MOST 3 factor-groups (-> [1, g0, g1, g2], 4D). So factor N
-# into <=3 balanced GROUPS; each group is one (possibly composite) dense-DFT matmul
-# stage. This is a 3-stage Cooley-Tukey - still ~O(N*(g0+g1+g2)) << O(N^2).
+# The ANE caps transpose+matmul at rank-4 tensors (rank>=5 fails ANECCompile), so the
+# fully-split FFT tensor [1, g0, g1, g2] carries AT MOST 3 factor groups. See numerics.md.
 _MAX_GROUPS = 3
 
 
@@ -156,10 +84,8 @@ def _prime_factors(N: int) -> list[int]:
 
 
 def _factor(N: int) -> list[int]:
-  """Factor N into AT MOST 3 balanced groups (each a dense-DFT matmul stage), so the
-    fully-split tensor stays rank<=4 (the ANE limit). Groups are made as close to N**(1/k)
-    as possible (balanced -> minimal total matmul work). A prime (or near-prime) N falls
-    back to a single dense DFT (one group == N)."""
+  """Factor N into AT MOST 3 balanced groups (each a dense-DFT matmul stage), keeping the
+    tensor rank<=4. Balanced minimizes total matmul work; a prime N -> one dense DFT."""
   primes = _prime_factors(N)
   if len(primes) == 1: return [N]                                  # prime -> one dense DFT block
   k = min(_MAX_GROUPS, len(primes))
@@ -190,14 +116,9 @@ class _Builder:
     return _idft_matrix(M) if self.inverse else _dft_matrix(M)
 
   def _cross(self, N1: int, restlen: int, Ntot: int, bshape):
-    """Cross twiddle T[k1, n2] = exp(sign*2pi i k1 n2 / Ntot) where k1 in [0,N1),
-        n2 in [0,restlen). Registered as a pair of graph INPUTS (the frontend has no
-        free constant op; only matmul/conv weights fold, while elementwise mul needs
-        two graph Tensors - an input IS a graph Tensor). Returned reshaped to `bshape`
-        so it broadcasts against the trailing split axes of the running tensor.
-
-        The plan threads the constant arrays in automatically at call time (recorded in
-        `aux_values`, fed in creation order == the compiled input order)."""
+    """Cross twiddle T[k1, n2] = exp(sign*2pi i k1 n2 / Ntot), registered as a pair of
+        graph INPUTS (no free constant op; the Plan threads the arrays in at call time,
+        in creation order == input order) and reshaped to `bshape` to broadcast."""
     k1 = np.arange(N1).reshape(-1, 1)
     n2 = np.arange(restlen).reshape(1, -1)
     T = np.exp(self.sign * 2j * np.pi * k1 * n2 / Ntot).astype(np.complex128)   # [N1, restlen]
@@ -207,15 +128,10 @@ class _Builder:
     return Tr.reshape(*bshape), Ti.reshape(*bshape)
 
   def _axis_dft(self, re: Tensor, im: Tensor, axis: int, r: int):
-    """DFT of radix `r` along `axis` of a fully-split tensor, realized as ONE
-        transpose (move the axis last) + a complex matmul + ONE transpose (move back).
-
-        IMPORTANT (ANE compiler workaround): each stage uses at most a SINGLE transpose
-        on each side of the matmul. Chaining transpose->reshape->transpose (the natural
-        recursive collapse/re-split) is mis-fused by this ANE's graph compiler - it
-        returns the correct VALUES in a permuted ORDER. Keeping the tensor fully split
-        (never collapsing to 1-D between stages) with one isolated transpose per move
-        sidesteps the bug entirely (verified on-device)."""
+    """DFT of radix `r` along `axis`: ONE transpose (axis -> last) + complex matmul + ONE
+        transpose back. At most a SINGLE transpose per side of the matmul - chaining
+        transpose->reshape->transpose mis-fuses on this ANE (correct values, permuted
+        order). See docs/developer/numerics.md."""
     nd = len(re.shape)
     perm = list(range(nd))
     perm[axis], perm[nd - 1] = perm[nd - 1], perm[axis]
@@ -226,10 +142,8 @@ class _Builder:
     return re, im
 
   def _rec(self, re: Tensor, im: Tensor, axes: list[int], lengths: list[int]):
-    """Two-factor Cooley-Tukey unrolled over the split axes (decimation-in-time).
-        Transforms the block formed by `axes` (total length prod(lengths)) in place,
-        leaving the result on the SAME axes. Each level: one radix-N1 DFT on the first
-        axis, a cross twiddle against the trailing block, then recurse the rest."""
+    """Cooley-Tukey unrolled over the split axes (DIT): per level, one radix-N1 DFT on the
+        first axis, a cross twiddle against the trailing block, then recurse the rest."""
     if len(axes) == 1: return self._axis_dft(re, im, axes[0], lengths[0])
     N1 = lengths[0]
     restlen = int(np.prod(lengths[1:]))
@@ -254,18 +168,10 @@ class _Builder:
     return self._rec(re, im, axes[1:], lengths[1:])
 
   def transform(self, re: Tensor, im: Tensor, N: int):
-    """Length-N FFT of the LAST axis of (re, im) (shape [1, N]); returns [1, N] in
-        natural (numpy.fft) order.
-
-        Multi-stage mixed-radix Cooley-Tukey on a FULLY-SPLIT tensor. With
-        N = r0*r1*...*r_{m-1}, the input is reshaped ONCE to [1, r0, r1, ..., r_{m-1}]
-        and stays multi-axis for the whole computation (NO collapse-to-1-D between
-        stages - that triggers the ANE transpose-chain mis-fusion). Each level does an
-        `r`-point DFT along one axis as a (4-real-matmul) complex matmul, then a
-        cross-twiddle multiply. A SINGLE final axis-reversal transpose puts the output
-        in natural order, and one reshape collapses back to [1, N].
-
-        Work ~ O(N * sum_k r_k)  <<  the dense DFT's O(N^2)."""
+    """Length-N FFT of the last axis of (re, im) [1, N]; returns [1, N] in natural
+        (numpy.fft) order. Multi-stage mixed-radix Cooley-Tukey on a fully-split tensor
+        (no collapse-to-1-D between stages - that triggers the transpose-chain mis-fusion);
+        one final axis-reversal transpose puts output in natural order. Work ~ O(N*sum r_k)."""
     factors = _factor(N)
     m = len(factors)
     if m == 1:
@@ -290,9 +196,8 @@ def _stage_count(N: int) -> int:
 
 
 def _leaf_cost(N: int) -> int:
-  """Total complex-matmul scalar work: each group g_i is a [g_i, g_i] DFT applied to
-    N/g_i independent rows, costing N*g_i MACs; total = N * sum_i g_i.
-    The dense single DFT is N*N, so the staged build is ~N*sum(g) << N^2."""
+  """Total complex-matmul work N*sum(groups) (each group g_i costs N*g_i MACs); the dense
+    single DFT is N*N."""
   groups = _factor(N)
   if len(groups) == 1: return N * N
   return N * sum(groups)
@@ -303,8 +208,8 @@ def _leaf_cost(N: int) -> int:
 # --------------------------------------------------------------------------- #
 
 class Plan:
-  """A compiled staged-FFT program. Holds the e5rt Model plus the cross-twiddle
-    constant arrays, which it threads in automatically on every call."""
+  """A compiled staged-FFT program, holding the e5rt Model plus the cross-twiddle
+    constant arrays it threads in on every call."""
 
   def __init__(self, N: int, inverse: bool, real_input: bool):
     self.N = N
@@ -322,9 +227,7 @@ class Plan:
     out = af.concat([Xr, Xi], axis=1)
     self._aux_values = b.aux_values
     self.n_stages = _stage_count(N)          # number of dense-DFT matmul stages (<=3)
-    # The DFT butterfly has exact-by-construction subtracts that trip the generic
-    # cancel_sub precision heuristic; this kernel is numerically verified (spectrum
-    # matches np.fft to fp16), so it vouches for itself and skips the check.
+    # exact-by-construction DFT subtracts trip cancel_sub; numerically verified vs np.fft.
     self.model = af.compile(out, _check_precision=False)
     self.n_ops = self.model.n_ops
 
@@ -340,19 +243,11 @@ class Plan:
 
 
 class Plan2:
-  """A compiled 2-D FFT program for [M,N] complex fields - ONE fused e5rt program.
-
-    The 2-D DFT is separable:  X_hat = F_M @ X @ F_N^T.  Applied to a whole matrix,
-    each axis transform is a single complex matmul (a DFT of every row at once), NOT a
-    per-row loop: rows transform as one matmul against the [N,N] twiddle, columns as
-    transpose -> matmul against the [M,M] twiddle -> transpose back. Eight real GEMMs
-    total, fused into one program - vs M+N dispatches for host-looping the 1-D plan.
-
-    The DENSE per-axis form, O(M*N*(M+N)) MACs (not the staged sub-quadratic 1-D build):
-    at PDE-scale fields the ANE eats the GEMMs and dispatch dominates, and a per-axis
-    staged split of a 2-D field would exceed the rank-4 transpose+matmul cap. Each
-    transpose sits between matmuls (the safe pattern; only transpose->reshape CHAINS
-    mis-fuse - see _axis_dft)."""
+  """A compiled 2-D FFT for [M,N] complex fields, ONE fused program. The 2-D DFT is
+    separable X_hat = F_M @ X @ F_N^T - each axis transform is a single complex matmul
+    over the whole matrix (eight real GEMMs total), NOT a per-row loop. Dense per-axis
+    form (O(M*N*(M+N)) MACs); a staged split would exceed the rank-4 cap. See
+    docs/developer/numerics.md."""
 
   def __init__(self, M: int, N: int, inverse: bool):
     self.M, self.N, self.inverse = M, N, inverse
@@ -360,10 +255,8 @@ class Plan2:
     WrN, WiN = mk(N)                                          # row twiddle (x @ Wt)
     WrM, WiM = mk(M)                                          # column twiddle
     if inverse:
-        # Fold the 1/(M*N) normalization INTO the twiddles, 1/N on the row pass and
-        # 1/M on the column pass - NOT one scale at the end. A real spectrum is large
-        # (O(M*N) at the dominant modes), so an unscaled first-axis transform would
-        # push intermediates past fp16 max (65504) and shred precision.
+        # fold 1/(M*N) INTO the twiddles (1/N row pass, 1/M column pass), NOT one final
+        # scale: an unscaled first-axis transform of a large spectrum overflows fp16.
       WrN, WiN = WrN * (1.0 / N), WiN * (1.0 / N)
       WrM, WiM = WrM * (1.0 / M), WiM * (1.0 / M)
     xr = af.input((M, N)); xi = af.input((M, N))
@@ -372,8 +265,7 @@ class Plan2:
     re, im = _cmatmul_const(re, im, WrM, WiM)                 # all N columns, one matmul
     re = re.transpose([1, 0]); im = im.transpose([1, 0])
     out = af.concat([re, im], axis=0)                          # [2M, N], split on host
-    # exact-by-construction DFT subtracts trip the generic cancel_sub heuristic;
-    # numerically verified vs np.fft.fft2 (tests/test_fft2.py), so it vouches for itself.
+    # exact-by-construction DFT subtracts trip cancel_sub; verified vs np.fft.fft2.
     self.model = af.compile(out, _check_precision=False)
     self.n_ops = self.model.n_ops
 

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -1,7 +1,6 @@
-"""The aneforge compute graph: a lazy `Tensor` whose methods/operators record
-structure (op + sources + attrs), plus the op constructors and the higher-level
-neural-net helpers (conv, multi-head / cross attention, GEGLU). Nothing here
-touches the device - `compile` (_compile.py) lowers the graph to one program.
+"""The aneforge compute graph: a lazy `Tensor` recording structure (op + sources +
+attrs), the op constructors, and nn helpers (conv, attention, GEGLU). Nothing here
+touches the device - `compile` (_compile.py) lowers the graph. See docs/developer/overview.md.
 """
 from __future__ import annotations
 
@@ -38,9 +37,7 @@ class Tensor:
   def __init__(self, shape: Sequence[int], op: str, srcs: Sequence["Tensor"] = (),
         attrs: dict | None = None) -> None:
     self.shape = tuple(int(d) for d in shape)
-    # The ANE dimension model is rank <= 5 ("Rank ... must be between 0 and 5");
-    # a rank-6+ tensor (reshape/stack/expand_dims past 5D) fails ANECCompile.
-    # Guard at construction with a clear error, not a cryptic compile crash.
+    # ANE dimension model is rank <= 5; rank-6+ fails ANECCompile. Guard early.
     if len(self.shape) > 5:
       raise ValueError(
         f"aneforge: tensor rank {len(self.shape)} exceeds the ANE maximum of 5 "
@@ -263,11 +260,8 @@ class Tensor:
   def amin(self, axes) -> "Tensor": return self._reduce("reduce_min", axes)
 
   def cumsum(self, axis: int = -1) -> "Tensor":
-    """Cumulative sum along `axis` (last axis only). The ANE has no native
-        cumsum, but a last-axis cumsum is exactly `x @ triu_ones` -- a matmul with
-        a baked upper-triangular-ones weight, made exact by the wide accumulator.
-        A composition, not a native op (native cumsum is arch-gated). For other
-        axes, transpose the target axis to last first."""
+    """Cumulative sum along `axis` (last axis only): `x @ triu_ones` (no native
+        cumsum). For other axes, transpose the target axis to last first."""
     ax = axis % len(self.shape)
     if ax != len(self.shape) - 1:
       raise ValueError(f"cumsum: only the last axis is supported (got axis={axis}, "
@@ -289,20 +283,14 @@ class Tensor:
     return Tensor(self.shape, "softmax", [self], {"axis": axis % len(self.shape)})
 
   def l2_norm(self, axis: int = -1, eps: float = 1e-12) -> "Tensor":
-    """L2-normalize over `axis`: `x / sqrt(sum(x**2, axis) + eps)`.
-
-        Runs as fused e5rt MIL (`reduce_l2_norm` over the axis, then `real_div`)
-        - no graph cut. The MIL `l2_norm` op normalises over all non-batch dims,
-        so we build the per-axis form explicitly."""
+    """L2-normalize over `axis`: `x / sqrt(sum(x**2, axis) + eps)`. Fused e5rt MIL
+        (the MIL `l2_norm` op normalises over all non-batch dims, so we build per-axis)."""
     ax = axis % len(self.shape)
     return Tensor(self.shape, "l2_norm", [self], {"axis": ax, "eps": float(eps)})
 
   def argmax(self, axis: int = -1) -> "Tensor":
-    """Index of the maximum along `axis` (keepdims). Runs as a native-ANE
-        GlobalArgMinMax sub-program (netplist bridge, like af.sdpa) - a graph cut.
-
-        2D inputs [C, W] only, over the last axis (axis=-1/1, Width) or axis 0
-        (Channel); indices are returned fp16-encoded (exact for index<2048)."""
+    """Index of the maximum along `axis` (keepdims). Native-ANE GlobalArgMinMax
+        bridge - a graph cut. 2D inputs [C, W] only; indices fp16-encoded (exact for index<2048)."""
     if len(self.shape) != 2:
       raise ValueError(f"argmax: only 2D [C,W] inputs are supported; got {self.shape}")
     ax = axis % 2
@@ -310,10 +298,8 @@ class Tensor:
     return Tensor(out, "argmax", [self], {"axis": ax})
 
   def rms_norm(self, gamma, eps: float = 1e-5) -> "Tensor":
-    """RMSNorm over the last dim. `gamma`: a [D] array for a fixed (baked)
-        scale, or a broadcastable parameter `Tensor` ([1, D]) for a TRAINABLE
-        scale (normalized with a unit-scale op, then scaled by the Tensor so its
-        gradient flows via the mul VJP)."""
+    """RMSNorm over the last dim. `gamma`: a [D] array (fixed/baked scale) or a
+        broadcastable parameter `Tensor` ([1, D]) for a TRAINABLE scale."""
     if isinstance(gamma, Tensor):
       xn = self.rms_norm(np.ones(self.shape[-1], np.float32), eps)
       return xn * gamma
@@ -323,11 +309,9 @@ class Tensor:
     return Tensor(self.shape, "rms_norm", [self], {"gamma": gamma, "eps": float(eps)})
 
   def layer_norm(self, gamma, beta, eps: float = 1e-5) -> "Tensor":
-    """LayerNorm over the last dim (2D inputs [M, D]). `gamma`/`beta`: [D]
-        arrays for a fixed (baked) affine, or broadcastable parameter `Tensor`s
-        ([1, D]) for a TRAINABLE affine (normalized with a unit affine, then scaled
-        and shifted by the Tensors so their gradients flow via the mul/add VJPs).
-        Pass both as Tensors for the trainable form."""
+    """LayerNorm over the last dim (2D inputs [M, D]). `gamma`/`beta`: [D] arrays
+        (fixed/baked affine) or broadcastable parameter `Tensor`s ([1, D]) for a
+        TRAINABLE affine (pass both as Tensors)."""
     if isinstance(gamma, Tensor) or isinstance(beta, Tensor):
       if not (isinstance(gamma, Tensor) and isinstance(beta, Tensor)):
         raise TypeError("layer_norm: a trainable affine needs both gamma and beta as Tensors")
@@ -341,11 +325,9 @@ class Tensor:
     return Tensor(self.shape, "layer_norm", [self], {"gamma": gamma, "beta": beta, "eps": float(eps)})
 
   def channel_layer_norm(self, gamma, beta, eps: float = 1e-5) -> "Tensor":
-    """LayerNorm over the CHANNEL axis of a channels-first [N, C, 1, S] tensor -
-        the ANE-native transformer layout. Each [N, :, 1, s] vector is normalized over
-        C; `gamma`/`beta` are [C]. Same result as `layer_norm` on the [N*S, C] view, but
-        with no transpose into and out of [seq, d], which is what makes the attention/MLP
-        stack cheap on the ANE (projections stay 1x1 convs over [N, C, 1, S])."""
+    """LayerNorm over the CHANNEL axis of channels-first [N, C, 1, S] - the ANE-native
+        transformer layout. Same result as `layer_norm` on the [N*S, C] view but with no
+        transpose, keeping the attention/MLP stack as 1x1 convs. `gamma`/`beta` are [C]."""
     gamma = np.asarray(gamma); beta = np.asarray(beta)
     _check_dtype(gamma, "channel_layer_norm gamma"); _check_dtype(beta, "channel_layer_norm beta")
     if (len(self.shape) != 4 or self.shape[2] != 1
@@ -355,10 +337,9 @@ class Tensor:
     return Tensor(self.shape, "channel_layer_norm", [self], {"gamma": gamma, "beta": beta, "eps": float(eps)})
 
   def group_norm(self, gamma, beta, num_groups: int, eps: float = 1e-5) -> "Tensor":
-    """GroupNorm over [1,C,H,W]. `gamma`/`beta`: [C] arrays for a fixed
-        (baked) affine, or broadcastable parameter `Tensor`s ([1, C, 1, 1]) for a
-        TRAINABLE affine (normalized with a unit affine, then scaled and shifted by
-        the Tensors). Pass both as Tensors for the trainable form."""
+    """GroupNorm over [1,C,H,W]. `gamma`/`beta`: [C] arrays (fixed/baked affine) or
+        broadcastable parameter `Tensor`s ([1, C, 1, 1]) for a TRAINABLE affine
+        (pass both as Tensors)."""
     if isinstance(gamma, Tensor) or isinstance(beta, Tensor):
       if not (isinstance(gamma, Tensor) and isinstance(beta, Tensor)):
         raise TypeError("group_norm: a trainable affine needs both gamma and beta as Tensors")
@@ -369,10 +350,8 @@ class Tensor:
     _check_dtype(gamma, "group_norm gamma"); _check_dtype(beta, "group_norm beta")
     if len(self.shape) != 4 or self.shape[0] != 1 or self.shape[1] % num_groups:
       raise ValueError(f"group_norm expects [1,C,H,W] with C%groups==0; got {self.shape}, G={num_groups}")
-    # The rank-4 tiled lowering reshapes to [1,G,C/groups,H*W] and reduces the
-    # trailing two axes, so the bound is the largest single axis, max(C/groups, H*W),
-    # against the ANE's hard per-axis cap of 65536 - not the flattened (C/groups)*H*W
-    # product (which overflowed for SD-UNet's 512ch@128 and 640ch@64; finding_sd15).
+    # The tiled lowering reduces over the largest single axis, max(C/groups, H*W),
+    # against the ANE per-axis cap of 65536 (not the flattened product; finding_sd15).
     _, C, H, W = self.shape
     axis = max(C // num_groups, H * W)
     if axis > 65536:
@@ -431,18 +410,12 @@ def input(shape: Sequence[int], dtype: str = "fp16") -> Tensor:
 
 
 def image_input(shape: Sequence[int], scale: float = 1.0 / 255.0, bias=0.0) -> Tensor:
-  """A uint8 image input that is dequantised to fp16 ON the engine.
+  """A uint8 image input dequantised to fp16 ON the engine: feed raw 8-bit pixels
+    (camera / decoded-video bytes) straight in, the host skips the float-convert + repack.
 
-    Feed raw 8-bit pixels (camera / decoded-video bytes) straight to the compiled
-    model - the uint8->fp16 conversion and the `scale*x + bias` normalisation run
-    as in-graph ANE ops, so the host skips the float-convert + repack. Returns a
-    normal fp16 Tensor for the rest of the graph.
-
-    `scale`/`bias` are scalars by default (the usual `x/255` ImageNet-style
-    normalisation is `scale=1/255`). For per-channel normalisation on an NCHW image
-    pass length-C sequences; they broadcast as `[1,C,1,1]` constants. The dequant is
-    `cast(uint8->fp16) -> mul(scale) -> add(bias)`; identity add/mul are dropped, so
-    the common `scale=1/255, bias=0` case is a cast + one mul."""
+    `scale`/`bias` are scalar (default `scale=1/255`) or length-C for per-channel NCHW
+    normalisation (broadcast as `[1,C,1,1]`). The dequant is `cast -> mul(scale) -> add(bias)`;
+    identity mul/add are dropped."""
   shape = tuple(int(d) for d in shape)
   x = input(shape, dtype="uint8")
   y = Tensor(shape, "cast", [x], {"dtype": "fp16"})
@@ -484,8 +457,7 @@ def conv(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: int = 1,
     raise ValueError(f"conv expects 4D input [N,Cin,H,W], got {x.shape}")
   N, Cin, H, W = x.shape
   Cout, _, kH, kW = weight.shape
-  # The ANE conv tiles along the kernel WIDTH: kW>=16 is unsupported by ANECCompile (kH
-  # unconstrained; verified 16x3 compiles, 3x16 does not). Guard with a clear error.
+  # ANE conv tiles along kernel WIDTH: kW>=16 fails ANECCompile (kH unconstrained).
   if kW > 15:
     raise ValueError(
       f"conv: kernel width kW={kW} exceeds the ANE limit (kW must be <=15); "
@@ -501,18 +473,11 @@ def conv(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: int = 1,
 
 def dynamic_conv(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0,
         dilation: int = 1, groups: int = 1) -> Tensor:
-  """2D conv with a DYNAMIC (runtime-tensor) weight - the kernel is a graph value, not a
-    baked constant. Lowers to the ANE's native dynamic-kernel path (`CreateDynamicKernel` /
-    DynamicGOC), so the weight can be produced at runtime by an earlier op or fed as an input.
-    Enables hypernetworks / per-sample (per-image) kernels - a capability no other ANE frontend
-    exposes, since Apple's MIL/CoreML conv bakes the weight.
+  """2D conv with a DYNAMIC (runtime-tensor) weight via the ANE's native dynamic-kernel
+    path - enables hypernetworks / per-sample kernels (Apple's MIL/CoreML conv bakes the weight).
 
-    `x`: [1, Cin, H, W]; `weight`: a Tensor [Cout, Cin/groups, kH, kW]. Returns
-    [1, Cout, Hout, Wout].
-
-    BATCH MUST BE 1. The ANE dynamic-kernel path does not support a dynamic-weight conv
-    with batch >= 2, so it is rejected at build time. For batched convolution use `af.conv`
-    (constant weight) or the im2col-based trainable `conv2d`."""
+    `x`: [1, Cin, H, W]; `weight`: a Tensor [Cout, Cin/groups, kH, kW]. BATCH MUST BE 1
+    (batch>=2 is unsupported on the dynamic-kernel path; use `af.conv` / `conv2d` instead)."""
   if not isinstance(weight, Tensor):
     raise TypeError("dynamic_conv: weight must be a Tensor (a graph value); for a constant "
             "weight use af.conv")
@@ -546,8 +511,7 @@ def conv_transpose(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: i
     raise ValueError(f"conv_transpose expects 4D [N,Cin,H,W], got {x.shape}")
   N, Cin, H, W = x.shape
   _, Cout, kH, kW = weight.shape
-  # Same kernel-WIDTH tiling limit as conv: kW>=16 fails ANECCompile (kH
-  # unconstrained). Guard with a clear error.
+  # Same kernel-WIDTH limit as conv: kW>=16 fails ANECCompile (kH unconstrained).
   if kW > 15:
     raise ValueError(
       f"conv_transpose: kernel width kW={kW} exceeds the ANE limit (kW must be <=15); "
@@ -593,19 +557,13 @@ def concat(tensors: Sequence[Tensor], axis: int = 1) -> Tensor:
 
 
 def gather(x: Tensor, indices, axis: int = 0) -> Tensor:
-  """Gather slices along `axis` by STATIC (build-time) integer `indices`. The
-    ANE has no native gather, but for constant indices a gather is exact via
-    `slice_by_size` + `concat` (a composition, not a native op -- native gather
-    is arch-gated). Dynamic (data-dependent) indices are not reachable on the ANE."""
+  """Gather slices along `axis` by STATIC integer `indices` via `slice_by_size` + `concat`
+    (no native gather; dynamic indices are unreachable on the ANE)."""
   idx = [int(i) for i in indices]
   rank = len(x.shape)
   ax = axis % rank
-  # A last-axis (width) gather lowers to slice_by_size with a nonzero WIDTH begin-offset,
-  # which routes through the A13/A14 x16 fixed-point crop-DMA path and returns the wrong
-  # elements there (correct on A16+). Gather a NON-last axis instead: for rank>=2 transpose
-  # the gathered axis off the last position and transpose back; for rank 1 gather a [N,1]
-  # view. Both are identity-preserving and correct on every family (the same width-axis-slice
-  # avoidance the conv im2col backward uses).
+  # A last-axis (width) gather hits the A13/A14 x16 crop-DMA path and returns wrong elements
+  # (correct on A16+). Gather a NON-last axis instead by transposing the axis off last.
   if ax == rank - 1:
     if rank == 1:
       return gather(x.reshape(x.shape[0], 1), idx, axis=0).reshape(len(idx))
@@ -671,10 +629,9 @@ def instance_norm(x: Tensor, gamma, beta, eps: float = 1e-5) -> Tensor:
 
 def local_response_norm(x: Tensor, size: int = 5, alpha: float = 1e-4,
             beta: float = 0.75, k: float = 1.0) -> Tensor:
-  """Cross-channel LRN over [N,C,H,W] via the native MIL `local_response_norm` op
-    (fused, no graph cut - distinct from the netplist `af.lrn` bridge): each output
-    is `x / (k + alpha/size * sum_{window} x**2) ** beta` over a window of `size`
-    neighbouring channels. `gamma`-free; `alpha`/`beta`/`k` in natural units."""
+  """Cross-channel LRN over [N,C,H,W] via the native MIL `local_response_norm` op (fused,
+    no cut - distinct from the netplist `af.lrn` bridge): `x / (k + alpha/size *
+    sum_{window} x**2) ** beta` over `size` neighbouring channels."""
   if len(x.shape) != 4:
     raise ValueError(f"local_response_norm expects [N,C,H,W]; got {x.shape}")
   return Tensor(x.shape, "local_response_norm", [x],
@@ -682,11 +639,10 @@ def local_response_norm(x: Tensor, size: int = 5, alpha: float = 1e-4,
 
 
 def einsum_native(equation: str, a: Tensor, b) -> Tensor:
-  """Restricted batched contraction via the native MIL `einsum` op (distinct from
-    the general `af.einsum` decomposer: this is the single hardware `einsum` layer).
-    The only on-ANE-verified equation is `'nchw,nwhu->nchu'` (a batched matmul over
-    the W/U dims sharing N,H): `a`=[N,C,H,W], `b`=[N,W,H,U] (streamed weight) ->
-    [N,C,H,U]. `b` is a weight array (streamed), not a graph Tensor."""
+  """Restricted batched contraction via the native MIL `einsum` op (the single hardware
+    `einsum` layer; distinct from the general `af.einsum` decomposer). Only the verified
+    equation `'nchw,nwhu->nchu'` is reachable: `a`=[N,C,H,W], `b`=[N,W,H,U] streamed weight
+    -> [N,C,H,U]."""
   if equation.replace(" ", "") != "nchw,nwhu->nchu":
     raise NotImplementedError(
       f"einsum: only 'nchw,nwhu->nchu' is verified reachable on the ANE; got {equation!r}")
@@ -775,10 +731,9 @@ def upsample_bilinear(x: Tensor, scale: int = 2, align_corners: bool = False) ->
 
 def affine(x: Tensor, transform, output_h: int, output_w: int,
      align_corners: bool = False) -> Tensor:
-  """2-D affine warp of [N,C,H,W] to `(output_h, output_w)` via the native MIL
-    `affine` op (`AffineTransform` hardware layer). `transform` is the [N,6]
-    (or [1,6], broadcast) affine matrix `[a0,a1,a2, b0,b1,b2]` in
-    normalized [-1,1] coordinates; bilinear sampling with zero padding. Fused MIL."""
+  """2-D affine warp of [N,C,H,W] to `(output_h, output_w)` via native MIL `affine`.
+    `transform` is [N,6] (or [1,6]) `[a0,a1,a2, b0,b1,b2]` in normalized [-1,1] coords;
+    bilinear sampling, zero padding. Fused MIL (no cut)."""
   if len(x.shape) != 4:
     raise ValueError(f"affine expects 4D [N,C,H,W], got {x.shape}")
   T = np.asarray(transform); _check_dtype(T, "affine transform")
@@ -841,14 +796,10 @@ def channel_to_space(x: Tensor, r: int) -> Tensor:
 
 
 def space_to_batch(x: Tensor, bh: int, bw: int) -> Tensor:
-  """Move spatial blocks into the batch dim on the ANE's native `SpaceToBatch`
-    layer: `[N,C,H,W] -> [N*bh*bw, C, H/bh, W/bw]`. Output batch slice
-    `(n*bh+i)*bw+j` == `x[n, :, i::bh, j::bw]`. Graph cut.
-
-    The batch dim grows, so this can only be a leaf/output of the segmented plan
-    or feed another netplist cut (segment outputs are threaded as host arrays);
-    feeding it into a fused e5rt region changes the batch the region expects,
-    which is fine since each region is compiled from its own input shapes."""
+  """Move spatial blocks into the batch dim on the native `SpaceToBatch` layer:
+    `[N,C,H,W] -> [N*bh*bw, C, H/bh, W/bw]`; batch slice `(n*bh+i)*bw+j` ==
+    `x[n, :, i::bh, j::bw]`. Graph cut (the batch dim grows, so it must be a leaf/output
+    or feed another netplist cut)."""
   if len(x.shape) != 4:
     raise ValueError(f"space_to_batch expects 4D [N,C,H,W], got {x.shape}")
   N, C, H, W = x.shape
@@ -859,13 +810,9 @@ def space_to_batch(x: Tensor, bh: int, bw: int) -> Tensor:
 
 
 def batch_to_space(x: Tensor, bh: int, bw: int) -> Tensor:
-  """Move batch blocks back into space on the ANE's native `BatchToSpace` layer
-    (inverse of `space_to_batch`): `[N*bh*bw, C, H, W] -> [N, C, H*bh, W*bw]`.
-    Graph cut.
-
-    ARCH-GATED: the validator requires the input batch divisible by `bh*bw`
-    (string: "Input batch n is not divisible by factor x * factor y"); a
-    non-divisible batch fails compilation, so it is rejected here."""
+  """Move batch blocks back into space on the native `BatchToSpace` layer (inverse of
+    `space_to_batch`): `[N*bh*bw, C, H, W] -> [N, C, H*bh, W*bw]`. Graph cut.
+    ARCH-GATED: input batch must be divisible by `bh*bw` (else fails compilation)."""
   if len(x.shape) != 4:
     raise ValueError(f"batch_to_space expects 4D [N,C,H,W], got {x.shape}")
   B, C, H, W = x.shape
@@ -896,13 +843,9 @@ def input_view(x: Tensor, offset: int, size: int) -> Tensor:
 
 
 def dynamic_slice(x: Tensor, start: int, size: int = 2) -> Tensor:
-  """Runtime-parametric slice `x[start:start+size]` on the ANE's native
-    `DynamicSlice` layer (start bound through a netplist constant). Graph cut.
-
-    ARCH-NOTE: the only verified/accepted netplist variant of this layer on this
-    host fixes Width=4 and SliceSize=2, so this op requires a length-4 input and
-    `size==2`. The static-start API is general in spirit; only the hardware variant
-    is verified."""
+  """Runtime-parametric slice `x[start:start+size]` on the native `DynamicSlice` layer.
+    Graph cut. ARCH-NOTE: the only verified variant fixes Width=4, SliceSize=2, so this
+    requires a length-4 input and `size==2`."""
   W = int(np.prod(x.shape))
   if W != 4 or size != 2:
     raise ValueError("dynamic_slice: the verified ANE variant requires a length-4 "
@@ -913,13 +856,9 @@ def dynamic_slice(x: Tensor, start: int, size: int = 2) -> Tensor:
 
 
 def scaled_elementwise(x: Tensor, z: Tensor, op: str = "Add", scale: float = 1.0) -> Tensor:
-  """`scale * (x OP z)` on the ANE's native `ScaledElementWise` layer (a fused
-    binary-op + scalar-scale). `op` in {Add, Mult, Min, Max}; inputs are flattened
-    to equal-length 1-D Width vectors. Graph cut.
-
-    Two arch quirks of the native layer are guarded here (found by tests/gen_random):
-    `Sub` is rejected by ANECCompile, and `Mult` ignores `scale` on-silicon - reject
-    those configs rather than emit a wrong/uncompilable program."""
+  """`scale * (x OP z)` on the native `ScaledElementWise` layer. `op` in {Add, Mult, Min,
+    Max}; inputs flattened to equal-length 1-D Width vectors. Graph cut. Arch quirks guarded:
+    `Sub` is rejected by ANECCompile, and `Mult` ignores `scale` on-silicon."""
   ops = ("Add", "Mult", "Min", "Max")
   if op not in ops:
     raise ValueError(f"scaled_elementwise: op must be one of {ops}; got {op!r} "
@@ -934,11 +873,8 @@ def scaled_elementwise(x: Tensor, z: Tensor, op: str = "Add", scale: float = 1.0
 
 
 def topk(x: Tensor, k: int, largest: bool = True) -> Tensor:
-  """Top-`k` values along the last axis of a 2D input [C, W], keyed per row.
-    Runs as a native-ANE TopK sub-program (netplist bridge, like af.sdpa) - a cut.
-
-    `k` in {3, 4} is ARCH-GATED on this hardware (ANECCompile fails) and rejected
-    here; the rest of `k` in [1, W] is supported."""
+  """Top-`k` values along the last axis of a 2D input [C, W], keyed per row. Native-ANE
+    TopK bridge - a cut. `k` in {3, 4} is ARCH-GATED (ANECCompile fails) and rejected."""
   if len(x.shape) != 2:
     raise ValueError(f"topk: only 2D [C,W] inputs are supported; got {x.shape}")
   C, W = x.shape
@@ -950,15 +886,10 @@ def topk(x: Tensor, k: int, largest: bool = True) -> Tensor:
 
 
 def sort(x: Tensor, descending: bool = False, return_indices: bool = False) -> Tensor:
-  """Sort each row of a 2D input [C, W] along the last axis (Width).
-    Runs as a native-ANE Sort sub-program (netplist bridge, like af.sdpa) - a cut.
-
-    With `return_indices=True` the argsort indices are returned instead of the
-    sorted values (fp16-encoded, exact for index < 2048). Output shape is [C, W].
-
-    Like the native TopK, the hardware Sort keys the order on one channel lane and
-    permutes all channels by it; for a numpy-like per-row independent sort the
-    bridge dispatches each row as its own 1-channel tile."""
+  """Sort each row of a 2D input [C, W] along the last axis (Width). Native-ANE Sort
+    bridge - a cut. `return_indices=True` returns argsort indices (fp16-encoded, exact for
+    index < 2048). The hardware Sort keys on one channel lane and permutes all channels by
+    it, so the bridge dispatches each row as its own 1-channel tile for a per-row sort."""
   if len(x.shape) != 2:
     raise ValueError(f"sort: only 2D [C,W] inputs are supported; got {x.shape}")
   return Tensor(x.shape, "sort", [x],
@@ -1044,29 +975,13 @@ def minmax_norm(x: Tensor, dimension: str = "Width", eps: float = 1e-4) -> Tenso
 
 
 def lrn(x: Tensor, alpha: float = 1.0, beta: float = 0.75, k: float = 1.0) -> Tensor:
-  """Cross-channel local response normalization (classic AlexNet LRN) on the ANE's
-    native LocalResponseNormalization layer (Channel mode). `x` is [1, C, H, W];
-    graph cut.
-
-    Per-channel, per-pixel:
+  """Cross-channel LRN (classic AlexNet) on the native LocalResponseNormalization layer
+    (Channel mode). `x` is [1, C, H, W]; graph cut. Per-channel, per-pixel:
         `y[c] = x[c] / (k + alpha * sum_{j in window(c)} x[j]^2) ** beta`
-
-    The window is a LOCAL channel window of size N = C (the bridge fixes the layer's
-    `KernelChannel` to the channel count), asymmetric-centered on c and CLIPPED at
-    the channel boundaries:
-        `window(c) = [max(0, c-(N-1)//2) : min(C, c + N//2 + 1)]`.
-    So only the center channel sees all C channels; edge channels see a partial sum.
-    This is NOT a full-channel sum (the old docstring's `sum_j x[j]^2` over all j
-    was wrong - see the corrected reference in tests/test_numerical.py and the RE in
-    the reverse-engineering corpus).
-
-    `alpha`/`beta`/`k` are the standard LRN coefficients in their natural units;
-    `alpha` is the TRUE effective alpha. The bridge encodes `alpha` as an fp16
-    bit-pattern and pre-multiplies by KernelChannel to cancel the layer's internal
-    divide-by-KernelChannel; callers do not see that.
-
-    ARCH-GATED: the layer compiles only for C <= 15 (KernelChannel = C; C >= 16 fails
-    ANECCompile on this hardware), so larger channel counts are rejected here."""
+    The window is a LOCAL channel window of size N=C, asymmetric-centered on c and CLIPPED
+    at the boundaries: `window(c) = [max(0, c-(N-1)//2) : min(C, c + N//2 + 1)]` (NOT a
+    full-channel sum). `alpha`/`beta`/`k` are the standard LRN coefficients (`alpha` is the
+    TRUE effective alpha). ARCH-GATED: compiles only for C <= 15 (C >= 16 fails ANECCompile)."""
   if len(x.shape) != 4 or x.shape[0] != 1:
     raise ValueError(f"lrn: expects [1,C,H,W]; got {x.shape}")
   C = x.shape[1]
@@ -1091,10 +1006,8 @@ def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
   qh, kh, vh = _heads(q, n_heads, dh), _heads(k, n_heads, dh), _heads(v, n_heads, dh)
   kt = kh.transpose([0, 2, 1])
   scale = 1.0 / dh ** 0.5
-  # Query-tiling: compute [tile, S] score tiles per head instead of the full [H, S, S]
-  # score matrix. Exact (each tile attends to all keys) and ~3x faster on the ANE at
-  # large S, which pipelines the smaller tiles better (same fission as af.sdpa). The
-  # count is the S-based heuristic unless a tuned value is cached (af.tune_attention).
+  # Query-tiling: [tile, S] score tiles per head instead of the full [H, S, S] matrix.
+  # Exact and ~3x faster at large S (same fission as af.sdpa). Count from af.tune_attention.
   from . import _optimize as _opt
   n_tiles = _opt.attention_tiles(S, n_heads, dh)
   if n_tiles == 1:
@@ -1120,10 +1033,8 @@ def cross_attention(x: Tensor, context: Tensor, Wq, Wk, Wv, Wo, n_heads: int,
   kt = kh.transpose([0, 2, 1])                                            # [H,dh,T]
   scale = 1.0 / dh ** 0.5
   # Query-tiling: when query and context are both long the [H, S, T] score matrix hits
-  # the ANE's materialization wall (~2.4x slower past it). Tiling the query into
-  # [tile, T] score blocks avoids it, exact, the same fission as af.sdpa/af.mha. Gated
-  # on score area so small-T cross-attention (SD text conditioning, T=77) stays
-  # single-shot, where it is byte-identical and already fastest.
+  # the ANE materialization wall (~2.4x slower). Tile the query into [tile, T] blocks
+  # (exact). Gated on score area so small-T cross-attention (SD T=77) stays single-shot.
   from . import _optimize as _opt
   n_tiles = _opt.attention_tiles(S, n_heads, dh, T=T) if (S >= 768 and T >= 512) else 1
   if n_tiles == 1:
@@ -1136,39 +1047,25 @@ def cross_attention(x: Tensor, context: Tensor, Wq, Wk, Wv, Wo, n_heads: int,
   return o.linear(Wo, bo)
 
 
-# The native fused-attention layer is numerically reliable only up to this sequence
-# length. Measured 2026-06-02 (the reverse-engineering corpus): native vs an fp32
-# reference is ~3e-3 at S<=2048 but ~1.0 (garbage) at S=4096, while the decomposed
-# matmul/softmax/matmul stays ~5e-3 (the wide matmul accumulator holds). So above
-# this S, af.sdpa emits the accurate decomposition instead of the native node.
+# Native fused-attention is numerically reliable only up to this seq length (garbage at
+# S=4096); above it af.sdpa emits the accurate decomposition (the wide matmul accumulator holds).
 SDPA_NATIVE_MAX_SEQ = 2048
-# The native fused-attention layer returns garbage once BOTH the query and key sequence axes
-# are large: reliable only while min(q_seq, k_seq) < this bound (measured 2026-06-09: a hard
-# 512x512 score-tile cliff - cos collapses to ~0.67 at 512x512, while the KV-cache decode
-# shape min=1 stays correct to large k_seq). Outside it we decompose (non-causal) or refuse
-# (causal - the decomposition can't build the additive mask here).
+# Native fused-attention returns garbage once BOTH q and k seq axes are large: reliable only
+# while min(q_seq, k_seq) < this (hard 512x512 cliff; KV-cache decode min=1 stays correct).
 SDPA_NATIVE_MIN_BOTH = 512
 
 
 def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
     is_causal: bool = False, attn_mask: "Tensor | None" = None) -> Tensor:
-  """Scaled-dot-product attention. Uses the ANE's *native* fused-attention hardware
-    layer (ANECSDPALayerDesc) - a path Apple's user-space MIL compiler never emits
-    (it always decomposes SDPA) - for sequence lengths where it is numerically
-    reliable (S <= SDPA_NATIVE_MAX_SEQ); above that it emits the accurate fused
-    decomposition instead (the native layer returns garbage at large S). q/k/v:
-    [1, heads, seq, d_head], fp16. Returns the same shape. `scale` defaults to
-    1/sqrt(d_head).
+  """Scaled-dot-product attention via the ANE's *native* fused-attention layer
+    (ANECSDPALayerDesc) - a path Apple's MIL compiler never emits - inside the reliable
+    regime, else the accurate fused decomposition. q/k/v: [1, heads, seq, d_head], fp16;
+    `scale` defaults to 1/sqrt(d_head).
 
-    Where the native layer is used this is a graph-cut boundary: the surrounding graph
-    runs as e5rt program(s) and this node runs as a separate native-SDPA ANE
-    sub-program (see _compile.compile). `is_causal=True` is NATIVE: the causal additive
-    mask rides the SDPA layer's optional 5th bottom (kept on the native bridge route -
-    the route optimizer does not decompose it, since the decomposition is unmasked).
-    Validated on M1: cos 1.0 vs softmax(QK^T*scale + causal)*V, single + multi-head.
-    Requires S <= SDPA_NATIVE_MAX_SEQ (above that the op decomposes, which has no mask)."""
-  # K and V share shape (the cached sequence); Q's SEQUENCE may differ from K/V's - the
-  # KV-cache DECODE shape (q seq_q attends to cached k/v of length seq_kv). Q,K share H+D.
+    Native use is a graph-cut boundary (a separate native-SDPA sub-program). `is_causal=True`
+    is NATIVE: the causal additive mask rides the SDPA layer's optional 5th bottom, and
+    requires S <= SDPA_NATIVE_MAX_SEQ (the decomposition has no mask)."""
+  # K,V share shape (cached seq); Q's seq may differ (KV-cache decode). Q,K share H+D.
   if not (len(q.shape) == 4 == len(k.shape) == len(v.shape)):
     raise ValueError(f"af.sdpa expects 4D q,k,v of [1,H,S,D]; got {q.shape}, {k.shape}, {v.shape}")
   if k.shape != v.shape:
@@ -1184,13 +1081,10 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
   if attn_mask is not None:
     if is_causal:
       raise ValueError("af.sdpa: pass either is_causal or an explicit attn_mask, not both")
-    # attn_mask is a RUNTIME additive bias broadcastable with the [.,.,Sq,Skv] scores
-    # (rides the native SDPA layer's 5th bottom). The native layer applies ONE additive-mask
-    # plane shared across all heads, over the FULL query axis: shape must be [1,1,Sq,Skv].
-    # A per-head mask ([1,H,Sq,Skv], H>1) is silently mis-applied (one plane used for all
-    # heads -> wrong), and a query-broadcast mask ([1,1,1,Skv] with q_seq>1) underflows the
-    # bridge -- reject both rather than return garbage. (For KV-cache decode q_seq==1, so
-    # [1,1,1,Skv] is a full-query plane and is accepted.)
+    # attn_mask is a RUNTIME additive bias on the native layer's 5th bottom: ONE plane
+    # shared across all heads over the full query axis, so shape must be [1,1,Sq,Skv].
+    # Per-head ([1,H,..], H>1) is silently mis-applied and query-broadcast ([1,1,1,Skv]
+    # with q_seq>1) underflows the bridge -- reject both. (KV-cache decode q_seq==1 is ok.)
     if (len(attn_mask.shape) != 4 or attn_mask.shape[0] != 1 or attn_mask.shape[1] != 1
         or attn_mask.shape[2] != q.shape[2] or attn_mask.shape[3] != k.shape[2]):
       raise ValueError(
@@ -1200,28 +1094,20 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
         f"(Sq-axis=1 while q_seq>1) are not supported by the native layer.")
   _scale: float = scale if scale is not None else 1.0 / q.shape[-1] ** 0.5
   seq = max(q.shape[2], k.shape[2])               # attention spans the K/V (cached) length
-  both = min(q.shape[2], k.shape[2])              # the native layer breaks when BOTH axes are large
-  # Native fused-attention is reliable only inside this envelope; outside it returns garbage.
+  both = min(q.shape[2], k.shape[2])              # native layer breaks when BOTH axes are large
   native_ok = both < SDPA_NATIVE_MIN_BOTH and seq <= SDPA_NATIVE_MAX_SEQ
   if not native_ok:
     if is_causal:
-      # The accurate decomposition would need a causal additive mask, but there's no
-      # host-constant add on the graph here, and the native layer is unreliable at this
-      # size -- refuse rather than return a wrong answer. Chunk the query into tiles whose
-      # min(q,k) seq stays < SDPA_NATIVE_MIN_BOTH.
+      # The decomposition has no causal mask and the native layer is unreliable here --
+      # refuse. Chunk the query so each tile's min(q,k) seq stays < SDPA_NATIVE_MIN_BOTH.
       raise NotImplementedError(
         f"af.sdpa: causal attention at min(q,k)seq={both} (>= {SDPA_NATIVE_MIN_BOTH}) "
         f"or seq={seq} (> {SDPA_NATIVE_MAX_SEQ}) is outside the reliable native regime "
         f"and the causal decomposition is not wired; chunk the query so each tile's "
         f"min(seq) < {SDPA_NATIVE_MIN_BOTH}.")
-    # non-causal (optionally with a runtime Tensor mask): the accurate fused decomposition
-    # (handles the decode shape too - Q[.,.,Sq,.] @ K^T -> [.,.,Sq,Skv].softmax @ V).
-    #
-    # Query-tiling: for a large query axis, compute the attention in [tile, Skv] score
-    # tiles instead of materializing the full [Sq, Skv] score matrix. This is exact (each
-    # tile attends to all keys) and is markedly faster on the ANE, which pipelines the
-    # smaller score tiles far better than one big matmul+softmax (~3x at Sq=1500, H=16).
-    # Tiles target ~512 query rows; a small query (e.g. KV-cache decode) takes one shot.
+    # non-causal: the accurate fused decomposition (handles the decode shape too).
+    # Query-tiling: for a large query axis, compute [tile, Skv] score tiles instead of the
+    # full [Sq, Skv] matrix - exact and ~3x faster (small queries take one shot).
     kt = k.transpose([0, 1, 3, 2])
     from . import _optimize as _opt
     n_tiles = _opt.attention_tiles(q.shape[2], q.shape[1], q.shape[3], T=k.shape[2])

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -1,69 +1,12 @@
-"""aneforge.linalg - a linear-algebra toolkit for the Apple Neural Engine.
+"""aneforge.linalg - linear algebra on the Apple Neural Engine.
 
-WHAT FITS THIS HARDWARE
------------------------
-The ANE is a fp16 feed-forward dataflow engine: it has no in-graph loop and no
-data-dependent control flow. Anything with a FIXED, data-independent schedule
-fits, and that covers two families, both shipped here:
+Iterative solvers (CG/Jacobi/refinement/LSQR/GMRES/rSVD) and small-n direct
+factorizations (QR/Cholesky/LU/eigh/eigvals/svd) - both are fixed-schedule
+dataflow that unrolls into one on-ANE program. See docs/developer/applied-math.md
+and docs/developer/numerics.md (the fp16 envelope and the reduce_sum trap: on this
+ANE reduce_sum accumulates fp16-narrow while matmul accumulates wide, so every dot
+is (u*v)@ones, never .sum()).
 
-  * ITERATIVE, MATMUL-DOMINATED methods with a FIXED iteration count (CG, Jacobi,
-    refinement, LSQR, GMRES, randomized SVD, ...): pure static dataflow. The
-    expensive matmuls (A@x, A@Omega, A^T@Q, Q@Ub, A^T@A) run on the ANE via a
-    compiled aneforge graph; fixed-K recurrences unroll into ONE on-ANE program.
-    The host keeps only what the ANE cannot do: RNG, the occasional small dense
-    decomposition, the loop counter.
-  * DIRECT factorizations at SMALL n (qr, cholesky, lu, lu_pivoted, eigh,
-    eigvals, svd, ...): a fixed recurrence with no data-dependent branch ALSO
-    unrolls into one on-ANE program. The unrolled chain is O(n^3) graph ops, so
-    these are small-n. The UNPIVOTED lu/cholesky also require well-conditioned
-    leading minors / a safe diagonal; lu_pivoted does true partial pivoting via
-    the on-engine argmax bridge (a SEGMENTED program, still all on ANE silicon).
-
-What stays ARCH-LIMITED is narrower than "direct factorizations": only
-CONVERGENCE-GATED / pivot-shifted-deflated variants, whose data-dependent
-control flow cannot be expressed in-graph - and the native MatrixDecomposition
-composite is `not_currently_callable` (see tests/test_numerical.py).
-
-THE fp16 ENVELOPE (from the reverse-engineering corpus, re-measured in __main__)
----------------------------------------------------------------------------
-The ANE matmul accumulator is WIDE (>=fp32), so a single A@x is clean even at
-cond~1e4 - BUT the iterates/residuals are stored and re-fed as fp16, and the
-residual b - A x is a catastrophic-cancellation subtract. Fixed-K iterative
-refinement recovers about ONE order of magnitude of accuracy for moderate
-conditioning; by cond~1e3 the fp16 approximate solve barely converges and
-refinement only nibbles. We claim no accuracy past what the sweep shows.
-
-  IMPORTANT (the reduce_sum trap): on this ANE `reduce_sum` accumulates NARROWLY
-  (fp16) while `matmul` accumulates WIDE. So every dot product / accumulation in
-  this module is `(u * v) @ ones` (a matmul), never `(u*v).sum()`.
-
-API (importable as `from aneforge.linalg import conjugate_gradient, qr, eigh, ...`)
-
-  Iterative solvers
-    conjugate_gradient(A, b, iters=K)         - CG for SPD A, fixed K iters
-    jacobi(A, b, iters=K) / gauss_seidel(...) - classic stationary iterations
-    iterative_refine(A, b, x0, iters=K)       - residual-correction refinement
-    least_squares(A, b, iters=...)            - normal equations solved by CG + refine
-    lsqr(A, b, iters=K)                       - Golub-Kahan least squares, fully on-ANE
-    gmres(A, b)                               - general square solve, one GMRES(n) cycle
-
-  Direct factorizations (small-n, fixed recurrences unrolled on-ANE)
-    qr(A)                                     - thin QR by modified Gram-Schmidt
-    cholesky(A)                               - unpivoted Cholesky of an SPD A
-    lu(A)                                     - unpivoted Doolittle LU (well-conditioned A)
-    lu_pivoted(A)                             - partial-pivoted LU (argmax bridge, segmented)
-
-  Eigenvalues / SVD
-    eigh(A, sweeps=...)                       - full symmetric spectrum, cyclic Jacobi
-    eigvals(A, iters=...)                     - general (nonsymmetric) eigenvalues, unshifted QR
-    generalized_eigh(A, B, sweeps=...)        - symmetric-definite A x = lambda B x
-    dominant_eig(A) / dominant_svd(A)         - dominant eigenpair / singular triple
-    svd(A, sweeps=...)                        - all singular values via Gram matrix + eigh
-    svdvals_topk(A, k, ...)                   - top-k singular values, fully on-ANE
-    randomized_svd(A, k, oversample, power_iters) - sketch + range-finder + small host SVD
-    pca(X, k, ...)                            - randomized_svd of centered data
-
-Run the self-test:
     PYTHONPATH=. python3 aneforge/linalg.py
 """
 from __future__ import annotations
@@ -79,20 +22,11 @@ import aneforge as af
 f16 = np.float16
 
 
-# =========================================================================== #
-# ANE GEMM primitive (used by randomized_svd / least_squares for the one-shot   #
-# sketch / projection / Gram products). The iterative SOLVERS do NOT use this:   #
-# they unroll their whole recurrence into ONE graph (see _solve_once) rather     #
-# than dispatching a fresh GEMM per step. Accumulation via matmul (wide), never   #
-# reduce_sum (narrow).                                                            #
-# =========================================================================== #
+# One-shot ANE GEMM for the sketch/projection/Gram products. The iterative solvers
+# do NOT use this; they unroll their whole recurrence into one graph (_solve_once).
 
 def _ane_gemm(A16: np.ndarray, B16: np.ndarray, transpose_a: bool = False) -> np.ndarray:
-  """C = A @ B  (or A^T @ B) on the ANE.
-
-    Used by randomized_svd for the big sketch / projection products. `A` is the
-    activation; `B` is folded as a weight if it is a fixed (host-drawn) array.
-    When `transpose_a` we transpose the activation in-graph (A^T @ B)."""
+  """C = A @ B (or A^T @ B) on the ANE; B folds in as a weight."""
   A16 = A16.astype(f16); B16 = B16.astype(f16)
   if transpose_a:
     m, n = A16.shape
@@ -108,26 +42,15 @@ def _ane_gemm(A16: np.ndarray, B16: np.ndarray, transpose_a: bool = False) -> np
   return np.asarray(C, f16)
 
 
-# =========================================================================== #
-# host helpers                                                                 #
-# =========================================================================== #
-
 def _spectral_omega(A16: np.ndarray | np.floating[Any]) -> float:
-  """Richardson/Jacobi relaxation factor omega from the max abs row-sum (an
-    upper bound on the spectral radius). Host-side scalar."""
+  """Richardson/Jacobi relaxation omega from the max abs row-sum (host scalar)."""
   rowsum = np.abs(np.asarray(A16, np.float64)).sum(1).max()
   return float(f16(1.0 / rowsum))
 
 
 def _solve_once(out, *feeds):
-  """Compile ONE fused graph, run it in a SINGLE dispatch, release, return fp64.
-
-    The point of the module: a fixed-iteration method is static dataflow, so the
-    whole K-step recurrence UNROLLS into one program that lives entirely on the ANE.
-    The host builds the graph and reads the answer back - it never re-enters the loop,
-    and there is no per-iteration host<->device round-trip."""
-  # vouched numerical kernel (the residual subtracts are intrinsic, accuracy-swept in
-  # __main__), so skip the user-facing cancel_sub precision check.
+  """Compile the unrolled recurrence as ONE fused graph, run once, return fp64."""
+  # vouched numerical kernel (residual subtracts are intrinsic, swept in __main__).
   net = af.compile(out, _check_precision=False)
   y = np.asarray(net(*feeds), np.float64)
   net.release()
@@ -139,35 +62,14 @@ def _solve_once(out, *feeds):
 # =========================================================================== #
 
 def conjugate_gradient(A, b, iters: int = 20, x0=None, refine: int = 0):
-  """Solve A x = b for SYMMETRIC POSITIVE-DEFINITE A by CG, FIXED `iters`.
-
-    Static dataflow: the iteration count is fixed (no convergence test), so the
-    schedule is data-independent and ANE-friendly. Per iteration the ONE heavy op
-    is the GEMV `A @ p` (ANE, wide accumulator). The two dot products
-    (r.r, p.Ap) are also ANE matmuls; the scalar ratios / axpy updates are host.
-
-    ANE: A@p, r.r, p.Ap, r2.r2  (every matmul/dot).
-    HOST: alpha/beta scalar ratios, x/r/p axpy updates, the fixed loop.
-
-    fp16 RANGE: symmetric Jacobi (diagonal) preconditioning, A~ = D^{-1/2} A D^{-1/2},
-    bounds A~'s entries to ~1 so the fp16 dot products p.Ap do not OVERFLOW (raw
-    cond~1e2 GEMV products blow past 65504 otherwise). The scaling is a host diagonal
-    rescale of the FOLDED constant matrix (graph setup), not re-entered per iteration.
-
-    FULLY ON THE ANE: the entire K-iteration recurrence - the A@p GEMV, the r.r and
-    p.Ap dot products (as (u*v)@ones matmuls, wide accumulator), the alpha/beta scalar
-    ratios (as [1,1] real_div), and the x/r/p axpy updates (broadcast mul + add) - is
-    UNROLLED into ONE graph and compiled ONCE. No Python loop issues per-iteration
-    dispatches; the solve is a single ANE program, a single execute.
-
-    `refine` unrolls that many residual-correction rounds into the SAME graph (each
-    recomputes r = b - A x and re-solves a short inner CG), useful near the ceiling.
-    """
+  """Solve A x = b for SPD A by CG, FIXED `iters` (the whole recurrence unrolls into
+    one on-ANE program). `refine` adds residual-correction rounds, useful near the
+    fp16 ceiling. Symmetric Jacobi preconditioning keeps the fp16 dots in range; see
+    docs/developer/numerics.md."""
   A0 = np.asarray(A, np.float64); b0 = np.asarray(b, np.float64).reshape(-1)
   n = A0.shape[0]
-  # symmetric Jacobi preconditioner: solve A~ y = b~ with A~ = Dh^{-1} A Dh^{-1},
-  # b~ = Dh^{-1} b, then x = Dh^{-1} y.   Dh = sqrt(diag(A)).  A~ is symmetric, so
-  # the matrix-vector A~ p as a row vector is p @ A~.
+  # symmetric Jacobi preconditioner: A~ = Dh^{-1} A Dh^{-1}, b~ = Dh^{-1} b,
+  # x = Dh^{-1} y;  Dh = sqrt(diag(A)).  A~ symmetric, so A~ p (row) is p @ A~.
   dh = np.sqrt(np.abs(A0.diagonal())); dh[dh == 0] = 1.0
   A16 = f16((A0 / dh[:, None]) / dh[None, :])
   b16 = f16(b0 / dh).reshape(1, n)
@@ -203,9 +105,7 @@ def conjugate_gradient(A, b, iters: int = 20, x0=None, refine: int = 0):
 
   feeds = [b16] if x0T is None else [b16, (np.asarray(x0, np.float64).reshape(-1) * dh).astype(f16).reshape(1, n)]
   y = _solve_once(x, *feeds).ravel()
-  # fp16 BREAKDOWN at high cond: the unrolled iterates can overflow fp16 (no in-graph
-  # convergence test to stop early), surfacing as non-finite. Report the ceiling as a
-  # finite large relerr rather than a nan answer.
+  # high cond: unrolled iterates can overflow fp16 (no early-stop) -> guard nan to 0.
   if not np.isfinite(y).all(): y = np.zeros(n)
   return (y / dh).astype(np.float32)
 
@@ -215,17 +115,8 @@ def conjugate_gradient(A, b, iters: int = 20, x0=None, refine: int = 0):
 # =========================================================================== #
 
 def jacobi(A, b, iters: int = 60, x0=None):
-  """Jacobi iteration  x_{k+1} = D^{-1} (b - (A - D) x_k),  FIXED `iters`.
-
-    Rewritten so the heavy op is the full GEMV `A @ x` on the ANE:
-        x_{k+1} = x_k + D^{-1} (b - A x_k).
-    Converges for diagonally-dominant A.
-
-    FULLY ON THE ANE: all `iters` steps unroll into ONE program (single dispatch).
-    The matrix-vector A x (row form x @ A^T) is the ANE GEMV; D^{-1} is fed once as a
-    constant vector and the update x + (b - A x) * D^{-1} is broadcast mul + add. The
-    host builds the graph and reads the answer; it does not loop.
-    """
+  """Jacobi iteration x_{k+1} = x_k + D^{-1}(b - A x_k), FIXED `iters`; converges for
+    diagonally-dominant A. All steps unroll into one on-ANE program (A x is the GEMV)."""
   A16 = np.asarray(A, f16); b0 = np.asarray(b, np.float64).reshape(-1)
   n = A16.shape[0]
   AT16 = np.ascontiguousarray(A16.T)                     # x @ A^T = (A x) as a row
@@ -243,27 +134,15 @@ def jacobi(A, b, iters: int = 60, x0=None):
 
 
 def gauss_seidel(A, b, iters: int = 60, x0=None):
-  """Gauss-Seidel iteration, FIXED `iters`.
-
-    Gauss-Seidel uses the freshest x-components within a sweep, so the inner sweep
-    is INHERENTLY SEQUENTIAL (component i depends on already-updated components <i).
-    That serial dependence is what the ANE cannot express in-graph, so the
-    per-component back-substitution sweep runs on the HOST, while the heavy
-    full-matrix residual GEMV `A @ x` (recomputed once per outer sweep to keep the
-    host work O(n^2)) still runs on the ANE.
-
-    ANE: A@x (the bulk FLOPs).   HOST: the sequential triangular sweep + loop.
-    The division: Gauss-Seidel's serial sweep is the arch-limited part; only
-    the dense GEMV stays on-device.
-    """
+  """Gauss-Seidel iteration, FIXED `iters`. The serial forward sweep is arch-limited
+    (host); only the dense residual GEMV stays on the ANE. See
+    docs/developer/applied-math.md."""
   A16 = np.asarray(A, f16); b16 = np.asarray(b, f16).reshape(-1)
   Af = np.asarray(A16, np.float64); bf = b16.astype(np.float64)
   n = A16.shape[0]
   x = np.zeros(n, np.float64) if x0 is None else np.asarray(x0, np.float64).reshape(-1).copy()
   L = np.tril(Af, -1); U = np.triu(Af, 1); d = Af.diagonal()
   for _ in range(iters):
-    # ANE supplies the off-diagonal contribution via the full GEMV, then the
-    # host does the serial forward sweep with the fresh values.
     for i in range(n):
       s = L[i, :i] @ x[:i] + U[i, i + 1:] @ x[i + 1:]
       x[i] = (bf[i] - s) / d[i]
@@ -275,21 +154,10 @@ def gauss_seidel(A, b, iters: int = 60, x0=None):
 # =========================================================================== #
 
 def iterative_refine(A, b, x0, iters: int = 3, inner: int = 60):
-  """Sharpen an approximate solve x0 of A x = b by fixed-K residual correction.
-
-    Each round:  r = b - A x  (the cancellation-prone subtract),  solve A dx = r
-    approximately,  x <- x + dx.  The static-dataflow stand-in for the arch-limited
-    direct factorizations; it extends the well-conditioned fp16 envelope ~1 order of
-    magnitude (the reverse-engineering corpus).
-
-    The inner approximate-solve is a short Richardson sweep (matmul-only), so the
-    whole thing is matmul-dominated.
-
-    FULLY ON THE ANE: both loops - the `iters` outer refinements and each `inner`
-    Richardson sweep - UNROLL into ONE program (single dispatch). A~ is symmetric, so
-    A~ x is the GEMV x @ A~; omega is a compile-time scalar (fused `muls`); the
-    subtract and axpy are elementwise. Host: build the graph, read the answer.
-    """
+  """Sharpen an approximate solve x0 by fixed-K residual correction (r = b - A x,
+    solve A dx = r, x += dx). Extends the well-conditioned fp16 envelope ~1 order of
+    magnitude; both loops unroll into one on-ANE program. The inner solve is a short
+    Richardson sweep (matmul-only). See docs/developer/numerics.md."""
   A0 = np.asarray(A, np.float64); b0 = np.asarray(b, np.float64).reshape(-1)
   n = A0.shape[0]
   # same symmetric Jacobi scaling as CG, to keep the fp16 GEMV products in range
@@ -317,28 +185,9 @@ def iterative_refine(A, b, x0, iters: int = 3, inner: int = 60):
 
 def randomized_svd(A, k: int, oversample: int = 5, power_iters: int = 2):
   """Truncated SVD of A [m,n] via Halko-Martinsson-Tropp randomized range finding.
-
-    Steps:
-      1. Omega = host-drawn Gaussian [n, l]    (a constant, not on-device compute)   HOST
-      2. Y = A @ Omega   (the big sketch)                                            ANE
-         power iterations with re-orthonormalization: Q = qr(Y); Y = A @ (A^T @ Q)   ANE + host QR
-      3. Q = orthonormal basis of Y  (l columns)                                     HOST
-      4. B = Q^T @ A   (the projection)                                              ANE
-      5. (Ub, S, Vt) = svd(B)  (small l x n SVD)                                      HOST
-      6. U = Q @ Ub   (the back-projection)                                          ANE
-    Return (U[:, :k], S[:k], Vt[:k, :]).
-
-    UNLIKE the iterative SOLVERS in this module (CG / Jacobi / refinement, matmul +
-    elementwise only, so they unroll into ONE fully-on-ANE program), rSVD has an
-    irreducible host step: the subspace ORTHONORMALIZATION between power steps. Pure
-    in-graph column-normalization cannot stand in - power iteration aligns the columns
-    toward the dominant singular vector, and only a QR re-spreads them, so skipping it
-    collapses the trailing spectrum (measured: relerr 0.4-0.7 on the small singular
-    values). QR is a serial, pivoted recurrence the ANE cannot express in-graph (the
-    documented arch limit on DIRECT factorizations). So every heavy O(mnl) matmul
-    (A@Omega, A^T@Q, A@(A^T Q), Q^T@A, Q@Ub) is one ANE dispatch; the QR and the l x n
-    SVD run on the host on the tiny l-wide factors. This is the on-ANE ceiling for rSVD.
-    """
+    Returns (U[:, :k], S[:k], Vt[:k, :]). Every heavy O(mnl) matmul runs on the ANE;
+    the QR re-orthonormalization between power steps and the small l x n SVD stay on
+    the host (the irreducible host step - see docs/developer/applied-math.md)."""
   A16 = np.asarray(A, f16)
   m, n = A16.shape
   l = min(k + oversample, n)
@@ -361,10 +210,8 @@ def randomized_svd(A, k: int, oversample: int = 5, power_iters: int = 2):
 
 
 def pca(X, k: int, oversample: int = 5, power_iters: int = 2):
-  """Principal components of data X [samples, features] via randomized SVD of the
-    CENTERED data. Centering is a host mean-subtract (cheap); the SVD's matmuls run
-    on the ANE. Returns (components [k, features], singular_values [k], mean [features]).
-    """
+  """Principal components of X [samples, features] via randomized_svd of the centered
+    data. Returns (components [k, features], singular_values [k], mean [features])."""
   Xf = np.asarray(X, np.float64)
   mean = Xf.mean(0)
   Xc = (Xf - mean).astype(f16)                                           # HOST centering
@@ -377,19 +224,9 @@ def pca(X, k: int, oversample: int = 5, power_iters: int = 2):
 # =========================================================================== #
 
 def least_squares(A, b, iters: int = 40, refine: int = 2):
-  """Solve min_x ||A x - b||_2 via the normal equations A^T A x = A^T b, solved by
-    CG (A^T A is SPD) with iterative refinement.
-
-    The normal-equations operator A^T A is formed as a single ANE GEMM (Gram/SYRK),
-    and the right-hand side A^T b as an ANE GEMV-via-matmul. CG then runs on the
-    n x n SPD system. Forming A^T A SQUARES the condition number, so this is the
-    textbook accuracy-limited route - refinement (the envelope finding) buys back
-    roughly the order of magnitude that squaring cost. For very ill-conditioned A a
-    QR-based lstsq would be better, but QR is arch-limited on the ANE; CG on the
-    normal equations is the iterative alternative that fits.
-
-    ANE: A^T A (Gram), A^T b, and every A_normal@p inside CG.   HOST: CG scalars + loop.
-    """
+  """Solve min_x ||A x - b||_2 via the normal equations A^T A x = A^T b, by CG (A^T A
+    is SPD) + refinement. Forming A^T A squares cond(A); refinement buys back roughly
+    the order of magnitude that costs. See docs/developer/numerics.md."""
   A16 = np.asarray(A, f16); b16 = np.asarray(b, f16).reshape(-1)
   m, n = A16.shape
   AtA = _ane_gemm(A16, A16, transpose_a=True)                            # ANE: A^T A -> [n,n]
@@ -402,27 +239,13 @@ def least_squares(A, b, iters: int = 40, refine: int = 2):
   return conjugate_gradient(AtA, Atb, iters=iters, refine=refine)
 
 
-# =========================================================================== #
-# 6. KRYLOV solvers, FULLY on the ANE (general/least-squares solve + eigenpair)   #
-# --------------------------------------------------------------------------- #
-# A fixed-iteration Krylov method's orthogonalization is SEQUENTIAL in data       #
-# dependency but STATIC in structure (no pivoting, no data-dependent branch), so   #
-# for a fixed step count the WHOLE recurrence UNROLLS into ONE graph and runs       #
-# entirely on the ANE, like conjugate_gradient. Matvecs are matmuls (A folded as a  #
-# const), dots / norms are (z*z)@ones (wide accumulator), and the Givens /          #
-# bidiagonalization scalars are [1,1] tensors. Nothing is on host.                  #
-# =========================================================================== #
+# Krylov solvers, FULLY on the ANE: a fixed-step Krylov recurrence is sequential but
+# STATIC, so it unrolls into one graph like conjugate_gradient. See applied-math.md.
 
 def lsqr(A, b, iters: int = 80):
   """Solve min_x ||A x - b||_2 by LSQR (Golub-Kahan bidiagonalization), FULLY on the
-    ANE: the entire bidiagonalization + Givens recurrence unrolls into ONE program. The
-    two matvecs per step (A@v, A^T@u) are matmuls with A/A^T folded as constants; the
-    norms are sqrt((z*z)@ones); the scalars (alpha, beta, rho, c, s, phi) are [1,1]
-    tensors. No host orthogonalization. fp16 envelope for OVERDETERMINED least squares:
-    ~1e-3 at cond(A)<=1e1, ~1e-2 at cond(A)<=1e2. It also solves a SQUARE nonsingular
-    system (the min-residual point is the exact solution) but only to cond~1e1 in fp16 -
-    the bidiagonalization loses orthogonality on square systems; use `gmres` for a
-    square general solve at cond<=1e2."""
+    ANE. fp16 envelope (overdetermined): ~1e-3 at cond(A)<=1e1, ~1e-2 at cond(A)<=1e2.
+    Solves a SQUARE system only to cond~1e1 (orthogonality loss) - use `gmres` there."""
   A0 = np.asarray(A, f16); m, n = A0.shape; AT = np.ascontiguousarray(A0.T)
   onem = np.ones((m, 1), f16); onen = np.ones((n, 1), f16)
   bT = af.input((1, m))
@@ -442,11 +265,9 @@ def lsqr(A, b, iters: int = 80):
 
 
 def dominant_eig(A, iters: int = 60, seed: int = 0):
-  """Dominant (largest-|.|) eigenvalue + eigenvector of a SYMMETRIC A by power iteration,
-    FULLY on the ANE: x <- A x / ||A x|| unrolls into ONE program; the eigenvalue is the
-    in-graph Rayleigh quotient (x^T A x)/(x^T x). Returns (lambda, eigenvector). A few
-    extremal pairs follow by deflation; the FULL spectrum needs the arch-limited dense QR
-    iteration. fp16-clean to ~1e-3 for a well-separated dominant eigenvalue."""
+  """Dominant eigenpair of SYMMETRIC A by power iteration, FULLY on the ANE (eigenvalue
+    is the in-graph Rayleigh quotient). Returns (lambda, eigenvector); ~1e-3 fp16 for a
+    well-separated dominant eigenvalue."""
   A0 = np.asarray(A, f16); n = A0.shape[0]; AT = np.ascontiguousarray(A0.T)
   onen = np.ones((n, 1), f16)
   x0 = af.input((1, n))
@@ -464,15 +285,10 @@ def dominant_eig(A, iters: int = 60, seed: int = 0):
 
 
 def gmres(A, b):
-  """Solve A x = b for GENERAL (nonsymmetric) A by ONE full GMRES(n) cycle, FULLY on the
-    ANE: Arnoldi (double modified-Gram-Schmidt reorthogonalization), the Givens rotations,
-    and the upper-triangular back-substitution ALL unroll into one program. Each Arnoldi
-    matvec A@q is a matmul (A folded); the projections are (q*w)@ones dots; the rotation
-    and back-solve scalars are [1,1] tensors. More accurate than lsqr for a square general
-    system at higher conditioning (~7e-3 at cond<=1e2), but HEAVIER: the m^2 orthogonalization
-    plus the sequential back-substitution make a large, deep graph (~5.7k ops at n=24) that
-    compiles slowly, so prefer lsqr unless the extra accuracy is needed. fp16 envelope ~1e-2
-    at cond<=1e2; SPD systems should use the cheaper conjugate_gradient."""
+  """Solve A x = b for GENERAL A by ONE full GMRES(n) cycle, FULLY on the ANE (Arnoldi
+    with double MGS, Givens rotations, and back-substitution all unroll). ~7e-3 at
+    cond<=1e2, more accurate than lsqr on square systems but HEAVIER (~5.7k ops at n=24,
+    slow compile) - prefer lsqr unless needed; SPD -> conjugate_gradient."""
   A0 = np.asarray(A, f16); n = A0.shape[0]; m = n
   AT = np.ascontiguousarray(A0.T); onen = np.ones((n, 1), f16)
   bT = af.input((1, n))
@@ -506,12 +322,9 @@ def gmres(A, b):
 
 
 def dominant_svd(A, iters: int = 60, seed: int = 0):
-  """Dominant singular triple (sigma1, u1, v1) of A by power iteration on A^T A, FULLY
-    on the ANE: v <- A^T(A v)/||.|| unrolls into one program (the matvec is two matmuls,
-    A and A^T folded); sigma1 = ||A v1|| as an in-graph norm, u1 = A v1 / sigma1. Returns
-    (sigma1, u1, v1). The dominant triple only - a top-k SVD needs the subspace/
-    Rayleigh-Ritz step whose dense l x l decomposition is the on-ANE frontier (see
-    randomized_svd, which keeps that small factorization on the host)."""
+  """Dominant singular triple (sigma1, u1, v1) by power iteration on A^T A, FULLY on
+    the ANE. Returns (sigma1, u1, v1). Normalize between the A and A^T applications:
+    A^T(A v) has magnitude ~sigma^2 and overflows fp16 for sigma>~250."""
   A0 = np.asarray(A, f16); m, n = A0.shape
   AT = np.ascontiguousarray(A0.T); onen = np.ones((n, 1), f16); onem = np.ones((m, 1), f16)
   v0 = af.input((1, n))
@@ -521,10 +334,7 @@ def dominant_svd(A, iters: int = 60, seed: int = 0):
   ATx = lambda u: u @ A0                                 # [1,m]@[m,n] = A^T u
   v = v0 / nn(v0)
   for _ in range(iters):
-    # power iteration on A^T A, but NORMALIZE between the A and A^T applications:
-    # A^T(A v) has magnitude ~sigma^2, which overflows fp16 for sigma>~250; keeping
-    # each half-step unit-norm holds everything O(1).
-    Av = Ax(v); Av = Av / nm(Av)
+    Av = Ax(v); Av = Av / nm(Av)                          # half-step renorm: holds O(1)
     v = ATx(Av); v = v / nn(v)
   Av = Ax(v); sig = nm(Av)                               # sigma1 = ||A v1||  [1,1]
   u = Av / sig
@@ -534,20 +344,9 @@ def dominant_svd(A, iters: int = 60, seed: int = 0):
   return float(r[0]), r[1:1 + m].astype(np.float32), r[1 + m:].astype(np.float32)
 
 
-# =========================================================================== #
-# 7. DENSE factorization - the FULL spectrum, on the ANE via cyclic Jacobi        #
-# --------------------------------------------------------------------------- #
-# The "direct factorizations are arch-limited" wall is only half true: PIVOTED /  #
-# convergence-GATED variants need data-dependent control flow, but the FIXED-sweep #
-# cyclic-Jacobi eigensolver does not - its sweep order is compile-time fixed, each  #
-# Givens rotation is a closed-form function of three matrix entries (no pivot, no   #
-# branch), and it converges quadratically in ~6-10 sweeps for ANY symmetric input.  #
-# So the WHOLE eigendecomposition unrolls into one on-ANE program, each rotation a   #
-# fixed row/column slice+combine+concat (no constant matrices). HEAVY: O(sweeps*n^2) #
-# rotations -> O(n^3)-ish ops, so a SMALL-n method (the deep unrolled graph compiles  #
-# slowly; the iterative topo in _compile.py is what lets it build at all). fp16: full #
-# spectrum to ~4e-3 at n<=16, cond<=1e2.                                              #
-# =========================================================================== #
+# Full spectrum on the ANE via FIXED-sweep cyclic Jacobi: the sweep order is
+# compile-time fixed and each rotation is closed-form (no pivot/branch), so the whole
+# eigendecomposition unrolls into one program. Small-n (O(n^3) graph). applied-math.md.
 
 def _jacobi_sweep(M, n):
   """One full cyclic-Jacobi sweep over a symmetric M [n,n] (all (p,q) rotations), in-graph."""
@@ -585,18 +384,10 @@ def _jacobi_sweep(M, n):
 
 
 def eigh(A, sweeps: int = 8, iterate: bool = False):
-  """ALL eigenvalues of a SYMMETRIC A by fixed-sweep cyclic Jacobi on the ANE. Returns the
-    eigenvalues sorted ascending.
-
-    `iterate=False` (default): the whole `sweeps`-sweep recurrence UNROLLS into ONE fused
-    program. Cleanest, but small-n only - the O(n^3) rotation chain is a deep graph (caps near
-    n=20 at ~4e-3 vs numpy.eigh, cond<=1e2).
-
-    `iterate=True`: compile ONE cyclic-Jacobi sweep and host-loop it `sweeps` times,
-    feeding the matrix back each round. The per-sweep graph is O(n^2) instead of O(sweeps*n^2),
-    so it reaches MUCH larger n (n~48 at ~1.2-1.8e-2). The sweep compute is on-engine; the host
-    only shuttles the matrix between sweeps (a data move, no tensor math). Use when n exceeds
-    the unrolled ceiling. For a few extremal pairs of a large matrix use dominant_eig."""
+  """ALL eigenvalues of SYMMETRIC A by fixed-sweep cyclic Jacobi, sorted ascending.
+    `iterate=False`: the whole recurrence unrolls into one program (small-n, ~4e-3 to
+    n~20). `iterate=True`: compile ONE sweep and host-loop it (O(n^2)/sweep, reaches
+    n~48). See docs/developer/applied-math.md."""
   A0 = np.asarray(A, f16); n = A0.shape[0]
   if iterate:
     net = af.compile(_jacobi_sweep(af.input((n, n)), n), _check_precision=False)
@@ -611,14 +402,12 @@ def eigh(A, sweeps: int = 8, iterate: bool = False):
 
 
 def svd(A, sweeps: int = 8):
-  """ALL singular values of A, FULLY on the ANE: form the symmetric Gram matrix A^T A as
-    one ANE GEMM, then take its full spectrum with the on-ANE cyclic-Jacobi `eigh`
-    (sigma_i = sqrt(eig_i)). Returns singular values descending. Forming A^T A SQUARES the
-    condition number, so this is accurate for cond(A)<=1e1 in fp16; for top-k of a large /
-    ill-conditioned A use randomized_svd. Small-n (eigh is the heavy unrolled Jacobi)."""
+  """ALL singular values of A (descending), FULLY on the ANE: Gram matrix A^T A as one
+    GEMM, then its spectrum via cyclic-Jacobi `eigh` (sigma = sqrt(eig)). Forming A^T A
+    squares cond(A), so accurate for cond(A)<=1e1; small-n. See docs/developer/numerics.md."""
   A16 = np.asarray(A, f16); m, n = A16.shape
-  # form the SMALLER Gram matrix (A A^T if wide, A^T A if tall) - both share the nonzero
-  # eigenvalues, but eigh's graph is O(dim^3), so a wide [5,96] B uses the 5x5, not 96x96.
+  # form the SMALLER Gram matrix (A A^T if wide, A^T A if tall): same nonzero eigenvalues,
+  # but eigh's graph is O(dim^3), so a wide [5,96] B uses the 5x5, not 96x96.
   M = A16 if m >= n else np.ascontiguousarray(A16.T)
   G = _ane_gemm(M, M, transpose_a=True)                  # ANE: M^T M  [min(m,n), min(m,n)]
   ev = eigh(G, sweeps=sweeps)
@@ -626,18 +415,10 @@ def svd(A, sweeps: int = 8):
 
 
 def svdvals_topk(A, k: int, oversample: int = 2, power_iters: int = 1, seed: int = 0):
-  """Top-k singular VALUES of a large A, FULLY on the ANE - randomized range finding with
-    every step on the engine: the sketch A@Omega and the power products (matmuls), the
-    range-basis orthonormalization (the on-ANE Gram-Schmidt `qr`, re-run between power
-    steps), the projection Q^T A, and the small-block `svd` (on-ANE cyclic Jacobi). The
-    host only orchestrates (array transposes/slices, no tensor math). Unlike
-    `randomized_svd` - which keeps the QR + small SVD on the host - this is the fully-on-
-    engine top-k. Returns the k largest singular values, ~1e-2 for a rank-k matrix.
-
-    NOTE the fp16 tradeoff: extra power iterations HURT here (relerr 1.2e-2 -> 8e-2 -> 0.2 as
-    power_iters goes 1 -> 2 -> 3). Each A^T A step squares the spectrum, and in fp16 that
-    crushes the trailing singular values toward the dominant one, so the minimal sketch
-    (oversample 2, one power step) is the most accurate for a clean low-rank matrix."""
+  """Top-k singular VALUES of a large A, FULLY on the ANE (sketch + on-ANE `qr` +
+    projection + on-ANE `svd`; host only orchestrates). ~1e-2 for a rank-k matrix.
+    NOTE: extra power iterations HURT (each A^T A squares the spectrum and fp16 crushes
+    the trailing values) - the minimal sketch is most accurate. See numerics.md."""
   A16 = np.asarray(A, f16); m, n = A16.shape; l = min(k + oversample, n)
   Om = np.random.default_rng(seed).standard_normal((n, l)).astype(f16)
   Y = _ane_gemm(A16, Om); Q = qr(Y)[0].astype(f16)                  # ANE sketch + Gram-Schmidt
@@ -647,17 +428,10 @@ def svdvals_topk(A, k: int, oversample: int = 2, power_iters: int = 1, seed: int
   return np.sort(svd(B, sweeps=8))[::-1][:k]                         # ANE svd of the small block
 
 
-# =========================================================================== #
-# 8. DIRECT factorizations on the ANE - QR / Cholesky / LU (UNPIVOTED)            #
-# --------------------------------------------------------------------------- #
-# A direct factorization is a FIXED recurrence (no pivot = no data-dependent      #
-# branch), so it unrolls into one on-ANE program. QR is column Gram-Schmidt (dots #
-# as (a*b)@ones, wide accumulator); Cholesky/LU build entries as [1,1] tensors,    #
-# dividing by the pivot with real_div. Small-n (the unrolled recurrence is an O(n^3) #
-# graph). Pivoting (for a zero/tiny pivot) needs an argmax+one-hot permutation,      #
-# which segments the graph (a bridge op) - these are the unpivoted forms, valid when #
-# the leading minors / diagonal are well-conditioned.                                #
-# =========================================================================== #
+# Direct factorizations on the ANE - QR/Cholesky/LU. A no-pivot direct factorization is
+# a FIXED recurrence, so it unrolls into one program; small-n (O(n^3) graph). Pivoting
+# needs an argmax+one-hot (a bridge op that segments) - these are the unpivoted forms,
+# valid for well-conditioned leading minors. See docs/developer/numerics.md.
 
 def _grid(entries: dict, n: int, zero):
   """Assemble an n x n matrix from a dict {(i,j): [1,1] tensor} (missing -> zero)."""
@@ -666,25 +440,17 @@ def _grid(entries: dict, n: int, zero):
 
 
 def _els_routed(Xt, n: int):
-  """Element accessor `el(i, j)` for an [n,n] input, routed OFF the width axis: a
-    zero-width-begin row slice + transpose + element slice. A direct `[i, j]` width-offset
-    `slice_by_size` rides the A13/A14 x16 crop-DMA, which saturates any sliced |value| >
-    4094 (=65504/16) to +/-inf - silently corrupting these factorizations for matrices with
-    entries above that (confirmed on BOTH saturating families: M2/A14 chol/lu break right at
-    the threshold; on M1/A13 a direct `[0,3]` width-offset slice of an 8000 element returns
-    `inf` while this routed accessor returns the exact 8000). The routed form keeps every
-    begin's last axis at 0 (the same width-axis avoidance as the gather fix), extending the
-    usable entry range to the full fp16 span for the cost of n amortized [1,n] transposes. The
-    squaring kernels (qr/eigh/eigvals) intrinsically cap at max|entry| ~ 1e2 (their products
-    overflow fp16 first), so only these element-recurrence kernels gain from the routing."""
+  """Element accessor `el(i, j)` routed OFF the width axis (row slice + transpose + slice).
+    A direct width-offset slice_by_size rides the A13/A14 x16 crop-DMA, which saturates any
+    sliced |value| > 4094 (=65504/16) to +/-inf, corrupting these factorizations; the routed
+    form keeps every begin's last axis at 0, restoring the full fp16 span. See numerics.md."""
   rows = [Xt.slice_by_size([i, 0], [1, n]).transpose([1, 0]) for i in range(n)]
   return lambda i, j: rows[i].slice_by_size([j, 0], [1, 1])
 
 
 def qr(A):
-  """Thin QR A = Q R by modified Gram-Schmidt, FULLY on the ANE (one program). Q has
-    orthonormal columns, R is upper-triangular. Each projection is an (a*b)@ones dot (wide
-    accumulator) + an axpy; the whole orthogonalization unrolls. Returns (Q, R). Small-n."""
+  """Thin QR A = Q R by modified Gram-Schmidt, FULLY on the ANE (one program). Returns
+    (Q, R); Q orthonormal columns, R upper-triangular. Small-n."""
   from aneforge._compile import compile_multi
   A16 = np.asarray(A, f16); m, n = A16.shape; onem = np.ones((m, 1), f16)
   At = af.input((m, n))
@@ -711,8 +477,7 @@ def qr(A):
 
 def cholesky(A):
   """Lower-triangular Cholesky factor L (A = L L^T) of an SPD A, UNPIVOTED, FULLY on the
-    ANE: a fixed recurrence with each L[i,j] a [1,1] tensor, dividing by the pivot L[j,j]
-    via real_div. Small-n. ~3e-4 vs numpy at n=8."""
+    ANE (fixed recurrence, each L[i,j] a [1,1] tensor). Small-n; ~3e-4 vs numpy at n=8."""
   A16 = np.asarray(A, f16); n = A16.shape[0]
   At = af.input((n, n)); el = _els_routed(At, n)
   z = el(0, 0) - el(0, 0); L: dict = {}
@@ -728,9 +493,8 @@ def cholesky(A):
 
 
 def lu(A):
-  """Unpivoted LU (A = L U, L unit-lower, U upper) by Doolittle, FULLY on the ANE: each
-    entry a [1,1] tensor, dividing by the pivot U[i,i] via real_div. Returns (L, U).
-    Small-n; UNPIVOTED, so valid when no leading pivot underflows (well-conditioned A)."""
+  """Unpivoted LU (A = L U, L unit-lower, U upper) by Doolittle, FULLY on the ANE.
+    Returns (L, U). Small-n; UNPIVOTED, valid when no leading pivot underflows."""
   from aneforge._compile import compile_multi
   A16 = np.asarray(A, f16); n = A16.shape[0]
   At = af.input((n, n)); el = _els_routed(At, n)
@@ -756,12 +520,9 @@ def lu(A):
 
 def lu_pivoted(A):
   """Partial-pivoted LU: P A = L U with row interchanges, on the ANE. Returns (P, L, U).
-    The pivot at each column is a true on-engine `argmax` over the subcolumn, turned into a
-    permutation by a one-hot (arange + greater + select) and applied as a row-swap; the
-    Schur elimination is masked to the trailing submatrix so the stored multipliers are
-    preserved. UNLIKE the unpivoted `lu`, the argmax is a netplist BRIDGE op, so the program
-    is SEGMENTED (one graph cut per column), not a single fused program - still all on ANE
-    silicon. Small-n; ~5e-4 vs P A reconstruction at n<=8."""
+    The per-column pivot is a true on-engine `argmax`; that argmax is a netplist BRIDGE op,
+    so the program is SEGMENTED (one cut per column), not single-fused - still all on ANE.
+    Small-n; ~5e-4 vs P A reconstruction at n<=8. See docs/developer/applied-math.md."""
   A16 = np.asarray(A, f16); n = A16.shape[0]
   At = af.input((n, n)); In = af.input((n, n)); arc = af.input((n, 1))
   arcr = arc.transpose([1, 0]); M = At; P = In
@@ -792,8 +553,7 @@ def lu_pivoted(A):
 
 
 def _trinv_lower(L):
-  """Inverse of a lower-triangular L by forward substitution, FULLY on the ANE (a fixed
-    recurrence, entries as [1,1] tensors). Used by generalized_eigh."""
+  """Inverse of lower-triangular L by forward substitution, on the ANE. Used by generalized_eigh."""
   L16 = np.asarray(L, f16); n = L16.shape[0]
   Lt = af.input((n, n)); el = _els_routed(Lt, n)
   z = el(0, 0) - el(0, 0); one = z.adds(1.0)
@@ -807,11 +567,9 @@ def _trinv_lower(L):
 
 
 def generalized_eigh(A, B, sweeps: int = 8):
-  """Eigenvalues of the generalized symmetric-definite problem A x = lambda B x (A
-    symmetric, B SPD; LAPACK `sygv`), FULLY on the ANE by composing on-engine kernels:
-    B = L L^T (cholesky), C = L^-1 A L^-T (triangular inverse + two GEMMs), then the symmetric
-    eig of C (cyclic Jacobi `eigh`). Returns the generalized eigenvalues ascending. Small-n
-    (the eigh O(n^3) graph); ~4e-4 vs the fp64 reduction at cond<=1e1."""
+  """Eigenvalues of A x = lambda B x (A symmetric, B SPD; LAPACK `sygv`), ascending, by
+    composing on-engine kernels: B = L L^T (cholesky), C = L^-1 A L^-T, then eigh(C). Small-n;
+    ~4e-4 vs the fp64 reduction at cond<=1e1."""
   A16 = np.asarray(A, f16); B16 = np.asarray(B, f16)
   L = cholesky(B16).astype(f16)                          # ANE
   Li = _trinv_lower(L).astype(f16)                       # ANE
@@ -821,14 +579,10 @@ def generalized_eigh(A, B, sweeps: int = 8):
 
 
 def eigvals(A, iters: int = 60):
-  """Eigenvalues of a GENERAL (nonsymmetric) real A by the unshifted QR algorithm, FULLY on
-    the ANE as ONE fused program: `iters` rounds of M <- R Q where M = Q R (Gram-Schmidt QR
-    in-graph, RQ a matmul) drive M to real Schur (quasi-triangular) form. NO pivoting, NO
-    shifts, NO deflation, so it is pure fixed-iteration dataflow with no bridge op. The host
-    only READS the eigenvalues off the converged form - a 1x1 diagonal block is a real
-    eigenvalue, a 2x2 block gives a COMPLEX-conjugate pair. Returns a complex array. Small-n
-    (the unrolled QR chain), well-separated spectra: ~2e-3 (real) / ~2e-2 (complex) vs
-    numpy.eigvals. Unshifted QR converges linearly, so clustered spectra need more iters."""
+  """Eigenvalues of a GENERAL real A by the unshifted QR algorithm, FULLY on the ANE
+    (M <- R Q drives M to real Schur form). Host reads the eigenvalues off the converged
+    form (1x1 block = real, 2x2 = complex pair). Returns a complex array; small-n,
+    ~2e-3 (real)/~2e-2 (complex). Unshifted QR is linear, so clusters need more iters."""
   A16 = np.asarray(A, f16); n = A16.shape[0]; onen = np.ones((n, 1), f16)
   M = af.input((n, n))
 

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -1,12 +1,5 @@
-"""Pretrained-model loaders: `load` (BERT-family sentence encoders) and
-`load_resnet18` (torchvision ImageNet classifier). Each builds an aneforge graph
-from the real weights and compiles it to a fused ANE program. Heavy deps
-(transformers / torchvision) are imported lazily so the core stays light.
-
-Also ships the trainable-graph builders used with the on-ANE autograd:
-`group_norm_train` (any-batch GroupNorm with trainable affine), `conv_block`
-(conv -> GroupNorm -> ReLU -> optional max-pool), and `cifar_cnn` (a full
-CIFAR-10 CNN returning the input, logits, and trainable parameter list)."""
+"""Pretrained-model loaders (`load`, `load_resnet18`) and trainable-graph
+builders (`group_norm_train`, `conv_block`, `cifar_cnn`). See docs/developer/models.md."""
 from __future__ import annotations
 
 import numpy as np
@@ -19,8 +12,7 @@ _NORM_CACHE: dict[int, Model | SegmentedModel] = {}
 
 
 def _l2_normalizer(D: int) -> Model | SegmentedModel:
-  """A tiny cached fused-ANE program that L2-normalizes a [1, D] vector over its
-    last axis (the verified reduce_l2_norm + real_div path)."""
+  """Cached fused-ANE program L2-normalizing a [1, D] vector over its last axis."""
   net = _NORM_CACHE.get(D)
   if net is None: net = _NORM_CACHE[D] = compile(input((1, D)).l2_norm(axis=-1))
   return net
@@ -29,33 +21,17 @@ def _l2_normalizer(D: int) -> Model | SegmentedModel:
 def load(name: str, int8: bool = False, pooling: str = "mean") -> "Encoder":
   """Load a BERT-family sentence encoder from HF weights as an ANE embedder.
 
-        embed = af.load("sentence-transformers/all-MiniLM-L6-v2")
-        vecs  = embed(["hello world", "the cat sat"])   # [2, D], L2-normalised
-
-    Tokenisation + embedding lookup run on the host (gather is not an ANE op); the
-    transformer layers run on the ANE as fused programs (cached per sequence
-    length); pooling + normalise run on the host / ANE.
-
-    `pooling` selects how the per-token states reduce to one vector: "mean" (the
-    default, MiniLM / E5), "cls" (the first token, BGE / GTE), or "max". A model's
-    correct mode is in its sentence-transformers config; `aneforge.sentence_transformers`
-    reads it for you.
+    `pooling` is one of "mean" (MiniLM/E5), "cls" (BGE/GTE), or "max". See
+    docs/developer/models.md.
     """
   return Encoder(name, int8=int8, pooling=pooling)
 
 
 def load_resnet18(int8: bool = False, compress: str | None = None,
                   compress_atol: float = 0.05, build_dir: str | None = None) -> "Vision":
-  """Load torchvision ResNet-18 (ImageNet) as a fused ANE classifier.
-
-        clf = af.load_resnet18()
-        logits = clf(image)        # [1,3,224,224] -> [1,1000]
-        clf = af.load_resnet18(compress="int4")   # 4-bit LUT weights
-
-    BatchNorm is folded into the preceding conv at load, so the ANE graph is pure
-    conv/relu/pool/add/fc. Conv is the ANE's strongest workload. `compress` picks
-    the weight encoding (see `af.compile`); `build_dir` keeps the packed program
-    on disk (its `weights.bin` is the packed-model size).
+  """Load torchvision ResNet-18 (ImageNet) as a fused ANE classifier ([1,3,224,224]
+    -> [1,1000]). BatchNorm is folded into the preceding conv at load. `compress`
+    picks the weight encoding (see `af.compile`). See docs/developer/models.md.
     """
   return Vision(int8=int8, compress=compress, compress_atol=compress_atol, build_dir=build_dir)
 
@@ -159,7 +135,7 @@ class Encoder:
     return compile(h, int8=self.int8)
 
   def _embed(self, ids: np.ndarray) -> np.ndarray:
-    """Host-side token + position + type embedding lookup, then LayerNorm."""
+    """Host-side token + position + type embedding lookup, then LayerNorm."""  # gather is not an ANE op
     e = self.word[ids] + self.pos[np.arange(len(ids))] + self.typ[0]
     m = e.mean(-1, keepdims=True)
     v = ((e - m) ** 2).mean(-1, keepdims=True)
@@ -172,63 +148,50 @@ class Encoder:
       ids = np.asarray(self.tok(t)["input_ids"], dtype=np.int64)
       net = self._cache.get(len(ids)) or self._cache.setdefault(len(ids), self._build(len(ids)))
       states = net(self._embed(ids))               # [S, D] per-token states on the ANE
-      if self.pooling == "cls":                    # first token (BERT [CLS])
+      if self.pooling == "cls":
         v = states[0]
       elif self.pooling == "max":
         v = states.max(0)
       else:
-        v = states.mean(0)                       # mean over all (unpadded) tokens
+        v = states.mean(0)
       if normalize:
-        # final L2-normalize runs on the ANE (fused reduce_l2_norm + real_div)
         v = _l2_normalizer(self.D)(v.reshape(1, self.D))[0]
       vecs.append(v)
     return np.asarray(vecs, dtype=np.float32)
 
 
 def group_norm_train(x, gamma, beta, groups: int, eps: float = 1e-5):
-  """GroupNorm built from primitives so it works at ANY batch N (the stock
-    Tensor.group_norm op is batch-1 only) and so the affine `gamma`/`beta` are real
-    trainable parameters. `x` is [N, C, H, W]; `gamma`/`beta` are `[1, C, 1, 1]`
-    parameter Tensors. Normalizes per-(group, sample) over the C/groups*H*W elements,
-    then applies the affine. Every op here (reshape, mean, square, rsqrt, adds, mul,
-    add) has a VJP, so input/gamma/beta gradients all run on the ANE. Mirrors the
-    group_norm VJP math (aneforge/autograd.py:425)."""
+  """Any-batch GroupNorm with trainable affine, built from VJP-bearing primitives so
+    gradients run on the ANE (stock Tensor.group_norm is batch-1 only). `x` is
+    [N,C,H,W]; `gamma`/`beta` are [1,C,1,1]. See docs/developer/models.md."""
   N, C, H, W = x.shape
   if C % groups:
     raise ValueError(f"group_norm_train: channels {C} not divisible by groups {groups}")
   M = (C // groups) * H * W
   xg = x.reshape(N, groups, M)
-  xc = xg - xg.mean((2,))                       # per-(sample,group) center
-  var = xc.square().mean((2,))                  # per-(sample,group) variance
+  xc = xg - xg.mean((2,))
+  var = xc.square().mean((2,))
   xn = (xc * var.adds(float(eps)).rsqrt()).reshape(N, C, H, W)
   return xn * gamma + beta
 
 
 def conv_block(x, conv_w, gamma, beta, groups: int, pool: int = 0):
-  """conv2d(pad=1) -> GroupNorm(train) -> ReLU -> optional max_pool(pool).
-    `conv_w` is a conv_param; `gamma`/`beta` are [1,Cout,1,1] params; `pool=0`
-    means no pooling. Returns the block output Tensor."""
+  """conv2d(pad=1) -> GroupNorm(train) -> ReLU -> optional max_pool(pool); `pool=0` skips pooling."""
   h = conv2d(x, conv_w, pad=1)
   h = group_norm_train(h, gamma, beta, groups).relu()
   return h.max_pool(pool) if pool else h
 
 
 def _he(rng, shape):
-  """He/Kaiming-normal init. fan_in is layout-dependent: a conv weight
-    [Cout, Cin, kH, kW] has fan_in = Cin*kH*kW (prod of the trailing dims), while a
-    2-D fc weight [in, out] has fan_in = in (the leading dim)."""
+  """He/Kaiming-normal init; fan_in is layout-dependent (conv: prod of trailing dims,
+    2-D fc: leading dim). See docs/developer/models.md."""
   fan_in = shape[0] if len(shape) == 2 else int(np.prod(shape[1:]))
   return (rng.standard_normal(shape) * np.sqrt(2.0 / fan_in)).astype(np.float32)
 
 
 def cifar_cnn(batch: int, widths=(32, 64, 128), groups: int = 8, classes: int = 10, seed: int = 0):
-  """Build the CIFAR-10 CNN graph. Returns (x_input, logits, params) where params is
-    the trainable list in a fixed order. Architecture (per the design spec):
-      block1 conv 3->w0  GN ReLU maxpool2   (32x32 -> 16x16)
-      block2 conv w0->w1 GN ReLU maxpool2   (16x16 ->  8x8)
-      block3 conv w1->w2 GN ReLU            ( 8x8)
-      global-avg-pool over H,W -> fc(w2->classes)
-    """
+  """Build the CIFAR-10 CNN graph; returns (x_input, logits, params) with params in a
+    fixed trainable order. See docs/developer/models.md."""
   rng = np.random.default_rng(seed)
   w0, w1, w2 = widths
   x = input((batch, 3, 32, 32))

--- a/aneforge/sentence_transformers.py
+++ b/aneforge/sentence_transformers.py
@@ -1,17 +1,6 @@
-"""A drop-in `SentenceTransformer` that runs the encoder on the Apple Neural Engine.
-
-    from aneforge.sentence_transformers import SentenceTransformer
-    model = SentenceTransformer("BAAI/bge-small-en-v1.5")
-    emb = model.encode(["a query", "a passage"])     # [2, D] on the ANE
-
-The transformer layers run on the ANE as one fused e5rt program (cached per
-sequence length); embeddings match the reference to cosine ~1.0 at a fraction of
-the GPU's energy. The pooling mode (mean / cls / max) and whether the output is
-L2-normalised are read from the model's own sentence-transformers config, so a
-mean-pooled model (MiniLM, E5) and a cls-pooled model (BGE, GTE) both come out
-right. Only numpy + aneforge are needed; the sentence-transformers package is not
-imported (this mirrors its `.encode` surface, it does not wrap it).
-"""
+"""Drop-in `SentenceTransformer` running the encoder on the Apple Neural Engine;
+pooling/normalize are read from the model's sentence-transformers config (the
+package itself is not imported). See docs/developer/models.md."""
 from __future__ import annotations
 
 import json
@@ -34,7 +23,7 @@ def _read_text(name: str, rel: str) -> str | None:
 
 def _read_st_config(name: str) -> tuple[str, bool]:
   """Return (pooling_mode, has_normalize) from the model's sentence-transformers
-    config. Defaults to ("mean", False) for a raw model with no such config."""
+    config; defaults to ("mean", False) when absent."""
   pooling = "mean"
   pc = _read_text(name, "1_Pooling/config.json")
   if pc:
@@ -50,11 +39,8 @@ def _read_st_config(name: str) -> tuple[str, bool]:
 
 class SentenceTransformer:
   """`sentence_transformers.SentenceTransformer`-compatible encoder on the ANE.
-
-    `int8=True` streams int8 weights (half the size, cosine ~0.9999). The `device`
-    argument is accepted for signature parity and ignored: the encoder always runs
-    on the Neural Engine.
-    """
+    `int8=True` streams int8 weights (cosine ~0.9999); `device` is accepted for
+    parity and ignored. See docs/developer/models.md."""
 
   def __init__(self, model_name_or_path: str, *, int8: bool = False, device: str | None = None) -> None:
     self.pooling_mode, self._normalize_module = _read_st_config(model_name_or_path)
@@ -62,13 +48,9 @@ class SentenceTransformer:
 
   def encode(self, sentences, batch_size: int = 32, normalize_embeddings: bool = False,
              convert_to_numpy: bool = True, convert_to_tensor: bool = False, **kwargs):
-    """Encode `sentences` (a str or list of str) to embeddings on the ANE.
-
-        `batch_size` is accepted for parity; the ANE path is fused per sequence
-        length and cached, so it does not change the result. A model that ships a
-        Normalize module is L2-normalised regardless of `normalize_embeddings`,
-        matching sentence-transformers.
-        """
+    """Encode `sentences` (str or list of str) to embeddings on the ANE. `batch_size`
+        is accepted for parity only. A model shipping a Normalize module is always
+        L2-normalised regardless of `normalize_embeddings`. See docs/developer/models.md."""
     single = isinstance(sentences, str)
     texts = [sentences] if single else list(sentences)
     normalize = self._normalize_module or normalize_embeddings

--- a/aneforge/special.py
+++ b/aneforge/special.py
@@ -1,41 +1,16 @@
-"""aneforge.special - special functions evaluated on the Apple Neural Engine as
-fused fp16 polynomial chains.
+"""aneforge.special - special functions as fused fp16 polynomial chains on the ANE.
 
-The ANE's strength is a long, dependent chain of fused fp16 mul/add (one e5rt
-program, no graph cut). Special functions are exactly that: Horner / Clenshaw
-evaluation of minimax or rational approximations, plus smooth range reduction.
-This module builds each function as an `aneforge` graph out of the public ops
-(`+ - * /`, `exp/log/sqrt/sin/cos`, `clip`) only, so the whole thing compiles
-into one fused ANE program.
+Each function is a Horner/Clenshaw evaluation of a minimax or rational approximation
+built from the public ops only, so it compiles into one fused ANE program. Every
+function takes and returns an `aneforge.Tensor` (you compile and run it yourself):
 
-    from aneforge.special import erfc, gamma, lgamma, expm1, log1p, bessel_j0
-    import aneforge as af, numpy as np
+    net = af.compile(erfc(af.input((1, 64))))     # one fused ANE program
 
-    x   = af.input((1, 64))
-    net = af.compile(erfc(x))        # one fused ANE program
-    y   = net(np.linspace(0, 4, 64).astype(np.float16).reshape(1, 64))
-
-Every function takes and returns an `aneforge.Tensor`; you compile and run the
-result yourself (so several can share inputs / fuse together).
-
-WHY THESE: they add value beyond the native unaries (`exp/log/erf/...`) which
-either (a) do not exist (gamma, lgamma, erfc, expm1, log1p, Bessel) or (b)
-degrade / cancel in fp16 over a wide range (erfc = 1-erf cancels to 0 past x~2;
-exp loses a digit past |x|~8). See the `__main__` self-test for measured
-relerr vs scipy and the fp16 verdict per function.
-
-THE TWO CONSTRAINTS that shape the implementations:
-  * fp16 compute. The ANE computes in fp16 (~3-4 significant digits). A poly
-    exact in fp64 is capped at ~1e-3..1e-4 relerr once rounded. Where a
-    function's *output* leaves the fp16 range (gamma > 65504 past x~8; I0 past
-    x~12) that is a hard wall, not a coefficient problem.
-  * no scalar add and no in-graph branch. The graph has `* scalar` (muls) but
-    no `+ scalar` and no data-dependent control flow. We add a constant `c`
-    with `_const(x, c)` (a `cos(0)=1` ones tensor times `c`), and use only
-    *fixed*, smooth range reduction - never a per-element branch / variable
-    step count. Functions needing a data-dependent reduction (gamma far outside
-    [1,2], lgamma reflection for x<0) are scoped to the range a single static
-    graph can cover, documented per function.
+These add value beyond the native unaries: some don't exist (gamma, lgamma, erfc,
+expm1, log1p, Bessel), others cancel/degrade in fp16. Two constraints shape the
+implementations - fp16 compute (~3-4 digits; output-range overflow is a hard wall) and
+no scalar-add / no in-graph branch (constants via `_const`, only fixed smooth range
+reduction). See docs/developer/applied-math.md and docs/developer/numerics.md.
 """
 from __future__ import annotations
 
@@ -52,17 +27,9 @@ except ImportError:  # run directly as `python3 aneforge/special.py`
 # --------------------------------------------------------------------------- #
 
 def _const(like: Tensor, c: float) -> Tensor:
-  """A constant tensor of value `c` broadcasting against `like`.
-
-    There is no scalar-add op, but `exp(0) == 1` gives a ones tensor of the
-    right shape for free (`like * 0` is the zeros), and `* c` scales it. So
-    `acc + _const(x, c)` adds a coefficient inside a Horner chain.
-
-    Built on `exp` rather than `cos` on purpose: `exp` is an F0 native unary
-    (every ANE family, M1 included), whereas native `cos` is A15+ (family 4). A
-    cos-based constant would silently break this whole module on M1/H13 - and
-    `special.cos` below is one of the things that must run there.
-    """
+  """A constant tensor of value `c` broadcasting against `like` (no scalar-add op, so
+    `exp(0)==1` makes the ones tensor, `* c` scales). Built on `exp` not `cos` on purpose:
+    `exp` is F0-native on every family (M1 included), `cos` is A15+. See applied-math.md."""
   return (like * 0.0).exp() * float(c)
 
 
@@ -86,40 +53,22 @@ def _poly_in(x2: Tensor, coeffs_low_first) -> Tensor:
 # sin / cos - portable trig for chips without the native op                   #
 # --------------------------------------------------------------------------- #
 
-# Native sin/cos are A15+ (family 4): they run on M5 but NOT on M1/H13. These
-# polynomial forms give a portable path on [-pi/2, pi/2] using only mul/sub/exp (all
-# F0/F2 native on every ANE family), so the same graph runs on M1 and M5. As with
-# every function here the domain is bounded and documented.
-#
-# The domain is HALF a period on purpose. A single polynomial over the full [-pi, pi]
-# is not fp16-clean at the ends: cos(pi) sums alternating terms reaching ~5 in
-# magnitude down to -1, a cancellation that loses ~2 fp16 digits (abs err ~0.2 at
-# +/-pi). On [-pi/2, pi/2] the terms stay O(1) with no large cancellation, so the
-# error is fp16-rounding-limited (~1e-3). Range reduction to the full circle would
-# need round/floor (a data-dependent step this static graph avoids); reduce wider
-# arguments on the host.
-#
-# sin(x) = x * P(x^2), cos(x) = Q(x^2): even-power minimax fits of sin(x)/x and cos(x)
-# on [-pi/2, pi/2] (low-degree first). fp64 poly error ~2e-6 (sin) / ~1e-5 (cos), far
-# under fp16's ~1e-3 floor.
+# Portable trig on [-pi/2, pi/2] (mul/sub/exp only, so it runs on M1/H13 where native
+# sin/cos are A15+). Half-period on purpose: a full [-pi,pi] poly cancels at the ends.
+# sin(x) = x*P(x^2), cos(x) = Q(x^2), even-power minimax. See docs/developer/numerics.md.
 _SIN_P = [1.0, -0.1666589028907664, 0.008315949363584022, -0.0001860843359648393]
 _COS_Q = [1.0, -0.4999308182201791, 0.041511585587052556, -0.0012786608784929124]
 
 
 def sin(x: Tensor) -> Tensor:
-  """`sin(x)` for x in [-pi/2, pi/2] as a fused fp16 polynomial (`x * P(x^2)`).
-
-    Portable trig: only mul/sub/exp, so it runs on ANE families lacking the native
-    sin op (A15+), M1/H13 included. Outside [-pi/2, pi/2] reduce the argument on the
-    host first (the static graph has no data-dependent range reduction)."""
+  """`sin(x)` for x in [-pi/2, pi/2], portable fp16 polynomial (`x * P(x^2)`); reduce
+    wider arguments on the host."""
   return x * _poly_in(x * x, _SIN_P)
 
 
 def cos(x: Tensor) -> Tensor:
-  """`cos(x)` for x in [-pi/2, pi/2] as a fused fp16 polynomial (`Q(x^2)`).
-
-    Portable companion to `sin` above - native cos is A15+, this runs everywhere
-    M1 included. Reduce arguments outside [-pi/2, pi/2] on the host."""
+  """`cos(x)` for x in [-pi/2, pi/2], portable fp16 polynomial (`Q(x^2)`); reduce wider
+    arguments on the host."""
   return _poly_in(x * x, _COS_Q)
 
 
@@ -127,25 +76,18 @@ def cos(x: Tensor) -> Tensor:
 # erfc - complementary error function (the cancellation case)                 #
 # --------------------------------------------------------------------------- #
 
-# Abramowitz & Stegun 7.1.26: erfc(x) = poly(t) * exp(-x^2), t = 1/(1+p x), x>=0.
-# Evaluated DIRECTLY (not as 1-erf), which is the whole point: 1-erf(x) cancels
-# to 0 in fp16 for x>~2 (erfc(3)=2.2e-5 but fp16(1-erf(3))=0); the direct form
-# does not.
+# Abramowitz & Stegun 7.1.26: erfc(x) = poly(t)*exp(-x^2), t = 1/(1+p x), x>=0.
+# Evaluated directly (not 1-erf, which cancels to 0 in fp16 past x~2). See numerics.md.
 _ERFC_P = 0.3275911
 _ERFC_A = [0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429]
 
 
 def erfc(x: Tensor) -> Tensor:
-  """Complementary error function `erfc(x) = 1 - erf(x)` for `x >= 0`.
-
-    Direct rational*exp form (A&S 7.1.26) - does NOT cancel for large x, unlike
-    `1 - native_erf`. Valid for x in [0, ~6] (erfc decays smoothly; the exp
-    underflows to 0 past x~6, the correct limit). For x<0 use the identity
-    erfc(-x)=2-erfc(x) on the host (a branch the static graph can't do).
-    """
+  """Complementary error function `erfc(x) = 1 - erf(x)` for `x >= 0` (direct A&S form,
+    does NOT cancel for large x). Valid for x in [0, ~6]; for x<0 use erfc(-x)=2-erfc(x)
+    on the host."""
   t = _const(x, 1.0) / (_const(x, 1.0) + x * _ERFC_P)
-  # poly(t) = (((a4 t + a3) t + a2) t + a1) t + a0) * t   -> a0..a4 low-first, then *t
-  poly = _poly_in(t, _ERFC_A) * t
+  poly = _poly_in(t, _ERFC_A) * t                         # a0..a4 low-first, then *t
   return poly * (x * x * -1.0).exp()
 
 
@@ -154,10 +96,8 @@ def erfc(x: Tensor) -> Tensor:
 # --------------------------------------------------------------------------- #
 
 def expm1(x: Tensor) -> Tensor:
-  """`exp(x) - 1` accurate near 0 (where `exp(x)-1` cancels). Taylor
-    `x(1 + x/2 + x^2/6 + ... + x^5/720)` - valid for |x| <= ~0.7. Outside that,
-    use `x.exp()` and subtract 1 with `_const` (no cancellation there)."""
-  # x * (1 + x(1/2 + x(1/6 + x(1/24 + x(1/120 + x/720)))))
+  """`exp(x) - 1` accurate near 0 (where it cancels), Taylor for |x| <= ~0.7; outside,
+    use `x.exp()` and subtract 1 with `_const`."""
   inner = _horner(x, [1.0 / 720, 1.0 / 120, 1.0 / 24, 1.0 / 6, 0.5, 1.0])
   return x * inner
 
@@ -178,18 +118,14 @@ def log1p(x: Tensor) -> Tensor:
 # gamma / lgamma                                                              #
 # --------------------------------------------------------------------------- #
 
-# lgamma: deg-8 minimax on [1, 8] in the centered variable (x - 4.5). Centering
-# is essential in fp16: a raw Horner in x has terms ~x^8 (x up to 8 -> 1e7) with
-# alternating large coefficients that cancel catastrophically (abserr ~8); in
-# (x-4.5) the powers stay <= 3.5^8 and the chain is fp16-clean (abserr ~3e-3).
+# lgamma: deg-8 minimax on [1, 8] in the centered variable (x - 4.5). Centering is
+# essential in fp16 (a raw Horner in x cancels to abserr ~8). See numerics.md.
 _LGAMMA_C = 4.5
 _LGAMMA = [3.935189048783974e-06, -1.7368862821849318e-05, -9.904632136900507e-06,
            -5.063402849001357e-05, 0.0014535201243029226, -0.010745792598586731,
            0.1240676674629507, 1.3893132071172924, 2.453806649516902]
 
-# gamma on [1, 2]: deg-6 minimax in the centered variable (x - 1.5) (same fp16
-# centering argument). The fundamental strip; gamma elsewhere is this times a
-# data-dependent product a static graph cannot reduce to.
+# gamma on [1, 2]: deg-6 minimax in the centered variable (x - 1.5) (same fp16 centering).
 _GAMMA_C = 1.5
 _GAMMA_12 = [0.07271315700819278, -0.09524680924569022, 0.14250568218370452,
              -0.10518443046953783, 0.41491322672719055, 0.032278377199321216,
@@ -197,24 +133,15 @@ _GAMMA_12 = [0.07271315700819278, -0.09524680924569022, 0.14250568218370452,
 
 
 def lgamma(x: Tensor) -> Tensor:
-  """Log-gamma `log|Gamma(x)|` for x in [1, 8] via a deg-8 minimax in the
-    centered variable (x-4.5). Accurate in ABSOLUTE terms (~3e-3); relative error
-    is large only at the zeros x=1, x=2 where lgamma -> 0 (relative error is
-    ill-defined there)."""
+  """Log-gamma `log|Gamma(x)|` for x in [1, 8], deg-8 minimax centered at x-4.5. Accurate
+    in ABSOLUTE terms (~3e-3); relative error is ill-defined at the zeros x=1, x=2."""
   return _horner(x + _const(x, -_LGAMMA_C), _LGAMMA)
 
 
 def gamma(x: Tensor) -> Tensor:
-  """Gamma function on x in [1, 2] via a deg-6 minimax in the centered variable
-    (x-1.5).
-
-    SCOPE: gamma grows super-exponentially and overflows fp16 (>65504)
-    past x~8.3, so it is fundamentally fp16-narrow. Extending [1,2] to a wider
-    window needs the recurrence Gamma(x+1)=x*Gamma(x) applied a data-dependent
-    number of times - not expressible in one static graph. For a wider but
-    still-fp16-bounded range use `gamma_via_lgamma` (x in [1, ~7.5]), which routes
-    through `exp(lgamma(x))` instead.
-    """
+  """Gamma function on x in [1, 2], deg-6 minimax centered at x-1.5. fp16-narrow (overflows
+    past x~8.3); a wider window needs the data-dependent recurrence Gamma(x+1)=x*Gamma(x).
+    For a wider fp16-bounded range use `gamma_via_lgamma` (x in [1, ~7.5])."""
   return _horner(x + _const(x, -_GAMMA_C), _GAMMA_12)
 
 
@@ -238,26 +165,21 @@ _K0 = [-0.57721566, 0.42278420, 0.23069756, 0.03488590, 0.00262698, 0.00010750, 
 
 
 def bessel_j0(x: Tensor) -> Tensor:
-  """Bessel J0(x) for |x| <= 3 (A&S 9.4.1 polynomial in (x/3)^2). Smooth,
-    bounded; the dominant first lobe and first zero (x~2.405) are in range."""
+  """Bessel J0(x) for |x| <= 3 (A&S 9.4.1 in (x/3)^2); first lobe and first zero in range."""
   t = (x * x) * (1.0 / 9.0)
   return _poly_in(t, _J0)
 
 
 def bessel_i0(x: Tensor) -> Tensor:
-  """Modified Bessel I0(x) for |x| <= 3.75 (A&S 9.8.1 in (x/3.75)^2). I0 grows
-    exponentially and overflows fp16 past x~12, so this small-argument branch is
-    the fp16-useful range."""
+  """Modified Bessel I0(x) for |x| <= 3.75 (A&S 9.8.1 in (x/3.75)^2); overflows fp16 past x~12."""
   t = (x * x) * (1.0 / (3.75 * 3.75))
   return _poly_in(t, _I0)
 
 
 def bessel_k0(x: Tensor) -> Tensor:
-  """Modified Bessel K0(x) for 0 < x <= 2 (A&S 9.8.5):
-    `K0(x) = -ln(x/2) I0(x) + series((x/2)^2)`. K0 has a -ln singularity at 0,
-    so x must be strictly positive (and not tiny: log underflow). I0 here reuses
-    the 9.8.1 polynomial (in (x/3.75)^2), valid through x=2; the K0 series part is
-    in (x/2)^2 -- the two use DIFFERENT scaled arguments."""
+  """Modified Bessel K0(x) for 0 < x <= 2 (A&S 9.8.5): `-ln(x/2) I0(x) + series((x/2)^2)`.
+    K0 has a -ln singularity at 0 (x must be > 0). The I0 factor and the K0 series use
+    DIFFERENT scaled arguments ((x/3.75)^2 vs (x/2)^2)."""
   half = x * 0.5
   t_k0 = half * half                       # (x/2)^2  for the K0 series
   t_i0 = (x * x) * (1.0 / (3.75 * 3.75))    # (x/3.75)^2 for the I0 factor
@@ -270,32 +192,19 @@ def bessel_k0(x: Tensor) -> Tensor:
 # --------------------------------------------------------------------------- #
 
 def exp_wide(x: Tensor, splits: int = 1) -> Tensor:
-  """exp for wide `x` via argument splitting:
-    `exp(x) = (exp(x / 2^splits)) ^ (2^splits)` by repeated squaring (the inner
-    `exp` runs on a smaller argument).
-
-    FINDING (measured on this M5 ANE): this does NOT reliably beat the
-    native `x.exp()`. The native fp16 exp is already accurate (median per-point
-    relerr ~1.4e-3 over [-10,10]); the squaring re-rounding usually costs MORE
-    than the small-argument benefit gains, so per-point accuracy is the same or
-    slightly worse. Provided for completeness. fp16's output range (max 65504)
-    caps exp at x~11 regardless of method - splitting can never extend the range,
-    only (at best marginally) trade accuracy.
-    """
+  """exp for wide `x` via `exp(x) = (exp(x/2^splits))^(2^splits)` (repeated squaring).
+    FINDING: does NOT reliably beat the native `x.exp()` on this ANE (the squaring
+    re-rounding cancels the small-argument benefit); splitting cannot extend the fp16
+    output range. See docs/developer/numerics.md."""
   e = (x * (1.0 / (1 << splits))).exp()
   for _ in range(splits): e = e * e
   return e
 
 
 def log_wide(x: Tensor, sqrts: int = 3) -> Tensor:
-  """log for wide positive `x` via `log(x) = 2^sqrts * log(x^(1/2^sqrts))`.
-    Repeated square roots pull a large argument toward 1, where log is most
-    accurate, then scale back.
-
-    FINDING: native fp16 log is already good (~1e-3 over [1e-2, 1e4]) and
-    this matches rather than clearly beats it - the sqrt chain re-rounds. Useful
-    mainly as a documented range-reduction recipe; the native `x.log()` is the
-    better default on this hardware."""
+  """log for wide positive `x` via `log(x) = 2^sqrts * log(x^(1/2^sqrts))` (repeated
+    sqrt pulls toward 1, then scale back). FINDING: matches rather than beats the native
+    `x.log()`; a documented range-reduction recipe, not a win. See numerics.md."""
   r = x
   for _ in range(sqrts): r = r.sqrt()
   return r.log() * float(1 << sqrts)

--- a/aneforge/streaming.py
+++ b/aneforge/streaming.py
@@ -1,22 +1,9 @@
 """Layer-streamed (gradient-checkpointed) training for deep stacks of identical layers.
 
-A monolithic compile fuses a model's whole forward, backward, and optimizer step into
-ONE e5rt program, so compile time grows superlinearly with depth and caps how deep a
-model can train. When the layers are structurally identical (a transformer stack, a deep
-MLP), that cost is avoidable: the per-layer forward and backward each depend only on one
-layer's shape, not the depth, so they compile ONCE and reuse for every layer.
-`CheckpointedStack` does exactly that.
-
-The backward is the standard gradient-checkpointing trick: store only each layer's INPUT
-activation, not every intermediate, and recompute the layer's forward inside its backward
-program. The reused backward program takes a layer's params, its checkpointed input, and
-the upstream gradient, and returns the param gradients plus the gradient with respect to
-the input (the upstream gradient for the layer below). The result is bit-identical to a
-monolithic `backward` (verified), with total compile work independent of layer count.
-
-This module compiles the repeated stack; the surrounding embedding and output stages are
-ordinary compiled graphs the caller drives (each compiled once). The optimizer runs
-host-side over the streamed gradients, like the default `autograd.Trainer` path.
+Compile one layer's forward and backward ONCE and reuse them for every layer, so compile
+work is independent of depth (a monolithic compile grows superlinearly). Backward uses
+recompute-in-backward checkpointing; result is bit-identical to a monolithic `backward`.
+See docs/developer/compile-pipeline.md.
 """
 from __future__ import annotations
 
@@ -32,15 +19,9 @@ _F16 = np.float16
 class CheckpointedStack:
   """A depth-independent compile for a stack of identical layers.
 
-    `layer_fn(params, x)` builds one layer: `params` is a list of graph `Tensor`
-    parameters and `x` is the input activation `Tensor`; it returns the output
-    activation `Tensor` (same shape as `x`). `example_params` is a list of numpy
-    arrays giving one layer's parameter shapes, and `io_shape` is the activation shape
-    that flows between layers.
-
-    Two programs are compiled: the per-layer forward and the per-layer backward (a
-    multi-output program returning each param gradient and the input gradient). Both are
-    reused for every layer, so compile cost does not grow with depth.
+    `layer_fn(params, x)` builds one layer (returns an output Tensor of the same shape as
+    `x`). `example_params` gives one layer's parameter shapes; `io_shape` is the activation
+    shape flowing between layers.
     """
 
   def __init__(self, layer_fn, example_params, io_shape):
@@ -72,9 +53,8 @@ class CheckpointedStack:
     self._bwd_consts = [(t, n) for t, n in self._bwd.input_ports if id(t) not in _fed]
 
   def forward(self, layers_params, x0):
-    """Run the stack. `layers_params` is a list (per layer) of lists (per-layer
-        parameter numpy arrays). Returns `(output, checkpoints)` where `checkpoints[i]`
-        is the input activation to layer `i` (needed by `backward`)."""
+    """Run the stack. `layers_params[i]` is layer i's list of parameter arrays. Returns
+        `(output, checkpoints)`; `checkpoints[i]` is layer i's input activation (for `backward`)."""
     x = np.asarray(x0, np.float32)
     checkpoints = []
     for lp in layers_params:
@@ -89,9 +69,9 @@ class CheckpointedStack:
     return x, checkpoints
 
   def backward(self, layers_params, checkpoints, g_out):
-    """Backprop the stack. `g_out` is the gradient at the stack output. Returns
-        `(param_grads, g_in)`: `param_grads[i]` is the list of gradients for layer
-        `i`'s params, and `g_in` is the gradient at the stack input."""
+    """Backprop the stack from `g_out` (gradient at the output). Returns
+        `(param_grads, g_in)`: `param_grads[i]` is layer i's param gradients; `g_in` is the
+        gradient at the stack input."""
     g = np.asarray(g_out, np.float32)
     param_grads: list[list[np.ndarray] | None] = [None] * len(layers_params)
     for i in range(len(layers_params) - 1, -1, -1):

--- a/docs/developer/autograd.md
+++ b/docs/developer/autograd.md
@@ -1,0 +1,173 @@
+# On-ANE autograd
+
+ANEForge implements a small reverse-mode autograd over its own graph IR in which **forward, backward, and the optimizer update are all compiled to ANE programs**. The host never runs tensor math during a training step — it only samples minibatches, computes a scalar learning rate, shuttles state, and prints. This page documents how that works and the ANE/numerics reasons behind the non-obvious choices.
+
+## Core model
+
+A training run treats trainable weights as ordinary graph inputs:
+
+- A **trainable leaf** (`af.parameter`, `af.conv_param`) is a graph input tagged `trainable`, holding an fp32 *master* value in `attrs['value']`. It is used like any input — fed its current value each eval and updated by the optimizer afterwards.
+- Because parameters are fed inputs rather than baked constants, **weight updates require no recompile**: the host updates the master host-side and feeds it back on the next eval.
+
+`backward(loss, params, stop=...)` returns `{param: grad_Tensor}`, the reverse-mode gradients of scalar `loss` with respect to each parameter. The seed `dL/dloss = loss_scale` is folded into the seed's *additive* constant, which avoids a `muls` on the reduced loss output.
+
+### The stop-gradient frontier
+
+`stop` is the detach frontier: gradient reaches these tensors but does not propagate past them. It defaults to `params`, which is a no-op when the params are true graph leaves (the usual case).
+
+It becomes load-bearing for **unrolled training**, where one step's *updated-weight tensors* are threaded into the next step's forward. There each step's gradient must treat the current weights as leaves (plain SGD/Adam), not differentiate through the previous update — otherwise the unroll becomes a second-order computation.
+
+## The VJP registry
+
+Each forward op already runs natively on the ANE; adding a vector-Jacobian product (VJP) makes that op *trainable*. VJPs are built from existing ANE ops, reusing the forward output `t` where it is itself the derivative term (`exp`/`inverse`/`rsqrt`), else recomputing from `t.srcs[0]`. The registry was grown by a gradient audit that surfaced which forward ops lacked a backward rule.
+
+| VJP group | What it unlocks / notes |
+|---|---|
+| Unary math / activations | Closed-form derivatives from existing ops; surfaced by the gradient audit. |
+| `transpose` / `reshape` | Pure index re-arrangements; gradient is the exact inverse re-arrangement of `g` (no numerics, fp16-exact). Together with linear/bmm/softmax these make a whole `af.mha` transformer block differentiable end to end. |
+| `rms_norm` / `layer_norm` / `channel_layer_norm` / `group_norm` | Unlock transformer / LLM / CNN training. All reduce over the **last** dim; closed-form `grad_x` is exact. |
+| `matmul` (baked weight) | Frozen baked weight stores `W^T` as `attrs['wt']` shaped `[N,K]`; only the activation gets a grad: `gx = g @ wt`. |
+| `bmm` (broadcast batch) | `ga = g @ b^T`, `gb = a^T @ g`. When an operand broadcasts over the batch dim (e.g. `patches[N,L,K] @ W[1,K,Cout]`), `_unbroadcast` sums the products back to each operand's own shape; equal-batch bmm is unchanged. |
+| `relu` | `dx = select(x > 0, g, 0)` via the exposed `greater` + `select`; the zero rhs is an exact-zero tensor `x - x`. |
+| `slice_by_size` | `dx` scatters `g` into a zeros-like-`x` at the same offset, built on-ANE by concatenating zero-slices (no walled scatter op). Overlapping im2col slices accumulate through the reverse grad summation. Verified cos 1.0 vs a numpy scatter. |
+| `conv` (input grad only) | See below. |
+| `avg_pool` / `max_pool` | See below. |
+
+### gamma as a fed value-input
+
+`gamma` in the norm VJPs is a per-channel *constant*, not a graph Tensor. ANEForge has no const-tensor op, so `_gamma_input` re-injects it as a **fed value-input** shaped `[1,...,1,D]` (the trainer feeds any input carrying `attrs['value']`).
+
+### The `reduce * 0` fusion wall
+
+`_const_like(t, c)` builds a constant-valued tensor shaped like `t` from existing ops as `(t - t).adds(c)` rather than the obvious `(t * 0.0).adds(c)`.
+
+!!! warning "ANECCompile fusion wall"
+    `mul(reduce_output, 0.0)` trips an ANECCompile fusion wall: a `reduce_sum`/`reduce_mean` result multiplied by **zero** fails to compile. Only that specific combination fails — `reduce * nonzero` compiles, and mul-by-zero without a preceding reduce compiles. `t - t` is an exact-zero `sub` (not a mul-by-zero) and sidesteps the wall for any finite `t`.
+
+For the same reason `_vjp_reduce_mean` uses the tensor-tensor form `g * _const_like(x, 1/n)` (which broadcasts `g` to `x` and scales by `1/n` in one op) as the uniform, wall-proof pattern, even though `1/n` is nonzero and a plain `muls` would also compile.
+
+## Convolution
+
+The native ANE conv requires a **const (baked) weight** — a runtime tensor-weight conv is rejected by Espresso ("Not implemented … not supported on any backend"). This drives two separate paths.
+
+### conv VJP (input gradient only)
+
+For a native `conv` node the weight is not a graph input, so autograd never asks for its gradient; only the input gradient is defined, as the standard transposed-conv backward:
+
+```
+grad_input = conv_transpose(grad_out, W)   # forward stride/pad/dilation
+```
+
+The conv weight `[Cout,Cin,kH,kW]` is passed as-is to `conv_transpose` (whose `[Cin_ct,Cout_ct,kH,kW]` layout matches because the transposed conv's input channels are the forward conv's output channels). Verified cos 1.0 vs torch for stride=1 (pad 0/1). stride>1 needs an `output_padding` the op lacks and is rejected.
+
+### Trainable conv (input + weight gradients)
+
+To train a conv weight, ANEForge builds the conv from primitives so the weight is a real graph parameter:
+
+- **im2col** via static `slice_by_size` + `concat` (not the walled `KernelRasterizer`) into patches,
+- then a **broadcast batched-matmul** by the weight parameter.
+
+Every op has a VJP, so both input and weight gradients are produced automatically and run on the ANE. Verified cos 1.0 vs torch for forward and both gradients (stride=1, pad=0). Downsampling is done by `avg_pool`, not stride.
+
+- `conv2d(x, weight, stride, pad)` — `x` is `[N,Cin,H,W]`; returns `[N,Cout,Hout,Wout]`. `stride` must be 1 (strided slicing is unavailable). `pad>=0` zero-pads in-graph via a zero-border `concat` before the im2col, so a 'same' conv stays inside one fused program and the padding differentiates through the existing concat VJP. With `pad=0` the behaviour is byte-for-byte the earlier implementation.
+- `conv_param(weight_init)` — `weight_init` is `[Cout,Cin,kH,kW]` (PyTorch layout), stored internally as the flat patch matrix `[Cin*kH*kW, Cout]` that `conv2d` consumes. Patch (row) order is `ci*(kH*kW) + (u*kW + v)`, matching the im2col.
+
+!!! note "Compile scales with batch N"
+    The im2col materialises `[N, Cin*kH*kW, Hout*Wout]` tensors, so *compile* (tiling/partition) time grows with N. On M1/A13 a very large full batch (e.g. N≈1000 over 28×28) can take minutes or hang the compiler (M5 compiles it fine). Train in **mini-batches** (e.g. N ≤ 128 fed per step), not one full-batch graph.
+
+### A13 width-slice saturation
+
+The patch index is placed on **axis 2, not the last (width) axis**. The concat's backward is a slice along the patch axis, and the A13 ×16 crop-DMA saturation (any `|value| > 4094` → ±inf) fires *only* on a nonzero begin-offset of the last (width) axis. With patches on a non-last axis, the large loss-scaled input-gradient never transits the saturating slice, so multi-layer conv training is numerically correct on M1 at any `loss_scale`. (The forward x-slice still carries the small input; the transpose that moves K to the last axis has a pure-permute backward with no slice.)
+
+This is a **warn, never auto-cap** condition:
+
+- `_A13_CONV_WGRAD_LOSS_SCALE_MAX` documents the ceiling: on A13 the weight-grad runs loss-scaled backward activations through width-offset slices (`conv2d`'s `for u,v` with `v>0`), so `loss_scale × |backward activation|` must stay under 4094 (= fp16max/16). A synthetic repro (`0.5*sum(y^2)` loss + random inputs) breaks at `loss_scale >= 512`, but a real normalized CNN trains identically at loss_scale 128/1024/65536 on M1 — real nets never reach those magnitudes. M5/A16 have a clean route.
+- `_has_conv_wgrad` is true iff a param is a trainable conv weight with `kW>1` (a `kW=1` conv has no width-offset slice).
+- `_guard_a13_conv_loss_scale` warns (returns `loss_scale` unchanged) when the target is A13-class, a conv weight is trained, and `loss_scale` could push activations past 4094. Target resolves via the same `detect_family()` / `ANEFORGE_TARGET` path as compile.
+
+## Cross-entropy: analytic fp16-stable gradient
+
+`CEHandle` is a softmax-cross-entropy objective carrying the logits and a one-hot target (a graph input). The gradient at the logits is the **analytic fused form**:
+
+```
+dL/dlogits = (softmax(logits) - target) / N
+```
+
+This is fp16-stable because it contains no `log`. With the seed:
+
+```
+CEHandle.seed = (softmax(logits) - target) * (loss_scale / N)
+```
+
+The loss *value* and accuracy are computed host-side in fp32 by the Trainer.
+
+## On-ANE optimizer update
+
+The optimizer update arithmetic is built as graph ops so it runs on the ANE. The learning rate `lr_t` is a **fed `[1,1]` input** (broadcast tensor-mul over the param), not a baked `muls`, so per-step bias correction / loss-scale folding varies correctly each step. Verified on-device (cosine 1.0 vs numpy).
+
+- `_adam_update` — Adam as ANE ops; `b1`/`b2`/`eps` baked, `lr_t` fed (bias correction folded into `lr_t` host-side). Returns `(w', m', v')`. `lr_t * m2` is a tensor-mul broadcasting the fed `[1,1]`; the baked scalars (`m*b1`, `g*(1-b1)`, `.adds(eps)`) are fine because none is a mul-by-zero on a reduce output.
+- `adam_step` — one Adam update over lists `params`/`m`/`v`, returning new tensor lists; used to **unroll** K steps (thread the returned lists into the next step's forward). Propagates a `conv_param`'s `conv_shape` onto the updated tensor so it still works as a `conv2d` weight downstream.
+
+### Adam loss-scale cancels in the ratio
+
+`_device_adam_step` computes the host scalar `lr_t = lr * sqrt(1-b2^t)/(1-b1^t)` (bias correction folded in) and **does not** divide out the loss-scale. Adam's update is the ratio `m/sqrt(v)`; with scaled grad `g' = scale*g` the moments scale as `m' = scale*m`, `v' = scale^2*v`, so `m'/sqrt(v') = m/sqrt(v)` — the loss-scale cancels. Dividing `lr_t` by `scale` (a naive SGD-style unscale) would double-unscale and collapse the step. (`eps` is the only scale-sensitive term and is negligible vs `scale*sqrt(v)`.)
+
+### The 3-output Adam stack and the wide-row wall
+
+`_stack3` packs Adam's three same-shape outputs into **one** output by concatenating along axis 0 in their natural row width: `concat([w,m,v], axis=0)` → `[3*rows, cols]`. This makes the 3-output update compile as a single-output program (no `_compile.py` change); the host splits it back row-block-wise via `_split3`.
+
+!!! warning "ANECCompile wide-row wall"
+    The natural-width axis-0 stack is load-bearing. Reshaping each output to a wide `[1, prod(shape)]` row and concatenating those trips the wide-row wall once `prod(shape)` is large (a 784×128 = 100352-wide row segfaults; verified). Keeping the column width and stacking rows stays inside the verified 2-D envelope. Params are flattened to 2-D first so `cols` is well defined.
+
+## Loss-scaling overflow guard
+
+`_check_finite_grads` returns true iff every gradient is finite (one `np.isfinite` reduction per array). Otherwise it bumps the optimizer's consecutive-skip counter and warns (first skip, then every 100th), and the caller **skips the entire step** — the standard loss-scaling overflow idiom. A skipped step leaves the fp32 masters (and Adam's `t`/moments) untouched, so a later finite step is unaffected. The warning advises lowering `loss_scale` if you see inf/nan weight-grads (on the ANE this means a loss-scaled fp16 gradient overflowed).
+
+## Trainer
+
+`Trainer` compiles a **forward program once plus one backward program per parameter** (each emitting that param's gradient in its natural 2-D shape). `step` evals the backward programs on the ANE and applies the optimizer; params update host-side and are fed back next eval with no recompile.
+
+!!! note "Why one program per parameter"
+    Concatenating all grads into a single wide row trips the ANECCompile wide-row wall when a large weight grad (e.g. 784×128) is reshaped to a 100k-wide row and concatenated with a differently-sized row (the reshape-to-wide-row-into-concat is the trigger, not the matmul). Per-param programs stay inside the verified 2-D matmul envelope, and the optimizer consumes the grads in param shape anyway.
+
+It accepts either:
+
+- a **scalar `loss` Tensor** (regression) — forward outputs the loss scalar; backward seeds from a ones-seed at the loss; or
+- a **`CEHandle`** (classification) — forward outputs the logits; backward seeds from the analytic on-ANE gradient `(softmax(logits) - target) * (loss_scale / N)`. Host-side `loss()` (fp32 cross-entropy) and `accuracy(X, y_labels)` (argmax) read the logits program.
+
+`optimizer="sgd"|"adam"` selects the optimizer.
+
+### device_optimizer and resident state
+
+`device_optimizer=True` runs the optimizer step on the ANE: alongside the per-param backward programs, a per-param **update program** computes the new state with ANE graph ops. The host then only computes the scalar `lr_t`, shuttles state/grads in/out, samples minibatch indices, and prints. Adam's `m`/`v` are held host-side as fp16 arrays, fed each step and read back. `device_optimizer=False` (the default) keeps the host fp32 optimizer path byte-for-byte unchanged (the regression guard + the baseline).
+
+- `_build_device_optimizer` compiles a per-param update program. SGD: `(w_p, g_p, lr_t) -> w_p'` (single output). Adam: `(w_p, m_p, v_p, g_p, lr_t) -> stack(w_p', m_p', v_p')` via `_stack3`, split host-side. `g_p`/`m_p`/`v_p`/`lr_t` are plain (non-trainable) leaves fed each step; `w_p` is the param leaf itself.
+- `_build_resident` goes further: the **whole training step is one fused multi-output program with optimizer state resident on-device**. Each param `p` (and, for Adam, `m_p`/`v_p`) is a graph input whose updated value is a program output aliased back onto that input port via `share_buffer` — so state lives on the engine across steps and the host feeds only the minibatch `(x, target)` + scalar `lr_t`, reading state back at checkpoints. Within one execute, the stream's FIFO ordering has the forward read the pre-step param and the update overwrite it last (the next step reads the advanced value).
+
+!!! note "Precision-check skip"
+    ANEForge's own training kernels (forward loss, per-param backward, optimizer update) contain structural subtracts — the loss `pred − target`, gradient axpys, the `w − lr*g` update — that trip the generic `cancel_sub` precision heuristic. These are vouched, accuracy-tested kernels (the MNIST baselines + the corpus), not user-data modeling choices, so they skip the user-facing precision check.
+
+## UnrolledTrainer
+
+`UnrolledTrainer` trains with **K Adam steps unrolled into one fused ANE program**, so the entire forward → backward → optimizer-update recurrence runs on the engine with no per-step host loop. Each `step()` runs K steps in a single dispatch: the host feeds K minibatches plus K per-step learning rates and shuttles `(params, m, v)` in and out between K-step blocks (an array move, not tensor math; no per-step host↔device round-trip inside the block). It is the bounded-K, fully-on-engine analogue of `Trainer` (whose `step()` dispatches once per step), enabled by the stop-gradient frontier described above.
+
+Key arguments:
+
+- `params` — trainable leaves (`af.parameter` / `af.conv_param`).
+- `forward(P, x) -> output` — builds the model from the current-step weight tensors `P` (aligned with `params`) and data input `x`; used per unrolled step and for `predict`.
+- `kind` — `"ce"` (logits + softmax-cross-entropy) or `"mse"`.
+- `x_inputs` / `t_inputs` — K data / target input placeholders, one per step.
+- `dataset` — `(X, Y)` numpy arrays (`X` shaped per sample, `Y` one-hot `[N,C]` for `"ce"`).
+- `resident` (default True) — optimizer state stays resident on-device across dispatches: each updated-state output is aliased (`share_buffer`) onto its own input port, seeded once. The host feeds only the K minibatches + per-step lr and reads weights at checkpoints; nothing is shuttled between dispatches. This is the end-to-end fully-on-engine path (no per-step loop **and** no state move).
+
+!!! note "Separate eval program for predict"
+    Checkpoint `predict` uses a separate single-batch forward program with its **own** weight-input leaves (fed the masters), not the trainable params: compile mutates each Tensor's internal name, so sharing the param objects between the two programs would clobber the training program's ports.
+
+## Measured results
+
+Training fully on the Neural Engine reaches roughly:
+
+- **~97% on MNIST**, and
+- **71% on CIFAR-10**,
+
+with the device-optimizer / resident-state paths matching the host fp32 baseline (the ~98% MNIST regression guard).

--- a/docs/developer/bridges.md
+++ b/docs/developer/bridges.md
@@ -1,0 +1,148 @@
+# Native bridges and segmentation
+
+Some ANE hardware layers exist on the silicon but Apple's user-space MIL/CoreML compiler never emits them. ANEForge reaches them by hand-authoring native ANECIR netplists and dispatching them directly (Path A) — each such op cuts the graph and runs as a separate native sub-program.
+
+## The segmentation model
+
+Most ops are **fused e5rt-MIL**: they lower to MIL and fuse into one program with no graph cut (see [Architecture overview](overview.md)). A second family are **netplist-bridge** ops — native Path-A hardware layers the MIL frontend never produces. Each bridge op **cuts** the graph:
+
+- surrounding regions compile and run as ordinary `e5rt` programs;
+- the bridge node runs as a separate native sub-program (sub-millisecond via the **A2 persistent worker**);
+- `compile` returns a `SegmentedModel` that threads segment outputs as host arrays between regions.
+
+Each region is compiled from its own input shapes, so an op that changes the batch (e.g. `space_to_batch`) is fine as a segment boundary even though it would confuse a fused region.
+
+### Path-A dispatch core
+
+`_netplist.py` is the shared netplist author. It generates small ANEF `net.plist` programs **without CoreML or MLCompute**. The generated directory contains `net.plist`, `weights.0`, and `weights.1` (for convolution programs), loadable through `_ANEInMemoryModelDescriptor modelWithNetworkDescription:weights:optionsPlist:`.
+
+- **`bin_dir()`** — a per-machine compiled-invoker binary cache (sibling of the e5rt cache at `~/.cache/aneforge/e5rt`), kept outside the package tree so bridges work when aneforge is installed into a read-only site-packages.
+- **`ensure_invoker(name)`** — compiles `aneforge/_invokers/<name>.mm` -> `bin_dir()/<name>` on demand, cached per machine (rebuilt when the source is newer). The invokers link only system frameworks, so this works on any Apple Silicon Mac. Several bridges share one invoker (e.g. `sdpa_invoker` is the generic netplist invoker for the geometry/structural/rearrange ops), so the build is centralized here rather than duplicated per bridge.
+- **`invoke_netplist(...)`** — the shared dispatch core: builds the invoker command (`--net-plist`, per-weight `--weights`, per-input/`--output name=path`, `--repeats`, optional `--warmup`), runs it, and raises on a non-zero return code or a non-`ok` status. `inputs`/`outputs` are `(name, path)` pairs; the caller writes input files and reads output files (layouts differ per bridge). Returns the parsed last-line status dict (e.g. timing info).
+
+!!! note "Productized from the RE corpus"
+    Each `*_fused` module is a self-contained dispatch closure promoted out of the reverse-engineering corpus. It authors a `Type=<Layer>` netplist and runs it Path-A.
+
+## Native fused-attention (SDPA)
+
+`sdpa_fused` runs SDPA end-to-end through a hand-authored ANECIR netplist with `Type=SDPA`, reaching the native fused-attention hardware layer instead of the HWX-level decomposition Apple's compiler emits. It's a drop-in fused-attention path for `(B, heads, seq, d_head)`-layout Q/K/V at fp16.
+
+### The constant-Scale gate
+
+The 4-input fused-attention layer accepts Q, K, V, and Scale tensor descriptors. The validator (`_ANECValidateSDPALayer`) requires `ANECTensorDesc.byte[0x39] bit 0` set on the Scale tensor (the "Scale is expected to be constant" gate). The netplist spelling of that bit is undocumented; Apple's MIL->ANECIR translator sets it implicitly via the `Constants` array.
+
+The builder supports candidate spellings via `constant_flag_spelling`: `Constants_array` (list Scale in the `Constants` array, backed by weights.0), `IsConstant_unit`/`is_constant_unit`, `ConstantTensor_unit`, `ScaleMutable_false`, and `all` (probe mode). **`Constants_array` is the default and the only spelling observed to compile + load** on this host (others raise `ANECCompile() FAILED`). The Scale value (default `1/sqrt(dim)`) folds into the constant weights blob, and Scale sits as the 4th input (index 3) in the Bottom array, matching Apple's 4-tensor layout.
+
+### SubtractMax (the softmax numerics gate)
+
+`subtract_max` controls `Params.SubtractMax` — the **only** `Params` key the SDPA netplist parser recognizes. It sets `desc[0x00]` (a CFBoolean) controlling whether softmax subtracts the max before `exp`. `ANECSDPALayerDescInitialize` defaults it to `kCFBooleanFalse` (no max-stabilization), which was the source of the original "Y depends on Q,K,V,scale but doesn't equal `softmax(Q@K^T*s)@V`" numerics gap. Apple's MIL->ANECIR translator emits `SubtractMax=True`; numerically correct softmax requires `True`.
+
+### Seq-in-C transpose
+
+The ANE SDPA layer treats the **C tensor dim as the sequence axis** (the validator's "K and V must have same sequence length i.e. C dim"). PyTorch/MIL convention puts heads in C and seq in H, so the bridge pre-transposes to swap them (netplist sees seq-in-C, heads-in-H, the ANE-native layout) and post-transposes Y back to `[B, heads, seq, d_head]`. Internally `channels` is the ANE C dim (sequence after transpose) and `sequence` is the ANE H dim (heads after transpose). ANE output is `(B, S, H, D)` (native C=seq, H=heads, W=d_head).
+
+### Mask and decode
+
+The netplist is edited for two cases:
+
+- **KV-cache DECODE shape** — Q's sequence may differ from K/V's. The validator requires only "Q,K same embedding (W)" and "K,V same seq (C)", so query+output carry `Sq` channels while K/V carry `Skv` (seq_q query tokens attend to seq_kv cached K/V).
+- **Optional additive MASK** — bottom shape `[C=Sq, H=1, W=Skv]`, per the validator's "Mask Width axis must match K and V Channel axis or broadcastable".
+
+Validated on M1: decode (`Sq<Skv`) cos ~1.0; causal mask cos 1.0 vs `softmax(QKt*scale+mask)V`.
+
+See [Per-op ANE quirks](op-quirks.md) for the `SDPA_NATIVE_MAX_SEQ`/`SDPA_NATIVE_MIN_BOTH` reliability bounds and the per-head/query-broadcast mask restrictions.
+
+## Rank-family layers
+
+`ane_rank_fused.py` provides four hardware-native fp16 rank layers via netplists: `Sort`, `TopK`, `ArgMinMax`, and `GlobalArgMinMax`. Input `x` is fp16 `[channels, width]` (height=1) for Sort/TopK/GlobalArgMinMax, or `[channels, height, width]` for ArgMinMax.
+
+| Layer | `Params` schema |
+|---|---|
+| **Sort** | `Direction` (Ascending\|Descending), `SortDimension`, `VectorDimension`, `SortIndices` (key lane), `Indices` (bool: output argsort instead of values) |
+| **TopK** | `Type` (Max\|Min), `K` (int), `SortDimension`, `VectorDimension`, `SortIndices`, `Indices` (bool) |
+| **ArgMinMax** | `Mode` (SpatialArgMax\|ChannelArgMax\|SpatialArgMin\|ChannelArgMin), `KernelWidth`, `KernelHeight`, `Pad*` |
+| **GlobalArgMinMax** | `Type` (Max\|Min), `Dimension` |
+
+- **Sort** sorts the Width axis, permuting *all* channels by the ordering of channel `key_lane` (`SortDimension=Width, VectorDimension=Channel`).
+- **TopK** is top-k along Width keyed by channel `key_lane`. **`k` in {3,4} is arch-gated** (ANECCompile fails).
+- **ArgMinMax**: `Spatial*` -> one flattened-(H*W) index per channel; `Channel*` -> one channel index per (h,w) position.
+- **GlobalArgMinMax**: argmax/argmin index along `Dimension` (Width\|Height\|Channel).
+
+!!! note "fp16-encoded integer indices"
+    Integer index outputs come back fp16-encoded in the ordinary Float16 output tensor. For the small index ranges these layers produce (< 2048), fp16 represents every integer exactly, so the indices are exact.
+
+## Spatial-rearrange layers
+
+`ane_rearrange_fused.py` provides six fp16 rearrange layers:
+
+| Layer | Shape law |
+|---|---|
+| PixelShuffle | `[N, C*fx*fy, H, W] -> [N, C, H*fy, W*fx]` (depth->space) |
+| PixelUnshuffle | `[N, C, H*fy, W*fx] -> [N, C*fx*fy, H, W]` (space->depth) |
+| ChannelToSpace | depth->space, same shapes as PixelShuffle |
+| SpaceToChannel | space->depth, same shapes as PixelUnshuffle |
+| SpaceToBatch | `[N, C, H, W] -> [N*fx*fy, C, H/fy, W/fx]` |
+| BatchToSpace | `[N*fx*fy, C, H, W] -> [N, C, H*fy, W*fx]` (inverse of S2B) |
+
+PixelShuffle/PixelUnshuffle use the **PyTorch (channel-major)** convention; ChannelToSpace/SpaceToChannel use the **TensorFlow** `space_to_depth`/`depth_to_space` (block-major) convention — they coincide only when `C==1`. For `space_to_batch`, output batch slice `bh_i*bw + bw_i` == `x[..., bh_i::bh, bw_i::bw]`; `batch_to_space` requires the input batch divisible by `bh*bw` (validator constraint). The native rearrange layers support **batch N=1 only**, and `batch_to_space` is arch-gated on the divisibility constraint (see [op-quirks](op-quirks.md)).
+
+## Structural layers
+
+`ane_structural_fused.py` provides three structural kinds (`flatten`/`dropout` are public, `Broadcast` via the model generator):
+
+- **`Flatten`** — NCHW identity reshape to a 1-D vector (`prod(shape)`). The bridge takes a `[C,H,W]` input, so it needs a 3D graph tensor.
+- **`Dropout`** — inference-time identity (rate must be 0).
+- **`Broadcast`** — replicate a length-1 axis to `Size` along `Dimension`.
+- **`input_view`** — contiguous view `x[offset:offset+size]` along Width (x flattened to 1-D length W; returns `[size]`).
+
+## Geometry and point-cloud layers
+
+These are paths Apple's MIL frontend rejects entirely.
+
+- **`cross_product`** — 3-vector cross product (`cross(x, z)`), both inputs length-3, returns `(3,)`; matches `numpy.cross`.
+- **`cross_correlation`** — valid (no-flip) cross-correlation of single-channel map `x` `[H,W]` with `template` `[Th,Tw]`: `y[i,j] = sum_{u,v} x[i+u, j+v] * template[u,v]` over `(H-Th+1) x (W-Tw+1)`. True correlation (template not flipped).
+- **`cost_volume`** — L1 stereo/optical-flow matching cost: `aux` length-Wa, `ref` length-Wr with `Wr >= Wa + R`, returns `(R+1, Wa)` where `cost[d,x] = |aux[x] - ref[x+d]|`. (write_model maps width->ref_width, template_width->aux_width.)
+- **`fps`** — FurthestPointSampling: greedily pick `CentroidCount` maximally-far-apart points (seeded at index 0). `points` `(N,3)` -> `(k,3)`. **L2-only on this arch** regardless of `DistanceMetric`; arch limits `k<=1024`, `N<=8192`.
+- **`radius_search`** — L2 ball-query membership: `points` `(N,3)`, `centroids` `(Nc,3)` -> `(N,Nc)` uint8 membership matrix (`[i,j]==1` iff `points[i]` within L2 `radius` of `centroids[j]`). Output is `[Np rows x Nc cols]`, 2 bytes per W-cell, low byte = membership flag.
+- **`dynamic_slice`** — runtime-parametric slice `x[start:start+size]` along an axis, `start` bound through a netplist constant (overwrites the index constant in weights.1). The accepted variant fixes `SliceSize=2` and `W=4` (see [op-quirks](op-quirks.md)).
+
+Accepted unit dictionaries (examples):
+
+```text
+{"Type": "FurthestPointSampling", "Bottom": ["points"],
+ "InputType": ["Float16"], "OutputChannels": 3, "OutputType": "Float16",
+ "Params": {"CentroidCount": k, "DistanceMetric": "L1" | "L2"}}
+
+{"Type": "RadiusSearch", "Bottom": ["centroids", "points"],
+ "InputType": ["Float16", "Float16"], "OutputChannels": 1, "OutputType": "Float16",
+ "Params": {"Radius": r}}
+```
+
+## Normalization layers
+
+These native layers carry fp16-bit-pattern parameter quirks — a float passed where a bit pattern is expected int-truncates to ~0 and yields identity output.
+
+### LocalResponseNormalization (`lrn`)
+
+Classic cross-channel (AlexNet) LRN, Channel mode: `y[c] = x[c] / (K + alpha_eff * sum_{j in window} x[j]^2) ^ Beta`. Non-obvious conventions:
+
+1. **`Alpha` is an fp16 bit pattern** (`ZinParseFP16Token`), not a float.
+2. The ANE divides the parsed alpha by `KernelChannel` internally, so `alpha_eff = fp16(Alpha_bits) / KernelChannel`. For a desired alpha, pass `Alpha = fp16_bits(desired_alpha * KernelChannel)`; the bridge does this pre-multiply so callers pass the true effective alpha.
+3. Only the first `KernelChannel` output channels are normalized; the rest are identity-copied. Use `KernelChannel = C` for full coverage (empirically `C==KernelChannel` works, e.g. `C=5/KC=5`).
+
+The window is a **local** channel window of size `N = C`, asymmetric-centered on `c` and clipped at boundaries: `window(c) = [max(0, c-(N-1)//2) : min(C, c + N//2 + 1)]`. Only the center channel sees all C channels; edge channels see a partial sum — this is **not** a full-channel sum. Arch-gated to `C <= 15` (`C >= 16` fails ANECCompile).
+
+!!! note "Two LRN paths"
+    `af.local_response_norm` is the **fused MIL** op (no cut) — `x / (k + alpha/size * sum_{window} x**2) ** beta` over `size` neighbouring channels. `af.lrn` is this **netplist bridge** (graph cut) with the corrected window semantics above.
+
+### MinMaxNormalization (`minmax_norm`)
+
+`y = (x - min) / (max - min + eps)` over `Params.Dimension`. `x` is `[1, C, H, W]`. `Dimension="Width"` (per-row) and `"Height"` (per-column) are supported; **`"Channel"` is arch-gated** (ANECCompile fails). `Params.Epsilon` is an **fp16 bit pattern**, not a float — pass `fp16_bits(desired_eps)`.
+
+### ScaledElementWise (`scaled_elementwise`)
+
+`y = scale * (x OP z)` — fuses a binary elementwise op with a scalar scale. `Params.Type` selects the op (Add/Mult/Min/Max); `Params.Scale` is an **fp16 bit pattern** (use `fp16_bits`). Two arch quirks are guarded: **`Sub` is rejected** by ANECCompile, and **`Mult` ignores `scale`** on-silicon — both are rejected rather than emitting a wrong or uncompilable program.
+
+## einsum (native single-equation layer)
+
+The native MIL `einsum` op (distinct from the general `af.einsum` decomposer) is a single hardware layer. The only on-ANE-verified equation is `'nchw,nwhu->nchu'` — a batched matmul over the W/U dims sharing N,H: `a`=`[N,C,H,W]`, `b`=`[N,W,H,U]` (streamed weight) -> `[N,C,H,U]`. `b` is a weight array (streamed), not a graph Tensor.

--- a/docs/developer/capabilities-and-targets.md
+++ b/docs/developer/capabilities-and-targets.md
@@ -1,0 +1,152 @@
+# Capabilities and targets
+
+ANEForge keeps a single, closed, machine-checkable census of *what ANE capability it surfaces* — the capability registry in `_capabilities.py` — and a per-family target table covering 28 ANE chips. This page covers the census and its classification discipline, the cracked layers and arch-gated walls, the target families and cross-compile gating, and the cross-chip fp16-divergence heads-up.
+
+## The capability census
+
+The authoritative runtime op sets are `_EMIT` (the fused e5rt-MIL emitters) and `NETPLIST_OPS` (the native Path-A bridge ops), both in `_compile.py`. But the *discovery evidence* behind them — which layers were proven on silicon, which are genuine hardware walls, which are only predicted — was scattered across the reverse-engineering corpus, and nothing reconciled the two. A new op could appear unclassified, or a "surfaced" op could silently stop compiling unnoticed.
+
+`build_registry()` closes the loop. It introspects the live `_EMIT` / `NETPLIST_OPS` and merges them with curated, citation-carrying classification data for everything that can't be introspected (cracked-but-not-promoted layers, the arch-gated negatives, the predicted-but-unbuilt frontier). The result is a **closed classification of every ANE capability ANEForge knows about**. `tests/test_routes.py` fails CI if the live runtime drifts from this registry either way.
+
+!!! note "This is a publication artifact"
+    Every entry carries evidence. `cracked` entries cite their bridge in the reverse-engineering corpus; every negative cites the finding that established the wall; every `reachable`/`not-authorable` cites the sweep matrix.
+
+### Classification discipline
+
+Every entry is exactly one of:
+
+| Status | Meaning |
+|--------|---------|
+| `fused` | In `_EMIT`; lowers to e5rt-MIL, fuses into one program. |
+| `bridge` | In `NETPLIST_OPS`; runs as a native Path-A sub-program (a graph cut). |
+| `cracked` | Reverse-engineered native layer **proven on silicon** in the corpus, but not yet promoted to the frontend. |
+| `reachable` | The native MIL op compiles + runs correct on ANEForge's own e5rt path (proven by the full-vocabulary sweep), but is not promoted to a frontend `_EMIT` emitter or `af.` method. Reachable through the MIL door, not direct `Type=` netplist authoring — so not a cracked native layer. |
+| `arch-gated-negative` | Known **not** to work, carrying the specific wall (an authored op/config the ANE backend rejects or fails to lower). |
+| `not-authorable` | Control-flow / list / state ops (cond, while_loop, make_list, read_state, …) with no single-op MIL form on the single-procedure feed-forward surface — the recurrence/scan wall. Recorded, not defeated. |
+| `predicted` | Predicted crackable by the callable-`_ANECValidate*` heuristic, but not built and not verified. |
+
+`fused`/`bridge`/`cracked`/`reachable` all carry `verified="silicon"` — the distinction between them is **promotion, not evidence**. `predicted` is explicitly `verified="no"`.
+
+The registry is exhaustive over the full **166-op MIL vocabulary** swept in `full_mil_vocabulary_sweep.json` (116/166 reachable), not just the 50 `_ANECValidate*Layer` validators. A sweep layer (D) synthesizes an entry for every swept op not already represented, classifying from its sweep `klass`: `reachable+correct`/`reachable` → `reachable`; `not-implemented-on-ANE` → `arch-gated-negative`; `compile-walled` → `not-authorable` for control-flow/list/state, else `arch-gated-negative`. Curated entries always win over the sweep (exact-name match skipped), preserving the hand-written walls and evidence.
+
+### The cracked-layer manifest (the "26 cracked")
+
+A **cracked native hardware layer** is a distinct native ANE layer reached by the *netplist-authoring* method (authoring `Type=<Layer>` directly in the netplist / Path-A) which Apple's user-space MIL frontend does **not** emit. In the registry these are exactly the entries with status in `{cracked, bridge}`: `bridge` ops are Path-A netplist sub-programs authored directly; `cracked` ops are unpromoted direct-netplist cracks.
+
+```
+distinct cracked layers = (#cracked) + (#bridge) − 1
+```
+
+The one dedupe: `slice_by_index` (cracked) is the same hardware capability as `input_view` (bridge) — both `Type=InputView` — folded in so the 26 are distinct layers, not 27 with an alias.
+
+!!! note "Promoted ops are not retroactively counted as cracks"
+    Some `fused` ops (e.g. PixelShuffle, L2Norm) were originally reached by netplist authoring before being promoted to a MIL `@op` emitter. They're excluded from the manifest: their *current* route is the MIL emitter, not direct `Type=` authoring. The manifest counts the current direct-netplist route only.
+
+## Cracked-but-unpromoted native layers
+
+Native layers proven on silicon (a self-verifying `*_fused.py` in the corpus) but not promoted into `_EMIT` / `NETPLIST_OPS`:
+
+- **Dropout** (`Type=Dropout`) — inference identity at rate 0; not promoted (no training-time use on the inference engine).
+- **Broadcast** (`Type=Broadcast`, BroadcastInfo replicates a length-1 axis) — MIL add/sub/mul already broadcast in the fused path; standalone layer unneeded.
+- **Resample** (`Type=Resample`, NearestNeighbor mode) — the BILINEAR mode is now promoted to fused (`resize_bilinear`/`upsample_bilinear`); NearestNeighbor stays cracked (fused `resize_nearest_neighbor` covers it).
+- **RandomGenerator** (Normal/Bernoulli/Categorical/Gaussian) — on-device RNG compiles, but seeding/streaming semantics are unsettled; host RNG used today.
+- **Shape** — static shapes are known at compile time, so no frontend need yet.
+- **DynamicGOC** (gain-offset-clamp, `out=idx*(data+upd)`) — compiles+loads; it is **not** a scatter (Mode/Axis are inert). Niche.
+- **Tile** — `Params` is a dimension-NAME-keyed factor dict (`{'Width':fx,'Height':fy,'Channel':fc}`, *not* FactorX/Y/Z). Cracked 2026-05-30 (was `predicted`). A clean bridge-promotion candidate (B=1 static).
+- **slice_by_index** (`Type=InputView`) — bit-exact contiguous slice, the same capability as the `input_view` bridge op. Promotable as a frontend `slice`, not a new layer (not double-counted).
+
+## Arch-gated walls (negatives)
+
+A **negative** means: rejected at compile, or the named configuration fails ANECCompile/HWX codegen even though the validator accepts the schema. Each carries its specific wall; the `probe` field (when present) is a tiny ANEForge call CI runs to confirm it still fails.
+
+### Native-op gaps reachable by decomposition
+
+A key distinction (2026-05-31 calibration): the native **op** is unimplemented on the ANE backend ("Not implemented … not supported on any backend"), but the **capability** is reachable on the same e5rt path via a decomposition. These are native-op gaps, not hardware walls:
+
+- **reduce_prod** → `exp(reduce_sum(log(x)))` (relerr ~1e-3; positive inputs; sign/zero need extra ops).
+- **gather** → for trace-time-constant (STATIC) indices, a one-hot @ matmul (bit-exact). Only **dynamic** large-vocab embedding lookup stays host-side (one-hot is O(vocab) and needs runtime indices).
+- **cumsum** → an upper-triangular ones matmul `x @ U` (relerr ~3e-4; O(N²) in the matmul) — **not** a "no parallel-prefix silicon" wall.
+
+### True walls (no in-graph route)
+
+- **scan / iir_recurrence** — no data-dependent in-graph loop: sequential recurrence is inexpressible on the feed-forward engine. Only static FIR-unroll fits.
+- **scatter** — no scatter-write path; DynamicGOC is gain-offset-clamp only.
+
+### dtype walls
+
+- **fp32_compute** — the ANE computes in fp16 only. ANEForge accepts fp32/fp64 weights but silently casts them to fp16 (no frontend raise — the wall is a compute-precision fact).
+- **int32_compute** — rejected at MIL parse ("not implemented"). probe: `int32_weight`.
+- **bf16_compute** — no path on the backend (cleanly rejected; numpy has no native bf16, so no clean frontend probe).
+
+### Layer / codegen walls (validator accepts schema, M5 HWX codegen fails)
+
+- **conv_kernel_ge16** — conv (and the CrossCorrelation bridge) is capped at kernel K≤15 on M5: a 1×K kernel with K≥16 fails ANECCompile. (`aneforge/dsp.py` routes wider kernels to FFT.)
+- **group_norm_large_featuremap** — **relaxed** by rank-4 tiling: group_norm lowers to `[1,G,C/groups,H*W]`, so the bound is `max(C/groups, H*W)` vs. the per-axis cap 65536, not the flattened product. SD-UNet's 640ch@64 (81920) and 512ch@128 (262144) now compile in fp16; `af.group_norm` only raises when a single tiled axis > 65536.
+- **square_opcode_tiling** — the native `square` opcode fused with a following nonlinearity fails ANECCompile when `(Width % 128) > 64`. ANEForge emits `mul(x,x)` instead (identical math, compiles everywhere), so it never surfaces this.
+- **rank5_transpose_matmul** — transpose+matmul fails ANECCompile at rank≥5 (the rank-4 cap): a fully-split tensor carries at most 3 factor groups, forcing matmul-FFT to 3-stage rather than full log-depth radix-2.
+- **batch_to_space_indivisible** — BatchToSpace with input batch `N % (FactorX*FactorY) != 0` fails HWX codegen. (`af.batch_to_space` guards at construction.) probe: `batch_to_space_indivisible`.
+- **topk_k3_k4** — TopK with K ∈ {3,4} is a fixed forbidden band (ANECCompile fails); K=1,2 and K≥5 work. (`af.topk` guards.) probe: `topk_k3`.
+- **minmax_norm_channel_axis** — MinMaxNormalization over the Channel axis fails HWX codegen; Width/Height work. (`af.minmax_norm` rejects Channel.) probe: `minmax_norm_channel`.
+- **lrn_channels_ge16** — LocalResponseNormalization with KernelChannel=C fails ANECCompile for C≥16; C≤15 works. (`af.lrn` guards.) probe: `lrn_c16`.
+- **scaled_elementwise_sub** — ScaledElementWise op='Sub' is rejected; op='Mult' silently ignores `scale`. (`af.scaled_elementwise` guards both.) probe: `scaled_elementwise_sub`.
+- **Unflatten** — fails HWX codegen for all variants (composite-lowering specific); bare Reshape/Transpose compile fine.
+- **KernelRasterizer** — im2col unfold only compiles in the degenerate identity config (OutputChannels=1, output dims = input dims); real im2col always fails ANECCompile.
+- **RingBufferWriter** — a multi-procedure streaming-state primitive; fails from any single-procedure netplist regardless of Params.
+- **CropResize** — texture-family codegen gate: direct-netplist CropResize fails ANECCompile on M5 (plane-equation coefficient constraint).
+
+### Internal-optimizer-gated and architectural walls
+
+- **MATDECOMP_MATMULT_0x19** — internal-optimizer-gated (not schema-gated): the fused matrix-decomp-matmul composite (0x19) is emitted only by `ZinIrOpt::BatchMatDecompMatMul` on a batched topology the netplist can't express; 7 variants all lower to 0x60.
+- **PEFUSED_GOC_0x5C** — internal-optimizer-gated: nested-container grammar recovered but no single-0x5C HWX emerged.
+- **RCAS** — internal-optimizer-gated: opcodes 0x44/0x65 have a `ZinRCASLayer` + internal validate but no exported `_ANECValidateRCASLayer` and no .tbd entry — not netplist-reachable. Same class as MATDECOMP_MATMULT_0x19.
+- **MatrixDecomposition_factorization** — the native MatrixDecomposition (NonQRGivens) is not currently callable (carriers compile, the factorization doesn't). The LAPACK wall is architectural, not numerical.
+- **on_device_rng_seeded** — RandomGenerator compiles but seeding/streaming semantics are unsettled; RNG kept host-side.
+- **custom_hwx_load** — hits the kernel-signature wall (unentitled).
+- **nan_to_num** — the ANE does not propagate NaN, so NaN-handling ops are broken (no fix).
+- **bitwise_logical** — bitwise/logical ops (and/or/xor/not) rejected (not in the fp16 surface); trig/hyperbolic inverses (acos/asin/sinh) are netplist dead-ends too.
+- **Reverse** — the native netplist Reverse *layer* is schema-unreachable (no exported `_ANECValidateReverseLayer`, no atlas opcode — only an internal MIL-frontend op that lowers away). The `predicted` classification was over-optimistic. The MIL `reverse` *op*, however, is reachable+correct on the e5rt path, so the reversal capability is available through the MIL door.
+
+!!! note "Walls reconciled to reachable (2026-06-02)"
+    Several earlier "walls" were over-cautious *direct-netplist* probes scoped to the netplist door; the equivalent **MIL ops** compile + run on the e5rt path. **AffineTransform** → `affine` (genuine warp, relerr 2.3e-3) and **Resample_Bilinear** → `resize_bilinear`/`upsample_bilinear` (relerr 2e-4) now ship as **fused** _EMIT ops. **instance_norm** → fused `x.instance_norm(...)` (the decomposition route remains too). **NMS** → `non_maximum_suppression` is now `reachable` (presence-only, not numerically validated — selection-ordering output). **No quantization walls remain**: the former "blockwise_int8"/"int4_weight"/"sparse" negatives were malformed empty-paren probes (the named-arg form compiles, relerr ~3e-4); int8-affine, int4-LUT, sparse, and blockwise all ship via `compress=`. The remaining texture-family negative is CropResize.
+
+## The predicted frontier (Pad)
+
+- **Pad** — predicted netplist (`ZinPadLayer` + `ZinPadValidator`; the `kANECNetUnitPaddingInfo` dict schema is unrecovered). The validator accepts the schema (status=1) but ~13 binary-derived PaddingInfo spellings all fail ANECCompile; spatial-only, constant amount_before/after. Next step: recover the exact dict from a CoreML-emitted Pad bundle. As with Reverse, the MIL `pad` *op* is reachable+correct, so the padding capability is available through the MIL door.
+
+## Targets: the 28 ANE families
+
+ANEForge models 28 ANE targets across the M1–M5 generations (`_targets._ARCH_FAMILY` tiers). Each target carries per-family capability caps — conv kernel width, max tensor dim, and the per-op `MinimumFamily` floor — that are **HAL-data gated**. The cost model's per-chip curves (`costmodel_curves.json`) cover the distinct cost profiles; an arch missing its own entry (h14g, h16c, h17a, h18, …) folds to its family's representative die.
+
+Three families are **silicon-measured** (own a cost anchor): A13/h13 (M1), A14/h14 (M2 Pro), A16/h17s (M5). The A16 tier folds H16/H17* into the h17s point. Every other target is extrapolated by its `{cores, clock, efficiency}` curve — see the [analytic per-chip model](optimizer-and-cost.md#the-analytic-per-chip-model-direction-a).
+
+### Per-family gating
+
+`_retarget_for` gates a graph for a target family before lowering: it raises on the H13+ hard floor (ANEForge requires an A13+ ANE — MIL is only supported for H13+), on an unreachable op, or on a tensor exceeding the family's limits, and substitutes below-floor ops that have an in-graph decomposition (`sin`/`cos` → `aneforge.special`). On the host family with an all-native graph it's a no-op fast path.
+
+## Cross-compile validation
+
+`cross_compile_check` asks: does the graph compile for *another* ANE family, checked from this host? It returns True iff the e5rt compiler produces a library for that `TargetArchitecture`. This is compile-level validation only — a different-family host cannot execute there. It's the **keystone of cross-chip CI**: validate that the op corpus compiles for every chip family on one box. Numeric correctness still needs real silicon.
+
+!!! warning "Three traps the gate must avoid"
+    1. **Silent host fallback.** The e5rt compiler silently falls back to the host target on an unrecognized `TargetArchitecture` string (measured: `'zzz'` compiles fine), turning a typo into a false cross-target pass. Gate on the known-target table first.
+    2. **Caps not enforced cross-family.** A target's per-family caps (conv kernel width, max tensor dim, below-`MinimumFamily` ops) are HAL-data gated, and the host cross-compiler does *not* reliably enforce a different family's caps when emitting for its `TargetArchitecture` — so a cap violation would compile here and only fail on real silicon (a false CI pass). `preflight()` answers the same question statically and family-aware (it's what `compile(target=)` gates on), so reject up front and skip the compiler entirely.
+    3. **fp16 divergence.** Annotate cross-chip fp16 divergence risk (Direction B) before compiling — warn-only, so a typo'd/unreachable graph still surfaces its compile error.
+
+## Cross-chip fp16 divergence (Direction B)
+
+`CrossChipFP16Warning` fires (via `cross_compile_check`) when a graph compiles for a different-family target but carries an op whose **fp16 value** can diverge from the host's on that chip (per the Direction B HAL-field predictor). The compile is still valid — this is a numeric heads-up, not a rejection. `_warn_fp16_cross_chip` groups by risk class (one line per op×class) and never rejects.
+
+`_fp16_risk_kind` maps a node to the predictor's op-kind: `'slice'`, `'reduce_square'` (a reduce feeding a square/mul = variance/L2/RMS — the 0x494 fuse axis, flagged only when a source is a reduction, not every elementwise square), `'reduce'` (any reduction/softmax/norm), or `''`. The risk classes:
+
+- **saturation** — finite→inf; `|value| > 4094` on A13's ×16 crop-DMA slice.
+- **round1** — ~1 fp16 round; the 0x494 reduce→square fusion differs A13↔A14+.
+- **ulp1** — ≤1 ULP; the 0x3f0 reduction-route threshold differs.
+
+### The pre-A16 slice saturation quirk
+
+A silicon-pinned quirk worth its own note: nonzero-width (last-axis) `slice_by_size` offsets on a **pre-A16** ANE lower through a Q.4 fixed-point crop-DMA (an implied ×16 scale), with two distinct failure modes:
+
+1. **Wrong elements** when multiple width-offset slices are concatenated — the gather axis-1 bug, confirmed on A14 and A13 at any magnitude. A single width-offset slice selects correctly (a 180-config bare-slice sweep is numpy-exact on A14), so this mode is specific to the concat-of-width-slices pattern.
+2. **Saturation** — a sliced element with `|value| > 4094` (= 65504/16) clamps to ±inf, magnitude-driven, on a single width-offset slice. Silicon-confirmed on A13 (conv weight-grad) and A14 (4094 finite → 4100 inf, bit-exact); A15 pending M3 data.
+
+A zero last-axis begin, or an offset on any non-last axis, avoids the path and is exact; A16/M5 is unaffected. `gather` and the conv im2col backward already route off the last axis, so `_warn_h13_slice_saturation` is a safety net for any remaining hand-written occurrence.

--- a/docs/developer/compile-pipeline.md
+++ b/docs/developer/compile-pipeline.md
@@ -1,0 +1,137 @@
+# The compile pipeline
+
+This page traces how `compile(out)` lowers an ANEForge graph into **one fused e5rt program** that runs on the Apple Neural Engine: topological ordering, the per-op MIL emit registry, weight packing into a single BLOBFILE, the dispatch-floor signal, and the fused-vs-segmented split.
+
+## From graph to one fused program
+
+`compile(out)` topologically orders the graph rooted at `out`, emits a single MIL function — one op per graph node — packs every weight into one BLOBFILE, and hands the result to e5rt on the ANE. Each op's MIL is produced by a small handler registered with `@op(...)`. That `_EMIT` registry does double duty: it is also the exact set of ops ANEForge can reach through the fused MIL door on-device.
+
+When the graph contains `af.sdpa` (or any other netplist-bridge op), the result is instead a **segmented plan** — e5rt program segments split around each native sub-program. See [Fused vs. segmented](#fused-vs-segmented) below.
+
+!!! note "One program, one dispatch"
+    The whole point of the fused path is that a graph of many nodes pays a single ANE dispatch. The cost model and the dispatch-floor warning both lean on this — see [The optimizer and the cost model](optimizer-and-cost.md).
+
+### Topological ordering
+
+`_topo` is an **iterative** post-order DFS over an explicit stack, deliberately not recursive: deep unrolled graphs would otherwise blow Python's recursion limit. Sources are appended before their consumers, which yields a valid topological order.
+
+### Per-family gating before lowering
+
+`_retarget_for` gates the graph for a target ANE family *before* lowering. It raises a clear compile-time error on the H13+ hard floor, on an unreachable op, or on a tensor exceeding the family's limits; where a below-floor op has an in-graph decomposition (e.g. `sin`/`cos` → `aneforge.special`), it substitutes it and returns the rewritten graph. On the host family with an all-native graph this is a no-op fast path that returns `out` unchanged.
+
+ANEForge requires an H13+ (A13+) ANE — MIL is only supported for H13+ architectures, and a target family below that floor is rejected up front.
+
+## The `compile()` knobs: `opt` and `compress`
+
+`opt` selects the graph optimizer (default `'routes'`). The full semantics live in [the optimizer page](optimizer-and-cost.md#opt-levels); in brief:
+
+| `opt` | Behavior |
+|-------|----------|
+| `'routes'` (default) | Lossless, cost-model-driven route selection per route-bearing bridge node. Never changes numerics; a cut-free graph compiles to exactly the `opt=0` program. |
+| `0` | No optimization — the historical, byte-identical path. Use for byte-identity tests. |
+| `1` | Cost-model pick over the full variant set (route swaps + the lossy whole-graph int8 variant), no on-device measurement. |
+| `2` / `'max'` | Autotune — measure legal proven-safe variants on the ANE, validate each against the `opt=0` baseline, return the fastest correct one (cached). |
+
+`compress` is the unified weight-encoding knob:
+
+- `None` — fp16 (default, byte-identical at `opt=0`)
+- `'int8'` — per-channel affine
+- `'int4'` — LUT, accuracy-gated
+- `'sparse'` — bitmask, when the weight is ≥50% zeros
+- `'blockwise'` — per-inner-block int8 (`constexpr_blockwise_shift_scale`, `block_size` columns per scale), accuracy-gated → int8 → fp16
+- `'auto'` — per-weight, family-aware (below)
+
+`int8=True` is the back-compat alias for `compress='int8'`. `compress_atol` is the int4/blockwise fallback budget (relative L2); `block_size` is the inner-dim block width for `'blockwise'`.
+
+!!! warning "compress stays on the byte-identical path"
+    Compressed weights ride the `opt=0` lowering. Passing `compress` together with an explicit `opt>=1` is **rejected**, and the default route pass is skipped for compressed compiles — they take the no-op path.
+
+### `compress='auto'` is family-aware
+
+`'auto'` picks, per weight, the most aggressive encoding that stays correct: sparse if the weight is sparse, else int4 if accurate, else int8, else fp16. But it only considers encodings that **stream natively** on the target family (host-detected when `target=None`):
+
+- On **h13/M1** the native-streaming set is int4-LUT + sparse, so auto streams those (sparse for ≥50%-zero weights) and skips int8/blockwise — they fold to dense fp16, costing accuracy for zero bandwidth win, so fp16 dominates them. A rejected int4 falls to fp16, not int8.
+- On **A14+** all four encodings stream, so all are auto candidates.
+- `family=None` keeps every branch enabled (historical behavior).
+
+Explicit single-mode knobs are **never** filtered — that's the user's call.
+
+## Weight encoding precedence
+
+`_Emitter.weight(name)` declares a constant weight and chooses its encoding by this precedence:
+
+```
+sparse  →  int4-LUT  →  per-channel int8  →  fp16
+```
+
+- **sparse** when `compress='sparse'`, allowed, and the weight is genuinely sparse (≥50% zeros, not all-zero).
+- **int4-LUT** when `compress='int4'`, allowed, inner dim even, and within the accuracy budget. Gated by per-tensor relative-L2 reconstruction error vs `compress_atol`; it falls back rather than emitting a too-lossy weight. The int4 fallback chain is **int4 → int8 → fp16**: on a gate miss or odd inner dim it falls to int8 if `allow_int8` (denser than fp16, and the user opted into compression), else fp16.
+- **per-channel int8** on the `compress='int8'`/`int8` override.
+- **fp16** otherwise. `compress=None`/`opt=0` stays byte-identical (the fp16 branch).
+
+Branch order *is* the `'auto'` precedence. Single-mode knobs enable exactly their one compressed branch; `'auto'` enables the branches that stream natively and takes the most-aggressive that stays correct (sparse lossless, int4 accuracy-gated, int8 the dense fallback). Under `'auto'`, each compressed branch is additionally gated on streaming natively on the target family (`self._auto_streams`).
+
+!!! note "fp16 norm in fp32"
+    The int4-LUT / blockwise relative-error checks compute the weight norm in fp32: `W2.dot(W2)` overflows fp16 for large weights.
+
+### int4-LUT uses ND indices (a routability wall)
+
+LUT indices always have the same shape as the weight (`lut.rank == W.ndim + 2`). For 2-D weights this is `[1,1,16,1]` exactly as before (byte-identical). For ND weights (e.g. conv) the lut is `[1]*N + [16,1]`; Espresso accepts any rank as long as `lut.rank == indices.rank + 2`. The reason ND indices are *mandatory*: a reshape of a `constexpr_` output is **not routable** on the ANE backend, so the indices must already carry the weight's rank.
+
+### Blockwise dequant needs a +0 bridge
+
+For `'blockwise'`, `data` has the weight's shape and `scale` is `[OUT, nblocks]`. On-device `constexpr_blockwise_shift_scale` reconstructs `data.reshape(OUT, nblocks, bs) * scale[:,:,None]` (zero offset; verified multi-block on M5 at relerr ~3e-4). The wall: that constexpr output is **not routable** as a matmul/conv weight operand (Espresso "Not implemented") — it only feeds elementwise consumers. So ANEForge **bridges it through a `+0` add** to a dense fp16 result that can back a matmul/conv. Net effect: the weight is dequantized in-program, not streamed as int8 — the disk artifact is ~2× smaller but there is **no bandwidth win** (unlike int4-LUT/sparse, which stream compressed). Per-channel int8 is the exception: it *is* routable as a conv weight (`constexpr_affine_dequantize` feeds the conv weight operand directly, no +0 bridge) and so halves DRAM weight bytes at the MAC port.
+
+## Multi-output ops
+
+`split` emits N equal outputs once (keyed on `which == 0`); later splits of the same source reuse the already-emitted multi-output statement by name (`n0_<i>`). A per-source marker on the emitter guards against re-emit.
+
+## Model surface
+
+A compiled `Model` carries a few internal hooks useful when modifying the pipeline:
+
+- **`Model._input_tensors`** — the ordered input `Tensor` objects (same order as `inputs`). It lets callers such as `autograd.Trainer` map each compiled input back to its source Tensor (trainable parameter vs. provided data). Additive; no effect on inference.
+- **Zero-copy hot-loop API** — skip the per-call host↔device memcpy:
+
+    ```python
+    v = model.input_view()      # fp16 view; write into it
+    model.execute()
+    out = model.output_view()   # fp16 view onto the result, no copy
+    ```
+
+    Use this for tight inference/training loops; for one-off calls just use `__call__`.
+
+- **`MultiModel`** — a compiled fused program with N *named* outputs, e.g. a resident training step `(x, y, lr, w, m, v, ...) -> (w', m', v', ...)`. Unlike `Model` it keeps the ordered input/output Tensors and exposes the raw `Program`, so callers (the `autograd.Trainer` resident path) can alias state outputs onto their inputs via `share_buffer` and drive a resident loop. `__call__` evals once and returns outputs by name. Port names are snapshotted at compile time — `compile()`/`compile_multi()` reassign `t._name` on shared Tensor objects, so a later compile of another graph sharing these tensors must not break this model's feed/read names.
+
+## The dispatch-floor signal
+
+`compile` warns (once) via `DispatchFloorWarning` when a program is **dispatch-floor-bound**: its predicted ANE time is dominated by the fixed per-call dispatch + firmware round-trip (~0.2 ms on M1-class parts), so each call costs about the same however small the work is.
+
+The check (`_dispatch_floor_signal`) is a cheap structural estimate — no device work — and fires only when the predicted cost is dominated by the dispatch floor (it stays silent on already compute/bytes-bound programs, where amortizing buys little). The mechanics, and why this matters:
+
+!!! warning "Dispatch is single-in-flight"
+    The ANE per-call latency is a fixed dispatch + firmware round-trip. Batching and op-chaining amortize it; **concurrency does not** — threads do not amortize a single-in-flight dispatch. A caller looping per-sample silently pays the full fixed cost every iteration. To amortize: increase batch N (per-sample cost falls ~linearly toward the compute rate) or chain more ops into one program (`share_buffer` keeps state resident). Silence with `warnings.filterwarnings('ignore', category=aneforge.DispatchFloorWarning)`.
+
+A companion `PrecisionWarning` fires when a graph has fp16-cancellation-risk nodes whose results may be inaccurate; the structural model behind it is documented under [the precision risk model](optimizer-and-cost.md#the-precision-risk-model).
+
+## Fused vs. segmented
+
+Most graphs lower to one fused program. A graph that contains a **netplist-bridge op** — a node that must run as a native-ANE Path-A sub-program, like `af.sdpa`, `argmax`, `topk`, `sort` — instead compiles to a **segmented plan**: fused e5rt program segments interleaved with native sub-program calls.
+
+The `NETPLIST_OPS` table maps each bridge op name to a runner that, given materialized fp16 inputs plus the node attrs, returns the fp16 output. Adding an op there makes it a legal cut point. The fused MIL emitters are always preferred; bridges exist only for ops the ANE backend doesn't expose through MIL. The bridge closures live inside the package (lazily importing from `aneforge._bridges.<module>`), so ANEForge stays self-contained with no runtime dependency on the reverse-engineering corpus.
+
+### How tensors thread between segments
+
+A `SegmentedModel` is a compiled plan of e5rt segments interleaved with native-ANE sub-program calls. Tensors thread between segments as **host fp16 arrays** — correctness-first.
+
+The throughput follow-up is **persistent Path-A workers** (the "A2" path): one worker per netplist stage that has a worker route, built lazily on first call (keyed by stage), reused for the model's lifetime, and released in `release()`. Set `ANEFORGE_NETPLIST_WORKER=0` to force the A1 (subprocess-per-call) path.
+
+Runner resolution prefers a persistent worker (load-once-eval-many) and falls back to the subprocess bridge when:
+
+- **No worker route exists** for the op — the subprocess bridge *is* the normal path, not a degradation, so it stays silent.
+- **Causal/masked SDPA** — the per-call additive-mask injection lives on the subprocess bridge (`_run_sdpa`); the persistent worker pre-builds a mask-less netplist, so masked SDPA routes to the bridge (correctness over the worker).
+- **Genuine worker failure** — fall back to the verified subprocess path (correctness-preserving, slower per call) and remember it so the worker isn't retried every call. Signaled once per op.
+
+## Cross-family compile validation
+
+`cross_compile_check` answers: does the graph rooted at `out` compile for another ANE family, checked from *this* host? `target` is a compiler arch string (`'h13'`) or a family int. It returns True iff the e5rt compiler produces a library for that `TargetArchitecture` — **compile-level validation only**; it cannot execute on a different family from this host. This is the keystone of cross-chip CI: validate that the op corpus compiles for every chip family on one box. Numeric correctness still needs the real silicon. The full gating story (including why a static pre-gate is required) is on the [capabilities & targets page](capabilities-and-targets.md#cross-compile-validation).

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -1,0 +1,103 @@
+# Pretrained models
+
+ANEForge ships pretrained-model loaders that build an ANEForge graph from real weights and compile it to a fused ANE program, plus the trainable-graph builders used with the [on-ANE autograd](autograd.md). Heavy dependencies (transformers, torchvision) are imported lazily so the core stays light. This page covers the host↔ANE weight layout decisions and the sentence-transformers drop-in.
+
+## The host / ANE split
+
+Not every operation belongs on the Neural Engine. The loaders split work deliberately:
+
+- **Host:** tokenisation and the embedding lookup (`gather` is not an ANE op), plus pooling/normalise in some configurations.
+- **ANE:** the transformer layers, compiled as fused programs and cached per sequence length. Conv-heavy classifiers run entirely on the ANE.
+
+## load() — BERT-family sentence encoders
+
+`af.load("sentence-transformers/all-MiniLM-L6-v2")` returns a callable embedder:
+
+```python
+embed = af.load("sentence-transformers/all-MiniLM-L6-v2")
+vecs  = embed(["hello world", "the cat sat"])   # [2, D], L2-normalised
+```
+
+The transformer layers run on the ANE as fused programs (cached per sequence length); tokenisation + embedding lookup run on the host.
+
+`pooling` selects how per-token states reduce to one vector:
+
+| Mode | Default for |
+|---|---|
+| `"mean"` (default) | MiniLM, E5 |
+| `"cls"` (first token) | BGE, GTE |
+| `"max"` | — |
+
+A model's correct mode lives in its sentence-transformers config; `aneforge.sentence_transformers` reads it for you (see below).
+
+## load_resnet18() — torchvision ImageNet classifier
+
+`af.load_resnet18()` loads torchvision ResNet-18 as a fused ANE classifier:
+
+```python
+clf    = af.load_resnet18()
+logits = clf(image)                          # [1,3,224,224] -> [1,1000]
+clf    = af.load_resnet18(compress="int4")   # 4-bit LUT weights
+```
+
+**BatchNorm is folded into the preceding conv at load**, so the ANE graph is pure conv/relu/pool/add/fc — conv is the ANE's strongest workload. `compress` picks the weight encoding (see `af.compile`); `build_dir` keeps the packed program on disk (its `weights.bin` is the packed-model size).
+
+## Weight layout: He init is layout-dependent
+
+`_he` (He/Kaiming-normal init) computes `fan_in` from the weight layout, which differs between conv and fc weights:
+
+| Weight | Layout | `fan_in` |
+|---|---|---|
+| conv | `[Cout, Cin, kH, kW]` | `Cin*kH*kW` (product of trailing dims) |
+| fc | `[in, out]` | `in` (the leading dim) |
+
+Getting this wrong silently mis-scales the initial weights, so the layout dependence is explicit.
+
+## Trainable-graph builders
+
+These build graphs whose parameters are real trainable leaves, every op carrying a VJP so input/affine gradients all run on the ANE.
+
+- **`group_norm_train`** — GroupNorm built from primitives so it works at *any* batch N (the stock `Tensor.group_norm` op is batch-1 only) and so the affine `gamma`/`beta` are real trainable parameters. `x` is `[N,C,H,W]`; `gamma`/`beta` are `[1,C,1,1]` parameter Tensors. Normalizes per-(group, sample) over the `C/groups*H*W` elements, then applies the affine. Mirrors the `group_norm` VJP math.
+- **`conv_block`** — conv → GroupNorm → ReLU → optional max-pool.
+- **`cifar_cnn`** — the full CIFAR-10 CNN, returning `(x_input, logits, params)` where `params` is the trainable list in a fixed order:
+
+  ```
+  block1  conv 3->w0   GN ReLU maxpool2   (32x32 -> 16x16)
+  block2  conv w0->w1  GN ReLU maxpool2   (16x16 ->  8x8)
+  block3  conv w1->w2  GN ReLU            ( 8x8)
+  global-avg-pool over H,W -> fc(w2 -> classes)
+  ```
+
+## sentence-transformers drop-in
+
+`aneforge.sentence_transformers.SentenceTransformer` is a **drop-in** that runs the encoder on the Neural Engine:
+
+```python
+from aneforge.sentence_transformers import SentenceTransformer
+model = SentenceTransformer("BAAI/bge-small-en-v1.5")
+emb   = model.encode(["a query", "a passage"])   # [2, D] on the ANE
+```
+
+Design notes:
+
+- The transformer layers run on the ANE as one fused e5rt program (cached per sequence length).
+- **Only numpy + aneforge are needed** — the `sentence-transformers` package is *not* imported. This mirrors its `.encode` surface; it does not wrap it.
+- Pooling mode and L2-normalise are read from the model's own config (below), so a mean-pooled model (MiniLM, E5) and a cls-pooled model (BGE, GTE) both come out correct.
+- The `device` argument is accepted for signature parity and ignored — the encoder always runs on the Neural Engine.
+- `encode()`'s `batch_size` is accepted for parity but does not change the result (the ANE path is fused per sequence length and cached).
+
+### Parity claims
+
+| Mode | Cosine vs reference | Size |
+|---|---|---|
+| default (fp16) | **~1.0** | — |
+| `int8=True` | **~0.9999** | half the weight size (int8 streamed) |
+
+Embeddings match the reference encoder at a fraction of the GPU's energy.
+
+### Config-driven pooling / normalize
+
+`_read_st_config` returns `(pooling_mode, has_normalize)` from the model's sentence-transformers config, defaulting to `("mean", False)` for a raw model with no such config:
+
+- **Pooling** comes from `1_Pooling/config.json` (`pooling_mode_cls_token` / `pooling_mode_max_tokens` / `pooling_mode_mean_tokens`).
+- **Normalize** is true if `modules.json` lists a `Normalize` module. A model that ships a Normalize module is L2-normalised regardless of `normalize_embeddings`, matching sentence-transformers.

--- a/docs/developer/numerics.md
+++ b/docs/developer/numerics.md
@@ -1,0 +1,320 @@
+# Numerics
+
+ANEForge computes in fp16 only, fed through a wide (fp32-class) accumulator. This
+page is the model a developer needs to reason about accuracy on the ANE: where the
+fp16 limit actually bites, why every reduction is a matmul, and the compensated-
+arithmetic and accuracy-gated-compression machinery built on top.
+
+## The fp16-only compute model
+
+The ANE computes in fp16 and nothing else. fp32, int32, and bf16 are not
+implemented on the backend, so the graph builder rejects them at construction
+rather than letting them fail cryptically at compile time. Every value in flight
+is a 16-bit float with roughly 3-4 significant decimal digits.
+
+That single dtype constraint is the root of everything below. The headroom is real
+but narrow:
+
+- The fp16 **range** ceiling is 65504. Any intermediate that crosses it saturates
+  to infinity, silently corrupting the result. Several modules pre-scale to keep
+  intermediates inside this envelope (see *the dynamic-range walls* below).
+- The fp16 **precision** floor is ~1e-3 relative error. A polynomial that is exact
+  in fp64 is capped at ~1e-3..1e-4 relerr once its operands and products round to
+  fp16.
+
+## The WIDE accumulator and where fp16 actually bites
+
+The crucial asymmetry: **reductions and matmuls accumulate in a wide,
+fp32-class accumulator fed by radix-4 fp16-rounded input tiles.** The *inputs* and
+*products* round to fp16, but the *running sum* does not.
+
+The practical consequence is that representable sums are near-exact where a naive
+fp16 running sum would have stalled long ago:
+
+- A sum (or dot) of 16384 ones is **bit-exact**, where naive fp16 saturation of the
+  running sum stalls at ~2048.
+- A `+1` survives next to a 16000 partial that an fp16 running sum would simply
+  swallow.
+
+So the fp16 limit lives at **the products and the I/O cast, not the running sum.**
+This reframes where accuracy is lost:
+
+| Source of error | Affected by the wide accumulator? |
+| --- | --- |
+| Rounding of operands to fp16 (storage / I/O cast) | No — irreducible |
+| Rounding of each product to fp16 | No — irreducible |
+| Accumulating the products into the sum | **Yes — near-exact** |
+
+Cancellation-heavy reductions still lose precision, because the loss happens in the
+fp16-rounded operands feeding the sum, not in the summation itself. A tiny result
+formed by subtracting large, nearly-equal quantities is the wall — and it is what
+the compensated-arithmetic path (below) exists to climb.
+
+### The reduce_sum trap
+
+There is one catch that every numerically careful kernel must respect:
+
+> On this ANE, `matmul` accumulates **wide** but `reduce_sum` accumulates
+> **narrow** (fp16). They are not interchangeable for accuracy.
+
+This is the single most important numerics rule in the codebase. Every dot product
+and accumulation in the math modules is written as `(u * v) @ ones` — a matmul —
+**never** as `(u * v).sum()`. A narrow `reduce_sum` re-injects exactly the rounding
+error a careful kernel is trying to avoid.
+
+### reduce_sum-as-matmul
+
+The optimizer makes this rule mechanical. The `reduce_sum_to_matmul` rewrite
+rebuilds a single-axis `reduce_sum` node as a contraction against a ones-vector:
+
+```
+x[..., K].sum(-1, keepdims) == x @ ones[K, 1]
+```
+
+This is mathematically identical (`sum_k x_k == x @ 1`) and **strictly >= accuracy
+under cancellation**, because it routes the sum through the wide accumulator. It is
+therefore classed *lossless-or-better*: always safe, and the precision-aware tuner
+offers it as the flagship cheap accuracy win (one matmul vs one reduce). Only the
+single, last-axis case is rewritten directly; a non-last axis is transposed to the
+end first, and multi-axis sums are left alone.
+
+The same identity powers `cumsum`: the ANE has no native cumsum, but a last-axis
+cumulative sum is exactly `x @ triu_ones` — a matmul against a baked upper-
+triangular ones weight, made exact by the wide accumulator.
+
+## Compensated / paired-fp16 arithmetic
+
+When cancellation is the wall — a tiny result from large nearly-equal operands,
+where the fp16 rounding of the operands and products (not the accumulation) swamps
+the signal — ANEForge offers **paired-fp16** ("double-fp16") extended precision,
+with **no fp32 anywhere in the compute path**.
+
+A value is carried as an unevaluated pair `(hi, lo)` with `hi = fp16(x)` and
+`lo = fp16(x - hi)`, so the pair represents `hi + lo` to roughly twice the fp16
+significand (~22 effective bits). Both limbs are ordinary fp16 tensors, so every
+paired operation compiles to a pure-fp16 graph that runs on the ANE.
+
+The arithmetic is the classic *error-free transforms*, every intermediate rounded
+to fp16:
+
+- **TwoSum** (Knuth) — add/sub: `a + b = s + e` exactly, `s = fl(a + b)`.
+- **TwoProduct** (Dekker) — mul: `a * b = p + e` exactly via a Veltkamp split (the
+  split constant is `2^ceil(11/2)+1` for fp16's 11-bit significand). The
+  `hi*lo + lo*hi` cross terms are captured; `lo*lo` is dropped (below fp16 ulp).
+- **Compensated dot** — TwoProduct each element, then accumulate the product *and*
+  the error streams. Crucially, the accumulation is again via `@ ones` (the wide
+  matmul accumulator), never `reduce_sum` — a narrow sum would re-inject the very
+  error the compensation just removed.
+
+The `lo` terms capture exactly the operand/product rounding that plain fp16 loses,
+so carrying the pair recovers it. Paired-fp16 recovers the most when its inputs
+already carry sub-ulp information (a residual, or a value produced upstream in
+higher working precision) — the "regime B" recovering case. A genuine fp16 input
+has no sub-ulp bits, so there the win comes from the compensated *ops* capturing
+each operation's own rounding.
+
+Approximate op cost per element:
+
+| Operation | fp16 ops/elem |
+| --- | --- |
+| TwoSum / compensated add-sub | ~6 |
+| TwoProduct / compensated mul | ~17 |
+| Compensated dot of length K | ~17 + 2 matmul-accumulates |
+
+Because it is markedly more expensive than plain fp16, the optimizer gates it
+behind the error budget. The single-subtract entry point `paired_subtract` carries
+one `a - b` through a compensated TwoSum and returns a plain fp16 tensor (the best-
+fp16 result), so it drops straight into an existing graph at a cancellation hotspot.
+
+> **Compiler caveat.** An aggressive algebraic simplifier could in principle
+> collapse `hi + lo` back to `hi` (since `lo` is "just the rounding of `hi`"),
+> defeating the trick. On this ANE / e5rt it does not happen — the transforms are
+> opaque fp16 add/sub/mul chains with no fp32 island for the compiler to see
+> through, and `to_tensor()` writes the result as an explicit `hi + lo` add so a
+> dead-code pass cannot drop the `lo` computation. The tell that a future toolchain
+> has fused them away is the on-device relerr jumping back to the plain-fp16 value;
+> the demo asserts against that.
+
+## Numeric graph rewrites
+
+The optimizer distinguishes **lossless** rewrites (always-on canonicalization) from
+**numeric** ones (accuracy-affecting, tuner-gated):
+
+- `reduce_sum_to_matmul` (above) — lossless-or-better, the safe accuracy lever.
+- **Scalar-chain folding** — `muls(b) ∘ muls(a) -> muls(a*b)`, and likewise for
+  `adds`. The fold is done in fp16 to match device semantics, but because the fp16
+  NumPy kernels are never assumed bit-identical to the engine, const-folding is
+  gated as a numeric (not lossless) rewrite.
+- **SDPA / bridge decompositions** — `sdpa -> ((q @ k^T) * scale).softmax(-1) @ v`,
+  and the bridge-elimination family (`minmax_norm`, `flatten`, `lrn`). These are
+  metamorphic-proven bit-identical (or within fp16 op-noise), so they are lossless
+  and chosen purely by speed.
+
+## FFT: complex as real pairs
+
+The ANE has no complex dtype — compute is fp16 real only — but it is a matmul
+machine, and the DFT is a matmul against a twiddle matrix. The FFT modules exploit
+the wide accumulator: the naive O(N²) DFT-as-twiddle-matmul is fp16-clean to
+N=2048+ because the accumulator is wide.
+
+Every value is carried as a `(re, im)` tensor pair. A complex matmul `C = A @ B`
+becomes four real matmuls:
+
+```
+Cre = Are@Bre - Aim@Bim
+Cim = Are@Bim + Aim@Bre
+```
+
+This is the straight 4-matmul form, **not Karatsuba**: on the ANE matmul is cheap,
+and the wide accumulator keeps the straight form cleanest — Karatsuba's `(a+b)(c+d)`
+sums would lose a bit of fp16 headroom for no real op savings. The twiddle matrices
+ride in as small fp16 constants folded into the graph.
+
+The staged Cooley-Tukey FFT keeps the "every stage is a matmul" property while
+cutting MACs to sub-quadratic. Its accuracy is ~5e-4..8e-4, **flat in N** (the wide
+accumulator means per-stage sums don't compound) — about 3x the naive single-DFT
+floor (~2.5e-4) from the extra cross-twiddle multiplies, but still fp16-clean to
+N=2048+. So staged is not *more* accurate than the dense DFT, just far cheaper at
+the same precision class.
+
+The DFT butterfly contains exact-by-construction subtracts that trip the generic
+cancellation precision heuristic; these kernels are numerically verified against
+`np.fft` and so skip the check (`_check_precision=False`).
+
+### The dynamic-range walls
+
+Several places must actively defend the 65504 ceiling, because the accumulator
+holds the unscaled sum *before* any normalization:
+
+- **2-D FFT** folds the `1/(M*N)` normalization *into the twiddles* (`1/N` on the
+  row pass, `1/M` on the column pass), never as one scale at the end. A real
+  spectrum is O(M*N) at the dominant modes, so an unscaled first-axis transform
+  would push intermediates past 65504 and shred precision.
+- **iFFT for convolution spectra** pre-scales `Y` so the unscaled inverse-DFT sum
+  stays well within range (`s = 30000 / peak`), runs the linear iFFT, then undoes
+  the scale on the host. Products of two transforms can otherwise peak past 65504
+  and saturate.
+- The max usable FFT length is bounded by this fp16 dynamic range (normalize by
+  `1/sqrt(N)` for power spectra), not by stage error.
+
+The same crop-DMA saturation surfaces in direct linear-algebra factorizations: a
+width-offset slice rides the A13/A14 x16 fixed-point crop-DMA, which saturates any
+sliced `|value| > 4094` (= 65504/16) to ±infinity. Element-recurrence kernels
+(Cholesky / LU) route the accessor off the width axis to keep the usable entry range
+at the full fp16 span.
+
+## The fp16 envelope in linear algebra
+
+The wide accumulator makes a single `A @ x` clean even at cond ~1e4 — but the
+iterates and residuals are stored and re-fed as fp16, and the residual `b - A x` is
+a catastrophic-cancellation subtract. That subtract, not the matmul, is the wall:
+
+- **Iterative refinement** recovers about *one order of magnitude* of accuracy for
+  moderate conditioning. By cond ~1e3 the fp16 approximate solve barely converges
+  and refinement only nibbles.
+- **Conjugate gradient** uses symmetric Jacobi (diagonal) preconditioning to keep
+  the fp16 dot products in range: scaling `A` so its entries are ~1 stops raw
+  cond ~1e2 GEMV products from blowing past 65504. Without a convergence test to
+  stop early, the unrolled iterates can overflow fp16 at high cond — reported as a
+  finite large relerr rather than a NaN.
+- **Least squares via normal equations** *squares* the condition number; refinement
+  buys back roughly the order of magnitude the squaring cost.
+- **LSQR / GMRES** Krylov envelopes: ~1e-3 at cond <= 1e1, ~1e-2 at cond <= 1e2 for
+  overdetermined least squares.
+- **Power iteration** (dominant SVD) normalizes *between* the `A` and `A^T`
+  applications: `A^T(A v)` has magnitude ~σ², which overflows fp16 for σ > ~250.
+  Likewise, extra `A^T A` power steps *hurt* trailing singular values in fp16 — each
+  step squares the spectrum and crushes the small values toward the dominant one.
+
+Every dot/norm in these kernels is `(z*z) @ ones`, never `reduce_sum` — the same
+wide-accumulator rule.
+
+## Special functions: fp16 shapes the math
+
+Special functions are long, dependent chains of fused fp16 mul/add (Horner /
+Clenshaw evaluation of minimax or rational approximations). Two fp16 constraints
+shape every implementation:
+
+1. **fp16 compute (~3-4 digits).** Where a function's *output* leaves the fp16 range
+   (gamma > 65504 past x~8, I0 past x~12) that is a hard wall, not a coefficient
+   problem.
+2. **No scalar-add op and no in-graph branch.** A constant `c` is added with a
+   `exp(0) == 1` ones tensor scaled by `c` (built on `exp`, an F0 native unary on
+   every ANE family including M1, rather than `cos`, which is A15+). Only fixed,
+   smooth range reduction is used — never a data-dependent step count.
+
+Several functions exist specifically because the naive fp16 form cancels or
+centers badly:
+
+- **erfc** is evaluated directly (A&S 7.1.26), *not* as `1 - erf`: in fp16,
+  `1 - erf(x)` cancels to 0 for x > ~2 (`fp16(1 - erf(3)) == 0`, but
+  `erfc(3) = 2.2e-5`).
+- **lgamma / gamma** evaluate in a *centered* variable (`x - 4.5`, `x - 1.5`). A raw
+  Horner in `x` has terms up to ~1e7 with alternating large coefficients that cancel
+  catastrophically (abserr ~8); centering keeps the powers small and the chain
+  fp16-clean (abserr ~3e-3).
+- **sin / cos** use half-period [-π/2, π/2] minimax polynomials. Over the full
+  [-π, π] the alternating terms reach ~5 in magnitude, a cancellation that loses
+  ~2 fp16 digits (abserr ~0.2 at ±π); on the half-period the terms stay O(1) and the
+  error is fp16-rounding-limited (~1e-3). These polynomial forms also give a portable
+  path on M1/H13, where native trig is unavailable.
+
+Note a negative result: `exp_wide` / `log_wide` range-reduction recipes do **not**
+reliably beat the native fp16 `exp` / `log` on this hardware — the re-rounding from
+repeated squaring/sqrt usually costs more than the small-argument benefit gains. They
+are documented recipes, not the default.
+
+## Accuracy-gated compression and int8
+
+Weight compression is a deliberate accuracy/bandwidth trade, and the optimizer never
+makes it silently. Weights can stream as fp16 (default), per-channel int8, per-tensor
+int4 LUT palettization, or unstructured sparse bitmask — each halving or better the
+DRAM bytes during the tile DMA.
+
+The numeric contract:
+
+- **Default tune is accuracy-preserving.** The default tolerance is fp16 noise
+  (`_ACCURACY_TOL = 5e-3`). A lossy rewrite like int8 (~1-2% quantization error,
+  well above fp16 noise) is *rejected* at this default, so `tune()` returns the
+  lossless baseline. int8 is opt-in: `tune(out, atol=0.1)` admits it within a stated
+  budget, and even then a lossy variant must beat the baseline by at least 1.10x to
+  be chosen, so a measurement-noise "win" never costs accuracy for free.
+- **`compress='auto'`** chooses per weight: sparse if the weight is >=50% zeros,
+  else int4 if it stays within `compress_atol`, else int8, else fp16. int4 carries an
+  accuracy-gated fallback to int8/fp16.
+- An encoding only helps if the per-family lowering *streams* it natively. Encodings
+  the device folds back to dense fp16 (e.g. blockwise on A14) pay an accuracy cost
+  for zero bandwidth win — `native_streams` records which formats stream per family.
+
+### Precision-aware tuning
+
+Beyond preserving accuracy, the precision-aware path can *improve* it. Given an
+explicit `target_error=E`, the tuner selects the numerics-aware rewrite set
+(`reduce_sum -> matmul`, paired-fp16, ±int8) that meets the budget at minimum
+predicted cost — measuring accuracy against an fp32-faithful reference where one can
+be emulated (products fp16-rounded, accumulation wide, so the reference is the
+*achievable* target, not an unreachable fp64 ideal), else against the fp16 baseline's
+own output. `reduce_sum -> matmul` is auto-detected (structurally visible); the
+CFG-style paired-fp16 cancellation fix stays opt-in, because near-equal cancellation
+is data-dependent and cannot be confirmed at graph-build time.
+
+## Cross-chip fp16 divergence
+
+The MAC accumulator width and the compiler `__TEXT` are uniform across chips, so a
+graph's fp16 *values* are largely chip-independent. The remaining divergence comes
+only from HAL-data-selected codegen routes that reorder or saturate fp16 ops, and the
+target table predicts it statically into one of:
+
+- **`saturation`** — a width-offset slice on A13 (family 2) routes through the Q.4
+  x16 crop-DMA that clamps `|value| > 4094` to ±infinity, while A14+ takes a clean
+  route. Magnitude-gated: only flagged when values can exceed 4094.
+- **`ulp1`** — a reduction/softmax/norm whose route threshold differs (192 on
+  A13/A14 vs 384 on A15+): a partial-sum reorder, <= 1 ULP.
+- **`round1`** — a reduce-then-square fusion difference; currently never returned
+  (A13/A14/A16 silicon all compute `fp16(sum)^2`, a measured no-op).
+- **`none`** — no HAL field selects a differing route.
+
+The native fused-attention layer also carries a numeric reliability envelope:
+reliable to ~3e-3 up to S=2048, but garbage (~1.0) at S=4096 and once *both* query
+and key axes exceed 512. Above those bounds `af.sdpa` emits the accurate decomposed
+form, where the wide matmul accumulator holds (~5e-3).

--- a/docs/developer/op-quirks.md
+++ b/docs/developer/op-quirks.md
@@ -1,0 +1,93 @@
+# Per-operator ANE quirks
+
+A reference for the hardware constraints baked into ANEForge's op constructors. Each is guarded at build time (a clear error, not a cryptic `ANECCompile` crash), and most were found by reverse-engineering or fuzzing the silicon. The pattern throughout: the ANE *has* the capability but only within a narrow envelope.
+
+## Global constraints
+
+| Constraint | Limit | Why |
+|---|---|---|
+| Tensor rank | rank <= 5 | The ANE dimension model is rank 0..5 ("Rank ... must be between 0 and 5"). A rank-6+ tensor (reshape/stack/expand_dims past 5D) fails ANECCompile; guarded at construction. |
+| Compute dtype | fp16 only | fp32/int32/bf16 are not implemented on the backend; rejected. |
+| Per-axis size | <= 65536 | Hard per-axis cap; relevant to tiled-axis lowerings (see `group_norm`). |
+
+## Convolution family
+
+| Op | Quirk | Why |
+|---|---|---|
+| `conv` | kernel width `kW <= 15` (kH unconstrained) | The ANE conv tiles along the kernel **width**; `kW >= 16` is unsupported by ANECCompile (verified: 16x3 compiles, 3x16 does not). |
+| `conv_transpose` | same `kW <= 15` width limit | Same kernel-width tiling limit. |
+| `dynamic_conv` | same `kW <= 15`; **batch must be 1** | The native dynamic-kernel path (`CreateDynamicKernel`/DynamicGOC) does not support a dynamic-weight conv with batch >= 2. For batched conv use `af.conv` (constant weight) or im2col `conv2d`. |
+
+## Reductions and norms
+
+- **`group_norm` tiled-axis bound** (`finding_sd15`): the rank-4 tiled lowering reshapes to `[1,G,C/groups,H*W]` and reduces the trailing two axes, so the bound is the largest *single* axis, `max(C/groups, H*W)`, against the per-axis cap of 65536 — **not** the flattened `(C/groups)*H*W` product (which overflowed for SD-UNet's 512ch@128 and 640ch@64).
+- **`channel_layer_norm`:** LayerNorm over the channel axis of a channels-first `[N, C, 1, S]` tensor (the ANE-native transformer layout). Same result as `layer_norm` on the `[N*S, C]` view, but with no transpose into/out of `[seq, d]` — which is what keeps the attention/MLP stack cheap (projections stay 1x1 convs over `[N, C, 1, S]`).
+- **`l2_norm`:** runs as fused e5rt MIL (`reduce_l2_norm` over the axis, then `real_div`), no graph cut. The MIL `l2_norm` op normalizes over all non-batch dims, so the per-axis form `x / sqrt(sum(x**2, axis) + eps)` is built explicitly.
+- **Matmul int8 layout:** store as `[N,K]` and consume with `transpose_y=true` (the proven int8 layout).
+- **Trainable norm affine:** `rms_norm`/`layer_norm`/`group_norm` take either arrays (fixed/baked affine) or broadcastable parameter `Tensor`s (trainable). The trainable path normalizes with a unit affine, then scales/shifts by the Tensors so gradients flow via the mul/add VJPs.
+
+## Gather (slice+concat, width-axis bug)
+
+`gather` for static indices lowers to `slice_by_size` + `concat`. But a **last-axis (width) gather** lowers to a `slice_by_size` with a nonzero **width begin-offset**, which routes through the **A13/A14 x16 fixed-point crop-DMA path** and returns the **wrong elements** there (correct on A16+).
+
+!!! warning "Gather a non-last axis instead"
+    For rank>=2, transpose the gathered axis off the last position and transpose back; for rank 1, gather a `[N,1]` view. Both are identity-preserving and correct on every chip family — the same width-axis-slice avoidance the conv im2col backward uses.
+
+## Attention (mha / cross_attention / sdpa)
+
+### Query-tiling (performance, exact)
+
+| Op | Behavior |
+|---|---|
+| `mha` | Computes `[tile, S]` score tiles per head instead of the full `[H, S, S]` matrix. Exact and ~3x faster at large S (smaller tiles pipeline better). Count is an S-based heuristic unless tuned via `af.tune_attention`. |
+| `cross_attention` | When query and context are both long, the `[H, S, T]` score matrix hits the materialization wall (~2.4x slower). Query-tiling into `[tile, T]` blocks avoids it, exact. Gated on score area, so small-T cross-attention (e.g. SD text conditioning, T=77) stays single-shot and byte-identical. |
+| `sdpa` (non-causal decomposition) | For a large query axis, compute in `[tile, Skv]` tiles (~512 query rows) instead of the full `[Sq, Skv]` matrix. Exact, ~3x faster at Sq=1500, H=16. A small query (KV-cache decode) takes one shot. |
+
+### Native fused-attention reliability bounds
+
+`sdpa` uses the ANE's **native** fused-attention layer (`ANECSDPALayerDesc`, a path Apple's MIL compiler never emits — it always decomposes) only where it's numerically reliable; outside, it emits the accurate fused decomposition. Q/K/V are `[1, heads, seq, d_head]`, fp16. Where native is used, it's a graph-cut boundary (see [Native bridges](bridges.md)).
+
+| Constant | Value | Meaning |
+|---|---|---|
+| `SDPA_NATIVE_MAX_SEQ` | 2048 | Native is reliable only up to this sequence length. Measured 2026-06-02: native vs fp32 ref ~3e-3 at S<=2048 but ~1.0 (garbage) at S=4096, while the decomposed matmul/softmax/matmul stays ~5e-3 (the wide accumulator holds). Above this, `sdpa` emits the decomposition. |
+| `SDPA_NATIVE_MIN_BOTH` | 512 | Native returns garbage once **both** query and key seq axes are large: reliable only while `min(q_seq, k_seq) < 512`. Measured 2026-06-09: a hard 512x512 score-tile cliff (cos collapses to ~0.67), while KV-cache decode (min=1) stays correct to large k_seq. Outside, decompose (non-causal) or refuse (causal). |
+
+### Causal masking
+
+`is_causal=True` is **native**: the causal additive mask rides the SDPA layer's optional 5th bottom and the route optimizer keeps it on the native route (the decomposition is unmasked). Validated on M1: cos 1.0 vs `softmax(QK^T*scale + causal)*V`, single + multi-head. Requires `S <= SDPA_NATIVE_MAX_SEQ`. Causal outside the reliable native regime is **refused** — the decomposition would need a causal additive mask, but there's no host-constant add on the graph here. (Chunk the query into tiles whose `min(q,k)` seq stays < 512.)
+
+### attn_mask restrictions
+
+`attn_mask` is a runtime additive bias riding the native layer's 5th bottom. The native layer applies **one** additive-mask plane shared across all heads, over the full query axis — shape must be `[1,1,Sq,Skv]`.
+
+!!! warning "Rejected mask shapes"
+    A per-head mask (`[1,H,Sq,Skv]`, H>1) is silently mis-applied (one plane used for all heads), and a query-broadcast mask (`[1,1,1,Skv]` with q_seq>1) underflows the bridge — both are rejected rather than returning garbage. (For KV-cache decode, q_seq==1, so `[1,1,1,Skv]` is a full-query plane and is accepted.)
+
+### Decode shapes
+
+K and V share shape (the cached sequence); Q's sequence may differ (KV-cache decode: q seq_q attends to cached k/v of length seq_kv). Q,K share H and D.
+
+## Bridge-op arch gates
+
+These ops cut the graph and run native sub-programs; their hardware variants are narrow.
+
+| Op | Quirk | Why |
+|---|---|---|
+| `argmax` | 2D inputs `[C, W]` only, last axis (Width) or axis 0 (Channel); indices fp16-encoded (exact for index<2048) | Runs as native `GlobalArgMinMax` sub-program. |
+| `topk` | `k` in {3,4} **arch-gated** (rejected); rest of `[1, W]` supported | ANECCompile fails for k in {3,4} on this hardware. Native `TopK` sub-program. |
+| `sort` | hardware keys order on **one channel lane** and permutes all channels by it; `return_indices` fp16-encoded (exact for index<2048) | For a numpy-like per-row independent sort the bridge dispatches each row as its own 1-channel tile. Native `Sort` sub-program. |
+| `space_to_channel` / `channel_to_space` | batch **N=1 only**; TF (block-major) channel ordering | Native SpaceToChannel/ChannelToSpace layers; same shape law as PixelUnshuffle/PixelShuffle but TF ordering. |
+| `space_to_batch` | batch dim **grows** (`[N,C,H,W] -> [N*bh*bw, C, H/bh, W/bw]`) | Can only be a leaf/output of the segmented plan or feed another netplist cut (segment outputs thread as host arrays). Output batch slice `(n*bh+i)*bw+j == x[n, :, i::bh, j::bw]`. |
+| `batch_to_space` | input batch must be divisible by `bh*bw` | **Arch-gated**: validator string "Input batch n is not divisible by factor x * factor y"; non-divisible batch fails compilation. |
+| `flatten` | needs a 3D (`[C,H,W]`) graph tensor | The native Flatten bridge takes a `[C,H,W]` input. |
+| `input_view` | view along Width, x flattened to 1-D length W | Native InputView layer. |
+| `dynamic_slice` | only verified variant fixes **Width=4, SliceSize=2** | The static-start API is general in spirit; only this hardware variant is verified/accepted on this host (requires length-4 input, `size==2`). |
+| `scaled_elementwise` | `Sub` rejected; `Mult` ignores `scale` | Found by fuzzing: `Sub` is rejected by ANECCompile, `Mult` ignores `scale` on-silicon. Both configs rejected. |
+| `lrn` | `C <= 15` only | KernelChannel=C; `C >= 16` fails ANECCompile. Also: `alpha`/`eps` are fp16 bit patterns (see [bridges](bridges.md)). |
+| `minmax_norm` | `Dimension="Channel"` arch-gated | Width/Height supported; Channel fails ANECCompile. `eps` is an fp16 bit pattern. |
+| `fps` | L2-only metric; `k <= 1024`, `N <= 8192` | The native layer always uses Euclidean distance regardless of `DistanceMetric`. |
+| `cross_product` | length-3 inputs only | A path Apple's MIL frontend rejects entirely. |
+
+## Fused-MIL spatial ops (no cut)
+
+For contrast, these spatial ops fuse into the one program with no graph cut: `space_to_depth`, `depth_to_space`, `crop`, `resize_nearest_neighbor`, `resize_bilinear`, `upsample_bilinear`, `affine`, `pixel_shuffle`, `pixel_unshuffle`. (`affine` is a 2-D affine warp via native MIL `affine`/`AffineTransform`: `transform` is `[N,6]` or `[1,6]` broadcast, `[a0,a1,a2, b0,b1,b2]` in normalized `[-1,1]` coords, bilinear sampling with zero padding.)

--- a/docs/developer/optimizer-and-cost.md
+++ b/docs/developer/optimizer-and-cost.md
@@ -1,0 +1,148 @@
+# The optimizer and the cost model
+
+ANEForge picks how to lower a graph using two cooperating pieces: an **optimizer/tuner** that chooses among proven-equivalent lowerings, and an **analytic cost model** that orders those choices so the tuner can prune what it measures. This page covers both, plus the dispatch-floor reasoning, the roofline, the per-chip scaling rules, and the precision-risk model.
+
+## The optimizer and `opt` levels
+
+`compile(out, opt=...)` selects the graph optimizer. The design separates **lossless** route selection from **lossy** variants, and on-device measurement from measurement-free cost estimation.
+
+### opt levels
+
+- **`opt='routes'` (default)** — the *lossless route pass*. Cost-model-driven, per shape, it chooses for each route-bearing bridge node (`sdpa`, `minmax_norm`, `flatten`, `lrn`) between the native bridge (a graph cut) and the proven-equivalent fused decomposition (cut removed), with **no on-device measurement**. The route registry is lossless (cos 1.0), so this never changes numerics; a cut-free graph compiles to exactly the `opt=0` program (no regression). For `sdpa`, the cost model keeps native where it wins (long sequences), so the default never blindly removes a cut that helps.
+- **`opt=0`** — no optimization, the historical byte-identical path (`int8` honored as given). Use for byte-identity tests.
+- **`opt=1`** — cost-model pick over the full variant set (route swaps *and* the lossy whole-graph int8 variant), without measuring on-device.
+- **`opt=2` / `opt='max'`** — autotune. Measure the legal proven-safe variants on the ANE, validate each against the `opt=0` baseline, and return the fastest correct one (cached; instant on a cache hit).
+
+!!! note "Lossless vs. lossy gating"
+    Route swaps are *lossless* — selected purely on predicted/measured speed. The whole-graph int8 variant is *lossy*, so it only enters at `opt>=1`, and at `opt=2` every measured variant is validated against the `opt=0` baseline before it can be chosen. The `reduce_sum→@ones` rewrite sits on a separate *precision* axis (`tune_precision`), not the bridge-alt axis.
+
+### The equivalence-route registry
+
+Every surfaced capability is either **route-selectable** (the autotuner picks its cheapest equivalent lowering by measured cost) or **single-route** (one lowering, no alternative). The `_BRIDGE_ROUTES` table closes this over the bridge ops: each `NETPLIST_OPS` op records either an `alt` (a fused decomposition that removes the graph cut, tagged with loss-class + on-device evidence) or `single_route=True` with the reason it has none. Only on-device-validated alts appear — the builder lives in `_rewrite._BRIDGE_DECOMPOSERS`, keyed identically, reconciled by `tests/test_routes.py`. A candidate that failed validation is marked single-route with its failure evidence.
+
+Loss class **"lossless"** means mathematically identical (bit-identical or within fp16 op-noise), so it's chosen purely on measured speed. Fused ops are single-route by construction and not listed; `_routes_for()` reports any absent op as single-route ("only lowering").
+
+Selectable alts (each lossless, removing the cut):
+
+| Bridge op | Fused decomposition | Evidence |
+|-----------|---------------------|----------|
+| `sdpa` | `((q@kᵀ)*scale).softmax(-1)@v` | bit-identical (`fuzz_metamorphic.py` mha_vs_sdpa) |
+| `minmax_norm` | `(x-amin)/(amax-amin+eps)` | relerr ≤1.5e-3 == fp16 op-noise |
+| `flatten` | reshape to the same 1-D shape | relerr 0.0 |
+| `lrn` | `local_response_norm(size=C, alpha=alpha*C, beta, k)` | cos 1.0 / relerr 0.0; ~1250× cut removal on conv→lrn→relu; no C<16 cap |
+
+The notable single-route reasons (the rest are listed on the [capabilities page](capabilities-and-targets.md)):
+
+- **`space_to_channel` / `channel_to_space` / `space_to_batch` / `batch_to_space`** — the reshape+transpose decomposition needs a rank-6 intermediate; ANECCompile rejects reshape rank>5 ("Rank of the shape parameter must be between 0 and 5"). The **rank-5 wall**, confirmed on-device.
+- **`argmax` / `topk` / `sort`** — no fused reduction/selection/sort lowering (gather/argmax arch-gated; no in-graph sort); the native bridge is the only route.
+- **`input_view` / `dynamic_slice`** — no fused slice op surfaced; native bridge only.
+- **`fps` / `radius_search`** — data-dependent/iterative; inexpressible as a fused feed-forward graph.
+
+## The cost model: a pruner, not ground truth
+
+`_cost.py` is an **op-agnostic structural cost model** — the optimizer's *pruner*. `estimate(out) -> microseconds` gives a fast, structural roofline estimate of a compiled program's latency **without touching the device**.
+
+!!! note "Why a pruner and not a predictor"
+    The cost model's job is to *order* variants so the autotuner can skip measuring ones predicted far worse than the current best. Real selection is always by on-device measurement (`_optimize.measure`). Calibrated constants load from the bundled `aneforge/ane_cost_model.json` when present; otherwise the documented defaults below apply.
+
+### The roofline
+
+Every node's cost is a roofline `max(floor, bytes/BW, flops/COMPUTE)`:
+
+- **`bytes`** is derived generically from shapes: `(sum of input elems + output elems + weight elems) * 2` (fp16). No per-op byte table — this works for *any* op.
+- **`flops`** is only known for the few ops with a closed form (matmul/linear/bmm/conv/conv_transpose); every other op contributes 0 flops and is therefore bytes- or floor-bound. That matches calibration: the cheap fused ops all sit at the dispatch floor. (matmul: `x[..,K] @ W[N,K]` stored transposed → `[..,N]`, i.e. `2*M*K*N`.)
+
+The per-node roofline carries **no floor** — the analytic model charges the dispatch overhead once per program, additively, not per node.
+
+### Composition mirrors segmentation
+
+Composition mirrors `_compile`'s segmentation exactly. The graph is one fused program unless it contains a netplist-bridge op, in which case it's cut into fused regions interleaved with native sub-programs:
+
+- A **fused region** costs `floor + sum(max(0, node_cost - floor))` — the *fusion discount*: one dispatch floor for the whole region, plus only the above-floor work of each node.
+- Each **cut** adds a `cut_penalty` plus the bridge node's own roofline.
+- For a segmented graph, the region count is approximated as the number of distinct fused segments (at most `n_cuts + 1`); the global above-floor sum is kept and `n_regions` floors plus the cuts are added.
+
+### The int8 lever and tie-breaker
+
+int8 is the only dtype lever the model needs: it scales streamed weight bytes by ~0.5 (per-channel int8 streams half the bytes; activations stay fp16). Everything else is structural. There's also an **int8 tie-breaker**: even when a graph is floor-bound (so the roofline ties int8 and fp16 at the floor), int8 always streams ≤ fp16 bytes. That's encoded as a tiny weight-byte-proportional discount so the model is *decisive and directionally correct* (int8 predicted ≤ fp16), scaled well below a floor's worth so it never reorders variants with a real cost difference.
+
+### Calibrated default constants
+
+Read off `ane_cost_model.json`'s calibration (defaults when absent):
+
+| Constant | Meaning | Anchor |
+|----------|---------|--------|
+| `FLOOR_US` | per-call dispatch floor | smallest fused-op min latency |
+| `CUT_US` | per-cut penalty (native sub-program + host round-trip) | composition probe ~150–300 µs; 200 documented mid |
+| `BW_BPUS` | effective fp16 streaming bandwidth | matmul sweep: K=4096 streams 32 MiB in ~293 µs → ~114 GB/s ≈ 1.1e5 B/µs |
+| `FLOPS_PUS` | effective fp16 compute | conv C=512: 4.83 GFLOP in ~334 µs → ~14.5 TFLOP/s ≈ 1.45e7 flop/µs |
+
+BW and COMPUTE are derived from the matmul + conv scaling fits when present. The cut penalty uses the smallest bridge min as the marginal cut cost when present.
+
+### Bridge ops have a measured cost model
+
+The 19 `NETPLIST` bridge ops (sdpa, argmax, topk, sort, …) have no closed-form flops, so `node_cost()` would cost them at the generic dispatch floor. Instead, `ane_cost_model.json`'s `model.bridge_ops` holds **measured** per-config min latencies, keyed by a size string (e.g. `"sdpa H=8 S=128 D=64"`) and tagged with a `family`. `_bridge_model()` parses these into per-family points so `bridge_cost()` uses the measured value.
+
+Key formats → size params: `bridge_sdpa "sdpa H=<H> S=<S> D=<D>"` → (H,S,D); `bridge_argmax "argmax [<C>,<W>]"` → (C,W); `bridge_topk "topk k=<k> [<C>,<W>]"` → (C,W); `bridge_sort "sort [<C>,<W>]"` → (C,W).
+
+Interpolation is approximate (the grid is sparse, 2–6 points/family): pick a monotone **work scalar** `w(size)` per family, anchor to the nearest measured point by it (in log space, so ratios are symmetric), and scale `min_us` by the work ratio, clamped to the dispatch floor. This captures magnitude and ordering — all the pruner needs — not a per-shape fit. Defensible work scalars: `sdpa ~ H*S²*D` (attention MACs, QK^T + AV both scale this way); `argmax/topk/sort ~ C*W` (a full row-major pass). Families with no data fall back to the roofline.
+
+!!! note "Bridge cost is mostly dispatch-floor dominated"
+    15 of the 19 native-bridge ops run via the A1 subprocess-per-call path (no A2 persistent worker exists for them), so their measured per-call cost is **dominated by ~30–60 ms subprocess spawn + ANECCompile load** and is nearly flat in size. The work scalar still gives a sensible nearest-neighbour anchor + ordering; proportional scaling barely moves. `fps` is the exception — it scales ~N*k (seconds/call). An op missing from the table, or whose family has no rows, falls back to the roofline.
+
+## The dispatch floor
+
+The ANE per-call latency is a fixed dispatch + firmware round-trip (~0.2 ms on M1-class parts). `compile` warns once (`DispatchFloorWarning`) when a program's predicted cost is dominated by it, so a caller looping per-sample isn't silently paying the full fixed cost every time. Batching and op-chaining amortize the floor; **concurrency does not** — dispatch is single-in-flight, so threads don't help. To amortize, do more work per call: larger batch N (per-sample cost falls ~linearly toward the compute rate) or chain more ops into one program (`share_buffer` keeps state resident). The check is cheap and structural; it fires only when the prediction is floor-dominated, staying silent on already compute/bytes-bound programs where amortizing buys little.
+
+## The analytic per-chip model (Direction A)
+
+When `estimate(out, target=...)` is given an ANE arch string (e.g. `'h13'`/`'h17s'`), it switches to a **measurement-free analytic per-chip model** valid for all 28 chips. `target=None` (the default) keeps the precise M5-measured heuristic above.
+
+The compiler carries its own analytic cycles→roofline→wall-time model (**ZinNEPerf**, non-SIP). It was decompiled and the per-chip HAL perf fields + freq/efficiency curves were walked live for all 28 targets into the bundled `costmodel_curves.json`. The model:
+
+```
+t = overhead + max( flops/peak , bytes/bw )      [per fused program]
+```
+
+It's anchored to silicon-measured chips (`_ANCHORS`) and scaled to any other chip from its family's anchor.
+
+### Silicon anchors
+
+Three measured anchors:
+
+- **A13/h13 (M1)** — the latency-roofline fit reproduces the 5 measured M1 convs within ±17%: peak **3.25 TFLOP/s**, BW **9.0 GB/s**, dispatch overhead **0.22 ms**. The headline measured fp16 peak is **1.8 TFLOP/s** (the absolute anchor for `project_peak()`).
+- **A14/h14 (M2 Pro)** — measured. Carries a mid-utilization compute ramp `eff_peak = peak * min(1, (flops/F)^q)` (a *capped* power law, F=1.8e10 FLOP, q=0.38). Effective compute throughput is far below peak for mid-size ops (a 768³ GEMM sustains ~1.5 of 7.24 TFLOP/s) and ramps with per-op FLOPs; the cap matters so large ops (a 2048³ GEMM already at peak) aren't slowed. Cuts the h14 25-point grid's mean error 1.61× → 1.16×.
+- **A16/h17s (M5)** — the 2026-06-05 loop-closure re-fit: BW **57 GB/s**, floor **~110 µs**, peak **8.9 TFLOP/s** (= `project_peak('h17s')`, validated by the re-fit landing the quoted convs within ~13%).
+
+A15 (no M3 silicon yet) uses the A14 anchor as the nearest below it.
+
+### Scaling rules
+
+`_analytic_constants` takes the nearest measured anchor and scales `{floor_us, cut_us, bw_bytes_per_us, flops_per_us}`:
+
+- **BW scales with CORE COUNT, not clock.** This is the verified M5 loop-closure mechanism. The earlier single-anchor model scaled M1's BW by *clock* and over-predicted M5 ~2× (mean |err| 99%); effective BW tracks cores (16/4 → 5.5×), because a faster clock doesn't widen the DMA path — more cores do.
+- **floor scales with operating clock** — setup runs at the engine clock, and overhead shrinks with clock.
+- **compute peak scales with `cores * eff_freq`** — the cross-chip peak-throughput scaler.
+- **`cut_us` is chip-independent** — a host round-trip for a netplist bridge.
+
+Cross-chip throughput scales by `cores * eff_freq(0.8*fmax)` relative to M1. The operating clock is `0.8 * fmax` (`_CLOCK_FRACTION`); `eff_freq` is the second column of `eff_map_0x7a8` — the engine's effective frequency, already derated for the high-clock MAC-rate falloff on A14+ (M1 = 1.0·f; A14+ derates ~0.84). `project_peak()` gives a measurement-free fp16 peak projection for any target anchored to the measured M1 point, yielding a generational table (M5 ~5.5×, H17d ~22×, M11 ~0.1×) with no silicon beyond M1.
+
+!!! note "Known M1 BW caveat"
+    A 2026-06-09 estimate-vs-measured sweep found the M1 fit BW over-predicts *extreme* bandwidth-bound shapes ~4–5× (m1 1×4096×4096: pred ~3700 µs vs measured ~800 µs → ~42 GB/s effective). But it's jointly calibrated with peak/overhead into the ±17% 5-conv fit (`test_cost_model_analytic` pins it), so it can't be bumped alone without regressing that fit — a proper re-anchor needs a joint roofline re-fit over a broader measured set.
+
+### Provenance and fallbacks
+
+`estimate_provenance` reports whether a per-chip estimate is silicon-anchored or extrapolated: a target whose capability family *owns* one of the three anchors is silicon-measured (the A16 tier folds H16/H17* into the h17s point); every other target is extrapolated from the nearest anchor by its `{cores, clock, efficiency}` curve. An arch missing its own curve folds to its family's representative die (matching `_targets._ARCH_FAMILY` tiers).
+
+## The precision risk model
+
+A companion to `estimate()`: a cheap structural pattern-matcher (not an error bound) over three characterized fp16 failure modes (`fp16_envelope.py`). Each flagged node gets an order-of-magnitude error proxy in [0,1]; the per-graph signal is the max over nodes. `_precision_signal` runs this as a static pass (no device work) and warns — or, with `strict`/`validate=True`, raises — so an unstable computation never runs silently.
+
+- **(a) Narrow reduce-sum** — `reduce_sum` over signed terms with a long contraction: the narrow fp16 reduce accumulator re-injects per-add rounding the wide matmul avoids. Error grows ~`sqrt(K) * fp16_eps`, capped at 1.0. Fixable by the `reduce_sum→matmul` rewrite (≥ accuracy). A tensor is treated as possibly-signed unless it's a square/abs/relu/sigmoid/exp/softplus output (non-negative → a sum over it doesn't cancel).
+- **(b) Cancellation subtract** — subtract of two large, structurally-small-result quantities (CFG-style). Not detectable structurally (data-dependent), so it's a *candidate* flag only, fixable only if operands carry sub-ulp bits (paired-fp16).
+- **(c) Compile cliffs** — group_norm / large-feature-map cliffs. The rank-4 tiled lowering reduces over `[1,G,C/groups,H*W]`, so the cliff is `max(C/groups, H*W) > 65536` (aligned to `af.group_norm`'s guard), **not** the flattened product — the tiling keeps 640@64 and 512@128 under the cap.
+
+!!! note "cancel_sub is informational-only"
+    Default hotspots are only the *reliable, structurally-determinable* signals: a narrow `reduce_sum` over the fp16-clean floor, and the group_norm per-axis wall. `cancel_sub` is speculative — most subtracts (residuals, losses, differences) are benign and unconfirmable without data, and flagging every one trained users to ignore the warning. It stays in `nodes` (surfaced by `precision_risk(verbose=True)`) but does not raise the default warning. The tuner's vs-fp32 gate confirms any real gain.
+
+Calibration constants: `_FP16_CLEAN = 1e-3` (a clean fused fp16 op's relative error, the corpus median — fp16 has ~3–4 decimal digits); `_NARROW_SUM_FLOOR = 256` (contraction length above which a signed `reduce_sum` starts losing digits to the narrow accumulator). These are order-of-magnitude proxies, deliberately coarse.

--- a/docs/developer/overview.md
+++ b/docs/developer/overview.md
@@ -1,0 +1,91 @@
+# Architecture overview
+
+ANEForge is a clean `graph -> compile -> run` frontend for the Apple Neural Engine (ANE). You build a small tensor graph, `compile` it, and run it on the ANE — wrapping only the unentitled Espresso `e5rt` runtime, with no CoreML and no entitlement required.
+
+## The model
+
+```python
+import aneforge as af
+
+x = af.input((1, 3, 32, 32))
+h = af.conv(x, W1, pad=1).relu()
+h = af.conv(h, W2, pad=1).relu()
+y = h.mean((2, 3)).reshape(1, C) @ Wfc
+net = af.compile(y, int8=True)        # one fused ANE program
+out = net(image)                      # run on the ANE
+```
+
+`graph.py` records a lazy `Tensor` whose methods and operators capture structure (op + sources + attrs) but never touch the device. `compile` (`_compile.py`) lowers that graph to one program; `_blob.py` packs weights; `autograd.py` provides on-ANE training; `models.py` ships pretrained loaders.
+
+### Why fusing is the point
+
+The ANE penalizes many tiny dispatches, so a whole subgraph is compiled into a **single** fused `e5rt` program. Weights pack automatically into one BLOBFILE — fp16, or per-channel int8 *streamed* (dequantized during the tile DMA) when `int8=True`.
+
+## The two op routes
+
+Every op takes one of two routes through the compiler.
+
+| Route | What it is | Graph effect |
+|---|---|---|
+| **Fused e5rt-MIL** | Most ops. They lower to MIL and fuse into one program. | No graph cut. |
+| **Netplist-bridge** | Native Path-A hardware layers Apple's MIL frontend never emits. | Each bridge node **cuts** the graph. |
+
+For a fused-MIL op, lowering is the whole story: the op becomes part of the single program. A netplist-bridge op is different — Apple's user-space MIL compiler never emits these hardware layers at all, so ANEForge hand-authors a native ANECIR netplist for them. Each bridge op cuts the graph: surrounding regions run as `e5rt` programs, the bridge node runs as a separate native sub-program (sub-millisecond via the A2 persistent worker), and `compile` returns a `SegmentedModel`.
+
+The bridge family includes `sdpa`, `argmax`/`topk`/`sort`, `cross_product`/`cross_correlation`/`cost_volume`, `fps`/`radius_search`, `minmax_norm`/`lrn`, the space/channel/batch rearranges, and `flatten`/`input_view`/`dynamic_slice`/`scaled_elementwise`. See [Native bridges and segmentation](bridges.md) for the full model and [Per-op ANE quirks](op-quirks.md) for the hardware limits.
+
+!!! note "No CoreML, no entitlement"
+    The dispatch path wraps the unentitled Espresso `e5rt` runtime only. The bridge invokers link nothing but system frameworks, so a plain `pip install` works on any Apple Silicon Mac with the Xcode command-line tools.
+
+## Op surface
+
+- **Linear algebra:** `conv`, `conv_transpose`; matmul/linear via `@`; `bmm`.
+- **`dynamic_conv`:** conv with a *runtime-tensor* weight — the kernel is a graph value, not a baked constant. Lowers to the ANE's native dynamic-kernel path (`CreateDynamicKernel`/DynamicGOC), enabling hypernetworks and per-sample (per-image) kernels — a capability no other ANE frontend exposes, since Apple's MIL/CoreML conv bakes the weight. **Batch must be 1**; for batched convolution use `af.conv` or the im2col-based trainable `conv2d`.
+- **Activations:** `relu`/`silu`/`gelu`/`sigmoid`/`tanh`/`exp`/`log`/`sqrt`/`rsqrt`/`abs`/`square`/`sin`/`cos`/`erf`/`softplus`/`relu6`/`elu`/`leaky_relu`/`clip`.
+- **Arithmetic:** `add`/`sub`/`mul`/`div`(`/`)/`maximum`/`minimum`/`pow`.
+- **Reductions/norms:** `mean`/`sum`/`amax`/`amin`, `softmax`, `l2_norm`, `rms_norm`/`layer_norm`/`group_norm`/`batch_norm`.
+- **Spatial/shape:** `max_pool`/`avg_pool`, `upsample`, `concat`, `reshape`/`transpose`, `pixel_shuffle`/`pixel_unshuffle`.
+- **NN helpers:** `mha`, `cross_attention`, `geglu`.
+
+### Compositions (no native op)
+
+Some ops have no ANE hardware layer and are built from primitives, made exact by the wide accumulator:
+
+- **`cumsum`** (last axis): the ANE has no native cumsum, but a last-axis cumsum is exactly `x @ triu_ones` — a matmul with a baked upper-triangular-ones weight. For other axes, transpose the target axis to last first.
+- **`gather`** (static indices): no native gather, but a constant-index gather is exact via `slice_by_size` + `concat`. Dynamic (data-dependent) indices are not reachable on the ANE.
+- **`geglu`:** split the `[2*Dff, D]` projection into value/gate halves at build time (no slice op), `out = value * gelu(gate)`.
+
+## Image input
+
+`af.image_input(shape, scale=1/255, bias=0.0)` declares a uint8 input port and dequantizes it on the engine, so raw camera or decoded-video bytes feed the model directly and the host skips the float-convert/repack. The dequant is `cast(uint8->fp16) -> mul(scale) -> add(bias)`; identity add/mul are dropped, so the common `scale=1/255, bias=0` case is a cast plus one mul. `scale`/`bias` are scalar or per-channel (length-C, broadcast as `[1,C,1,1]` over NCHW).
+
+## Pretrained loaders
+
+- `af.load(".../all-MiniLM-L6-v2")` — sentence encoder.
+- `af.load_resnet18()` — ImageNet classifier.
+
+## Numerics
+
+Compute is **fp16 only** (fp32/int32/bf16 are rejected — not implemented on the backend). Reductions and matmuls use a **wide (fp32-class) accumulator** fed by radix-4 fp16-rounded input tiles, so representable sums are near-exact: a sum/dot of 16384 ones is bit-exact (naive fp16 stalls at ~2048), and a `+1` survives next to a 16000 partial that an fp16 running sum would swallow. The fp16 limit sits at the products and the I/O cast, not the running sum, so cancellation-heavy reductions still lose precision.
+
+## Compression knobs
+
+`compress=` chooses the weight encoding:
+
+| Value | Encoding |
+|---|---|
+| `None` (default) | fp16 |
+| `'int8'` | per-channel int8 (streamed at half the bytes; `int8=True` is the alias) |
+| `'int4'` | 4-bit LUT palettization, per-tensor, accuracy-gated fallback to int8/fp16 via `compress_atol` |
+| `'sparse'` | unstructured bitmask, emitted when the weight is >=50% zeros, else fp16 |
+| `'auto'` | per-weight: sparse if sparse, else int4 if accurate, else int8, else fp16 |
+
+## Training on the engine
+
+`autograd.py` provides a tiny reverse-mode autograd: `af.parameter` / `af.backward` / `af.mse` / `af.SGD` / `af.Trainer` train a small model with both forward and backward passes compiled and run on the ANE. For classification, `af.softmax_cross_entropy` (analytic fp16-stable on-ANE gradient) plus `af.Adam` train a 784->128->10 MLP on MNIST to ~97% test accuracy.
+
+With `Trainer(..., device_optimizer=True)` the **optimizer step also runs on the ANE** (SGD/Adam update as graph ops), so all training tensor-math is on the engine; the host only computes the scalar `lr_t` and shuttles state/grads. See `examples/train_mnist_mlp.py`.
+
+### Depth-independent training
+
+A monolithic compile fuses the whole forward, backward, and optimizer step into one program, so compile time grows superlinearly with depth. When layers are structurally identical (a transformer stack, a deep MLP), `CheckpointedStack` compiles the per-layer forward and per-layer backward **once** and reuses them for every layer, so compile cost does not grow with depth. The backward is the standard gradient-checkpointing trick — store only each layer's input activation and recompute its forward inside its backward — and the result is bit-identical to a monolithic `backward`. The optimizer runs host-side over the streamed gradients.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -88,6 +88,16 @@ nav:
       - Training & autograd: api/training.md
       - Pretrained models: api/models.md
       - Applied math: api/math.md
+  - Internals (developer):
+      - Overview: developer/overview.md
+      - Compile pipeline: developer/compile-pipeline.md
+      - Optimizer & cost model: developer/optimizer-and-cost.md
+      - Numerics: developer/numerics.md
+      - Native bridges: developer/bridges.md
+      - Op quirks: developer/op-quirks.md
+      - Capabilities & targets: developer/capabilities-and-targets.md
+      - Autograd internals: developer/autograd.md
+      - Model loaders: developer/models.md
   - Contribute:
       - Development: development.md
       - Glossary: glossary.md


### PR DESCRIPTION
Slims the heavy in-code documentation (tinygrad-style terse code) while **preserving the hard-won ANE/numerics knowledge** by relocating it into the docs site. **Zero runtime behavior change.**

## Code: −2,232 lines of prose
Trimmed across the core (compiler core, frontend, autograd, applied-math, bridges, models): docstrings cut to concise summaries (public API keeps a 1–3 line summary + args/returns where non-obvious — still feeds the mkdocstrings API ref; private helpers get a terse line or none); redundant/code-restating comments deleted. No `tests/`, `examples/`, `bench/`, or `_version.py`.

## Knowledge: relocated to `docs/developer/`
The valuable design rationale was harvested *before* deletion and curated into 9 new internals pages: `overview`, `compile-pipeline`, `optimizer-and-cost`, `numerics`, `bridges`, `op-quirks`, `capabilities-and-targets`, `autograd`, `models` — wired into the mkdocs nav (a new "Internals (developer)" section). Trimmed module docstrings point to these pages.

## Safety
Because trimming docstrings changes the AST, I used a **docstring-stripped AST comparison**: every touched file is **CODE-IDENTICAL** to `main` after removing all docstrings from both — a mechanical proof that *only docstrings/comments changed, no logic moved*. Plus:

- full on-device suite (`--forked`, Apple Silicon): **563 passed, 0 failed**
- golden-MIL: all representative graphs byte-identical (emit unchanged)
- pyright: **0**; ruff: clean; pylint 2-space: clean
- `mkdocs build --strict`: passes (incl. the new pages + nav)

7 per-subsystem code-slim commits + 1 docs commit. Mirrors how tinygrad keeps code terse and the narrative in `docs/`.