### PR TITLE
Thin examples: one-line docstrings + terse comments (tinygrad-style)

### DIFF
--- a/examples/_common.py
+++ b/examples/_common.py
@@ -1,12 +1,4 @@
-"""Shared example scaffolding - environment setup plus the few helpers every demo
-repeated verbatim. Import this FIRST in an example: it puts the repo root on
-sys.path and imports aneforge, which sets the OpenMP duplicate-runtime guard
-before numpy loads.
-
-Deliberately minimal: error metrics, conditioned random test matrices, and the
-one-line pass/fail report. Demo logic stays in the demos so each file remains a
-self-contained, copy-pasteable example.
-"""
+"""Shared example scaffolding: env setup, error metrics, test matrices, pass/fail report. Import FIRST."""
 import os
 import sys
 import warnings
@@ -19,9 +11,7 @@ import numpy as np
 
 f16 = np.float16
 
-# Section headers print in green - the conventional INFO colour every logging
-# colouriser (colorlog, coloredlogs, rich) uses for ordinary output. tty-guarded
-# and NO_COLOR-aware, so piped output or redirected files stay plain text.
+# Green INFO headers / yellow warnings; tty-guarded and NO_COLOR-aware.
 _COLOR = sys.stdout.isatty() and not os.environ.get("NO_COLOR")
 _GREEN, _YELLOW, _BOLD, _DIM, _RESET = "\033[32m", "\033[33m", "\033[1m", "\033[2m", "\033[0m"
 
@@ -40,11 +30,7 @@ def aside(msg=""):
         print(msg)
 
 
-# Colour warnings yellow - the conventional WARNING level colour, paired with the
-# green INFO headers above - and show each distinct warning ONCE per run. The
-# examples compile at many call sites, so aneforge's DispatchFloorWarning would
-# otherwise repeat its whole paragraph per site; we collapse identical (category,
-# text) repeats here at the render step, leaving the library's filters untouched.
+# Show each distinct warning ONCE per run (collapse identical repeats at render).
 _warned: set = set()
 
 
@@ -103,7 +89,6 @@ def report(name, out, ref, route="netplist", exact=False, tol=0.02, abserr=None)
 
 
 # Conditioned random test matrices (geometric spectrum 1..cond).
-
 def spd(n, cond, seed):
     """Symmetric positive definite [n,n] with condition number `cond`."""
     r = np.random.default_rng(seed)

--- a/examples/autotune.py
+++ b/examples/autotune.py
@@ -1,34 +1,4 @@
-"""aneforge optimizer demo - measured speedups on REAL models, correctness preserved.
-
-The aneforge autotuner (``af.tune``) is a rewrite engine over a metamorphic-proven-
-safe variant space (see aneforge/_optimize.py): it enumerates the legal variants
-(native<->decomposed SDPA route, fp16<->int8 weight streaming), prunes with the
-cost model, MEASURES the survivors on the ANE, VALIDATES each against the opt=0
-baseline, and returns the fastest CORRECT one.
-
-This demo runs that tuner end-to-end on real models and proves two things at once:
-
-  1. CORRECTNESS (the headline, non-negotiable): the optimized program reproduces
-     the opt=0 baseline output. Default tune() is accuracy-PRESERVING (lossless
-     route selection / fp16) -> matches within fp16 noise. tune(atol=0.1) admits
-     int8 -> matches within its stated ~0.1 budget.
-  2. SPEED: the REAL measured end-to-end latency (warmup, then MIN over reps) of
-     opt=0 vs tune-lossless vs tune-int8.
-
-Models:
-  - ResNet-18           (af.load_resnet18; weight-heavy convs -> int8 candidate)
-  - MiniLM encoder      (af.load all-MiniLM-L6-v2; matmul-heavy, has attention)
-  - Attention block     (q/k/v proj + af.sdpa + out-proj; exercises the route
-                         rewrite: native SDPA cut vs decomposed-fused) at two sizes
-
-CAVEAT: this prints the REAL measured speedups. The route rewrite is expected to
-move the attention block; weight-heavy models may show an int8 win under atol=0.1;
-a floor-bound / already-optimal model correctly returns ~1.0x (tune returns the
-baseline) - that is correct behavior, not a failure. We report exactly what the
-tuner chose and never claim a speedup the measurement does not show.
-
-    python3 examples/autotune.py
-"""
+"""aneforge optimizer demo: measured tune() speedups on real models, correctness preserved. Run: python3 examples/autotune.py"""
 import sys, time
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
@@ -39,7 +9,7 @@ from aneforge._compile import compile as _compile
 from aneforge._optimize import _config_label, _graph_key, _input_shapes
 
 
-# measurement helpers                                                          #
+# measurement helpers
 def bench(net, inputs, reps: int = 30, warmup: int = 8) -> float:
     """End-to-end latency in microseconds: warmup, then MIN over reps."""
     for _ in range(warmup):
@@ -72,9 +42,7 @@ def tuner_decision(out) -> str:
         return "?"
 
 
-# graph builders (aneforge public ops + the loaders' exposed real weights)     #
-# These rebuild the SAME graph the loaders compile internally, but return the  #
-# output Tensor so af.tune() can optimize it. Inputs already-embedded (host).  #
+# graph builders: rebuild each loader's graph, returning the output Tensor for af.tune().
 def resnet18_graph(clf):
     """Rebuild ResNet-18's ANE graph from clf.sd (folded BN) -> output Tensor."""
     sd = clf.sd
@@ -139,7 +107,7 @@ def attn_block_graph(H, S, D):
     return o.linear(Wo)
 
 
-# per-model runner: opt=0 baseline vs tune-lossless vs tune-int8              #
+# per-model runner: opt=0 baseline vs tune-lossless vs tune-int8
 def run_model(label, build_graph, make_inputs, has_int8):
     """Compile/measure opt=0, tune-lossless, tune-int8 (if applicable); assert the
     optimized outputs match the opt=0 baseline; return a results row."""

--- a/examples/benchmarks/bench_encoder_batched.py
+++ b/examples/benchmarks/bench_encoder_batched.py
@@ -1,17 +1,4 @@
-"""Batched encoder throughput on the ANE - the serving number for embeddings.
-
-Encoders are the ANE's niche (compute-bound, fp16-tolerant, one forward). This
-processes B sequences of the SAME length as a width-B batch (length-bucketing - a
-real serving pattern that needs no padding/mask), measuring embeddings/sec vs B.
-Batched ANE matmuls are flat in B, so per-stream cost should fall sharply.
-
-Reuses the weights loaded by af.Encoder; builds a batched [B,S,D] encoder graph and
-fuses it into one program per (B,S). Correctness is checked against the
-transformers fp32 reference; throughput is reported vs B.
-
-    PYTHONPATH=. \\
-        python3 examples/benchmarks/bench_encoder_batched.py
-"""
+"""Batched encoder throughput on the ANE: B same-length sequences as a width-B batch, embeddings/sec vs B, validated vs fp32. Run: PYTHONPATH=. python3 examples/benchmarks/bench_encoder_batched.py"""
 import os, sys, time
 from pathlib import Path
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")

--- a/examples/benchmarks/bench_encoder_gpu.py
+++ b/examples/benchmarks/bench_encoder_gpu.py
@@ -1,13 +1,4 @@
-"""Batched-GPU encoder baseline - the fair counterpart to the aneforge ANE batched
-encoder (bench_encoder_batched.py: ~3978 embeds/sec @ B=16).
-
-Runs the same MiniLM encoder on the Apple GPU (torch MPS), batched at the same B and
-S, measuring embeds/sec + power, so encoder serving can be compared ANE-vs-GPU on
-both throughput and efficiency (the LLM-decode question, asked for the workload the
-ANE should actually win).
-
-    python3 examples/benchmarks/bench_encoder_gpu.py
-"""
+"""Batched-GPU (torch MPS) MiniLM encoder baseline measuring embeds/sec + power, the counterpart to bench_encoder_batched.py. Run: python3 examples/benchmarks/bench_encoder_gpu.py"""
 import os, re, subprocess, sys, time
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")

--- a/examples/benchmarks/rank_worker_bench.py
+++ b/examples/benchmarks/rank_worker_bench.py
@@ -1,19 +1,4 @@
-"""A1 vs A2 latency benchmark for af.argmax and af.topk (native rank ops).
-
-A1 = correctness-first subprocess-per-call netplist dispatch: every argmax/topk
-     call spawns a one-shot ObjC probe (ane_invoke_probe_rank) that
-     compiles+loads+maps the netplist, evaluates, exits. For topk that's ONE
-     subprocess *per row* (C rows -> C spawns/call).
-
-A2 = persistent Path-A worker (aneforge/_netplist_worker.py +
-     ane_persistent_worker probe): compiles+loads+maps ONCE, then services many
-     evals over a pipe. topk reuses ONE loaded 1-channel program, eval'd C times.
-
-We measure per-call wall latency under each, single-call (cold) and over a
-32-call steady-state loop, and assert A2 produces BIT-IDENTICAL outputs.
-
-    PYTHONPATH=. python3 examples/benchmarks/rank_worker_bench.py
-"""
+"""A1 (subprocess/call) vs A2 (persistent worker) latency for af.argmax and af.topk, asserting bit-identical outputs. Run: PYTHONPATH=. python3 examples/benchmarks/rank_worker_bench.py"""
 import os
 import sys
 import time

--- a/examples/benchmarks/sdpa_worker_bench.py
+++ b/examples/benchmarks/sdpa_worker_bench.py
@@ -1,19 +1,4 @@
-"""A1 vs A2 latency benchmark for af.sdpa at a fixed shape.
-
-A1 = correctness-first subprocess-per-call netplist dispatch (the current path):
-     every af.sdpa call spawns a one-shot ObjC probe that compiles+loads+maps the
-     netplist, evaluates once, exits. Repeated calls pay that tax every time.
-
-A2 = persistent Path-A worker (aneforge/_netplist_worker.py + the
-     ane_persistent_worker probe): compiles+loads+maps ONCE, then services many
-     evals over a pipe. Repeated calls pay only the eval + host<->surface memcpy.
-
-We measure per-call wall latency under each, single-call and over a 32-call loop,
-to show A2's amortization. A2 is selected by default; A1 is forced with
-ANEFORGE_NETPLIST_WORKER=0.
-
-    PYTHONPATH=. python3 examples/benchmarks/sdpa_worker_bench.py
-"""
+"""A1 (subprocess/call) vs A2 (persistent worker) latency for af.sdpa at a fixed shape, showing A2's amortization. Run: PYTHONPATH=. python3 examples/benchmarks/sdpa_worker_bench.py"""
 import os
 import sys
 import time
@@ -33,19 +18,16 @@ def make_inputs(rng):
 
 
 def time_path(label):
-    """Compile a fresh SDPA model, then time N calls. The compiled-model
-    lifetime is what the worker is cached against, so we build it here."""
+    """Compile a fresh SDPA model (the worker is cached against its lifetime), then time N calls."""
     rng = np.random.default_rng(0)
     Q, K, V = make_inputs(rng)
     net = af.compile(af.sdpa(af.input((1, H, S, D)), af.input((1, H, S, D)), af.input((1, H, S, D))))
 
-    # First call (cold): under A2 this includes the one-time worker
-    # compile+load+map; under A1 it's just the first subprocess spawn.
+    # cold first call (A2: includes one-time worker compile+load+map)
     t0 = time.perf_counter()
     out0 = net(Q, K, V)
     cold_ms = (time.perf_counter() - t0) * 1e3
 
-    # Steady-state: time each subsequent call.
     per_call_ms = []
     for _ in range(N):
         t0 = time.perf_counter()

--- a/examples/benchmarks/topk_worker_bench.py
+++ b/examples/benchmarks/topk_worker_bench.py
@@ -1,22 +1,4 @@
-"""Per-call latency benchmark for aneforge's A2 persistent Path-A workers.
-
-Measures steady-state per-call latency for topk (the per-row-tiled op), plus
-sdpa and argmax as controls. topk's per-call cost is set by per-row tiling: the
-native TopK keys all channels by one lane, so each of the C rows is its own
-1-channel program and gets its own ANE evaluateWithQoS dispatch.
-
-The A2 worker protocol is batched (a single request can carry N input sets and
-run N evals in ONE pipe round-trip; see _netplist_worker.eval_batch). For topk,
-however, the pipe round-trip is NOT the bottleneck: a single trip+eval is
-~0.08 ms and the C sequential ANE dispatches dominate. Batching all C rows into
-one round-trip removes only the (near-free) trips and actually regresses the
-median (the worker's back-to-back eval loop loses the pipe pacing). So topk
-keeps the per-call eval() dispatch. To see the batched path's effect directly:
-
-    --batch   route topk through eval_batch (one round-trip) instead of per-call
-
-    PYTHONPATH=. python3 examples/benchmarks/topk_worker_bench.py
-"""
+"""Per-call latency for the A2 persistent worker: topk (per-row-tiled) plus sdpa/argmax controls; --batch routes topk through eval_batch. Run: PYTHONPATH=. python3 examples/benchmarks/topk_worker_bench.py"""
 import sys
 import time
 from pathlib import Path
@@ -49,8 +31,7 @@ def main():
     ref = np.sort(xt.astype(np.float32), 1)[:, ::-1][:, :k]
 
     if use_batch:
-        # Drive the worker through eval_batch (all C rows in ONE round-trip) to
-        # measure the batched-eval path directly.
+        # drive the worker through eval_batch (all C rows in one round-trip)
         from aneforge import _netplist_worker as nw
         worker, _ = nw.build_worker("topk", (C, W), {"k": k, "largest": True})
         xa = np.ascontiguousarray(xt.reshape(C, W))

--- a/examples/cifar_data.py
+++ b/examples/cifar_data.py
@@ -1,7 +1,4 @@
-"""CIFAR-10 loading for the on-ANE training demo. Uses torchvision to download the
-dataset once into examples/data/cifar10 (the [models] extra). Returns normalized
-fp32 NCHW arrays + integer labels, plus a deterministic mini-batch iterator. No
-training logic here."""
+"""CIFAR-10 loading for the on-ANE training demo: normalized fp32 NCHW arrays + labels + batch iterator."""
 from pathlib import Path
 import numpy as np
 

--- a/examples/compress_weights.py
+++ b/examples/compress_weights.py
@@ -1,26 +1,4 @@
-"""aneforge compression demo - int4-LUT / sparse / int8 weight streaming on the ANE.
-
-``af.compile(out, compress=...)`` chooses how each weight is encoded in the single
-packed BLOBFILE. The compressed encodings STREAM: the weight is dequantised during
-the tile DMA, so a bandwidth-bound matmul moves fewer bytes per tile and runs
-faster, not just smaller on disk. ``compress=None`` is byte-identical fp16.
-
-  None      fp16, the deployed baseline
-  "int8"    per-channel int8           (half the weight bytes)
-  "int4"    4-bit LUT palettization    (per-tensor, accuracy-gated -> int8 -> fp16)
-  "sparse"  unstructured bitmask       (emitted when a weight is >=50% zeros)
-  "auto"    per-weight: sparse if sparse, else int4 if accurate, else int8, else fp16
-
-This demo shows the two halves of the story:
-
-  PART A  accuracy x size  on a real ImageNet ResNet-18 (logit cosine vs the
-          torchvision fp32 reference, top-1 match, and the packed weights.bin size).
-  PART B  the streaming SPEEDUP on a big bandwidth-bound matmul (4096x4096, B=1),
-          where compressed weights move fewer bytes per tile. (Compression is a
-          slight LOSS on sub-megabyte weights; the win is on big weights.)
-
-    python3 examples/compress_weights.py
-"""
+"""aneforge compression demo: int4-LUT / sparse / int8 weight streaming (accuracy x size, then streaming speedup). Run: python3 examples/compress_weights.py"""
 import sys, time, statistics, tempfile
 from pathlib import Path
 
@@ -54,8 +32,7 @@ def part_a_resnet18():
         ref = m(torch.from_numpy(img)).numpy()[0].astype(np.float64)
     ref_top1 = int(ref.argmax())
 
-    # (compress, compress_atol, label) - last row loosens the int4 accuracy gate to
-    # FORCE more int4 adoption, trading a little cosine for a real size drop.
+    # last row loosens the int4 accuracy gate to force more int4 adoption.
     rows = [(m, 0.05, m if m else "None") for m in MODES]
     rows.append(("int4", 0.5, "int4@0.5"))
 
@@ -98,11 +75,8 @@ def part_b_streaming_speedup():
     K = N = 4096
     x = rng.standard_normal((1, K)).astype(np.float16)
 
-    # dense weight: fp16 / int8 / int4 all encode the SAME weight (int4 needs a
-    # generous accuracy budget so random-normal weights clear the gate).
-    Wd = rng.standard_normal((K, N)).astype(np.float16)
-    # sparse weight: ~68% zeros so the sparse encoding is emitted.
-    Ws = Wd.copy(); Ws[np.abs(Ws) < 1.0] = 0.0
+    Wd = rng.standard_normal((K, N)).astype(np.float16)   # dense; int4 needs a generous gate
+    Ws = Wd.copy(); Ws[np.abs(Ws) < 1.0] = 0.0            # ~68% zeros -> sparse encoding emitted
 
     print(f"\n{'compress':>9} | {'weight':>7} | {'latency (ms)':>12} | {'speedup':>8} | "
           f"{'weights.bin':>12}")

--- a/examples/demo.py
+++ b/examples/demo.py
@@ -1,15 +1,4 @@
-"""ANEForge hero demo: a small transformer that writes about itself, on the ANE.
-
-A small causal char-level transformer (multi-head attention, SwiGLU, RMSNorm)
-trains end to end on the Apple Neural Engine - forward, backward, and the Adam
-update are all ANE graph programs - then generates text from the trained model,
-one character per on-engine forward pass. No CoreML, no GPU.
-
-    python3 examples/demo.py
-
-This is the script recorded for the README animation (docs/assets/demo.tape). It is
-a real run on real ANE silicon; the only thing staged is the typewriter pacing.
-"""
+"""ANEForge hero demo: a small char transformer trains and generates entirely on the ANE. Run: python3 examples/demo.py"""
 import sys
 import threading
 import time
@@ -120,8 +109,7 @@ def main():
             time.sleep(0.45)
     out()
 
-    # complete the prompt on the engine, one character per on-engine forward pass.
-    # the given prompt is dimmed; the model's continuation streams in bright teal.
+    # complete the prompt, one character per on-engine forward pass.
     def complete(seed, n):
         buf = [stoi[c] for c in seed]
         out(f"  {GREY}prompt{R}      {RUST}>{R} {DIM}{seed}{R}")

--- a/examples/demos/ane_vs_gpu_cpu.py
+++ b/examples/demos/ane_vs_gpu_cpu.py
@@ -1,14 +1,4 @@
-"""DEMO: the same workload on ANE vs CPU vs GPU.
-
-Exercises:
-  - running one matmul on the ANE (aneforge) and timing it
-  - the same matmul on the CPU (numpy fp32) and, if available, the GPU (torch MPS)
-  - the qualitative takeaway: per-call the ANE is latency-bound (dispatch floor) but very
-    power-efficient; CPU/GPU have their own floors and far higher power
-
-torch is optional (the [bench] extra). Run:
-  python3 examples/demos/ane_vs_gpu_cpu.py
-"""
+"""Same matmul on ANE vs CPU vs GPU. Run: python3 examples/demos/ane_vs_gpu_cpu.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/batching_amortization.py
+++ b/examples/demos/batching_amortization.py
@@ -1,11 +1,4 @@
-"""DEMO: batching amortizes the fixed dispatch floor (per-sample cost collapses ~127x).
-
-Reverse-engineering finding: per-CALL latency is ~flat in the batch size up to a point (the
-~0.2 ms round-trip dominates), so per-SAMPLE cost falls roughly linearly toward the true
-compute rate. Measured on M1: 196 us/sample at N=1 -> ~1.5 us/sample at N=512.
-
-Run:  python3 examples/demos/batching_amortization.py
-"""
+"""Batching amortizes the fixed dispatch floor. Run: python3 examples/demos/batching_amortization.py"""
 import sys, time
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -16,7 +9,7 @@ import aneforge as af
 
 
 def main() -> int:
-    warnings.filterwarnings("ignore")          # the floor warning is demonstrated in 01
+    warnings.filterwarnings("ignore")
     rng = np.random.default_rng(0)
     print(f"{'batch N':>8} | {'us/call':>8} | {'us/sample':>10}")
     print("-" * 32)

--- a/examples/demos/capability_surface.py
+++ b/examples/demos/capability_surface.py
@@ -1,12 +1,4 @@
-"""DEMO: the ANE capability surface - what the hardware can and can't do.
-
-Exercises:
-  - af.OP_CATALOG (the machine-checked op registry) and af.op_info(name)
-  - af.is_native / af.device_status / af.min_native_family (per-op, per-chip gating)
-  - af.ops_on(chip, status) and af.walled_everywhere() (ops no chip runs natively)
-
-Run:  python3 examples/demos/capability_surface.py
-"""
+"""The ANE capability surface: what the hardware can and can't do. Run: python3 examples/demos/capability_surface.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/chaining_depth.py
+++ b/examples/demos/chaining_depth.py
@@ -1,12 +1,4 @@
-"""DEMO: chaining (graph depth) amortizes the dispatch floor too - one submit, many ops.
-
-Reverse-engineering finding: aneforge fuses the whole graph into ONE program/submit, so a
-deep model pays one ~0.2 ms round-trip regardless of depth. Per-CALL latency is ~flat in the
-number of layers; per-OP cost collapses. Measured on M1: 222 us/op at depth 1 -> ~6 us/op at
-depth 32, with per-call latency staying ~190 us.
-
-Run:  python3 examples/demos/chaining_depth.py
-"""
+"""Graph depth amortizes the dispatch floor: one submit, many ops. Run: python3 examples/demos/chaining_depth.py"""
 import sys, time
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -17,7 +9,7 @@ import aneforge as af
 
 
 def main() -> int:
-    warnings.filterwarnings("ignore")          # the floor warning is demonstrated in 01
+    warnings.filterwarnings("ignore")
     rng = np.random.default_rng(0)
     print(f"{'depth':>6} | {'#ops fused':>10} | {'us/call':>8} | {'us/conv':>8}")
     print("-" * 42)
@@ -36,7 +28,6 @@ def main() -> int:
         for _ in range(M):
             net(img)
         per_call = (time.perf_counter() - t) / M * 1e6
-        # net.n_ops = graph ops fused into the single program (all depths -> 1 program)
         print(f"{K:>6} | {net.n_ops:>10} | {per_call:>8.0f} | {per_call / K:>8.2f}")
         net.release()
     print("\nEvery depth compiles to ONE program (the op count is what's fused into it);")

--- a/examples/demos/cross_chip_cost_model.py
+++ b/examples/demos/cross_chip_cost_model.py
@@ -1,13 +1,4 @@
-"""DEMO: the measurement-free cost model + cross-chip peak projection.
-
-Reverse-engineering finding: the ANE compiler's analytic roofline was extracted and walked
-for every chip. aneforge exposes af.estimate(out) (predicted microseconds, no device) and
-af.project_peak(arch) (fp16 peak per chip). The anchors are dispatch-bound-regime effective
-values (validated on M1 convs within +/-17%); the saturating ceilings are higher (see
-05/06). This shows the predictor and the cross-generation scaling.
-
-Run:  python3 examples/demos/cross_chip_cost_model.py
-"""
+"""Measurement-free cost model + cross-chip peak projection. Run: python3 examples/demos/cross_chip_cost_model.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/dispatch_no_coreml.py
+++ b/examples/demos/dispatch_no_coreml.py
@@ -1,12 +1,4 @@
-"""DEMO: dispatch straight to the ANE, without CoreML.
-
-Exercises:
-  - the aneforge compile->dispatch path (MIL -> on-device ANECompiler -> e5rt execute)
-  - that this reaches ANE silicon from plain user space, no CoreML / .mlmodel involved
-  - compile-once / eval-many reuse (the program handle persists across calls)
-
-Run:  python3 examples/demos/dispatch_no_coreml.py
-"""
+"""Dispatch straight to the ANE, without CoreML. Run: python3 examples/demos/dispatch_no_coreml.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -22,7 +14,7 @@ def main() -> int:
     x = af.input((1, 8, 16, 16))
 
     t = time.perf_counter()
-    net = af.compile(af.conv(x, W, pad=1).relu())     # MIL -> ANECompiler -> e5rt program
+    net = af.compile(af.conv(x, W, pad=1).relu())
     compile_ms = (time.perf_counter() - t) * 1e3
 
     img = (rng.standard_normal((1, 8, 16, 16)) * 0.5).astype(np.float32)

--- a/examples/demos/entitlement_boundary.py
+++ b/examples/demos/entitlement_boundary.py
@@ -1,13 +1,4 @@
-"""DEMO: aneforge reaches the ANE from UNENTITLED user space.
-
-Exercises:
-  - that a plain Python process (no special entitlements, no CoreML) compiles + runs on the ANE
-  - the split the RE found: the compile goes through the entitled ANECompilerService daemon
-    (XPC), but the per-inference SUBMIT is a direct IOKit call from this unentitled process
-  - a working dispatch as proof the boundary is crossed legitimately via the public daemons
-
-Run:  python3 examples/demos/entitlement_boundary.py
-"""
+"""aneforge reaches the ANE from unentitled user space. Run: python3 examples/demos/entitlement_boundary.py"""
 import sys, os, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -23,7 +14,7 @@ def main() -> int:
     W = (rng.standard_normal((8, 8, 3, 3)) * 0.1).astype(np.float32)
     x = af.input((1, 8, 16, 16))
     net = af.compile(af.conv(x, W, pad=1).relu().mean((2, 3)))   # compile via ANECompilerService (XPC)
-    out = net(rng.standard_normal((1, 8, 16, 16)).astype(np.float32))   # SUBMIT direct from here
+    out = net(rng.standard_normal((1, 8, 16, 16)).astype(np.float32))   # submit direct from here
     print(f"compiled + dispatched on the ANE: output shape {np.asarray(out).shape}")
     print("\nThe entitlement boundary, as decoded:")
     print("  - compile: handed to the entitled ANECompilerService daemon over XPC (it owns the")

--- a/examples/demos/execution_model_floor.py
+++ b/examples/demos/execution_model_floor.py
@@ -1,16 +1,8 @@
-"""DEMO: the ANE dispatch floor - every call pays a fixed firmware round-trip.
-
-Reverse-engineering finding (perf guide + latency docs): one ANE call costs a fixed
-~130-190us firmware round-trip on M1, almost independent of how small the work is, because
-the kernel scheduler dispatches one firmware command in-flight per die. Compile-time also
-emits a DispatchFloorWarning when a program is floor-bound.
-
-Run:  python3 examples/demos/execution_model_floor.py
-"""
+"""The ANE dispatch floor: every call pays a fixed firmware round-trip. Run: python3 examples/demos/execution_model_floor.py"""
 import sys, time, warnings
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))   # examples/ -> _common
-import _common  # noqa: F401  (sets KMP env + repo root on sys.path)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+import _common  # noqa: F401
 import numpy as np
 import aneforge as af
 
@@ -20,7 +12,6 @@ def main() -> int:
     W = (rng.standard_normal((8, 8, 3, 3)) * 0.1).astype(np.float32)
     x = af.input((1, 8, 16, 16))
 
-    # compile() warns when the program is dispatch-floor-bound
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         net = af.compile(af.conv(x, W, pad=1).relu().mean((2, 3)))

--- a/examples/demos/hidden_layers.py
+++ b/examples/demos/hidden_layers.py
@@ -1,14 +1,4 @@
-"""DEMO: hidden hardware layers - native ops the fused MIL route can't express.
-
-Exercises:
-  - a native hardware layer reached via the netplist-bridge route: af.sdpa maps to the ANE's
-    ANECSDPALayerDesc attention layer, which the public MIL toolchain does not emit, yet runs
-    here on M1 from unentitled user space (cos ~1 vs numpy)
-  - per-family gating of OTHER hidden ops (af.min_native_family): some need newer ANE families
-    (e.g. topk needs family 3+, so it is NOT reachable on M1/family-2)
-
-Run:  python3 examples/demos/hidden_layers.py
-"""
+"""Hidden hardware layers: native ops the fused MIL route can't express. Run: python3 examples/demos/hidden_layers.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -19,15 +9,13 @@ import aneforge as af
 
 def main() -> int:
     warnings.filterwarnings("ignore")
-    # a hidden hardware layer that IS reachable on M1 via the bridge route: native SDPA
     H, S, D = 2, 16, 16
     rng = np.random.default_rng(0)
     Q, K, V = (rng.standard_normal((1, H, S, D)).astype(np.float16) for _ in range(3))
     q, k, v = (af.input((1, H, S, D)) for _ in range(3))
     net = af.compile(af.sdpa(q, k, v), opt=0)
     got = np.asarray(net(Q, K, V)).astype(np.float64)
-    # numpy reference (non-causal)
-    ref = np.zeros((1, H, S, D))
+    ref = np.zeros((1, H, S, D))    # numpy reference (non-causal)
     for h in range(H):
         sc = Q[0, h].astype(np.float64) @ K[0, h].astype(np.float64).T / np.sqrt(D)
         sc -= sc.max(1, keepdims=True); p = np.exp(sc); p /= p.sum(1, keepdims=True)

--- a/examples/demos/llm_attention_kvcache.py
+++ b/examples/demos/llm_attention_kvcache.py
@@ -1,13 +1,4 @@
-"""DEMO: native attention (SDPA) on the ANE's dedicated attention hardware layer.
-
-Exercises:
-  - af.sdpa(q, k, v, is_causal=...) - the native ANECSDPALayerDesc hardware layer, a layer
-    the public MIL toolchain does not emit, reached from unentitled user space
-  - causal scaled-dot-product attention checked against a numpy reference (cos ~1)
-  - the KV-cache decode shape (seq_q=1 query over cached K/V) that autoregressive decode uses
-
-Run:  python3 examples/demos/llm_attention_kvcache.py
-"""
+"""Native attention (SDPA) on the ANE's dedicated attention hardware layer. Run: python3 examples/demos/llm_attention_kvcache.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -46,7 +37,7 @@ def main() -> int:
     # KV-cache decode shape: one new query token attends over S cached keys/values
     qd, kc, vc = af.input((1, H, 1, D)), af.input((1, H, S, D)), af.input((1, H, S, D))
     dec = af.compile(af.sdpa(qd, kc, vc), opt=0)
-    Qd = Q[:, :, :1, :].copy()                        # the single new-token query [1,H,1,D]
+    Qd = Q[:, :, :1, :].copy()
     out_shape = np.asarray(dec(Qd, K, V)).shape
     print(f"KV-cache decode shape (seq_q=1 over {S} cached): compiles + runs -> out {out_shape}")
     dec.release()

--- a/examples/demos/mil_dialect.py
+++ b/examples/demos/mil_dialect.py
@@ -1,12 +1,4 @@
-"""DEMO: see the CoreML MIL that aneforge feeds the ANE compiler.
-
-Reverse-engineering finding: aneforge emits a text CoreML MIL program (program(1.3),
-func main<ios18>) with weights referenced by BLOBFILE offset; that MIL is what the on-device
-ANECompiler lowers to a .hwx. compile(build_dir=...) writes the generated model.mil so you
-can read exactly what the compiler received.
-
-Run:  python3 examples/demos/mil_dialect.py
-"""
+"""See the CoreML MIL that aneforge feeds the ANE compiler. Run: python3 examples/demos/mil_dialect.py"""
 import sys, tempfile, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/numerical_scientific.py
+++ b/examples/demos/numerical_scientific.py
@@ -1,13 +1,4 @@
-"""DEMO: numerical / scientific compute on the ANE - a DFT as two matmuls.
-
-Exercises:
-  - expressing a scientific kernel (the discrete Fourier transform) as ANE matmuls
-    (real part via a cosine basis, imaginary via a sine basis)
-  - recovering the magnitude spectrum and checking it vs numpy's FFT (cosine ~1, right peaks)
-  - the ANE as a general fp16 array processor, not just a neural-net accelerator
-
-Run:  python3 examples/demos/numerical_scientific.py
-"""
+"""Numerical/scientific compute on the ANE: a DFT as two matmuls. Run: python3 examples/demos/numerical_scientific.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -28,7 +19,7 @@ def main() -> int:
     Wsin = (-np.sin(2*np.pi*jk/n)).astype(np.float32)
 
     x = af.input((1, n))
-    net = af.compile((x @ Wcos).square() + (x @ Wsin).square())   # |DFT|^2, all on the ANE
+    net = af.compile((x @ Wcos).square() + (x @ Wsin).square())   # |DFT|^2
     mag2 = np.asarray(net(sig.reshape(1, n))).reshape(-1).astype(np.float64)
     mag = np.sqrt(np.maximum(mag2, 0))
     ref = np.abs(np.fft.fft(sig.astype(np.float64)))

--- a/examples/demos/numerics_fp16.py
+++ b/examples/demos/numerics_fp16.py
@@ -1,12 +1,4 @@
-"""DEMO: ANE numerics - fp16 compute, and the cancellation pitfall + mitigation.
-
-Exercises:
-  - fp16 is the ANE compute/accumulator type: results track fp32 to ~1e-3, not bit-exact
-  - the catastrophic-cancellation hazard (variance of a large-mean signal in fp16)
-  - aneforge's structural precision check (PrecisionWarning) and a paired-fp16 mitigation
-
-Run:  python3 examples/demos/numerics_fp16.py
-"""
+"""ANE numerics: fp16 compute, the cancellation pitfall + mitigation. Run: python3 examples/demos/numerics_fp16.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -16,7 +8,7 @@ import aneforge as af
 
 
 def main() -> int:
-    warnings.filterwarnings("ignore")          # quiet the floor warning; we trigger PrecisionWarning below
+    warnings.filterwarnings("ignore")
     rng = np.random.default_rng(0)
 
     # 1) ordinary fp16 op tracks fp32 closely
@@ -28,8 +20,7 @@ def main() -> int:
     print(f"gelu fp16 vs fp32: relerr = {_common.relerr(got, ref):.2e}  (fp16-close, not exact)")
     net.release()
 
-    # 2) the cancellation hazard: a signed reduce_sum over a long axis uses the narrow fp16
-    #    accumulator -> aneforge flags it structurally at compile time (PrecisionWarning)
+    # 2) the cancellation hazard: signed reduce_sum over a long axis -> PrecisionWarning
     big = af.input((1, 4096))
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")

--- a/examples/demos/optimization_autotune.py
+++ b/examples/demos/optimization_autotune.py
@@ -1,12 +1,4 @@
-"""DEMO: the cost model + autotuner pick a fast lowering without you measuring by hand.
-
-Exercises:
-  - af.estimate(out): a no-device microsecond prediction (the optimizer's pruner)
-  - af.tune(out): compile several equivalent lowerings, measure on-device, keep the fastest
-  - the cost model orders variants so the tuner skips ones predicted far worse
-
-Run:  python3 examples/demos/optimization_autotune.py
-"""
+"""Cost model + autotuner pick a fast lowering without hand-measuring. Run: python3 examples/demos/optimization_autotune.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/pitfalls_limits.py
+++ b/examples/demos/pitfalls_limits.py
@@ -1,12 +1,4 @@
-"""DEMO: the pitfalls and the hard limits - what to expect and design around.
-
-Exercises:
-  - the two compile-time signals: PrecisionWarning (fp16 cancellation) and
-    DispatchFloorWarning (tiny dispatch-bound graph)
-  - the hard limits the RE established, stated plainly so they're not surprises
-
-Run:  python3 examples/demos/pitfalls_limits.py
-"""
+"""The pitfalls and the hard limits: what to expect and design around. Run: python3 examples/demos/pitfalls_limits.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -18,7 +10,7 @@ import aneforge as af
 def main() -> int:
     rng = np.random.default_rng(0)
 
-    # PITFALL 1: a dispatch-floor-bound graph (tiny work) -> DispatchFloorWarning
+    # PITFALL 1: tiny work -> DispatchFloorWarning
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         W = (rng.standard_normal((8, 8, 3, 3)) * 0.1).astype(np.float32)
@@ -27,7 +19,7 @@ def main() -> int:
     net.release()
     print(f"tiny graph -> DispatchFloorWarning: {floor}")
 
-    # PITFALL 2: a signed reduce_sum over a long axis (narrow fp16 accumulator) -> PrecisionWarning
+    # PITFALL 2: signed reduce_sum over a long axis -> PrecisionWarning
     with warnings.catch_warnings(record=True) as w:
         warnings.simplefilter("always")
         warnings.filterwarnings("ignore", category=af.DispatchFloorWarning)

--- a/examples/demos/power_efficiency.py
+++ b/examples/demos/power_efficiency.py
@@ -1,16 +1,4 @@
-"""DEMO: ANE power efficiency - high throughput at very low watts.
-
-Exercises:
-  - sustaining a compute-bound matmul and measuring achieved fp16 throughput
-  - estimating energy/op from the RE-measured ANE rail draw (~1.48 W sustained on M1)
-  - the efficiency story: the ANE is a low-power accelerator, not a latency racer
-
-Note: the exact rail draw needs `sudo powermetrics --samplers cpu_power` (prints "ANE Power");
-this demo reports throughput and an energy estimate from the measured 1.48 W so it runs without
-sudo. (RE measured: 0 W idle, ~0.75 W dispatch-bound N=1, ~1.48 W sustained N=512.)
-
-Run:  python3 examples/demos/power_efficiency.py
-"""
+"""ANE power efficiency: high throughput at very low watts. Run: python3 examples/demos/power_efficiency.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/resident_state.py
+++ b/examples/demos/resident_state.py
@@ -1,12 +1,4 @@
-"""DEMO: resident on-device state via share_buffer - no host re-feed between steps.
-
-Reverse-engineering finding: output->input buffer aliasing (share_buffer) keeps a tensor
-resident on the ANE across execute() calls. This is the chaining lever for autoregressive
-decode (zero-copy KV-cache) and unrolled training (resident optimizer state): the host feeds
-only new data, never the carried state. Here a counter accumulates entirely on-device.
-
-Run:  python3 examples/demos/resident_state.py
-"""
+"""Resident on-device state via share_buffer: no host re-feed between steps. Run: python3 examples/demos/resident_state.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -18,14 +10,13 @@ import aneforge as af
 def main() -> int:
     warnings.simplefilter("ignore")
     s = af.input((1, 8))
-    y = s.adds(1.0)                       # y = state + 1
+    y = s.adds(1.0)
     net = af.compile(y)
     prog = net._prog
     in_name = net._inputs[0][0]
     out_name = net._out_name
 
-    # alias the state INPUT to read the program's OWN OUTPUT buffer: the result of step k
-    # becomes the input of step k+1 - state stays on-device, never re-fed from the host.
+    # alias state INPUT to the program's OWN OUTPUT buffer: step k's result feeds step k+1
     prog.share_buffer(0, out_name, 0, in_name)
 
     print("execute() repeatedly, feeding NOTHING - state accumulates on-device:")

--- a/examples/demos/roofline_bandwidth.py
+++ b/examples/demos/roofline_bandwidth.py
@@ -1,12 +1,4 @@
-"""DEMO: the ANE streaming-bandwidth ceiling - measured ~51 GB/s on M1.
-
-Reverse-engineering finding: an M=1 matmul reads each weight exactly once (no reuse), so it
-is bandwidth-bound. Measured ~51 GB/s at large sizes on M1 (~74% of the ~68 GB/s unified
-memory), which matches the compiler's OWN internal GetEngineBwGbPerS = 50 GB/s constant. This
-is the streaming regime weights fall into once they exceed on-chip (KMEM/L2) capacity.
-
-Run:  python3 examples/demos/roofline_bandwidth.py
-"""
+"""The ANE streaming-bandwidth ceiling: ~51 GB/s on M1. Run: python3 examples/demos/roofline_bandwidth.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/roofline_compute.py
+++ b/examples/demos/roofline_compute.py
@@ -1,13 +1,4 @@
-"""DEMO: the ANE fp16 compute ceiling - measured ~4.8 TFLOP/s on M1.
-
-Reverse-engineering finding: large, compute-bound matmuls (call time >> the ~0.2 ms floor)
-reach ~4.8 TFLOP/s fp16 on M1 (~87% of the ~5.5 theoretical). This is the "saturating"
-ceiling - higher than aneforge's dispatch-bound cost-model anchor (which is calibrated for
-small ops). Past ~4096-8192 dim the weight stream exceeds on-chip capacity and it goes
-bandwidth-bound (see roofline_bandwidth).
-
-Run:  python3 examples/demos/roofline_compute.py
-"""
+"""The ANE fp16 compute ceiling: ~4.8 TFLOP/s on M1. Run: python3 examples/demos/roofline_compute.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/single_in_flight.py
+++ b/examples/demos/single_in_flight.py
@@ -1,13 +1,4 @@
-"""DEMO: dispatch is single-in-flight per die - threads don't amortize one die.
-
-Reverse-engineering finding (kernel decode): the ANEScheduler dispatches one firmware
-command in-flight per die, so two threads submitting to the SAME die serialize (~1x). The
-multi-die load balancer (M1 Max/Ultra) does dynamic least-busy steering, but only within a
-program's eligible-die mask - so the real multi-die lever is making programs all-die-eligible.
-This demo shows the single-die serialization (sequential vs 2-thread ~= same wall time).
-
-Run:  python3 examples/demos/single_in_flight.py
-"""
+"""Dispatch is single-in-flight per die: threads don't amortize one die. Run: python3 examples/demos/single_in_flight.py"""
 import sys, time, threading, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/training_on_ane.py
+++ b/examples/demos/training_on_ane.py
@@ -1,12 +1,4 @@
-"""DEMO: training ON the ANE - forward, backward, and the optimizer all on-device.
-
-Exercises:
-  - af.parameter (trainable tensors) + af.mse loss
-  - af.Trainer(device_optimizer=True): forward + backward + the Adam update run on the ANE
-  - a real fit: recover a known linear map from data, watching the loss fall
-
-Run:  python3 examples/demos/training_on_ane.py
-"""
+"""Training on the ANE: forward, backward, and the optimizer all on-device. Run: python3 examples/demos/training_on_ane.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/vision_conv_encoder.py
+++ b/examples/demos/vision_conv_encoder.py
@@ -1,12 +1,4 @@
-"""DEMO: a small vision conv encoder fused into one ANE program.
-
-Exercises:
-  - a conv->relu->maxpool x2 -> global-avg-pool -> fc encoder, the ANE's home turf
-  - the whole stack fused into ONE program (one dispatch for the entire forward pass)
-  - correctness vs a numpy fp32 reference (cosine ~1)
-
-Run:  python3 examples/demos/vision_conv_encoder.py
-"""
+"""A small vision conv encoder fused into one ANE program. Run: python3 examples/demos/vision_conv_encoder.py"""
 import sys, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/weights_compression.py
+++ b/examples/demos/weights_compression.py
@@ -1,14 +1,4 @@
-"""DEMO: int8/compression is PER-CHIP gated - M1 folds it, M4+ streams it natively.
-
-Reverse-engineering finding: weight compression is gated by the hardware Compression Engine,
-which only arrives at M4. On M1 (h13) only int4-LUT streams natively; int8 and sparse FOLD to
-dequant-at-the-engine - so int8 is a weight-SIZE / bandwidth lever (half the weight bytes,
-helps bandwidth-bound layers), NOT a guaranteed compute speedup, and can even be slower on a
-compute-bound layer because of the dequant overhead. This demo measures it directly so you
-see the nuance rather than assuming int8 is always faster.
-
-Run:  python3 examples/demos/weights_compression.py
-"""
+"""int8/compression is per-chip gated: M1 folds it, M4+ streams it natively. Run: python3 examples/demos/weights_compression.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/demos/what_the_ane_is.py
+++ b/examples/demos/what_the_ane_is.py
@@ -1,15 +1,7 @@
-"""DEMO: what the ANE is - a real matrix engine you can target directly.
-
-Exercises:
-  - building a graph (af.input + matmul) and compiling it to ONE ANE program
-  - dispatching to real ANE silicon and checking the result against a numpy fp32 reference
-  - confirming the op runs natively on the ANE (af.device_status / af.is_native)
-
-Run:  python3 examples/demos/what_the_ane_is.py
-"""
+"""What the ANE is: a real matrix engine you can target directly. Run: python3 examples/demos/what_the_ane_is.py"""
 import sys, warnings
 from pathlib import Path
-sys.path.insert(0, str(Path(__file__).resolve().parents[1]))   # examples/ -> _common
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 import _common  # noqa: F401
 import numpy as np
 import aneforge as af

--- a/examples/demos/zero_copy_io.py
+++ b/examples/demos/zero_copy_io.py
@@ -1,13 +1,4 @@
-"""DEMO: zero-copy I/O views skip the per-call host<->device memcpy.
-
-Reverse-engineering finding: the kernel memcpys host data into the DART-mapped port buffer
-every call. Model.input_view()/output_view() expose that ANE-visible buffer as an fp16 numpy
-view, so a hot loop writes the input / reads the output IN PLACE. Removes the only host
-overhead aneforge can remove (the ~0.2 ms firmware floor still dominates tiny calls; the win
-scales with I/O size - measured ~30% faster per call on large I/O).
-
-Run:  python3 examples/demos/zero_copy_io.py
-"""
+"""Zero-copy I/O views skip the per-call host<->device memcpy. Run: python3 examples/demos/zero_copy_io.py"""
 import sys, time, warnings
 from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))

--- a/examples/eigenvalues_svd.py
+++ b/examples/eigenvalues_svd.py
@@ -1,15 +1,4 @@
-"""Eigenvalues and singular values on the ANE - the full spectral decompositions.
-
-The full symmetric eigendecomposition runs as fixed-sweep cyclic Jacobi, every
-rotation a fixed slice+combine - one unrolled program (caps near n=20), or with
-``eigh(iterate=True)`` one compiled sweep host-looped to reach n~48. On top of it:
-the full SVD (Jacobi on the Gram matrix), the generalized symmetric problem
-A x = lambda B x (LAPACK sygv: chol + trinv + eigh, composed on-engine), and the
-NONSYMMETRIC eigenvalues (LAPACK geev) as unrolled unshifted QR iteration. Top-k
-singular values of a large matrix use a randomized sketch - every step on-engine.
-
-    python3 examples/eigenvalues_svd.py
-"""
+"""Eigenvalues and singular values on the ANE: full eig/SVD, generalized eig, nonsymmetric eig, top-k. Run: python3 examples/eigenvalues_svd.py"""
 import sys
 
 from _common import head, f16, relerr, spd, general, sym   # sets env + repo-root path
@@ -26,8 +15,7 @@ def main():
     ev = eigh(f16(As))
     print(f"\n  eigh (all 8 eigenvalues)  relerr vs np.eigh  = {relerr(ev, np.sort(np.linalg.eigvalsh(As))):.2e}")
 
-    # iterate=True: ONE compiled sweep host-looped - same rotations, same result,
-    # but the per-sweep graph is O(n^2), so it scales past the unrolled cap (n~48).
+    # iterate=True: one compiled sweep host-looped, scales past the unrolled cap.
     evi = eigh(f16(As), iterate=True)
     print(f"  eigh(iterate=True)        relerr vs unrolled  = {relerr(evi, ev):.2e}   (reaches n~48)")
 

--- a/examples/factorize.py
+++ b/examples/factorize.py
@@ -1,13 +1,4 @@
-"""Direct factorizations on the ANE - QR / Cholesky / LU, plus pivoted LU.
-
-A direct factorization is a fixed recurrence: with no pivot there is no
-data-dependent branch, so the whole O(n^3) recurrence UNROLLS into one on-engine
-program (small-n - the graph caps QR/Cholesky/LU near n=32). Pivoted LU (LAPACK
-gesv) runs too, via a true on-engine argmax pivot - but the argmax is a bridge op,
-so the program is SEGMENTED (one graph cut per column) rather than fully fused.
-
-    python3 examples/factorize.py
-"""
+"""Direct factorizations on the ANE: QR / Cholesky / LU as unrolled recurrences, plus pivoted LU. Run: python3 examples/factorize.py"""
 import sys
 
 from _common import head, f16, relerr, spd, general   # sets env + repo-root path

--- a/examples/fft.py
+++ b/examples/fft.py
@@ -1,13 +1,4 @@
-"""FFT on the ANE - staged Cooley-Tukey as dense-DFT matmuls (sub-quadratic MACs).
-
-The ANE has no complex dtype and no butterfly primitive, but a radix-decomposed FFT
-is a chain of SMALL dense-DFT matmuls + elementwise twiddle multiplies (complex
-carried as real/imag pairs). aneforge.fft stages N = f1 x f2 x ... so the MAC count
-is N*sum(f) instead of the dense DFT's N^2 - sub-quadratic, 32-51x fewer MACs at
-N=2048 - and each transform compiles to one fused ANE program.
-
-    python3 examples/fft.py
-"""
+"""FFT on the ANE: staged Cooley-Tukey as dense-DFT matmuls (sub-quadratic MACs). Run: python3 examples/fft.py"""
 import sys
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/fluid_vorticity.py
+++ b/examples/fluid_vorticity.py
@@ -1,35 +1,4 @@
-"""aneforge flagship: a fluid simulation on the Apple Neural Engine.
-
-This solves the 2-D incompressible Navier-Stokes equations (vorticity-streamfunction
-form) on a periodic grid by the *pseudo-spectral* method, and every Fourier transform
-in the loop runs on the ANE as one fused e5rt program. A passive dye is painted as
-the word "ANEForge" and carried by the flow: it is legible at t=0, then a field of
-vortices stirs it into thin glowing filaments.
-
-    vorticity transport:  d(omega)/dt + (u . grad) omega = nu  * lap(omega)
-    dye    transport:     d(c)/dt     + (u . grad) c     = kap * lap(c)
-    velocity from vorticity: lap(psi) = -omega,  u = d(psi)/dy,  v = -d(psi)/dx
-
-Each timestep transforms between physical and Fourier space to take derivatives and
-form the advection terms; the FFTs are the entire compute core. `aneforge.fft`
-realizes each 2-D transform as eight real GEMMs (`F_M @ X @ F_N^T`) fused into ONE
-ANE program (the engine has no complex dtype, so values ride as real/imag pairs).
-The two transform programs are compiled ONCE and reused for every step. A high-order
-spectral filter (hyperviscosity) holds the enstrophy cascade at the grid scale.
-
-CAVEAT (fp16). The ANE computes in fp16. The dense DFT is unnormalized, so spectral
-coefficients at this 256-grid exceed fp16's range; the transforms are scaled by
-linearity (exact) to fit, see FWD/INV below. Advection is chaotic, so an fp16
-trajectory is its own slightly-perturbed flow. The point here is that it stays
-bounded (the hyperviscosity filter holds the grid-scale modes) and looks like the
-scalar mixing it is, not that it tracks an fp64 run step for step. The run is gated
-on staying finite and bounded, nothing more.
-
-    python3 examples/fluid_vorticity.py
-
-Writes docs/assets/fluid_vorticity.png as an APNG (the dye dissolving, animated,
-full 24-bit colour) if Pillow is installed; the simulation runs either way.
-"""
+"""aneforge flagship: 2-D pseudo-spectral Navier-Stokes with every FFT on the ANE, stirring "ANEForge" dye. Run: python3 examples/fluid_vorticity.py"""
 import sys
 import time
 from pathlib import Path
@@ -132,9 +101,7 @@ def main():
 
     ane_t = [0.0]   # seconds spent in ANE transforms (dispatch included)
 
-    # The dense DFT is unnormalized, so at N=256 the spectra pierce fp16 range. Both
-    # transforms are scaled by linearity (exact) to fit: the forward INPUT by an upper
-    # bound on its largest coefficient (sum of |field|), the inverse INPUT by its max.
+    # Scale both transforms by linearity (exact) to fit the unnormalized spectra into fp16.
     def FWD(field):
         c = max(1.0, float(np.abs(field).sum()) / 4.0e4)
         t = time.perf_counter(); r, i = fwd((field / c).astype(np.float32))
@@ -222,8 +189,7 @@ def main():
     return 0 if ok else 1
 
 
-# rendering                                                                   #
-
+# rendering
 def colormap(c):
     """Map a dye field in [0,1] to RGB via the perceptual inferno table. Flat (no
     fake lighting), so it reads like a scientific scalar field, not an oil slick."""

--- a/examples/gpt_generate_ane.py
+++ b/examples/gpt_generate_ane.py
@@ -1,27 +1,4 @@
-"""End-to-end autoregressive (GPT-style) text generation on the Apple Neural Engine.
-
-This runs the full decoder inference loop - prefill, KV-cache, per-step decode, greedy
-sampling - natively on the ANE. The attention is the ANE's native fused-attention layer:
-prefill uses CAUSAL sdpa, and each decode step uses the **KV-cache DECODE shape**
-(``af.sdpa`` with seq_q=1 query attending to the cached K/V of length seq_kv), which the
-native SDPA layer supports (the validator constrains only "K,V same seq" + "Q,K same embed").
-
-A single decoder block (RMSNorm -> multi-head attention -> residual -> RMSNorm -> SwiGLU ->
-residual). Two compiled graphs are reused every step:
-  - ``proj``  : x -> (k, v) projections, to grow the host-side KV cache.
-  - ``decode``: x + cached K/V -> next hidden state (the decode-shape attention + FFN).
-The decode graph is compiled per cache length (aneforge programs are fixed-shape); the e5rt
-compile cache makes repeat lengths cheap. Greedy ``argmax`` over an unembedding gives the next
-token. Validated to produce token-for-token identical output to a numpy reference (see
-tests/test_decoder_block.py::test_ane_generate_matches_numpy).
-
-``generate_resident`` goes one step further: the fixed-max KV-cache lives ON-DEVICE across
-steps via ``share_buffer`` (the masked positional write is in-graph and the cache output is
-aliased onto its own input), so the cache never round-trips through the host - re-stream-free
-decode, the host feeding only the token embedding + a tiny position one-hot/mask each step.
-The decode attention is decomposed there (matmul->softmax->matmul) so the whole step is one
-fused program (the resident-cache ``compile_multi`` path cannot take the native-SDPA graph cut).
-"""
+"""End-to-end GPT-style autoregressive generation on the ANE: prefill + KV-cache decode (host, fixed-max, and on-device resident)."""
 from __future__ import annotations
 import numpy as np
 import aneforge as af
@@ -106,9 +83,7 @@ class TinyDecoderANE:
         k, v, q = self._heads1(xn @ self.W["Wk"]), self._heads1(xn @ self.W["Wv"]), self._heads1(xn @ self.W["Wq"])
         Kout = Kin * inv + k * oh                  # masked write of this token's K/V at position p
         Vout = Vin * inv + v * oh
-        # decode-shape attention DECOMPOSED (matmul->softmax->matmul) so the whole step is ONE
-        # fused program: compile_multi (the resident-cache share_buffer path) cannot take the
-        # native-SDPA graph cut. seq_q=1 makes the decomposed attention cheap.
+        # decode-shape attention decomposed (matmul->softmax->matmul): one fused program.
         scores = ((q @ Kout.transpose([0, 2, 1])) * scale + mask).softmax(-1)   # [H,1,M]
         a = (scores @ Vout).reshape(H, 1, dh)                                        # [H,1,dh]
         h = x + a.transpose([1, 0, 2]).reshape(1, D) @ self.W["Wo"]

--- a/examples/gpt_multilayer_resident.py
+++ b/examples/gpt_multilayer_resident.py
@@ -1,14 +1,4 @@
-"""Multi-layer GPT decode on the Apple Neural Engine with EVERY layer's KV-cache resident.
-
-Extends the single-layer ``TinyDecoderANE.generate_resident`` (the zero-copy resident KV-cache crack)
-to an L-layer decoder: each layer keeps its own K/V cache resident on the ANE across decode steps via
-``share_buffer`` (output buffer aliased onto its own input), and writes the step's K/V with a masked
-positional update (``Kout = Kin*(1-oh) + k*oh``). The whole L-layer step is ONE fused program
-(``compile_multi`` over the final hidden state + every layer's K/V output port). The host feeds only
-the token embedding + a position one-hot + the attention mask each step - NONE of the 2L caches ever
-round-trips. Decode attention is decomposed (matmul->softmax->matmul) since ``compile_multi`` cannot
-take the native-SDPA netplist cut; for seq_q=1 that is cheap. Validated token-for-token vs numpy.
-"""
+"""Multi-layer GPT decode on the ANE with every layer's KV-cache resident on-device via share_buffer."""
 from __future__ import annotations
 import numpy as np
 import aneforge as af

--- a/examples/heat_equation.py
+++ b/examples/heat_equation.py
@@ -1,32 +1,4 @@
-"""aneforge PDE demo - a 2D heat equation evolved over many timesteps on the ANE.
-
-This is "the ANE solving a PDE over time". The 2D heat equation
-
-    du/dt = alpha * Laplacian(u)
-
-is integrated with the explicit (forward-Euler) scheme. One timestep is a single
-3x3 convolution with the stencil  K = I + r*[[0,1,0],[1,-4,1],[0,1,0]],  where
-r = alpha*dt/h^2 (kept at 0.2, inside the r<=0.25 stability bound for the 2D
-explicit scheme). The conv is the ANE's home turf.
-
-We compile the step ONCE into a single fused e5rt program, then loop host-side:
-each step evaluates the program on the ANE and feeds the output field back in as
-the next input. We evolve a hot-spot initial condition for many steps on a 64x64
-grid (Dirichlet u=0 boundary, enforced host-side after each conv), then validate
-the FINAL field against the SAME scheme run in fp32 numpy.
-
-CAVEAT: fp16 rounding COMPOUNDS over the timesteps - the ANE trajectory and the
-fp32 numpy trajectory are genuinely different sequences, so they drift a little per
-step. We report the relerr-vs-steps curve (it grows ~linearly: ~9e-3 at 50 steps,
-~1.9e-2 at 100) and confirm the scheme stays STABLE: the field stays BOUNDED (no
-fp16 blow-up) and the total heat stays near its initial value (this clamped-edge
-diffusion is heat-conserving in the interior; fp16 rounding adds a small positive
-bias of ~2%, NOT a divergence). That distinguishes fp16 compounding (a few %,
-bounded, grows linearly) from a bug (an unstable scheme blows up by orders of
-magnitude). The reference is the SAME explicit scheme with the fp32-exact stencil.
-
-    python3 examples/heat_equation.py
-"""
+"""aneforge PDE demo: explicit 2D heat equation as one fused conv stencil, looped over timesteps on the ANE. Run: python3 examples/heat_equation.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np
@@ -109,9 +81,7 @@ def main():
     u_ref = evolve_numpy(u0, Kfp32, STEPS)
     relerr = float(np.linalg.norm(u_ane - u_ref) / (np.linalg.norm(u_ref) + 1e-12))
 
-    # stability: the field must stay BOUNDED (no fp16 blow-up) and total heat must
-    # stay near its initial value (clamped-edge diffusion conserves interior heat;
-    # fp16 adds only a small positive bias).
+    # stability: field stays bounded and total heat stays near its initial value.
     bounded = bool(peak.max() <= 1.0 + 1e-3)          # max never exceeds the hot-spot
     blew_up = bool(peak.max() > 10.0)
     heat_drift = abs(heats[-1] - heat0) / heat0

--- a/examples/llama_block_causal.py
+++ b/examples/llama_block_causal.py
@@ -1,17 +1,4 @@
-"""A LLaMA-style decoder transformer block with NATIVE CAUSAL attention, on the ANE.
-
-This is the core compute of GPT/LLaMA inference - and the causal mask runs on the Apple
-Neural Engine's native fused-attention hardware (``af.sdpa(..., is_causal=True)``), not a
-host/GPU fallback. The block is the standard pre-norm LLaMA layer:
-
-    h   = x + Wo - causal_attn(rms_norm(x) -> Q,K,V)        # masked multi-head attention
-    out = h + SwiGLU(rms_norm(h))                          # SwiGLU FFN
-    SwiGLU(z) = (silu(z @ Wg) * (z @ Wu)) @ Wd
-
-Layout: ``[S, D]`` (sequence x model dim, batch folded out); heads are ``[H, S, dh]``; the
-causal SDPA runs as ``[1, H, S, dh]`` on the native layer. Validated to cos 1.0 vs a numpy
-causal reference (see tests/test_decoder_block.py).
-"""
+"""A pre-norm LLaMA-style decoder block with native causal attention (af.sdpa is_causal) on the ANE."""
 from __future__ import annotations
 import math
 import numpy as np

--- a/examples/make_mnist_subset.py
+++ b/examples/make_mnist_subset.py
@@ -1,15 +1,4 @@
-"""One-time: fetch MNIST and save a small subset for the on-ANE classifier
-demo/test. Run once: python examples/make_mnist_subset.py  (needs network + sklearn).
-
-The subset is 1000 train / 1000 test (equal sizes): a single forward-logits program
-at the N=1000 batch shape then serves BOTH the train loss and the test accuracy with
-no different-shape recompile (see the classifier plan, Task 5/7 scope).
-
-Provenance: sklearn `fetch_openml("mnist_784", version=1)`. If OpenML is unavailable,
-falls back to the `ossci-datasets` MNIST IDX mirror
-(https://ossci-datasets.s3.amazonaws.com/mnist/), decoding the IDX files directly and
-taking the same seed-0 permutation subset.
-"""
+"""One-time: fetch MNIST and save a 1000/1000 subset for the on-ANE classifier demo. Run: python examples/make_mnist_subset.py"""
 import gzip
 import struct
 from pathlib import Path

--- a/examples/native_geometry.py
+++ b/examples/native_geometry.py
@@ -1,15 +1,4 @@
-"""Native ANE geometry + matching ops - cross_product / cross_correlation /
-cost_volume / fps / radius_search.
-
-All are native hardware layers Apple's public MIL/CoreML pipeline never emits
-(CrossProduct, CrossCorrelation, CostVolume, FurthestPointSampling, RadiusSearch);
-each runs as a native-ANE netplist-bridge sub-program (a graph cut, like af.sdpa).
-FPS and radius_search are the point-cloud primitives - see examples/pointcloud.py
-for them composed into a PointNet++-style sample/group step. The bridges in
-aneforge/_bridges/ must be reachable on disk.
-
-    python3 examples/native_geometry.py
-"""
+"""Native ANE geometry/matching ops via netplist bridges: cross_product / cross_correlation / cost_volume / fps / radius_search. Run: python3 examples/native_geometry.py"""
 import sys
 
 from _common import report   # sets env + repo-root path; import before aneforge

--- a/examples/native_norms.py
+++ b/examples/native_norms.py
@@ -1,13 +1,4 @@
-"""Native ANE normalization ops - l2_norm / minmax_norm / lrn / scaled_elementwise.
-
-l2_norm fuses as plain e5rt MIL (reduce_l2_norm + real_div - no graph cut). The
-rest are native hardware layers Apple's public MIL/CoreML pipeline never emits
-(MinMaxNormalization, LocalResponseNormalization, ScaledElementWise); each runs
-as a netplist-bridge sub-program (a graph cut, like af.sdpa). The bridges in
-aneforge/_bridges/ must be reachable on disk.
-
-    python3 examples/native_norms.py
-"""
+"""Native ANE normalization ops: l2_norm (fused MIL) / minmax_norm / lrn / scaled_elementwise (bridges). Run: python3 examples/native_norms.py"""
 import sys
 
 from _common import report   # sets env + repo-root path; import before aneforge

--- a/examples/native_pixel_ops.py
+++ b/examples/native_pixel_ops.py
@@ -1,14 +1,4 @@
-"""Native ANE pixel-rearrange + layout ops - every lossless data-movement layer.
-
-pixel_shuffle / pixel_unshuffle fuse as plain e5rt MIL (no graph cut). The rest
-are native hardware layers Apple's public MIL/CoreML pipeline never emits
-(SpaceToChannel, ChannelToSpace, SpaceToBatch, BatchToSpace, Flatten, InputView,
-DynamicSlice); each runs as a netplist-bridge sub-program (a graph cut, like
-af.sdpa). Inputs are integer-valued fp16 so any mismatch is a true permutation
-error, not rounding. The bridges in aneforge/_bridges/ must be reachable on disk.
-
-    python3 examples/native_pixel_ops.py
-"""
+"""Native ANE pixel-rearrange + layout ops: pixel_shuffle/unshuffle (fused MIL) + space/channel/batch reshapes, flatten, slice (bridges). Run: python3 examples/native_pixel_ops.py"""
 import sys
 
 from _common import report   # sets env + repo-root path; import before aneforge

--- a/examples/native_ranking.py
+++ b/examples/native_ranking.py
@@ -1,13 +1,4 @@
-"""Native ANE ranking ops - sort / argmax / topk via netplist bridges.
-
-Order statistics are the classic "neural engines can't do that" ops. The ANE has
-native hardware layers for all three (Sort, GlobalArgMinMax, TopK) - Path-A layer
-kinds Apple's public MIL/CoreML pipeline never emits. aneforge surfaces them as
-graph ops; each runs as a native-ANE netplist-bridge sub-program (a graph cut,
-like af.sdpa). The bridges in aneforge/_bridges/ must be reachable on disk.
-
-    python3 examples/native_ranking.py
-"""
+"""Native ANE ranking ops via netplist bridges: sort / argmax / topk. Run: python3 examples/native_ranking.py"""
 import sys
 
 from _common import report   # sets env + repo-root path; import before aneforge

--- a/examples/nbody.py
+++ b/examples/nbody.py
@@ -1,29 +1,4 @@
-"""aneforge N-body demo - one gravitational force + integration step on the ANE.
-
-This is "an N-body step on the ANE". For N point masses we compute the pairwise
-inverse-square (gravity/Coulomb) acceleration via a broadcast outer-difference and a
-reduction - the kernel shape behind any N-body solver:
-
-    d_ij   = p_j - p_i                      # [N,N,3] broadcast outer difference
-    a_i    = G * sum_{j != i} m_j * d_ij / (|d_ij|^2 + eps)^(3/2)
-
-The self term j=i is removed by adding a large value on the diagonal of the squared
-distance (a folded constant mask), so 1/r^3 -> ~0 there. We then take ONE explicit
-leapfrog/Euler kick-drift step:  v += a*dt;  p += v*dt.
-
-The whole force computation (broadcast diff, squared distance, rsqrt^3, masked sum)
-is compiled into ONE fused e5rt program. We validate the resulting accelerations AND
-the advanced positions against the SAME computation in fp32 numpy.
-
-CAVEAT: 1/r^3 is fp16-sensitive when two bodies get close (the denominator is a
-small number raised to the 3/2 power), so we seed well-separated bodies and use a
-softening eps (standard in collisionless N-body) to keep r in fp16 range. With that,
-the accelerations match numpy to ~1e-2. The intermediate [N,N,3] grows O(N^2), so
-this is the small-N direct-summation regime (no tree/Barnes-Hut, which needs the
-data-dependent control flow the feed-forward ANE lacks).
-
-    python3 examples/nbody.py
-"""
+"""aneforge N-body demo: pairwise inverse-square force + one kick-drift step as one fused ANE program. Run: python3 examples/nbody.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np
@@ -91,9 +66,7 @@ def main():
     v1_ref = v0.astype(np.float32) + a_ref * DT
     p1_ref = p0.astype(np.float32) + v1_ref * DT
     p_relerr = float(np.linalg.norm(p1_ane - p1_ref) / np.linalg.norm(p1_ref))
-    # the displacement is the part that actually depends on the ANE accel (the
-    # advanced position is dominated by the identical fp16 p0, so its relerr is tiny
-    # by construction - report the velocity-update relerr too, which isolates accel).
+    # velocity-update relerr isolates the ANE accel (position is dominated by p0).
     v_relerr = float(np.linalg.norm(v1_ane - v1_ref) / np.linalg.norm(v1_ref))
     print(f"  updated-velocity relerr vs fp32 numpy:  {v_relerr:.3e} (isolates the accel)")
     print(f"  advanced-position relerr vs fp32 numpy: {p_relerr:.3e} (dominated by p0)")

--- a/examples/paired_fp16.py
+++ b/examples/paired_fp16.py
@@ -1,23 +1,4 @@
-"""Paired-fp16 ("double-fp16") on the ANE - extended precision, NO fp32 anywhere.
-
-Validates aneforge's ``af.paired`` / :class:`Paired` capability on-device (compile +
-run on the Apple Neural Engine via e5rt) against an fp32/fp64 numpy reference:
-
-  (1) CFG-style compensated SUBTRACT - two vectors whose true difference is a tiny
-      fraction of their magnitude (the SD-1.5 classifier-free-guidance case). When
-      the values arrive as paired-fp16 (carrying their sub-ulp lo), the compensated
-      subtract recovers the difference where plain fp16 is ~100%+ broken.
-
-  (2) Cancellation-heavy compensated DOT - a signed contraction whose true value is
-      small vs the product magnitudes. The compensated (TwoProduct + matmul-accum)
-      dot beats plain fp16.
-
-Each on-device number is checked against numpy-fp16 (proves the win is algorithmic,
-not a device artifact) AND against fp32 truth (proves the accuracy recovered). The
-demo also asserts the compiled MIL is fp16-only - no fp32 op sneaks in.
-
-    python3 examples/paired_fp16.py
-"""
+"""Paired-fp16 extended precision on the ANE (fp16-only): compensated subtract + cancellation-heavy dot. Run: python3 examples/paired_fp16.py"""
 import re
 import sys
 from pathlib import Path
@@ -32,7 +13,6 @@ f16 = np.float16
 
 
 # data generators (fp32/fp64 ONLY for reference + reporting)
-
 def make_cfg_pair(D, ratio, seed):
     """Two vectors whose TRUE difference is `ratio` * magnitude, returned as
     paired-fp16 (hi, lo) limbs plus the fp64 true difference."""
@@ -65,20 +45,16 @@ def make_downproj(K, cancel, seed):
 
 
 # fp16-only guard: the compiled MIL must declare/emit no fp32 type
-
 def assert_fp16_only(build_dir):
     mil = (Path(build_dir) / "model.mil").read_text()
     bad = sorted(set(re.findall(r"\b(?:fp32|float32)\b", mil)))
     if bad:
-        # `bias` weights are stored fp32 by the matmul emitter, but the paired graphs
-        # use raw `@ ones` with no bias, so any fp32 here is a real leak.
         raise AssertionError(f"fp32 leaked into the compiled MIL: {bad}")
     n_fp16 = len(re.findall(r"\bfp16\b", mil))
     return n_fp16
 
 
 # (1) compensated SUBTRACT - on device
-
 def demo_subtract():
     head("(1) CFG-style compensated SUBTRACT - paired-fp16 (hi,lo) inputs, on the ANE")
     print("    true diff = ratio * magnitude;  plain fp16 vs af.paired compensated subtract")
@@ -135,7 +111,6 @@ def _np_comp_sub(chi, clo, uhi, ulo):
 
 
 # (2) compensated DOT - on device
-
 def demo_dot():
     print()
     print("(2) Cancellation-heavy compensated DOT - TwoProduct + matmul-accum, on the ANE")
@@ -186,7 +161,6 @@ def demo_dot():
 
 
 # op-cost report
-
 def op_cost():
     print()
     head("OP COST (fp16 ops/element - counted from the compiled graph)")

--- a/examples/pointcloud.py
+++ b/examples/pointcloud.py
@@ -1,26 +1,4 @@
-"""ANE point-cloud demo - a PointNet++-style sample/group/geometry step.
-
-Runs three private ANE point-cloud primitives that no mainstream Python
-framework exposes on this hardware - all unentitled, no CoreML - wired into one
-PointNet++-style set-abstraction step:
-
-    1. FurthestPointSampling  (ane_fps_fused)            sample K centroids from N points
-    2. RadiusSearch           (ane_radius_search_fused)  membership in an L2 ball per centroid
-    3. CrossProduct           (ane_cross_product_fused)  surface normal from two edge vectors
-
-These layers aren't in the aneforge frontend yet, so the demo calls the in-package
-``aneforge._bridges`` modules directly. Each stage is validated against a numpy reference (exact for
-the integer-discretised FPS/RadiusSearch, fp16-tolerance for the cross product).
-
-Conventions worth stating:
-    * FPS is L2-only on this arch - the ``DistanceMetric`` netplist param is
-      ignored, so the reference uses Euclidean distance regardless. Seed = point 0.
-    * RadiusSearch returns a [points x centroids] uint8 membership matrix
-      (1 = inside the L2 ball); we transpose to [centroids x points] for grouping.
-
-    PYTHONPATH=. \\
-        python3 examples/pointcloud.py
-"""
+"""ANE point-cloud demo: a PointNet++-style FPS -> RadiusSearch -> CrossProduct step via bridges. Run: PYTHONPATH=. python3 examples/pointcloud.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np
@@ -54,8 +32,6 @@ def main():
           f"neighbors/centroid={nbrs.tolist()}")
 
     # Stage 3: CrossProduct on the ANE (surface normal per centroid)
-    # For each centroid, take two neighbor edge vectors and compute their cross
-    # product on the ANE -> an (unnormalised) surface normal.
     max_err, n_normals = 0.0, 0
     for j in range(K):
         members = np.flatnonzero(grp[j])

--- a/examples/poisson_spectral.py
+++ b/examples/poisson_spectral.py
@@ -1,26 +1,4 @@
-"""Spectral Poisson solver on the ANE - lap(u) = f on a periodic grid by the
-Fourier (pseudo-spectral) method, each 2-D FFT running as ONE fused ANE program.
-
-        f_hat = FFT2(f)                                    # one ANE program
-        u_hat = f_hat / -(kx^2 + ky^2),  DC mode -> 0      # spectral divide, host
-        u     = real(iFFT2(u_hat))                         # one ANE program
-
-``aneforge.fft.fft2`` exploits separability: the 2-D DFT is F_M @ X @ F_N^T, and a
-DFT of EVERY row of a matrix is a single complex matmul - so the whole transform is
-eight real GEMMs fused into one e5rt program (complex carried as real/imag pairs;
-the ANE has no complex dtype). This demo used to host-loop a 1-D plan over rows and
-columns: 128 dispatches per transform at a ~70us dispatch floor. Now it is 1.
-
-We use a MANUFACTURED solution: pick a smooth u_true (a sum of a few sinusoids),
-form f = lap(u_true) ANALYTICALLY, solve, and compare the recovered (zero-mean) u to
-the (zero-mean) u_true. We also verify the spectral Laplacian round-trip lap(u) ~ f.
-
-CAVEAT (fp16): the spectral method is exact in infinite precision, so the reported
-relerr is the fp16 transform/divide floor (a few x1e-3 at this grid), NOT a
-discretization error.
-
-    python3 examples/poisson_spectral.py
-"""
+"""Spectral Poisson solver on the ANE: lap(u)=f by the Fourier method, each 2-D FFT one fused ANE program. Run: python3 examples/poisson_spectral.py"""
 import sys
 import time
 
@@ -33,17 +11,15 @@ def spectral_poisson(N=64, L=2.0 * np.pi):
     """Solve lap(u)=f on a periodic [0,L)^2 grid by the Fourier method, the 2-D FFTs
     on the ANE (one fused program each). Manufactured solution -> reports relerr +
     the lap(u)~f spectral-residual check."""
-    # grid + manufactured smooth solution
+    # grid + manufactured smooth solution (periodic, zero-mean sinusoids)
     x = np.linspace(0.0, L, N, endpoint=False)
     X, Y = np.meshgrid(x, x, indexing="ij")
-    # u_true = sum of a few low sinusoids (periodic, smooth, zero-mean).
     u_true = (np.sin(X) * np.cos(2 * Y)
               + 0.5 * np.sin(3 * X) * np.sin(Y)
               + 0.3 * np.cos(2 * X) * np.cos(2 * Y))
     u_true -= u_true.mean()
 
     # analytic forcing f = lap(u_true)
-    # lap[sin(a x) g(b y)] etc - differentiate each term in closed form.
     f = (-(1 + 4) * np.sin(X) * np.cos(2 * Y)
          - (9 + 1) * 0.5 * np.sin(3 * X) * np.sin(Y)
          - (4 + 4) * 0.3 * np.cos(2 * X) * np.cos(2 * Y))
@@ -65,7 +41,6 @@ def spectral_poisson(N=64, L=2.0 * np.pi):
     err = relerr(u, u_true)
 
     # verify the spectral Laplacian round-trip lap(u) ~ f
-    # lap(u) via the SAME ANE FFTs: f_check = real(iFFT2( -(kx^2+ky^2) FFT2(u) )).
     cu_re, cu_im = agfft.fft2(u)
     lap_re = cu_re * denom; lap_im = cu_im * denom
     lap_re[0, 0] = 0.0; lap_im[0, 0] = 0.0
@@ -86,9 +61,7 @@ def main():
     print(f"    recovered u vs manufactured u_true (zero-mean):  relerr = {err:.3e}")
     print(f"    spectral Laplacian round-trip   lap(u) ~ f:      relerr = {lap_err:.3e}")
     print(f"    solve + verification wall time (4 transforms + compiles): {dt*1e3:.0f} ms")
-    # Headline accuracy is u vs u_true. The lap(u)~f check chains TWO EXTRA transforms
-    # on top of the already-fp16-recovered u, so its fp16 floor is looser (compounded
-    # transform rounding) - we hold it to <1e-1.
+    # lap(u)~f chains two extra transforms on u, so its fp16 floor is looser (<1e-1).
     ok = err < 5e-2 and lap_err < 1e-1
     print(f"    -> {'PASS' if ok else 'FAIL'}  (fp16 transform/divide floor; the method is "
           f"exact in exact arithmetic)")

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -1,13 +1,4 @@
-"""Worked examples for the aneforge frontend - a vision CNN and a transformer
-ENCODER block, each built with the clean API, compiled to ONE fused ANE program,
-and checked against a numpy fp32 reference.
-
-These double as the API's end-to-end tests. The encoder is the case the LLM
-*decoder* could never be: one forward, no autoregressive accumulation, error-
-tolerant output - squarely in the ANE's niche.
-
-    python3 examples/quickstart.py
-"""
+"""aneforge frontend worked examples: a vision CNN and a transformer encoder block, each fused to one ANE program. Run: python3 examples/quickstart.py"""
 from __future__ import annotations
 import sys
 

--- a/examples/rag_embeddings.py
+++ b/examples/rag_embeddings.py
@@ -1,14 +1,4 @@
-"""Use ANEForge embeddings in a RAG pipeline: a LangChain `Embeddings` adapter.
-
-The embedding model runs on the Apple Neural Engine - `af.load` fuses the encoder's
-transformer layers into one e5rt program - about 4-5x faster than the PyTorch GPU
-path on Apple Silicon, at ~9x lower energy, and cosine 1.0000 against the fp32
-reference. The adapter is a standard `langchain_core.embeddings.Embeddings`, so it
-drops into any LangChain retriever or vector store.
-
-    pip install "aneforge>=0.1.3" "transformers[torch]" langchain-core
-    python3 examples/rag_embeddings.py
-"""
+"""ANEForge embeddings as a LangChain `Embeddings` adapter for RAG, running on the ANE. Run: python3 examples/rag_embeddings.py"""
 from __future__ import annotations
 
 import numpy as np

--- a/examples/reaction_diffusion.py
+++ b/examples/reaction_diffusion.py
@@ -1,33 +1,4 @@
-"""aneforge showpiece: a reaction-diffusion system grown on the Apple Neural Engine.
-
-The Gray-Scott model is two chemicals diffusing and reacting on a periodic grid:
-
-    dU/dt = Du * lap(U) - U*V^2 + F*(1 - U)
-    dV/dt = Dv * lap(V) + U*V^2 - (F + k)*V
-
-U is fed in and consumed where V is present; V breeds on U and decays. For the
-right F (feed) and k (kill) the two settle into Turing patterns - coral, mazes,
-mitosis - the same mechanism that pigments seashells and animal coats. The word
-"ANEForge" is seeded as V and blooms into a branching labyrinth as it reacts.
-
-The whole update is ONE fused e5rt program: the Laplacian is a 3x3 stencil run as
-a native ANE conv, the reaction terms are elementwise ops in the same graph, and
-the periodic boundary is built in-graph by wrapping the field's own edges (so the
-pattern tiles without a seam). The program is compiled ONCE and re-dispatched every
-step; the host only shuttles the two fields in and out. Companion to the fluid
-demo (examples/fluid_vorticity.py): that solves a PDE spectrally (FFTs on the
-engine), this one with a real-space stencil (a conv on the engine).
-
-CAVEAT (fp16). The ANE computes in fp16, but the Gray-Scott fields live in [0, 1],
-so no range rescaling is needed (unlike the unnormalized spectral transforms in the
-fluid demo). The run is gated on the fields staying finite, in range, and forming
-structure.
-
-    python3 examples/reaction_diffusion.py
-
-Writes docs/assets/reaction_diffusion.png as an APNG (the pattern emerging, full
-24-bit colour) if Pillow is installed; the simulation runs either way.
-"""
+"""aneforge showpiece: Gray-Scott reaction-diffusion as one fused conv-stencil program per step on the ANE, growing "ANEForge" into Turing patterns. Run: python3 examples/reaction_diffusion.py"""
 import sys
 import time
 from pathlib import Path
@@ -188,8 +159,7 @@ def main():
     return 0 if ok else 1
 
 
-# rendering                                                                   #
-
+# rendering
 def colormap(c):
     vs = np.array([p[0] for p in _CMAP]); cs = np.array([p[1] for p in _CMAP], float)
     v = np.clip(c, 0.0, 1.0) ** 0.85

--- a/examples/resnet18.py
+++ b/examples/resnet18.py
@@ -1,12 +1,4 @@
-"""aneforge vision demo - torchvision ResNet-18 on the Apple Neural Engine.
-
-Loads ImageNet ResNet-18 (BatchNorm folded into conv at load), runs the whole
-network as ONE fused ANE program, and checks the logits against the torchvision
-fp32 reference. Conv is the ANE's strongest workload (3.8x faster, 9x more
-energy-efficient than the GPU).
-
-    python3 examples/resnet18.py
-"""
+"""torchvision ResNet-18 as one fused ANE program, validated vs fp32. Run: python3 examples/resnet18.py"""
 import sys
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/sd15.py
+++ b/examples/sd15.py
@@ -1,41 +1,4 @@
-"""Real Stable-Diffusion-1.5 text->image on the Apple Neural Engine (via aneforge).
-
-Runs the per-step UNet and (the front of) the VAE decoder on the ANE using REAL
-SD-1.5 weights (downloaded from the `stable-diffusion-v1-5/stable-diffusion-v1-5`
-checkpoint via diffusers), drives a host-side scheduler denoise loop with
-classifier-free guidance, decodes the final latent to a 512x512 PNG, and validates
-every component against the reference diffusers pipeline.
-
-What runs where:
-  - TEXT (host, torch): CLIP tokenize + text_encoder -> cond/uncond [1,77,768].
-    (CLIP-on-ANE is out of scope; one-time host cost.)
-  - UNET (ANE): the full UNet2DConditionModel forward built from real weights with
-    aneforge ops. The whole UNet compiles as ONE fused e5rt program (1349 ops);
-    group_norm runs at every UNet size now that it lowers with rank-4 tiling, so no
-    block falls back to host. A per-RESNET split (conv_in / each resnet+attn /
-    samplers, chained host-side via numpy) remains as a fallback if the single
-    program ever fails to compile. Run twice per step (cond + uncond).
-  - SCHEDULER (host): the pipeline's own scheduler.step + CFG combine.
-  - VAE (ANE, partial): the AutoencoderKL decoder runs on the ANE through the
-    512ch@128x128 block; only the final 128ch@512x512 up block + conv_out exceed the
-    ANE per-axis cap (max(C/groups, H*W) > 65536) and run on host torch. VAE decode
-    is once per image, so the host tail is minor.
-
-This is the heaviest aneforge demo. PER-COMPONENT validates on real weights (UNet
-one-step ~2.9% relerr, VAE decode ~4.4%, both <5%). The END-TO-END image, however,
-is fp16-degraded - the cause is CATASTROPHIC CANCELLATION in classifier-free
-guidance: cond-uncond is only a ~0.4% difference of two near-identical UNet outputs,
-so the per-output fp16 error (which does NOT cancel, because cond and uncond take
-different rounding paths through the deep net) swamps the guidance signal, then x7.5
-amplifies it. The saved PNG is a coherent-but-abstract blob, not a recognizable
-scene. Computing cond-uncond in-graph (before the fp16 export) does NOT help -
-measured zero improvement, since the error is from divergent internal rounding, not
-the export. The script reports the real per-component + end-to-end relerr and the
-CFG-cancellation diagnostic, and saves the actual image produced - no faked clean
-generation. There is no known fp16-safe form of this sampling loop on the ANE.
-
-    python3 examples/sd15.py
-"""
+"""Real SD-1.5 text->image: UNet + VAE front on the ANE, per-component validated (end-to-end fp16-degraded by CFG cancellation). Run: python3 examples/sd15.py"""
 import os
 import sys
 import time
@@ -96,29 +59,19 @@ def _unet_transformer(x, context, g, p, H):
     return af.conv(hh, g(p + ".proj_out.weight"), bias=g(p + ".proj_out.bias")) + res
 
 
-# UNet as a CHAIN of per-block e5rt programs.
-#   conv_in -> [down0 down1 down2 down3] -> mid -> [up0 up1 up2 up3] -> conv_out
-# Each builder takes aneforge input Tensors and returns the block output Tensor;
-# at run time we compile each once and feed numpy between them, carrying the skip
-# stack (verified vs diffusers: conv_in pushes 1; down0-2 push [r0,r1,downsamp];
-# down3 pushes [r0,r1] -> 12 total; each up block pops 3, resnet r concats
-# skips[2-r] because diffusers pops res_hidden_states_tuple[-1] first).
+# UNet as a chain of per-block e5rt programs, chained host-side via numpy.
 class UNetANE:
     def __init__(self, g, has):
         self.g, self.has = g, has
         self.progs = {}
-        # per-block input channel/resolution (from real SD-1.5 config)
         self.ch = {0: 320, 1: 640, 2: 1280, 3: 1280}
         self.hw = {0: 64, 1: 32, 2: 16, 3: 8}      # down block input HW
-        # up block: input channels/HW and the 3 skip channels it concats
         self.up_in_ch = {0: 1280, 1: 1280, 2: 1280, 3: 640}
         self.up_in_hw = {0: 8, 1: 16, 2: 32, 3: 64}
         # skip channels in PUSH order (res[-3:]); resnet r concats skips[2-r].
-        # verified vs diffusers down-block trace.
         self.up_skip_ch = {0: [1280, 1280, 1280], 1: [640, 1280, 1280],
                            2: [320, 640, 640], 3: [320, 320, 320]}
 
-    # block graph builders
     def _conv_in(self, x):
         g = self.g
         return af.conv(x, g("conv_in.weight"), pad=1, bias=g("conv_in.bias"))
@@ -212,7 +165,7 @@ def main():
     one_program = False
     try:
         tc = time.time()
-        # 1) attempt the WHOLE UNet as one e5rt program (expected to fail at SD-1.5 scale)
+        # attempt the whole UNet as one e5rt program
         ce = af.input((77, 768)); te = af.input((1, 1280)); xx = af.input((1, 4, 64, 64))
         h = unet_blocks._conv_in(xx)
         res = [h]
@@ -238,19 +191,13 @@ def main():
         with torch.no_grad():
             return unet.time_embedding(unet.time_proj(torch.as_tensor([int(t)])).float()).numpy()
 
-    # Per-RESNET ANE sub-programs (the split that actually compiles)
-    # Each down/up resnet (+ its transformer) and each downsampler/upsampler is one
-    # small e5rt program, chained host-side; the skip stack is carried as numpy.
-    # up3 (final CrossAttnUpBlock at 64x64) and conv_out hit the group_norm
-    # feature-map limit (>=640 ch @ 64x64 -> Espresso "Not implemented"), so they
-    # run on HOST torch - a real hardware boundary, not a numerics choice.
+    # Per-RESNET ANE sub-programs (the split that actually compiles); up3 + conv_out
+    # run on host torch (group_norm feature-map limit at >=640 ch @ 64x64).
     if not one_program:
         g, has = ug, uhas
         progs = {}
         unet_ops = 0
-        # compiled-program input order == af.input() creation order (graph idx). We
-        # therefore create each program's inputs in a FIXED order: x, then temb (if
-        # used), then context (if used), and call with the same positional order.
+        # input order == af.input() creation order: x, temb (if used), context (if used).
         def reg(name, xshape, builder, use_temb=False, use_ctx=False):
             x = af.input(xshape)
             te = af.input((1, 1280)) if use_temb else None
@@ -258,11 +205,9 @@ def main():
             net = af.compile(builder(x, te, ce))
             progs[name] = net
             return net.n_ops
-        # conv_in (x only)
         unet_ops += reg("conv_in", (1, 4, 64, 64),
                         lambda x, te, ce: af.conv(x, g("conv_in.weight"), pad=1, bias=g("conv_in.bias")))
-        # down blocks: per resnet(+attn) + downsampler.
-        # resnet input channels == its norm1.weight size (matches diffusers exactly).
+        # down blocks: per resnet(+attn) + downsampler
         for b in range(4):
             attn = has(f"down_blocks.{b}.attentions.0.proj_in.weight")
             H = unet_blocks.hw[b]
@@ -279,7 +224,6 @@ def main():
                 unet_ops += reg(f"d{b}_ds", (1, Cd, H, H),
                                 lambda x, te, ce, b=b: af.conv(x, g(f"down_blocks.{b}.downsamplers.0.conv.weight"),
                                                                stride=2, pad=1, bias=g(f"down_blocks.{b}.downsamplers.0.conv.bias")))
-        # mid (whole block fits one program; uses temb + context)
         unet_ops += reg("mid", (1, 1280, 8, 8),
                         lambda x, te, ce: unet_blocks._mid(x, te, ce), use_temb=True, use_ctx=True)
         # up blocks 0,1,2 on ANE (per resnet+attn, then upsampler); up3 -> host
@@ -306,7 +250,7 @@ def main():
 
     def run_unet(lat_np, t, ctx_np):
         if one_program:
-            # inputs were created as (ce, te, xx) = (context, temb, latent); match that order
+            # input order: (context, temb, latent)
             return unet_net(ctx_np, temb_of(t), lat_np)
         te = temb_of(t)
         P = progs
@@ -329,7 +273,7 @@ def main():
                 concat = np.concatenate([h, sk[2 - r]], axis=1)
                 h = P[f"u{b}_r{r}"](concat, te, ctx_np) if attn else P[f"u{b}_r{r}"](concat, te)
             h = P[f"u{b}_us"](h)
-        # up3 + conv_out on HOST torch (group_norm hardware limit at 64x64 / >=640 ch)
+        # up3 + conv_out on host torch
         sk = res[-3:]; res = res[:-3]
         with torch.no_grad():
             ht = torch.as_tensor(h, dtype=torch.float32)
@@ -346,7 +290,6 @@ def main():
             return unet(lat, torch.as_tensor([int(t)]), encoder_hidden_states=ctx).sample
 
     # VAE: ANE through 128x128, host for 256/512
-    # build ANE programs for post_quant->conv_in->mid->up0->up1 (all <=128x128).
     vsd = {k: v.detach().numpy().astype(np.float32) for k, v in vae.state_dict().items()}
     vg, vhas = (lambda k: vsd[k]), (lambda k: k in vsd)
 
@@ -369,8 +312,6 @@ def main():
         return x + o.reshape(1, H, W, C).transpose([0, 3, 1, 2])
 
     def vae_front(z):                            # post_quant -> conv_in -> mid -> up0
-        # mid + up0 resnets run at 64x64 (group_norm OK); up0's upsampler emits 128x128
-        # (plain conv, OK). up1 resnets at 128x128 hit the group_norm limit -> host.
         h = af.conv(z, vg("post_quant_conv.weight"), bias=vg("post_quant_conv.bias"))
         h = af.conv(h, vg("decoder.conv_in.weight"), pad=1, bias=vg("decoder.conv_in.bias"))
         h = vae_resnet(h, "decoder.mid_block.resnets.0")
@@ -400,7 +341,7 @@ def main():
             h = vae.decoder.conv_norm_out(h); h = vae.decoder.conv_act(h); h = vae.decoder.conv_out(h)
         return h.numpy()
 
-    # PER-COMPONENT validation (the real headline)
+    # PER-COMPONENT validation
     sched.set_timesteps(STEPS)
     t0 = sched.timesteps[0]
     gen = torch.Generator().manual_seed(SEED)
@@ -420,7 +361,7 @@ def main():
     print(f"  VAE decode  relerr    {vae_rel:.4f}   (ANE front <=128, host tail) "
           f"{'OK' if vae_rel < 0.05 else 'HIGH (fp16)'}")
 
-    # DENOISE LOOP (host scheduler, CFG, UNet on ANE)
+    # DENOISE LOOP (host scheduler + CFG, UNet on ANE)
     def denoise(unet_fn):
         sc = type(sched).from_config(sched.config)
         sc.set_timesteps(STEPS)
@@ -445,8 +386,6 @@ def main():
     lat_rel = relerr(lat_ane.numpy(), lat_ref.numpy())
 
     # Diagnose the CFG cancellation (why the image degrades)
-    # guided noise = uncond + g*(cond-uncond). |cond-uncond| is a TINY difference of
-    # two large near-identical UNet outputs, so the fp16 per-output error swamps it.
     nc_ane = run_unet(lat0.numpy(), t0, cond_np); nu_ane = run_unet(lat0.numpy(), t0, uncond_np)
     nc_ref = unet_torch(lat0, t0, cond).numpy(); nu_ref = unet_torch(lat0, t0, uncond).numpy()
     diff_ref = nc_ref - nu_ref

--- a/examples/sd_unet.py
+++ b/examples/sd_unet.py
@@ -1,13 +1,4 @@
-"""Full Stable-Diffusion UNet forward on the ANE - real diffusers weights.
-
-Builds the complete UNet2DConditionModel forward (conv_in -> down blocks -> mid ->
-up blocks with skip-concat -> conv_out) in aneforge from REAL diffusers weights,
-fuses it into one ANE program, and validates the output against diffusers.
-
-Tiny SD config (same architecture as SD-1.5, small weights for fast iteration).
-
-    python3 examples/sd_unet.py
-"""
+"""Full SD UNet2DConditionModel forward as one ANE program from real diffusers weights (tiny config), validated vs diffusers. Run: python3 examples/sd_unet.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np, torch

--- a/examples/sd_vae.py
+++ b/examples/sd_vae.py
@@ -1,15 +1,4 @@
-"""Stable-Diffusion VAE decoder on the ANE - real diffusers weights.
-
-Builds the AutoencoderKL decode path (post_quant_conv -> conv_in -> mid block
-[resnet, spatial self-attention, resnet] -> up blocks [resnets + nearest-upsample
-+ conv] -> group_norm + silu + conv_out) in aneforge, fuses it into one ANE
-program, and validates the decoded image against diffusers.
-
-The VAE is the missing half of a text->image pipeline (the UNet is in
-sd_unet.py). Tiny config, same architecture as SD-1.5.
-
-    python3 examples/sd_vae.py
-"""
+"""SD AutoencoderKL decoder as one ANE program from real diffusers weights (tiny config), validated vs diffusers. Run: python3 examples/sd_vae.py"""
 import sys
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/sdpa.py
+++ b/examples/sdpa.py
@@ -1,18 +1,4 @@
-"""Native fused attention on the ANE via aneforge's af.sdpa().
-
-af.sdpa(q, k, v) runs scaled-dot-product attention on the Apple Neural Engine's
-*native* fused-attention hardware layer (ANECSDPALayerDesc) - a path Apple's own
-user-space MIL compiler never emits (it always decomposes SDPA into matmul/softmax/
-matmul). aneforge reaches it, unentitled, via a graph-cut hybrid: the surrounding
-graph runs as e5rt program(s), the SDPA node runs as a separate native-SDPA ANE
-sub-program, tensors threaded between them.
-
-    python3 examples/sdpa.py
-
-Note: this is the correctness-first integration (host-array handoff, per-call
-netplist dispatch). A persistent IOSurface worker is the throughput follow-up.
-is_causal is unsupported - the native layer has no mask parameter.
-"""
+"""Native fused attention on the ANE via af.sdpa() (the hardware SDPA layer Apple's MIL compiler never emits). Run: python3 examples/sdpa.py"""
 import sys
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
@@ -38,9 +24,7 @@ def main():
     Q, K, V = (rng.standard_normal((1, H, S, D)).astype(np.float16) for _ in range(3))
     ok = []
 
-    # (1) standalone native SDPA. opt=0 pins the NATIVE layer (the point of this
-    # demo); the default opt='routes' cost model would rewrite short-S SDPA to the
-    # proven-equivalent fused decomposition, where it is faster.
+    # (1) standalone native SDPA; opt=0 pins the native layer (default would rewrite short-S to fused decomposition)
     net = af.compile(af.sdpa(af.input((1, H, S, D)), af.input((1, H, S, D)), af.input((1, H, S, D))), opt=0)
     out = net(Q, K, V)
     r = ref_sdpa(Q, K, V, scale)

--- a/examples/sentence_embeddings.py
+++ b/examples/sentence_embeddings.py
@@ -1,14 +1,4 @@
-"""aneforge embedding demo - a real sentence encoder on the ANE in ~5 lines.
-
-Loads all-MiniLM-L6-v2 (HF weights), runs the transformer layers on the Apple
-Neural Engine via the clean aneforge frontend, and does a tiny semantic search.
-
-Embeddings match the fp32 reference to cosine 1.0000 (fp16) / 0.9996 (int8) - the
-encoder is the case the LLM decoder could never be: one forward, no autoregressive
-accumulation, error-tolerant output, squarely in the ANE's niche.
-
-    python3 examples/sentence_embeddings.py
-"""
+"""all-MiniLM-L6-v2 sentence encoder on the ANE with a tiny semantic search, validated vs fp32. Run: python3 examples/sentence_embeddings.py"""
 import sys
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/sentence_transformers_ane.py
+++ b/examples/sentence_transformers_ane.py
@@ -1,14 +1,4 @@
-"""Drop-in sentence-transformers on the Apple Neural Engine.
-
-`aneforge.sentence_transformers.SentenceTransformer` mirrors the `.encode` surface
-of the sentence-transformers package, but runs the encoder on the ANE. It reads the
-model's own pooling config, so a mean-pooled model (MiniLM, E5) and a cls-pooled
-model (BGE, GTE) both produce the right vectors, matching the reference to cosine
-~1.0 at a fraction of the GPU's energy.
-
-    pip install "aneforge[models]"
-    python3 examples/sentence_transformers_ane.py
-"""
+"""Drop-in sentence-transformers SentenceTransformer running the encoder on the ANE. Run: python3 examples/sentence_transformers_ane.py"""
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np
 

--- a/examples/solve_linear_systems.py
+++ b/examples/solve_linear_systems.py
@@ -1,16 +1,4 @@
-"""Solve A x = b on the ANE - conjugate gradient, K iterations as ONE fused program.
-
-The ANE has no in-graph loop, but a FIXED-iteration Krylov solver is static dataflow:
-every GEMV and dot product of all K CG iterations unrolls into a single on-engine
-program (the matrix folds in as a constant, so the program size is iteration-bound,
-not n-bound - the same solve runs unchanged at n=512). GMRES (general systems) and
-LSQR (least squares) follow the same pattern; see aneforge.linalg.
-
-Envelope (docs/api/math.md): fp16, clean to ~1e-3 at cond 1e2, then the
-fp16 iterates stall.
-
-    python3 examples/solve_linear_systems.py
-"""
+"""Solve A x = b on the ANE: conjugate gradient, K iterations unrolled into one fused program. Run: python3 examples/solve_linear_systems.py"""
 import sys
 
 from _common import head, f16, relerr, spd   # sets env + repo-root path; import before aneforge

--- a/examples/spectral_analysis.py
+++ b/examples/spectral_analysis.py
@@ -1,31 +1,4 @@
-"""aneforge spectral demo - FFT-class spectral analysis of a real 1-D signal on the ANE.
-
-This is "FFT-class spectral analysis on the ANE". The Apple Neural Engine has no
-complex dtype (compute is fp16 real only), so we run the Discrete Fourier Transform
-as a TWIDDLE-MATRIX MATMUL with complex emulated as real/imag PAIRS:
-
-    X_k = sum_n x_n * exp(-2*pi*i*k*n/N) = x @ W^T,   W[k,n] = exp(-2*pi*i*k*n/N).
-
-For a real input x (imag part = 0):
-    Xr = x @ Wr^T,   Xi = x @ Wi^T,   magnitude = sqrt(Xr^2 + Xi^2)
-where Wr, Wi are the real/imag parts of the twiddle matrix, folded as fp16 weight
-constants. The two GEMMs + the squared-magnitude map fuse into ONE e5rt program.
-
-We analyze a synthetic signal - a sum of pure sinusoids plus a linear chirp - and:
-  1. compute its magnitude spectrum on the ANE, validate vs numpy.fft.rfft magnitude;
-  2. recover the planted tone frequencies from the ANE spectrum's peaks and check
-     they match the ground truth;
-  3. sweep N from 64 to 2048 and print the relerr-vs-N curve - demonstrating the
-     "wide accumulator" finding: the length-N twiddle sum is accumulated in >=fp32,
-     so fp16 rounding does NOT compound with N and the spectrum stays fp16-CLEAN.
-
-CAVEAT: this is the NAIVE O(N^2) DFT (a dense twiddle matmul), not an O(N log N)
-FFT - the cost is the quadratic twiddle-matrix size/bandwidth, NOT precision. The
-relerr stays ~3e-4..1e-3 FLAT in N (it does not grow), so fp16 is not the wall for
-the transform. The reference is numpy's exact fft over the same fp16-rounded signal.
-
-    python3 examples/spectral_analysis.py
-"""
+"""FFT-class spectral analysis on the ANE: real-input DFT as a twiddle-matrix matmul (real/imag pairs), fused into one program and validated vs numpy.fft. Run: python3 examples/spectral_analysis.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np
@@ -33,29 +6,20 @@ import aneforge as af
 
 
 def make_signal(N, fs):
-    """A real signal: three pure tones + a linear chirp, on a length-N grid.
-    Returns (signal fp16, list of planted tone freqs in Hz)."""
+    """Real signal: three pure tones + a faint linear chirp. Returns (signal fp16, tone freqs)."""
     t = np.arange(N) / fs
     tones = [60.0, 180.0, 350.0]          # Hz - three clean spectral lines
     x = np.zeros(N, np.float32)
     for f in tones:
         x += np.sin(2 * np.pi * f * t)
-    # a faint linear chirp 400 -> 480 Hz (broadband, fills in the spectrum)
-    x += 0.4 * np.sin(2 * np.pi * (400 * t + 0.5 * 40.0 * t * t))
+    x += 0.4 * np.sin(2 * np.pi * (400 * t + 0.5 * 40.0 * t * t))   # chirp 400->480 Hz
     x /= np.abs(x).max()                  # normalize into fp16 range
     return x.astype(np.float16), tones
 
 
 def dft_program(N):
-    """Compile the real-input DFT magnitude spectrum as ONE fused ANE program.
-    Folds the fp16 twiddle matrices Wr, Wi as constant weights.
-
-    The twiddles carry a 1/sqrt(N) NORMALIZATION (the standard unitary DFT scaling).
-    This is not cosmetic: without it the peak |X_k| grows ~amplitude*N/2, so at
-    N=2048 the SQUARED intermediate Xr^2+Xi^2 (~1.2e5) OVERFLOWS fp16's 65504 max
-    and the spectrum becomes inf. The unitary normalization keeps the magnitude AND
-    its square comfortably in fp16 range at every N - a real fp16 dynamic-range
-    note (the wall here is fp16's max value, not its precision)."""
+    """Real-input DFT magnitude spectrum as one fused ANE program; twiddles folded as fp16
+    constants with a 1/sqrt(N) unitary normalization (keeps Xr^2+Xi^2 within fp16 range)."""
     n = np.arange(N)
     k = n.reshape(-1, 1)
     W = np.exp(-2j * np.pi * k * n / N) / np.sqrt(N)  # unitary [N,N] DFT matrix

--- a/examples/superres_espcn.py
+++ b/examples/superres_espcn.py
@@ -1,14 +1,4 @@
-"""aneforge super-resolution demo - ESPCN sub-pixel upscaler on the Apple Neural Engine.
-
-A small ESPCN-style super-resolution network - three convs with ReLU feature
-extractors followed by a sub-pixel convolution that upscales by ``r`` via
-``af.pixel_shuffle`` (depth-to-space). The whole network, including the
-PixelShuffle, fuses into ONE e5rt program: PixelShuffle runs as fused e5rt-MIL,
-so there is no graph cut. Output is validated against a numpy reference of the
-same forward pass (relative L2 error).
-
-    python3 examples/superres_espcn.py
-"""
+"""ESPCN sub-pixel super-resolution (3 convs + pixel_shuffle) fused into one ANE program, validated vs numpy. Run: python3 examples/superres_espcn.py"""
 import sys
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/train_charlm.py
+++ b/examples/train_charlm.py
@@ -1,20 +1,4 @@
-"""Train a multi-layer character-level language model on the Apple Neural Engine - a 4-layer causal LLaMA-style transformer, forward AND backward AND the optimizer step
-all on the engine, then generate from it.
-
-This is the "at scale" training demonstration: not a single block but a stacked,
-causally-masked transformer with token and positional embeddings, RMSNorm + SwiGLU
-blocks, a tied-shape output projection, and a next-token cross-entropy objective. Every
-parameter trains on the ANE, including the RMSNorm gains.
-
-Two notes on what makes this fit the engine's reachable surface:
-  - Token embedding is a one-hot matmul (`onehot @ W_emb`), not a `gather`: the
-    embedding gradient is then an ordinary matmul gradient, sidestepping the gather/
-    scatter wall while being mathematically identical to a lookup.
-  - Causal masking is an additive bias (a fixed upper-triangular `-1e4` matrix) added to
-    the attention scores before softmax, so position i attends only to positions <= i.
-
-    python3 examples/train_charlm.py
-"""
+"""Train a 4-layer causal LLaMA-style char-LM on the ANE (forward + backward + optimizer) and generate from it. Run: python3 examples/train_charlm.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np
@@ -81,16 +65,12 @@ def main():
     lf = tr.loss()
     print(f"\ncross-entropy {l0:.4f} -> {lf:.4f}; the model trained end to end on the engine")
 
-    # Next-token accuracy on the training window (the trained logits, argmax per position).
+    # Next-token accuracy on the training window
     logit = np.asarray(tr._fwd(*tr._feed(tr._fwd)))
     acc = float((logit.argmax(-1) == ids[1:S + 1]).mean())
     print(f"next-char accuracy over the {S} positions: {acc*100:.1f}%")
 
-    # Greedy autoregressive generation. The model uses absolute positional embeddings
-    # over a fixed S-position context, so generation reconstructs the sequence at its
-    # true positions: place the prefix at positions 0..k-1, right-pad, and read the
-    # logit at the last real position (which predicts the next character). Reuses the
-    # trained forward program by feeding each window through its `x` input.
+    # Greedy autoregressive generation: prefix at positions 0..k-1, right-pad, read last real position.
     def generate(seed):
         buf = [stoi[c] for c in seed]
         while len(buf) < S:

--- a/examples/train_charlm_corpus.py
+++ b/examples/train_charlm_corpus.py
@@ -1,19 +1,4 @@
-"""Train a character-level language model on a corpus on the Apple Neural Engine, and
-show it GENERALIZES - held-out next-character accuracy well above the unigram baseline,
-not memorization of a single window.
-
-This is the data-scale companion to `train_charlm.py` (which overfits one window as a
-sanity check). Here the 4-layer causal LLaMA-style model trains on random windows drawn
-from the training split of a structured corpus and is evaluated on a disjoint validation
-split it never trains on. Forward, backward, and the optimizer step all run on the engine.
-
-Same reachable-surface choices as `train_charlm.py`: one-hot matmul embedding (the
-embedding gradient is then a matmul gradient, sidestepping the gather/scatter wall), and
-an additive causal mask before softmax. Each window is re-based to absolute positions
-0..S-1, so the learned positional embeddings apply to every sampled window.
-
-    python3 examples/train_charlm_corpus.py
-"""
+"""Train a char-LM on a corpus on the ANE and show it generalizes (held-out accuracy above the unigram baseline). Run: python3 examples/train_charlm_corpus.py"""
 import sys
 from collections import Counter
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
@@ -26,9 +11,7 @@ STEPS, LR = 600, 0.003
 
 
 def make_corpus(rng):
-    # a small structured grammar: "the <animal> <verb> <adverb>." The word choices are
-    # random, so the model cannot memorize a single sequence; it must learn the grammar
-    # to predict the deterministic parts (articles, spaces, word completions, period).
+    # structured grammar "the <animal> <verb> <adverb>." with random word choices
     animals, verbs, advs = ["cat", "dog", "bird"], ["runs", "jumps", "sleeps"], ["fast", "slow"]
     out = []
     for _ in range(120):

--- a/examples/train_charlm_deep.py
+++ b/examples/train_charlm_deep.py
@@ -1,20 +1,4 @@
-"""Train a DEEP character-level language model on the Apple Neural Engine using a
-layer-streamed (gradient-checkpointed) compile, so depth is not bounded by compile size.
-
-`train_charlm.py` fuses the whole model's forward + backward + optimizer into one e5rt
-program, where compile time grows superlinearly with depth (about 9s/37s/84s/162s for
-2/4/6/8 layers). Here the identical transformer layers are compiled ONCE and reused for
-every layer via `aneforge.streaming.CheckpointedStack`, so the layer stack's compile cost
-is constant in depth. This trains a 16-layer model whose monolithic compile would be
-impractical, with forward, backward, and the optimizer all on the engine.
-
-The stack handles the repeated layers; the embedding and output stages are each compiled
-once (forward plus a `backward_from` gradient program). Cross-entropy and its gradient at
-the logits are computed host-side. Token embedding is a one-hot matmul (no `gather`), and
-causal masking is an additive bias the stack carries as a baked constant.
-
-    python3 examples/train_charlm_deep.py
-"""
+"""Train a deep (16-layer) char-LM on the ANE with a layer-streamed (gradient-checkpointed) compile, so depth doesn't bound compile size. Run: python3 examples/train_charlm_deep.py"""
 import sys
 import time
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/train_cifar_cnn.py
+++ b/examples/train_cifar_cnn.py
@@ -1,17 +1,4 @@
-"""Train a real CNN on CIFAR-10 ENTIRELY on the Apple Neural Engine, and compare to
-a PyTorch model with the same layer topology (same conv/GroupNorm/pool/fc shapes
-and Adam). The comparison is close but not exact: the ANE convs have no bias and
-use He-normal init, while torch's nn.Conv2d adds a bias and uses its default
-Kaiming-uniform init - so expect the curves to track, not coincide.
-
-  conv(pad=1)->GroupNorm->ReLU->maxpool  x2,  then conv->GroupNorm->ReLU,
-  global-avg-pool, fc.  forward + backward + Adam all run on the ANE
-  (device_optimizer=True); the host only feeds mini-batches and the scalar lr_t.
-  Includes a cosine LR schedule, periodic eval, and a checkpoint of the trained
-  params.
-
-  python3 examples/train_cifar_cnn.py
-"""
+"""Train a CNN on CIFAR-10 entirely on the ANE (forward + backward + Adam, device_optimizer) vs a same-topology torch reference. Run: python3 examples/train_cifar_cnn.py"""
 import math, sys, time
 from pathlib import Path
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
@@ -71,8 +58,7 @@ def main():
     print(f"\nANE final test accuracy {ane_acc:.4f}  ({STEPS} steps, {dt:.1f}s)")
     print(f"checkpoint saved to {CKPT}")
 
-    # --- torch reference: same layer topology + Adam (note: torch convs add a bias
-    # and use default Kaiming-uniform init; the ANE model has no conv bias + He-normal) ---
+    # torch reference: same layer topology + Adam (torch convs add bias + Kaiming-uniform; ANE has neither)
     try:
         import torch, torch.nn as nn, torch.nn.functional as F
     except ImportError:

--- a/examples/train_llama_block.py
+++ b/examples/train_llama_block.py
@@ -1,18 +1,4 @@
-"""Train a LLaMA-style transformer block on the Apple Neural Engine - RMSNorm
-pre-normalization and a SwiGLU feed-forward, forward AND backward on the engine.
-
-This exercises the two gradients that modern LLM blocks depend on and that previously
-had no backward rule: `rms_norm` and `silu` (the SwiGLU gate). The gradient flows
-through both to the trainable attention projections and the three SwiGLU weights, and
-the block converges. The RMSNorm affine (gamma) is held at its unit initialization - the norm VJP differentiates the input, not the affine.
-
-The block is the standard LLaMA layer: ``h = x + attn(rms_norm(x))`` then
-``out = h + swiglu(rms_norm(h))`` where ``swiglu(z) = (silu(z @ Wg) * (z @ Wu)) @ Wd``.
-The RMSNorm gains are trainable parameters: passing a parameter Tensor for gamma
-composes the normalize op with a learnable scale, so the gains learn too.
-
-    python3 examples/train_llama_block.py
-"""
+"""Train a LLaMA-style block (RMSNorm pre-norm + SwiGLU) on the ANE, forward + backward including the rms_norm/silu gradients. Run: python3 examples/train_llama_block.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np

--- a/examples/train_mnist_cnn.py
+++ b/examples/train_mnist_cnn.py
@@ -1,14 +1,4 @@
-"""Train a small CNN on MNIST FULLY on the Apple Neural Engine - conv + relu + avg_pool
-+ fc + softmax-CE, forward + backward + Adam, with K steps UNROLLED into ONE program.
-
-Same fully-on-engine story as the MLP (examples/train_mnist_mlp.py) but with a
-TRAINABLE conv: the native ANE conv needs a baked weight, so `af.conv2d`/`af.conv_param`
-build the conv from primitives (static im2col + batched matmul), giving a weight gradient
-that runs on the engine. `af.UnrolledTrainer` unrolls K steps into one dispatch; the conv
-weight's `conv_shape` is carried across each in-graph optimizer update automatically.
-
-    python3 examples/train_mnist_cnn.py
-"""
+"""Train a CNN on MNIST fully on the ANE with a trainable conv, K steps unrolled into one program. Run: python3 examples/train_mnist_cnn.py"""
 import sys, time
 from pathlib import Path
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/train_mnist_mlp.py
+++ b/examples/train_mnist_mlp.py
@@ -1,17 +1,4 @@
-"""Train an MNIST MLP FULLY on the Apple Neural Engine - forward, backward, and the
-Adam optimizer, with K steps UNROLLED into ONE fused program.
-
-ResNet *inference* already runs as one fused ANE program (examples/resnet18.py).
-Training is the part that used to run a HOST loop (one dispatch per step). Because a
-fixed number of steps has no data-dependent control flow, the whole forward -> backward
--> Adam-update recurrence unrolls into a single graph (the same trick as the iterative
-solvers in aneforge.linalg). `af.UnrolledTrainer` builds it: each `step()` runs K steps
-in ONE dispatch on the engine; the host feeds K minibatches + the per-step learning
-rates and shuttles weight/optimizer arrays between K-step blocks (an array move, no host
-tensor-math, no per-step round-trip).
-
-    python3 examples/train_mnist_mlp.py
-"""
+"""Train an MNIST MLP fully on the ANE (forward + backward + Adam), K steps unrolled into one fused program. Run: python3 examples/train_mnist_mlp.py"""
 import sys, time
 from pathlib import Path
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge

--- a/examples/train_neural_ca.py
+++ b/examples/train_neural_ca.py
@@ -1,39 +1,4 @@
-"""aneforge flagship: a neural cellular automaton TRAINED on the Apple Neural Engine.
-
-Growing Neural Cellular Automata (Mordvintsev et al., Distill 2020): one small
-per-cell update rule - a CNN shared across every cell and every step - is trained
-so that, from a single live seed pixel, repeated application of the rule grows a
-target image. It is morphogenesis as a learned local rule.
-
-The learning runs on the engine. Each training step rolls the rule forward T times,
-takes the MSE of the grown image to the target, and backpropagates through the whole
-rollout - and every one of those forward and backward steps is a compiled ANE
-program. The rollout is gradient-checkpointed (`aneforge.streaming.CheckpointedStack`):
-the per-step forward and the per-step backward each compile ONCE and stream over the T
-steps, so the rollout's depth does not bound the compile and the grid can be larger
-than a single fused forward+backward+Adam program would allow. The optimizer (Adam)
-runs host-side over the streamed gradients, the same path as `train_charlm_deep.py`.
-The trained rule is then dispatched step by step to grow the image, again on the engine.
-
-The rule, per cell, per step:
-  1. perceive   - a fixed depthwise [identity, Sobel_x, Sobel_y] stencil, periodic
-                  (wrap) padding built from slices of the state itself;
-  2. a 1x1 conv (-> 128) + ReLU, then a 1x1 conv (-> C) initialised to ZERO so the
-     initial update is a no-op (the dynamics start as the identity and stay stable);
-  3. an alive mask: a cell updates only if it or a neighbour is alive (alpha > 0.1),
-     computed as a 3x3 box conv of alpha so growth can spread into empty cells;
-  4. residual: state += update * alive.
-
-Two simplifications from the paper, both for a clean on-engine graph: the per-cell
-stochastic update is dropped (deterministic updates), and the alive mask uses a
-differentiable box-conv-and-sigmoid rather than a max-pool (whose overlapping backward
-is not on the engine).
-
-    python3 examples/train_neural_ca.py
-
-Writes docs/assets/neural_ca.png as an APNG (the image growing from the seed, full
-24-bit colour) if Pillow is installed; training runs either way.
-"""
+"""Growing Neural Cellular Automata (Mordvintsev et al., Distill 2020) trained on the ANE: a per-cell CNN rule grown from a seed via a gradient-checkpointed rollout (forward + backward on-engine, Adam host-side). Writes docs/assets/neural_ca.png if Pillow is present. Run: python3 examples/train_neural_ca.py"""
 import sys
 import time
 from pathlib import Path
@@ -98,10 +63,7 @@ _BOX = af.conv_param(np.ones((1, 1, 3, 3), np.float32))
 
 
 def layer_fn(params, x):
-    """One CA step as a graph builder (the `CheckpointedStack` layer). `params` are
-    the trainable 1x1-conv weights as flat conv tensors; the fixed perception and box
-    convs are module constants. Stamping `conv_shape` lets `conv2d` consume the stack's
-    plain parameter leaves as 1x1 conv weights."""
+    """One CA step as a CheckpointedStack layer builder; conv_shape stamps let conv2d treat the param leaves as 1x1 weights."""
     W1, b1, W2, b2 = params
     W1.attrs["conv_shape"] = (128, 3 * C, 1, 1)
     W2.attrs["conv_shape"] = (C, 128, 1, 1)
@@ -282,8 +244,7 @@ def render(frames, total_energy):
     ims = []
     for i, c in enumerate(frames):
         rgb = (np.clip(c, 0, 1) * 255).astype(np.uint8)
-        # crisp nearest-neighbour upscale: a cellular automaton's cells are the point,
-        # so show them as clean squares rather than blurring up from the grid.
+        # crisp nearest-neighbour upscale: show cells as clean squares
         im = Image.fromarray(rgb).resize((ANIM_SIZE, ANIM_SIZE), Image.NEAREST)
         e = total_energy * min(1.0, i / max(1, len(frames) - 1))
         ims.append(telemetry(im, e))

--- a/examples/train_transformer.py
+++ b/examples/train_transformer.py
@@ -1,21 +1,4 @@
-"""Train a transformer block (multi-head self-attention + residual + MLP) FULLY on the
-Apple Neural Engine, with K Adam steps UNROLLED into ONE fused program.
-
-Attention is differentiable end to end on the engine - the gradient flows through
-softmax, the batched score/value matmuls, and the head split/merge transposes, all of
-which have vjps. The projections are trainable `af.parameter` weights (not `af.mha`,
-which bakes const weights). The task is a fixed full-batch sequence regression, so this
-uses the `af.adam_step` helper to unroll the steps directly (the minibatch
-`af.UnrolledTrainer` fits the classification demos; this one trains one sequence).
-
-Because the data is full-batch (fixed), this goes one step further than the classifier
-demos: the data, the learning rate, AND the optimizer state all live on-device, so after
-seeding once the training loop is just `prog.execute()` - the host feeds NOTHING per
-dispatch (non-aliased input buffers persist across execute; state is share_buffer-aliased
-output->input). The host's only per-dispatch action is issuing the dispatch itself.
-
-    python3 examples/train_transformer.py
-"""
+"""Train a transformer block (MHA + residual + MLP) fully on the ANE with K Adam steps unrolled into one program; data + lr + optimizer state all resident on-device, so the loop is just prog.execute(). Run: python3 examples/train_transformer.py"""
 import sys
 from _common import f16   # sets env + repo-root path; import before aneforge
 import numpy as np
@@ -67,14 +50,7 @@ def main():
     inm = {id(t): n for t, n in net.input_ports}
     om = dict(net.output_ports)
 
-    # SEED ONCE, then the host does nothing but press "go". Everything the program
-    # needs lives on-device across dispatches:
-    #   - optimizer state (params, m, v): each updated output is share_buffer-aliased
-    #     onto its own input port (resident across dispatches), seeded once;
-    #   - the fixed full-batch data (x, y) and the learning rate: plain inputs SET ONCE
-    # - non-aliased input buffers persist across execute(), so they need no re-feed.
-    # (Full-batch is what makes this host-free: a shuffled MINIBATCH would change each
-    # step, so its data would be the one thing the host must still feed.)
+    # Seed once: optimizer state is share_buffer-aliased output->input; data + lr are plain inputs set once.
     for out_t, in_t in (list(zip(P, P0)) + list(zip(M, m_in)) + list(zip(V, v_in))):
         prog.share_buffer(0, om[out_t], 0, inm[id(in_t)])
     for p, mi, vi in zip(P0, m_in, v_in):

--- a/examples/train_transformer_prenorm.py
+++ b/examples/train_transformer_prenorm.py
@@ -1,17 +1,4 @@
-"""Train a PRE-NORM transformer block on the Apple Neural Engine, with LayerNorm
-applied before attention and before the MLP - forward AND backward on the engine.
-
-This is the end-to-end demonstration that LayerNorm no longer blocks training: the
-gradient flows through `layer_norm` to the trainable attention projections and MLP
-weights, and the block converges. The LayerNorm affine here is also trainable: passing
-parameter Tensors for gamma/beta composes the normalize op with a learnable scale and
-shift, so the norm's own affine learns alongside the projections.
-
-Compare with `train_transformer.py`, which trains the same shape with plain residual
-additions and no normalization.
-
-    python3 examples/train_transformer_prenorm.py
-"""
+"""Train a pre-norm transformer block (LayerNorm before attention + MLP) on the ANE, forward + backward including the layer_norm gradient and trainable affine. Run: python3 examples/train_transformer_prenorm.py"""
 import sys
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
 import numpy as np

--- a/examples/vit.py
+++ b/examples/vit.py
@@ -1,34 +1,4 @@
-"""Vision Transformer (ViT-B/16) forward on the Apple Neural Engine via aneforge.
-
-Builds the full ViT encoder forward (patch-embed conv -> CLS token + positional
-embedding -> N pre-norm transformer blocks -> final layer_norm -> classifier head)
-in aneforge from REAL torchvision pretrained weights, fuses it into ONE e5rt program,
-and validates the 1000-way logits against the torchvision fp32 reference (logit
-cosine + top-k). ViT is squarely in the ANE's niche: a single encoder forward, no
-autoregressive accumulation; conv + attention + matmul are the workloads it wins.
-
-The optimizer tie-in: ViT attention is the natural target for aneforge's lossless
-SDPA *route rewrite*. We rebuild one real ViT attention layer (q/k/v proj ->
-af.sdpa -> out-proj) and run af.tune on it. The tuner enumerates the legal
-variants (native fused-attention layer vs decomposed matmul/softmax/matmul),
-MEASURES them on the ANE, VALIDATES each is faithful to the opt=0 baseline, and
-returns the fastest CORRECT one. We report opt=0 vs tune latency, the route the
-tuner chose, and the maxdiff (lossless route -> ~0).
-
-WEIGHT SOURCE / CONFIG: torchvision.models.vit_b_16 IMAGENET1K_V1 (12 layers x
-768 dim x 12 heads, patch 16, 224x224 -> 197 tokens, 1000 classes; ~86M params).
-We attempt the full 12-layer model as a single fused program first; if that is too
-large to compile as one e5rt program, we fall back to the first K layers and
-validate against a torch forward truncated to the SAME K layers (real pretrained
-weights either way - never random, never faked). The chosen path is printed.
-
-The CLS token and per-position positional embedding are constants of the model;
-aneforge has no constant-tensor literal op, so we feed them as two extra graph
-inputs (fed the fixed pretrained arrays at every call) - the cheapest legal route
-(an alternative, building them with ~200 row constants, balloons the op count).
-
-    python3 examples/vit.py
-"""
+"""ViT-B/16 forward as one fused ANE program from real torchvision weights, validated vs fp32, plus an af.tune SDPA route rewrite on one attention layer. Run: python3 examples/vit.py"""
 import sys, time
 
 import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
@@ -52,16 +22,9 @@ def load_vit_weights():
     return m, sd
 
 
-# ViT graph (aneforge public ops). Inputs (in creation order):                  #
-#   x   [1,3,224,224]  image                                                   #
-#   cls [1,768]        CLS-token constant                                      #
-#   pos [197,768]      positional-embedding constant                           #
+# ViT graph. Inputs (creation order): x [1,3,224,224], cls [1,768], pos [197,768].
 def build_vit(sd, n_layers):
-    """aneforge graph for ViT-B/16 forward -> logits [1,1000].
-
-    Ops: conv (patch embed), reshape/transpose (patchify), concat (CLS prepend),
-    add (pos-embed + residuals), layer_norm, mha (attention), linear + gelu (MLP),
-    and a constant-picker matmul to read the CLS row for the classifier head."""
+    """aneforge graph for ViT-B/16 forward -> logits [1,1000]."""
     g = lambda k: sd[k]
     L = "encoder.layers.encoder_layer_"
 
@@ -69,11 +32,7 @@ def build_vit(sd, n_layers):
     cls = af.input((1, DIM))
     pos = af.input((SEQ, DIM))
 
-    # patch embed: [1,3,224,224] -> [1,768,14,14]. A direct strided 16x16 conv is WALLED
-    # on the ANE (kernel WIDTH kW>=16 fails ANECCompile; graph.py guards it), so route the
-    # identical math as space_to_depth(16) + 1x1 conv: s2d emits (bh,bw,c)-major channels
-    # (verified numerically vs the strided conv on A14), so the [768,3,16,16] weight
-    # flattens as (kh,kw,c) -> [768, 768, 1, 1].
+    # patch embed via space_to_depth(16) + 1x1 conv (a strided 16x16 conv is walled on the ANE)
     w_pe = np.ascontiguousarray(g("conv_proj.weight").transpose(0, 2, 3, 1)).reshape(DIM, -1, 1, 1)
     h = af.conv(af.space_to_depth(x, PATCH), w_pe, bias=g("conv_proj.bias"))
     # patchify: [1,768,14,14] -> [1,768,196] -> [196,768] (matches torch reshape+permute)
@@ -107,9 +66,7 @@ def build_vit(sd, n_layers):
 
 
 def _row0(h):
-    """Pick row 0 of h [M,D] -> [1,D] via a constant one-hot picker matmul:
-    out = sel @ h with sel=[1,M]=e0. Expressed with the available ops as
-    ((h^T) @ sel^T)^T = sel @ h (linear is x@W.T, so W=sel)."""
+    """Pick row 0 of h [M,D] -> [1,D] via a constant one-hot picker matmul."""
     M, D = h.shape
     sel = np.eye(1, M, dtype=np.float32)          # [1,M], picks row 0
     return h.transpose([1, 0]).linear(sel).transpose([1, 0])   # [D,1] -> [1,D]
@@ -131,9 +88,7 @@ def torch_ref(m, img, n_layers):
 
 # optimizer tie-in: one real ViT attention layer via af.sdpa (route rewrite)   #
 def attn_layer_graph(sd, layer=0):
-    """ViT layer-`layer` self-attention as q/k/v proj -> af.sdpa -> out-proj, with
-    the REAL pretrained weights. Input is the [SEQ,DIM] post-ln_1 activation. Built
-    with af.sdpa so af.tune has the native<->decomposed SDPA route to choose from."""
+    """ViT layer-`layer` self-attention as q/k/v proj -> af.sdpa -> out-proj (real weights), so af.tune can pick the SDPA route."""
     p = f"encoder.layers.encoder_layer_{layer}."
     Wqkv = sd[p + "self_attention.in_proj_weight"]; bqkv = sd[p + "self_attention.in_proj_bias"]
     Wq, Wk, Wv = Wqkv[:DIM], Wqkv[DIM:2 * DIM], Wqkv[2 * DIM:]


### PR DESCRIPTION
Brings `examples/` to tinygrad's terse showpiece style — the example *is* the documentation. **Zero code/behavior change.**

## What
Across all 76 example scripts (top-level + `demos/` + `benchmarks/`):
- module docstrings collapsed to **one line** ("what it shows. Run: python examples/<file>.py")
- long in-body explanatory/teaching comment blocks trimmed; kept only short `# why` notes and section markers
- code, names, strings, and all `print`/output text untouched

**Net −1,137 lines** (+140 / −1,277), comments now near tinygrad's ~4%-but-one-liners level.

## Safety
Every file is **CODE-IDENTICAL** to `main` under a docstring-stripped AST comparison — a mechanical proof that only docstrings/comments changed, no logic moved. Plus `compileall` clean and `ruff check` clean. (Examples aren't part of the test suite; the AST proof + compile is the gate.)

Pairs with the core-prose thinning (#37) and matches tinygrad's model: terse self-documenting examples, narrative in `docs/`. The `examples/README.md` is left as the index.