### PR TITLE
Thin bench/ and tests/ prose (one-line docstrings + terse comments)

### DIFF
--- a/bench/below_ridge_fusion.py
+++ b/bench/below_ridge_fusion.py
@@ -1,36 +1,5 @@
 #!/usr/bin/env python3
-"""Below-ridge fusion demo (addresses the "fusion lever is demonstrated where the
-roofline cannot prove it" objection).
-
-The paper's flagship fusion demonstration was a fused conv stack reaching 110% of
-the conv roof -- but those convs already sit far RIGHT of every ANE ridge, so the
-roofline predicts no AI-lever gain there; the 110% is dispatch/I-O amortization,
-not the arithmetic-intensity lever. To demonstrate the AI lever where the model
-actually predicts it, we need a chain whose STANDALONE operating point sits LEFT of
-the weight-path ridge (memory-bound), and show that FUSING it slides the operating
-point RIGHT, past the ridge, into the compute-bound region.
-
-Construction: a light-compute "neck" block, one small conv (cheap FLOPs) followed by
-a chain of memory-bound elementwise/normalization ops (group_norm, gelu, scale-add,
-a second gelu). Dispatched STANDALONE, each op pays full DRAM in+out traffic, so the
-block's effective AI is low (memory-bound, left of the ~71 FLOP/B weight ridge).
-Dispatched FUSED into one aneforge program, the intermediates never touch DRAM, so
-the block streams its input and weights once and its effective AI rises past the
-ridge. We measure both, compute effective AI = FLOPs / bytes-actually-moved, and
-show the fused operating point crossing the ridge AND the throughput rising.
-
-We measure the standalone path two ways:
-  (a) sum of per-op min latencies (each op compiled + dispatched separately), and
-  (b) the bytes each standalone op must move to/from DRAM (full in+out per op),
-and the fused path as one compiled program (one dispatch, intermediates on-chip).
-
-This is the AI-lever demonstration the roofline predicts, complementary to the
-amortization demonstration (the conv stack) the paper already has.
-
-Run from repo root:
-    PYTHONPATH=. python3 bench/below_ridge_fusion.py
-optionally with --window for the power pass. Writes results/below_ridge_fusion.json.
-"""
+"""Below-ridge fusion demo: fusing a memory-bound neck block slides its effective AI past the weight-path ridge. Run: PYTHONPATH=. python3 bench/below_ridge_fusion.py"""
 from __future__ import annotations
 
 import argparse
@@ -56,19 +25,15 @@ relerr = dc.relerr
 if HAVE_ANE:
     import aneforge as af
 
-# ANE weight-path ridge from the paper (FLOP/byte); the activation-path ridge is ~424.
+# ANE weight-path ridge (FLOP/byte); activation-path ridge ~424.
 WEIGHT_RIDGE = 71.0
 ACT_RIDGE = 424.0
 BYTES_FP16 = 2
 
 
 def build_block_ops(C, H, W):
-    """Return (op_specs, np_reference_fn). The block:
-        conv 1x1 (C->C, cheap)  -> group_norm -> gelu -> affine scale/shift -> gelu
-    Light compute, several memory-bound ops: standalone it is bandwidth-bound.
-    """
+    """Return (op_specs, np_reference_fn) for the conv1x1->group_norm->gelu->gelu neck block."""
     rng = np.random.default_rng(17)
-    # 1x1 conv keeps FLOPs modest: 2*C*C*H*W. (3x3 would push AI up; we want it low.)
     Wc = (rng.standard_normal((C, C, 1, 1)).astype(np.float32)
           * np.sqrt(2.0 / C))
     gn_g = (rng.standard_normal(C).astype(np.float32) * 0.1 + 1.0)
@@ -88,8 +53,6 @@ def build_block_ops(C, H, W):
         x = gelu_np(x)
         return x
 
-    # The block: conv1x1 (the only real FLOPs) -> group_norm -> gelu -> gelu.
-    # FLOP count: conv 1x1 (2 C^2 HW) + gn (~8 C HW) + 2*gelu (~10 C HW each).
     flops = 2.0 * C * C * H * W + (8 + 10 + 10) * C * H * W
     act_bytes = C * H * W * BYTES_FP16              # one CxHxW fp16 tensor
     weight_bytes = (C * C + 2 * C) * BYTES_FP16     # conv + gn gamma/beta
@@ -130,7 +93,7 @@ def run(window=0.0):
         n_ops = spec["n_ops"]
         print(f"\n=== neck block C={C} {H}x{W} ===", flush=True)
 
-        # --- fused: one program, one dispatch, intermediates on-chip ---
+        # fused: one program, one dispatch, intermediates on-chip
         try:
             xin = af.input((1, C, H, W))
             net = af.compile(fused_block(xin, spec))
@@ -141,40 +104,32 @@ def run(window=0.0):
             print(f"  fused build FAILED: {type(e).__name__}: {e}")
             results["blocks"].append({"C": C, "HW": [H, W], "error": str(e)})
             continue
-        # fused bytes moved to/from DRAM: input + weights + output (intermediates on-chip)
-        bytes_fused = act + wt + act
+        bytes_fused = act + wt + act   # input + weights + output (intermediates on-chip)
         ai_fused = flops / bytes_fused
         gf_fused = flops / lat_f / 1e9
         print(f"  fused      {lat_f*1e3:8.3f} ms  {gf_fused:8.1f} GFLOP/s  "
               f"AI_eff={ai_fused:7.1f}  relerr {err:.2e}")
 
-        # --- standalone: each op a separate compiled program (full in+out per op) ---
-        # We approximate the standalone cost by compiling each op alone and summing
-        # its min latency; bytes = sum over ops of (in + out + weights) DRAM traffic.
+        # standalone: each op a separate compiled program (full in+out per op)
         standalone_ops = []
         lat_s_total = 0.0
         try:
-            # conv alone
             n1 = af.compile(af.conv(af.input((1, C, H, W)), spec["Wc"].astype(np.float16), stride=1, pad=0))
             l1, o1 = min_latency_with_out(lambda: n1(u0.astype(np.float16)))
             lat_s_total += l1; standalone_ops.append(("conv1x1", l1))
             mid = np.asarray(o1).astype(np.float16)
-            # group_norm alone
             n2 = af.compile(af.input((1, C, H, W)).group_norm(spec["gn_g"].astype(np.float16), spec["gn_b"].astype(np.float16), spec["GROUPS"]))
             l2, o2 = min_latency_with_out(lambda: n2(mid))
             lat_s_total += l2; standalone_ops.append(("group_norm", l2))
             mid2 = np.asarray(o2).astype(np.float16)
-            # gelu alone
             n3 = af.compile(af.input((1, C, H, W)).gelu())
             l3, o3 = min_latency_with_out(lambda: n3(mid2))
             lat_s_total += l3; standalone_ops.append(("gelu", l3))
-            # second gelu as a stand-in for the affine+gelu tail (same byte profile)
             l4, _ = min_latency_with_out(lambda: n3(mid2))
             lat_s_total += l4; standalone_ops.append(("gelu2", l4))
         except Exception as e:
             print(f"  standalone chain note: {type(e).__name__}: {e}")
-        # standalone DRAM traffic: each of n_ops ops moves in+out (+ weights for conv/gn)
-        bytes_standalone = n_ops * (act + act) + wt
+        bytes_standalone = n_ops * (act + act) + wt   # each op moves in+out (+ weights)
         ai_standalone = flops / bytes_standalone
         gf_standalone = (flops / lat_s_total / 1e9) if lat_s_total else None
         print(f"  standalone {lat_s_total*1e3:8.3f} ms  "

--- a/bench/compress_speedup_bench.py
+++ b/bench/compress_speedup_bench.py
@@ -1,21 +1,4 @@
-"""Measure the eval-latency win of compressed weight streaming (int4-LUT, sparse)
-versus fp16, on the ANE via aneforge. This is the perf companion to the
-correctness/size results in tests/test_compress.py: it shows that compressed
-weights STREAM (dequant-during-DMA), giving a real per-matmul inference speedup
-on weight-bandwidth-bound ops, not just a smaller file.
-
-Methodology (latency only; no power, by project directive):
-  - one fused single-matmul program per (shape, batch, encoding)
-  - WARMUP warmup evals, then a timed block of ITERS evals -> median latency
-  - repeat the timed block REPS times (re-warming between) -> report median and
-    sample SD across the REPS block-medians, plus the speedup vs the fp16 median
-  - int4 uses a per-tensor LUT (compress_atol high enough that random-normal
-    weights pass the accuracy gate); sparse uses a ~68%-zero weight (|w|<1.0)
-  - weights.bin size is recorded per encoding (the on-disk/load win)
-
-Run: python3 bench/compress_speedup_bench.py
-Writes: bench/results/compress_speedup_bench.json
-"""
+"""Eval-latency win of compressed weight streaming (int4-LUT, sparse) vs fp16 on the ANE. Run: python3 bench/compress_speedup_bench.py"""
 from __future__ import annotations
 
 import json

--- a/bench/cross_path_compress_bench.py
+++ b/bench/cross_path_compress_bench.py
@@ -1,15 +1,4 @@
-"""Cross-path speed comparison for compressed weight streaming: ANEForge (ANE,
-fp16 + int4-LUT) versus MLX (GPU, fp16 + 4-bit group-affine quant), same matmul
-y = x @ W (x = [B, K], W = [K, N]). Latency only (no power), median of timed
-evals after warmup; each path's result is cosine-checked against the fp32
-reference so a wrong quantize/transpose convention cannot silently skew timing.
-
-This answers "how does ANEForge compressed streaming compare to the GPU's own
-int4 path", the cross-path companion to compress_speedup_bench.py (which is
-ANE-internal). Run: PYTHONPATH=<repo> python3 bench/cross_path_compress_bench.py
-(needs python3 with both aneforge and mlx; on this box that is the 3.14 interp).
-Writes: bench/results/cross_path_compress_bench.json
-"""
+"""Cross-path compressed-matmul speed: ANEForge (ANE fp16/int4-LUT) vs MLX (GPU fp16/4-bit). Run: PYTHONPATH=<repo> python3 bench/cross_path_compress_bench.py"""
 from __future__ import annotations
 
 import json

--- a/bench/decode_int8_accuracy.py
+++ b/bench/decode_int8_accuracy.py
@@ -1,28 +1,5 @@
 #!/usr/bin/env python3
-"""int8 decode accuracy validation (addresses "int8 within decode tolerance,
-asserted with no token-agreement or perplexity evidence").
-
-The decode section reports int8 weight-streaming at ~2x the fp16 relerr (~5e-2)
-and asserts it is "still within decode tolerance". This script backs that with
-a precision-divergence check: it runs one decode forward (the 8-layer TinyLlama-
-class block + vocab head) at several batch positions in three precisions, fp32
-(numpy reference), ANE fp16, and ANE int8 weight-stream, on SHARED weights, and
-compares the output logit distributions:
-
-  * next-token argmax agreement (does int8 pick the same top-1 token as fp32/fp16?)
-  * top-5 set overlap
-  * logit relative L2 error
-  * softmax KL divergence (int8||fp32 and fp16||fp32)
-
-Weights are random (this is a precision-divergence probe, not a trained-LM
-perplexity), so the meaningful quantity is whether int8 quantization changes the
-predicted token relative to fp16/fp32 on identical weights. A single forward (no
-sustained loop) keeps it fast and avoids the decode-loop's session-state issues.
-
-Run from repo root:
-    PYTHONPATH=. python3 bench/decode_int8_accuracy.py
-Writes bench/results/decode_int8_accuracy.json.
-"""
+"""int8 decode accuracy: token-agreement / top-5 / logit relerr / softmax KL of int8 weight-stream vs fp16/fp32 on shared weights. Run: PYTHONPATH=. python3 bench/decode_int8_accuracy.py"""
 from __future__ import annotations
 
 import json
@@ -67,7 +44,7 @@ def main() -> int:
     cfg = dm.Cfg(d_model=2048, n_layers=8, n_heads=16, d_ff=8192, vocab=32000, s_kv=256)
     print(f"=== int8 decode accuracy: {cfg.asdict()} ===")
     W = dm.make_weights(cfg)
-    B = 64                                   # 64 decode positions to average over
+    B = 64                                   # decode positions to average over
     rng = np.random.default_rng(123)
     x = (rng.standard_normal((B, cfg.d)).astype(np.float32) * 0.1)
 

--- a/bench/decode_measurement.py
+++ b/bench/decode_measurement.py
@@ -1,64 +1,5 @@
 #!/usr/bin/env python3
-"""Real autoregressive LLM-DECODE measurement - ANE (aneforge) vs GPU (MLX) vs CPU.
-
-WHY THIS EXISTS. The paper reasons extensively about LLM *decode* - "GEMV AI ~ 1,
-decode is bandwidth/GPU territory", the device ordering inferred from a single
-synthetic GEMV roofline point (ANE 112 / GPU 75 / CPU 81 GFLOP/s; ANE winning at
-B=1 up to K~4096; batched shifting toward the GPU). But the paper never MEASURES
-an actual decode loop. This harness measures one and states plainly whether the
-measured decode CONFIRMS or CONTRADICTS that inference.
-
-WHAT IS MEASURED. The per-token compute of a small transformer decoder in the
-canonical decode regime: seq position = 1 (the M=1 / GEMV / skinny-GEMM regime),
-with a fixed-length KV cache. One "token" = one forward of the full L-layer stack
-plus the vocab projection. We run:
-
-  * B=1   single-stream decode (the canonical on-device case), AND
-  * B=BATCH (default 32) batched decode (the serving case),
-
-for each device {ANE (aneforge fp16), GPU (MLX fp16), CPU (numpy/Accelerate fp32)}.
-
-Per device per batch we report: tokens/s, latency/token (ms), tokens/s/W and
-energy/token (mJ/token) - using the idle-subtracted total-package ACTIVE power
-from the device_compare_wattcomplete harness (imported, not reimplemented) - and
-relerr of one token's logits vs an fp32 numpy reference (sanity).
-
-THE PER-TOKEN LAYER. A decoder block in the decode regime:
-    h  = x
-    a  = attn(rmsnorm(h))          # QKV proj GEMVs + scores vs KV cache + out proj
-    h  = h + a
-    f  = ffn(rmsnorm(h))           # gate/up GEMVs + SiLU + down proj GEMV
-    h  = h + f
-then after L blocks: logits = rmsnorm(h) @ Wvocab  (the big vocab GEMV).
-
-The attention here uses a FIXED, PRE-FILLED KV cache of length S_KV: the query is
-the single new token (seq=1), scores are q @ Kcache^T  -> softmax -> @ Vcache. This
-is the faithful per-token decode shape - the projections are genuine M=1 GEMVs and
-dominate the FLOPs, which is exactly why decode is memory-bound. The KV cache is a
-constant baked into the graph (we measure steady-state per-token compute, not the
-cache-append bookkeeping, which is a memcopy on every backend and not the compute
-the roofline argument is about).
-
-ANE NOTE / PROXY LABELLING. aneforge fuses the whole block into e5rt program(s).
-af.sdpa requires equal-shape q,k,v so it can't express seq=1-query-vs-S_KV-cache;
-we therefore build attention from primitives (bmm scores + softmax + bmm context),
-which is the decomposed-SDPA route the ANE fuses natively anyway. This is a
-FULL-STACK decode forward (not a primitives-only proxy) - every per-token op of the
-block + vocab head is present and measured end-to-end as one compiled program per
-batch size. The only decode-loop element not measured is the KV-cache *append*
-(a memcopy, identical cost on every backend).
-
-CONFIG (default, TinyLlama/GPT-small class):
-    d_model=2048, n_layers=8, n_heads=16, FFN=4x (d_ff=8192), vocab=32000,
-    KV cache length S_KV=256.
-
-Run from repo root (energy needs passwordless sudo for powermetrics):
-
-    PYTHONPATH=. python3 bench/decode_measurement.py
-
-Writes bench/results/decode_measurement_results.json. --quick shrinks the model
-(d=1024,L=4) and the power window for a smoke test. Devices run SEQUENTIALLY.
-"""
+"""Real autoregressive LLM-decode measurement (full per-token stack + vocab head, fixed KV cache) - ANE vs GPU (MLX) vs CPU. Run: PYTHONPATH=. python3 bench/decode_measurement.py"""
 from __future__ import annotations
 
 import argparse
@@ -77,8 +18,7 @@ if str(REPO) not in sys.path:
 
 import numpy as np
 
-# Reuse the rigorous power harness (idle-subtracted total-package active W) - import,
-# do NOT reimplement. measure_energy/sample_idle live in device_compare_wattcomplete.
+# Reuse the wattcomplete power harness (measure_energy/sample_idle).
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import device_compare_wattcomplete as wc  # noqa: E402
 import device_compare as dc                # noqa: E402
@@ -109,9 +49,7 @@ class Cfg:
                 "s_kv": self.s_kv}
 
     def flops_per_token(self, B):
-        """2*MACs for the per-token forward of B streams: per layer = 4 proj GEMVs
-        (QKV=3*d*d, out=d*d) + attention (2 * H * s_kv * dh for scores+context) +
-        FFN (gate+up = 2*d*d_ff, down = d_ff*d); plus the vocab GEMV d*vocab."""
+        """2*MACs for the per-token forward of B streams (proj + attention + FFN + vocab GEMVs)."""
         d, L, H, dh, dff, V, s = self.d, self.L, self.H, self.dh, self.d_ff, self.vocab, self.s_kv
         per_layer = (4 * d * d) + (2 * H * s * dh) + (3 * d * dff)
         total_macs = L * per_layer + d * V
@@ -164,8 +102,7 @@ def ref_decode(cfg: Cfg, W, x, dt=np.float64):
         qh = q.reshape(B, H, dh)                       # [B, H, dh]
         Kc = w["Kc"].astype(dt)                        # [H, s, dh]
         Vc = w["Vc"].astype(dt)
-        # append the new token's k,v to the cache for this single decode step
-        # scores for the new query against (cache + self): [B,H,1,s+1]
+        # scores for the new query against (cache + self)
         kh = k.reshape(B, H, dh)
         vh = v.reshape(B, H, dh)
         out = np.empty((B, H, dh), dtype=dt)
@@ -191,22 +128,9 @@ def ref_decode(cfg: Cfg, W, x, dt=np.float64):
 
 # ANE graph (aneforge) - full per-token stack, batch B
 def build_ane(cfg: Cfg, W, B, int8=False):
-    """Build the B-stream per-token decoder forward as one aneforge graph.
-
-    ``int8=True`` compiles the linear weights as per-output-channel symmetric int8
-    streamed at half the bytes (dequantised during the tile DMA) - the verified
-    int8 weight-streaming path. Decode is the AI~1 memory-bound regime, so halving
-    the weight bytes is the one lever that can move decode THROUGHPUT, not just
-    energy; this row tests whether it does, or whether decode stays dispatch-bound.
-
-    aneforge has no constant-tensor leaf node, and a bmm (activation@activation) needs
-    Tensor operands - so the per-layer KV cache is supplied as GRAPH INPUTS (fed each
-    call). That's the only correct way to express a cache here; the cache bytes are
-    constant data the caller passes in, exactly like a real decode loop reads its cache
-    from memory. Returns (Model, list-of-cache-arrays) so the runner feeds x + caches.
-
-    Attention is per (batch*head): scores = concat(q@Kc^T, q@k_self) -> softmax ->
-    @ concat(Vc, v_self). Projections are the M=1 GEMVs that dominate; fp16 weights."""
+    """Build the B-stream per-token decoder forward as one aneforge graph. int8=True
+    streams per-channel int8 weights. KV cache is supplied as graph inputs; returns
+    (Model, list-of-cache-arrays) so the runner feeds x + caches."""
     f16 = np.float16
     H, dh, s, d = cfg.H, cfg.dh, cfg.s_kv, cfg.d
     x = af.input((B, d))
@@ -221,7 +145,7 @@ def build_ane(cfg: Cfg, W, B, int8=False):
         qh = q.reshape(B * H, 1, dh)
         kh = k.reshape(B * H, 1, dh)
         vh = v.reshape(B * H, 1, dh)
-        # KV cache as graph inputs (broadcast across batch): Kc_T [B*H,dh,s], Vc [B*H,s,dh]
+        # KV cache as graph inputs (broadcast across batch)
         Kc_T_arr = np.ascontiguousarray(
             np.tile(w["Kc"][None], (B, 1, 1, 1)).reshape(B * H, s, dh).transpose(0, 2, 1).astype(f16))
         Vc_arr = np.ascontiguousarray(
@@ -312,8 +236,7 @@ def min_latency(fn, reps, warmup):
 
 
 def measure_device(name, run_once, *, B, cfg, ref, window, reps, warmup, get_out):
-    """One device/batch point: min latency/token, throughput, energy via the
-    wattcomplete harness, relerr vs fp32 ref. get_out() returns the logits as np."""
+    """One device/batch point: min latency/token, throughput, energy, relerr vs fp32 ref."""
     row = {"device": name, "batch": B, "status": "ok"}
     try:
         lat = min_latency(run_once, reps=reps, warmup=warmup)   # s per token-step (B streams)
@@ -342,7 +265,6 @@ def measure_device(name, run_once, *, B, cfg, ref, window, reps, warmup, get_out
             row["energy_iter_ms"] = e.get("iter_ms")
             row["flags"] = e.get("flags")
             if apw == apw and apw > 0:
-                # throughput from the energy loop's own iter time (sustained), B streams
                 tok_s_energy = B / (e["iter_ms"] / 1e3)
                 row["tokens_per_s_sustained"] = tok_s_energy
                 row["tokens_per_s_per_W"] = tok_s_energy / apw
@@ -381,7 +303,7 @@ def main():
 
     W = make_weights(cfg)
 
-    # idle baseline ONCE (the wattcomplete harness subtracts it)
+    # idle baseline once (subtracted by the harness)
     if HAVE_SUDO:
         print("sampling idle baseline...", flush=True)
         wc.sample_idle(3.0)

--- a/bench/device_bandwidth_roofline.py
+++ b/bench/device_bandwidth_roofline.py
@@ -1,54 +1,5 @@
 #!/usr/bin/env python3
-"""Memory-bandwidth roofline - ANE (aneforge fp16) vs GPU (MLX) vs CPU.
-
-The compute-bound primitives (GEMM, conv) are covered by the saturation sweep
-(``device_saturation_sweep.py``). But those are the MINORITY of aneforge's op set.
-The large majority - elementwise activations, binaries, reductions, softmax, the
-norm family, data-movement (reshape/transpose/concat/upsample/pixel_shuffle) - are
-**memory-bandwidth-bound at size**, not compute-bound. For those, GFLOP/s is the
-wrong metric: the meaningful number is **achieved memory bandwidth (GB/s)** and
-**GB/s per watt**, and they all collapse onto one roofline. This script measures
-that roofline.
-
-KEY METHODOLOGY (a crude probe gave low/noisy numbers - done right here):
-
-  * SIZE TO SATURATION. At small N the ~70 us ANE / dispatch floor dominates and
-    HIDES bandwidth (you measure dispatch, not memory). We scale N until the
-    achieved GB/s CLIMBS and PLATEAUS - that plateau is the bandwidth ceiling. We
-    report the plateau AND the full climb curve as the evidence. If a device stays
-    dispatch-bound at all feasible sizes for an archetype, we say so.
-
-  * BYTES MODEL (stated, not hidden).  Bandwidth = bytes_moved / min_latency.
-      - streaming unary (x*s / relu):  read N + write N  = 2*N*dtbytes
-      - light-compute unary (gelu/silu): same traffic    = 2*N*dtbytes
-      - reduction (sum over all):      read N, write ~1  = 1*N*dtbytes
-      - softmax (last axis):           read N, write N    = 2*N*dtbytes
-        (max+exp/sum+div is read-once/write-once at the framework level; the two
-         logical passes are fused, so 2N is the actual external traffic)
-      - layer_norm (last axis):        read N, write N    = 2*N*dtbytes
-    dtbytes = 2 (fp16) for GPU/ANE, 4 (fp32) for CPU. The CPU bandwidth proxy uses
-    a genuinely memory-bound op (a*2.0 / a.sum), NOT a transcendental - a tanh-heavy
-    gelu is COMPUTE-bound in numpy and would understate CPU bandwidth.
-
-  * POWER at the saturating size. Reuses the rigorous energy harness from
-    ``device_compare_wattcomplete`` verbatim (idle-subtracted ACTIVE total-package
-    power from powermetrics' own ``Combined Power`` line, median + CV%, sustained
-    loop driven to sampler-exit). GB/s/W = peak GB/s / active-package-W.
-
-  * ACCURACY. relerr vs fp32 numpy reference where meaningful (the activations,
-    softmax, norm). Pure-copy/reduction relerr is ~0 by construction.
-
-PART 2 (op coverage): classifies EVERY op in aneforge's live ``_EMIT`` (50) and
-``NETPLIST_OPS`` (19) into a roofline class, driven off the live dicts so it can't
-silently omit an op. Emitted as a table to the JSON + printed.
-
-Run from repo root (energy needs passwordless sudo for powermetrics):
-
-    PYTHONPATH=. python3 bench/device_bandwidth_roofline.py
-
---quick runs a reduced window + a coarser size sweep for a smoke test.
-Writes bench/results/device_bandwidth_roofline_results.json alongside the tables.
-"""
+"""Memory-bandwidth roofline (achieved GB/s + GB/s/W for the BW-bound op archetypes) + op-coverage classification - ANE vs GPU (MLX) vs CPU. Run: PYTHONPATH=. python3 bench/device_bandwidth_roofline.py"""
 from __future__ import annotations
 
 import argparse
@@ -66,7 +17,6 @@ if str(REPO) not in sys.path:
 
 import numpy as np
 
-# Reuse the rigorous harnesses - do NOT reinvent the power methodology.
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 import device_compare as dc            # noqa: E402
 import device_compare_wattcomplete as wc  # noqa: E402  (energy harness + idle sampling)
@@ -81,20 +31,15 @@ if HAVE_ANE:
 if HAVE_MLX:
     import mlx.core as mx
 
-# size sweep: element counts (per archetype we pick a 2D shape with this many elems).
-# The climb-to-plateau evidence lives in this sweep; the largest size is the ceiling.
+# size sweep: element counts (largest size is the bandwidth ceiling)
 SIZES = [1 << 18, 1 << 20, 1 << 22, 1 << 23, 1 << 24, 1 << 25, 1 << 26]  # 256K .. 64M
 QUICK_SIZES = [1 << 20, 1 << 23, 1 << 25]
 
 RESULTS: dict = {"roofline": {}, "coverage": {}}
 
 
-# archetypes: each returns (ane_net_builder, mlx_run, cpu_run, bytes_per_elem_factor,
-# ref_fn) for a given element count. shape is 2D [R, Dlast] chosen near-square but with
-# a real last axis for the reductions/softmax/norm.
 def _shape_for(nelem: int, dlast: int = 4096) -> tuple[int, int]:
-    """A [R, D] shape with ~nelem elements and a sizeable last axis D for the
-    reduction/softmax/norm archetypes (so the reduced axis is non-trivial)."""
+    """A [R, D] shape with ~nelem elements and a sizeable last axis D."""
     d = dlast
     r = max(1, nelem // d)
     return (r, d)
@@ -184,8 +129,7 @@ def build_archetypes():
     """Return the archetype spec list. Each entry drives run_archetype."""
     specs = []
 
-    # 1. PURE STREAMING - relu (read+write, ~zero arithmetic). Cleanest BW probe.
-    #    bytes = 2*N*dt
+    # 1. streaming - relu (read+write, ~zero arithmetic); bytes = 2*N*dt
     def ane_relu(x, R, D):
         net = af.compile(af.input((R, D)).relu())
         return net, x.astype(np.float16)
@@ -195,14 +139,14 @@ def build_archetypes():
             mx.eval(mx.maximum(xg, 0))
         return fn, (lambda: np.array(mx.maximum(xg, 0), copy=False))
     def cpu_stream(x, R, D):
-        # genuinely memory-bound: scalar multiply (NOT a transcendental)
+        # memory-bound proxy: scalar multiply (not a transcendental)
         def fn():
             _ = x * 2.0
         return fn, None
     specs.append(("streaming (relu / x*2)", 2, ane_relu, mlx_relu, cpu_stream,
                   (lambda x: np.maximum(x, 0)), True))
 
-    # 2. LIGHT-COMPUTE ELEMENTWISE - gelu (a few flops/elem; still BW-bound at size)
+    # 2. light-compute elementwise - gelu (still BW-bound at size)
     def ane_gelu(x, R, D):
         net = af.compile(af.input((R, D)).gelu())
         return net, x.astype(np.float16)
@@ -214,20 +158,19 @@ def build_archetypes():
             mx.eval(gel(xg))
         return fn, (lambda: np.array(gel(xg), copy=False))
     def cpu_gelu_bw(x, R, D):
-        # CPU proxy stays memory-bound (copy), NOT the transcendental gelu - see header.
+        # CPU proxy stays memory-bound (copy), not the transcendental gelu
         def fn():
             _ = x.copy()
         return fn, None
     def ref_gelu(x):
         from scipy.special import erf  # noqa
         return x * 0.5 * (1 + erf(x / np.sqrt(2.0)))
-    # scipy may be absent; fall back to a numpy erf approximation for the ref.
     def ref_gelu_np(x):
         return x * 0.5 * (1.0 + np.tanh(np.sqrt(2/np.pi) * (x + 0.044715 * x**3)))
     specs.append(("gelu (light compute)", 2, ane_gelu, mlx_gelu, cpu_gelu_bw,
                   ref_gelu_np, True))
 
-    # 3. REDUCTION - sum over last axis (read N, write R). bytes ~ 1*N*dt
+    # 3. reduction - sum over last axis; bytes ~ 1*N*dt
     def ane_sum(x, R, D):
         net = af.compile(af.input((R, D)).sum(-1))
         return net, x.astype(np.float16)
@@ -243,7 +186,7 @@ def build_archetypes():
     specs.append(("reduction (sum)", 1, ane_sum, mlx_sum, cpu_sum,
                   (lambda x: x.sum(-1)), True))
 
-    # 4. SOFTMAX over last axis. bytes = 2*N*dt (read+write the full tensor)
+    # 4. softmax over last axis; bytes = 2*N*dt
     def ane_softmax(x, R, D):
         net = af.compile(af.input((R, D)).softmax(-1))
         return net, x.astype(np.float16)
@@ -265,7 +208,7 @@ def build_archetypes():
     specs.append(("softmax", 2, ane_softmax, mlx_softmax, cpu_softmax,
                   ref_softmax, True))
 
-    # 5. LAYER_NORM over last axis (the real-model primitive). bytes = 2*N*dt
+    # 5. layer_norm over last axis; bytes = 2*N*dt
     def make_ln(R, D):
         rng = np.random.default_rng(13)
         g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0)
@@ -365,13 +308,9 @@ def measure_peak_power(specs, sizes):
 
 
 # PART 2 - op -> roofline-class coverage (driven off live _EMIT / NETPLIST_OPS)
-# class -> set of op names. We classify by op semantics. Driven against the LIVE
-# dicts below so a missing op raises, not silently drops.
 COMPUTE_BOUND = {
     "matmul", "bmm", "conv", "conv_transpose",
 }
-# bandwidth-bound: activations, elementwise binaries, reductions, softmax, norms,
-# data-movement / shape ops.
 BANDWIDTH_BOUND = {
     # activations / elementwise unary (transcendental or cheap)
     "relu", "relu6", "leaky_relu", "elu", "gelu", "silu", "sigmoid", "tanh",
@@ -390,23 +329,18 @@ BANDWIDTH_BOUND = {
     "pixel_shuffle", "pixel_unshuffle",
 }
 # dispatch/latency-bound: scalar / tiny ops where the dispatch floor dominates
-# (covered by the floor finding - CPU wins tiny).
 DISPATCH_BOUND = {
-    "adds", "muls",  # scalar-broadcast ops, trivially tiny arithmetic
+    "adds", "muls",  # scalar-broadcast ops
 }
 
-# NETPLIST bridge ops. has_worker => persistent worker => fairly raceable silicon.
-# without => subprocess-per-call: dispatch-bound ARTIFACT, not a fair speed race.
+# NETPLIST bridge ops with a persistent worker are raceable silicon; the rest are subprocess artifacts.
 WORKER_OPS = {"sdpa", "argmax", "topk"}   # the persistent-worker op set
 
-# Map a bridge op to its measurement story.
 BRIDGE_CLASS = {
-    # has a persistent worker -> can benchmark silicon time
     "sdpa": "bridge:worker (raceable - covered as attention class)",
     "argmax": "bridge:worker (raceable silicon via persistent worker)",
     "topk": "bridge:worker (raceable silicon via persistent worker)",
 }
-# everything else in NETPLIST_OPS without a worker -> subprocess artifact, not raceable.
 
 
 def build_coverage():

--- a/bench/device_compare.py
+++ b/bench/device_compare.py
@@ -1,48 +1,5 @@
 #!/usr/bin/env python3
-"""Shared device-comparison harness - ANE (aneforge fp16) vs GPU (MLX) vs CPU (numpy).
-
-This module holds the timing, precision, energy, and device-runner helpers plus the
-workload builders that the other ``bench/`` scripts import; it is not run on its own.
-The single-stream device map is produced by ``device_compare_wattcomplete.py``.
-
-Each helper runs the SAME math on three devices and reports, per workload:
-
-    device | dtype | min-latency | (throughput) | relerr-vs-fp32
-
-across the workloads the project actually runs:
-
-    * GEMM at three regimes (K=256 floor, K=1024 bandwidth, K=4096 compute)
-    * conv (a small one + a ResNet-ish 3x3 stack)
-    * scientific kernels: DFT-as-matmul, a 2D 5-point stencil step, an N-body
-      pairwise-force step
-    * real models: ResNet-18 (af.load_resnet18), MiniLM encoder (af.load), a ViT
-      self-attention block (af.mha, the vit_demo shape)
-
-Devices
-    ANE  = aneforge fp16 (af.compile + call). Compute is fp16-only on the silicon;
-           the accumulator is >=fp32 (see ANE_MANUAL), so the precision cost shows
-           up only in cancellation-heavy reductions.
-    GPU  = MLX (Apple GPU / Metal), run at BOTH fp16 and fp32, so the GPU's own
-           fp16 precision cost is explicit and separable from the ANE's.
-    CPU  = numpy on Accelerate BLAS, fp32 (the precision reference) + fp16 where
-           it is a sensible comparison.
-
-Timing: warmup, then MIN over reps (the clean signal - min rejects scheduler
-noise). Each device's number includes its own host/dispatch overhead, which is
-called out: the ANE/MLX numbers are end-to-end Python-call latency
-(compile-once, run-many), NOT pure silicon time. At small shapes that overhead
-dominates and the comparison is a dispatch-cost comparison, not a FLOP one.
-
-Energy: powermetrics is sampled ONLY around the sustained compute-bound loops
-(the GEMM-K4096 and conv-stack workloads), where a multi-second loop gives a
-trustworthy rail average. Short per-call workloads do NOT get an energy number -
-a sub-millisecond op sampled at 100 Hz is an artifact, and we don't report it.
-Energy needs passwordless sudo; without it, latency/precision still run.
-
-Precision: every workload has an fp64/fp32 numpy reference. We report relative
-L2 error (||x - ref|| / ||ref||) for ANE-fp16, GPU-fp16 and GPU-fp32 against it,
-so "what does fp16 cost here" is answerable per workload, per device.
-"""
+"""Shared device-comparison harness (timing/precision/energy helpers + workload builders) imported by the other bench/ scripts - ANE vs GPU (MLX) vs CPU. Not run on its own."""
 from __future__ import annotations
 
 import os
@@ -61,7 +18,7 @@ if str(REPO) not in sys.path:
 
 import numpy as np
 
-# ---- optional backends; the script degrades gracefully ---------------------- #
+# optional backends; degrades gracefully
 HAVE_ANE = HAVE_MLX = HAVE_TORCH = HAVE_TV = HAVE_HF = False
 ANE_ERR = MLX_ERR = ""
 try:
@@ -223,13 +180,10 @@ def w_gemm(M, K, N, tag):
         lat, out = mlx_run(lambda: xg16 @ Wg16)
         add_row(wl, "GPU", "fp16", lat, gflops(flops, lat), relerr(out, ref))
 
-    # CPU fp32 (Accelerate BLAS - the reference-speed device).
+    # CPU fp32 (Accelerate BLAS - the reference-speed device)
     lat, out = cpu_run(lambda: x32 @ W32.T)
     add_row(wl, "CPU", "fp32", lat, gflops(flops, lat), relerr(out, ref))
-    # CPU fp16: numpy has NO BLAS fp16 GEMM kernel (it upcasts element-by-element),
-    # so this is pathologically slow and NOT a fair fp16 device - only run it at the
-    # FLOOR size to document that "CPU fp16" is not a real option, then skip the big
-    # ones (they take seconds for an uninteresting, GPU-fp16-identical relerr).
+    # numpy has no fp16 BLAS GEMM (upcasts, pathologically slow): only run it at the floor size
     if M * K * N <= 64 * 256 * 256:
         xh, Wh = x32.astype(np.float16), W32.T.astype(np.float16)
         lat, out = cpu_run(lambda: (xh @ Wh), reps=5)  # numpy upcasts internally
@@ -251,16 +205,12 @@ def w_conv(Cin, Cout, H, W, k, depth, tag, energy=False):
     rng = np.random.default_rng(1)
     pad = k // 2
     x32 = (rng.standard_normal((1, Cin, H, W)).astype(np.float32))
-    # He-style variance-preserving init (sqrt(2/fan_in)) so a deep ReLU stack keeps
-    # activations O(1) - a real ResNet does this via BatchNorm. Without it the
-    # activations decay geometrically below fp16's smallest normal and the fp16
-    # error becomes an underflow artifact rather than a real precision number.
+    # He init (sqrt(2/fan_in)) keeps a deep ReLU stack's activations O(1) (avoids fp16 underflow)
     Ws = [rng.standard_normal((Cout, (Cin if d == 0 else Cout), k, k)).astype(np.float32)
           * np.sqrt(2.0 / ((Cin if d == 0 else Cout) * k * k)) for d in range(depth)]
     flops = sum(2 * (Cin if d == 0 else Cout) * Cout * k * k * H * W for d in range(depth))
     note(wl, f"{flops/1e9:.3f} GFLOP, same-pad, He init (O(1) activations). ref = fp32 numpy.")
 
-    # fp32 numpy reference (naive, im2col-free via stride tricks would be heavy; use scipy-free loop)
     _ref = _np_conv_stack(x32, Ws, pad)
 
     if HAVE_ANE:

--- a/bench/device_compare_wattcomplete.py
+++ b/bench/device_compare_wattcomplete.py
@@ -1,60 +1,5 @@
 #!/usr/bin/env python3
-"""Watt-complete cross-device comparison - ANE (aneforge fp16) vs GPU (MLX) vs CPU.
-
-Companion to ``device_compare.py``. That harness covers raw latency + precision
-across every workload class but measures ENERGY for only two sustained loops. This
-script makes energy/watt *complete across every meaningful workload class*, with the
-power methodology a reviewer will attack first done right:
-
-  * IDLE SUBTRACTION. We sample a no-workload idle baseline (per rail) once at start
-    and report ACTIVE = (loaded - idle). The marginal cost of the workload is what
-    matters; reporting raw loaded power double-counts the ~0.6 W the CPU burns at rest.
-
-  * HEADLINE = TOTAL-PACKAGE ACTIVE POWER (sum of ane+gpu+cpu rails, idle-subtracted).
-    This is the actual number: an ANE workload still burns CPU on dispatch and an MLX
-    workload burns CPU too, so attributing only the "device" rail would flatter both.
-    We ALSO report the per-rail breakdown so the attribution is visible
-    (e.g. "ANE 1.2 W + CPU 0.8 W dispatch").
-
-  * CONFIDENCE. We report the MEDIAN total-package power AND the spread (CV% over the
-    per-sample package totals, plus min/median/p90). A workload whose power CV is large
-    is FLAGGED low-confidence rather than reported as a clean number. Implausible reads
-    (e.g. ANE 0 mW *during* an ANE workload - a 100 ms sampling miss) are flagged.
-
-  * STEADY STATE. Each sustained loop runs >= the requested window (default 4 s) after
-    a warmup, long enough for stable 100 ms-interval sampling. perf/watt is throughput
-    / active_W; for the real models we also report energy-per-inference in mJ.
-
-  * ACCURACY ALONGSIDE. Every workload still reports relerr vs an fp32/fp64 numpy
-    reference, presented next to the speed/watt numbers - a speed win at worse accuracy
-    must be visible (GPU is more accurate than the ANE at large K, the ANE matches or
-    beats it where the math is well-conditioned).
-
-SCOPE = workload classes where the ANE-vs-GPU choice is REAL:
-  1. GEMM at K = 256 (floor) / 1024 (bandwidth) / 4096 (compute)
-  2. conv: a single 3x3 + a ResNet-ish 3x3 stack
-  3. attention: the ViT self-attention block (vit_demo S=197 shape) + a long-seq S=512
-     shape; both via the in-graph af.mha (decomposed-SDPA fused route) - the FAIR
-     native-attention path. (NOT the subprocess-bridge SDPA - see EXCLUSIONS.)
-  4. norm family: layer_norm, rms_norm, group_norm at representative sizes
-  5. scientific kernels: matmul-DFT, a 2D 5-point stencil step, a fixed-iter Jacobi solve
-  6. real models: ResNet-18, MiniLM encoder, full ViT-B/16 forward
-
-EXCLUSIONS: the netplist *bridge* ops (sdpa-bridge / argmax / fps /
-cost_volume / radius_search / sort via the subprocess dispatch path) are NOT raced
-here. They run 25 ms - 2.5 s in the current subprocess path due to a DISPATCH artifact, not
-silicon speed; racing them against MLX would misrepresent the hardware. They are an
-ANE-EXCLUSIVE CAPABILITY, dispatch-bound in the current path - a separate story, not a
-fair speed race. The native in-graph af.sdpa / af.mha attention route (no subprocess)
-IS fair and is included as the attention class.
-
-Run from repo root (energy needs passwordless sudo for powermetrics):
-
-    PYTHONPATH=. python3 bench/device_compare_wattcomplete.py
-
-Writes bench/results/device_compare_wattcomplete_results.json alongside the printed
-tables. --quick runs a reduced rep/window for a smoke test.
-"""
+"""Watt-complete cross-device comparison: idle-subtracted ACTIVE package energy/watt + latency + precision across every workload class - ANE vs GPU (MLX) vs CPU. Run: PYTHONPATH=. python3 bench/device_compare_wattcomplete.py"""
 from __future__ import annotations
 
 import argparse
@@ -93,17 +38,11 @@ if HAVE_MLX:
 _RAIL = {"ane": re.compile(r"ANE Power:\s*([\d.]+)\s*mW"),
          "cpu": re.compile(r"CPU Power:\s*([\d.]+)\s*mW"),
          "gpu": re.compile(r"GPU Power:\s*([\d.]+)\s*mW")}
-# powermetrics prints the OS-computed package total once per sample - use it as the
-# authoritative per-sample package number (avoids the GPU-rail double-print, which
-# appears twice per block and would misalign a hand-summed per-sample total).
+# OS-computed package total, one per sample (authoritative; avoids the GPU-rail double-print)
 _PKG = re.compile(r"Combined Power \(CPU \+ GPU \+ ANE\):\s*([\d.]+)\s*mW")
 
 WINDOW = 6.0          # sustained-loop seconds (overridden by --quick)
-# powermetrics 'Power' is the AVERAGE over the sample interval. A sub-ms op sampled at
-# 100 ms catches the package mid-duty-cycle (huge CV - the exact artifact a reviewer
-# would flag). We integrate over a coarser 500 ms interval so each sample averages
-# many iterations -> the duty cycle is smoothed into a stable mean, and the residual
-# CV is real run-to-run variation, not a phase artifact.
+# coarse 500ms interval so each sample averages many iters -> stable mean (avoids duty-cycle CV)
 PM_INTERVAL_MS = 500
 
 # accumulate every workload's rows + per-device energy here
@@ -112,16 +51,14 @@ IDLE: dict[str, float] = {}   # per-rail idle mW, sampled once at start
 IDLE_PKG = 0.0                # total-package idle mW
 
 
-# rigorous power harness
+# power harness
 def _parse_pm_per_sample(txt: str) -> tuple[dict[str, list[float]], list[float]]:
-    """Per-rail lists of per-sample mW + the per-sample OS-combined package total.
-    The GPU rail is printed twice per sample block by powermetrics, so we keep the
-    aligned subset (every other match) to match the ANE/CPU one-per-sample cadence."""
+    """Per-rail lists of per-sample mW + the per-sample OS-combined package total."""
     per = {}
     for rail, rx in _RAIL.items():
         vals = [float(m) for m in rx.findall(txt)]
         if rail == "gpu" and len(vals) >= 2:
-            # GPU prints twice/sample; the first per block is the rail reading we want
+            # GPU prints twice/sample; keep the first per block
             ane_n = len(_RAIL["ane"].findall(txt))
             if ane_n and len(vals) == 2 * ane_n:
                 vals = vals[0::2]
@@ -149,17 +86,13 @@ def sample_idle(seconds: float) -> None:
 
 
 def measure_energy(run_once, *, tag: str, window: float = WINDOW) -> dict | None:
-    """Sustained-loop powermetrics around run_once(), with the rigor fixes:
-       idle-subtracted ACTIVE per rail + total-package, median + CV + min/p90 over the
-       per-sample package totals, perf-counter iter time, and low-confidence flags."""
+    """Sustained-loop powermetrics around run_once(): idle-subtracted ACTIVE per rail +
+       total-package, median + CV + min/p90, perf-counter iter time, low-confidence flags."""
     if not HAVE_SUDO:
         return None
     for _ in range(5):              # warmup before the sampling window
         run_once()
-    # Size the sampler to the window and keep the workload loop running until the
-    # sampler EXITS (poll), so every integrated sample is captured under load - the
-    # earlier bug was the loop stopping at `window` while powermetrics kept sampling
-    # idle for its remaining count, which manufactured the high CV.
+    # keep the workload loop running until the sampler exits, so every sample is under load
     samples = max(8, int(window / (PM_INTERVAL_MS / 1000.0)))
     log = Path(f"/tmp/pm_wattc_{tag}.log")
     pm = subprocess.Popen(
@@ -189,10 +122,7 @@ def measure_energy(run_once, *, tag: str, window: float = WINDOW) -> dict | None
         out[f"{rail}_active_mW"] = active
         rail_active[rail] = active
 
-    # per-sample OS-combined package total (powermetrics' own "Combined Power" line,
-    # which is the average over each sample interval - not an instantaneous spot read).
-    # CV is computed on the RAW loaded samples (no per-sample clamp - clamping at the
-    # idle floor manufactures variance); idle is subtracted ONCE, from the median.
+    # per-sample OS-combined package total; CV on raw loaded samples, idle subtracted once
     if pkg:
         arr = np.array(pkg)
         med = float(np.median(arr))
@@ -227,7 +157,7 @@ def _attach_energy(wl: str, device: str, run_once, *, tag: str,
         return
     apw = e.get("active_pkg_W", float("nan"))
     sane = apw == apw and apw > 0
-    # plausibility: an ANE workload reading ~0 on the ANE rail is a sampling miss
+    # an ANE workload reading ~0 on the ANE rail is a sampling miss
     if device == "ANE" and e.get("ane_active_mW", 0.0) < 5.0 and not e["flags"]:
         e["flags"].append("ANE rail ~0 mW during ANE workload - likely a 100ms sampling miss")
     if flops is not None and sane:

--- a/bench/device_saturation_sweep.py
+++ b/bench/device_saturation_sweep.py
@@ -1,43 +1,5 @@
 #!/usr/bin/env python3
-"""Saturation (roofline) sweep - PEAK throughput + PEAK perf/watt per compute engine.
-
-The watt-complete device comparison (``device_compare_wattcomplete.py``) raced each
-device on *representative* workload shapes. But representative != saturating: a 512x512
-GEMM runs the GPU at ~4% of its fp16 peak, so "the GPU is X GFLOP/s" measured there
-UNDER-reports the silicon. The fair "how fast / how efficient is each device at its
-BEST" answer requires sizing the workload until the device's cores/units are FULLY
-UTILIZED. That is what this script does.
-
-We scale two primitives that actually saturate compute:
-
-  1. GEMM   - square NxN @ NxN, FLOPs = 2 N^3. Sweep N until each device plateaus.
-  2. conv   - 3x3 same-pad conv, channels C with batch sized to fill, FLOPs =
-              2 * B * Cout * Cin * 9 * H * W. The ANE's home turf - find its conv peak.
-
-For each (primitive, size, device in {CPU, GPU, ANE}):
-  * THROUGHPUT  = GFLOP/s from the MIN latency over reps (device forced to sync:
-                  mx.eval / the compiled aneforge net / numpy inline).
-  * RELERR      vs an fp64 (GEMM) / fp32 (conv) reference, reported next to every
-                throughput number - the ANE's fp16 error grows at large N and that is
-                part of the story (a 30 TFLOP/s GPU number at 4e-4 != an ANE number
-                at 3e-2).
-  * POWER       at the SATURATING sizes (the plateau region, where the loop is
-                naturally multi-second) - idle-subtracted ACTIVE package power
-                (median + CV) via the REUSED harness in device_compare_wattcomplete
-                (measure_energy / sample_idle). perf/watt = GFLOP/s / active_W.
-
-DTYPE ASYMMETRY IS REAL AND LABELED. CPU is fp32 (numpy/Accelerate-AMX cannot do a fast
-fp16 GEMM - it upcasts), GPU and ANE are fp16. So the CPU peak is an fp32 number; it is
-NOT the same product as the fp16 peaks and is labeled as such everywhere.
-
-Run from repo root (energy needs passwordless sudo for powermetrics):
-
-    PYTHONPATH=. python3 bench/device_saturation_sweep.py
-
-Writes bench/results/device_saturation_sweep_results.json alongside the printed
-tables. --quick trims the largest (multi-second) sizes and shortens the power window
-for a smoke test. --no-power skips the energy phase (throughput curves only).
-"""
+"""Saturation (roofline) sweep: PEAK throughput + PEAK perf/watt per compute engine, scaling GEMM and conv to full utilization - CPU vs GPU (MLX) vs ANE. Run: PYTHONPATH=. python3 bench/device_saturation_sweep.py"""
 from __future__ import annotations
 
 import argparse
@@ -57,8 +19,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 import numpy as np
 
-# Reuse the watt-complete harness for power (idle-subtracted ACTIVE package, median+CV,
-# sampler-exit-driven loop) and device_compare for the latency/relerr helpers.
+# Reuse the watt-complete power harness + device_compare latency/relerr helpers.
 import device_compare as dc            # noqa: E402
 import device_compare_wattcomplete as wc  # noqa: E402
 
@@ -74,8 +35,7 @@ if HAVE_MLX:
 # sizes (overridable by --quick which trims the multi-second tail)
 GEMM_NS = [512, 1024, 2048, 4096, 6144, 8192]
 GEMM_NS_QUICK = [512, 1024, 2048, 4096]
-# conv: fixed-ish spatial 64x64, 3x3, batch chosen so total work tracks GEMM scale.
-# we scale channels C (=Cin=Cout) and pick batch B to keep the tensor fillable.
+# conv: fixed 64x64 spatial, 3x3; scale channels C, pick batch B to fill
 CONV_SPATIAL = 64
 CONV_CONFIGS = [  # (C, B)
     (64, 16), (128, 16), (256, 8), (512, 4),
@@ -84,8 +44,7 @@ CONV_CONFIGS_QUICK = [(64, 8), (128, 8), (256, 4), (512, 2)]
 
 REPS = 8           # reps for the min-latency probe (large GEMMs are seconds each)
 WARMUP = 3
-POWER_WINDOW = 8.0  # seconds for the sustained-power loop (>=16 samples @ 500ms -> clears
-                    # the watt-complete harness's <12-sample "short window" flag)
+POWER_WINDOW = 8.0  # sustained-power loop seconds (>=16 samples @ 500ms)
 
 RESULTS: dict = {"gemm": [], "conv": []}
 
@@ -106,8 +65,7 @@ def _min_lat(fn, reps=REPS, warmup=WARMUP):
 
 
 def _power_at(run_once, tag):
-    """Idle-subtracted ACTIVE package power (median W + CV%) over a sustained loop,
-    via the reused watt-complete harness. Returns the harness dict or None."""
+    """Idle-subtracted ACTIVE package power (median W + CV%) over a sustained loop."""
     if not HAVE_SUDO:
         return None
     return wc.measure_energy(run_once, tag=tag, window=POWER_WINDOW)
@@ -123,17 +81,14 @@ def sweep_gemm(ns, do_power):
         rng = np.random.default_rng(0)
         x32 = (rng.standard_normal((N, N)).astype(np.float32) / np.float32(np.sqrt(N)))
         W32 = (rng.standard_normal((N, N)).astype(np.float32) / np.float32(np.sqrt(N)))  # [out,in]
-        # fp64 reference (subsample rows for huge N to bound memory/time, relerr is a
-        # norm so a representative row-block is a faithful estimate)
+        # fp64 reference, subsampling rows for huge N (relerr is a norm)
         rblk = min(N, 256)
         ref_blk = x32[:rblk].astype(np.float64) @ W32.astype(np.float64).T
         row = {"N": N, "gflop": flops / 1e9, "devices": {}}
         print(f"\n N={N}  ({flops/1e9:.1f} GFLOP)")
 
         # --- CPU (fp32, numpy/Accelerate-AMX) ---
-        # IMPORTANT: feed CONTIGUOUS operands. A transposed view (W32.T) makes
-        # Accelerate fall off its fast fp32 GEMM path (~4x slower, ~fp64-rate) - the
-        # the AMX peak needs both operands C-contiguous.
+        # feed contiguous operands; a transposed view drops Accelerate off its fast GEMM path
         Wt = np.ascontiguousarray(W32.T)
         lat = _min_lat(lambda: x32 @ Wt)
         out = x32 @ Wt
@@ -178,8 +133,7 @@ def sweep_gemm(ns, do_power):
 
 
 def _power_phase_gemm(ns):
-    """Measure active package power for EVERY swept GEMM size (so the power-vs-size
-    curve shows the climb toward the plateau), per device."""
+    """Measure active package power for every swept GEMM size, per device."""
     print("\n" + "-" * 92)
     print(" GEMM power-vs-size (idle-subtracted active package W) - utilization evidence")
     print("-" * 92)
@@ -217,14 +171,14 @@ def sweep_conv(configs, do_power):
         x32 = rng.standard_normal((B, C, H, W)).astype(np.float32)
         w32 = (rng.standard_normal((C, C, k, k)).astype(np.float32)
                * np.sqrt(2.0 / (C * k * k)))
-        # fp32 numpy reference on a single batch element (relerr is a norm)
+        # fp32 numpy reference on one batch element (relerr is a norm)
         ref0 = dc._np_conv2d(x32[:1].astype(np.float32), w32, 1).astype(np.float64)
         row = {"C": C, "B": B, "HxW": f"{H}x{W}", "gflop": flops / 1e9, "devices": {}}
         print(f"\n C={C} B={B}  ({flops/1e9:.1f} GFLOP)")
 
         # --- CPU (fp32) ---
         lat = _min_lat(lambda: dc._np_conv2d(x32[:1].astype(np.float32), w32, 1), reps=max(3, REPS // 2))
-        # CPU only times one batch element to keep it bounded; scale to full-batch flops
+        # CPU times one batch element; scale to full-batch flops
         cpu_flops = flops / B
         out = dc._np_conv2d(x32[:1].astype(np.float32), w32, 1)
         err = relerr(out, ref0)
@@ -284,7 +238,7 @@ def _power_phase_conv(configs):
         w32 = (rng.standard_normal((C, C, k, k)).astype(np.float32)
                * np.sqrt(2.0 / (C * k * k)))
         print(f"\n C={C} B={B}")
-        # CPU power: drive full batch to make it a sustained load
+        # CPU power: drive full batch for a sustained load
         _attach_power(row["devices"]["CPU"],
                       lambda: dc._np_conv2d(x32.astype(np.float32), w32, 1),
                       f"sat_conv{C}_cpu", flops, "CPU")
@@ -321,7 +275,7 @@ def _attach_power(dev_row, run_once, tag, flops, device):
         thr = flops / (e["iter_ms"] / 1e3)  # FLOP/s at the sustained-loop rate
         rec["gflops_sustained"] = thr / 1e9
         rec["perf_per_W"] = (thr / 1e9) / apw  # GFLOP/s/W
-    # plausibility flag: ANE work that reads ~0 on the ANE rail is a sampling miss
+    # ANE work that reads ~0 on the ANE rail is a sampling miss
     if device == "ANE" and e.get("ane_active_mW", 0.0) < 5.0 and not rec["flags"]:
         rec["flags"].append("ANE rail ~0 mW during ANE work - likely a 100ms sampling miss")
     dev_row["power"] = rec

--- a/bench/device_serving_sweep.py
+++ b/bench/device_serving_sweep.py
@@ -1,59 +1,5 @@
 #!/usr/bin/env python3
-"""Batched SERVING sweep - ANE (aneforge fp16) vs GPU (MLX fp16) across BATCH SIZE.
-
-The serving-regime complement to the single-stream device map
-(``device_compare_wattcomplete.py``). That harness answers "which device per op at
-B=1". This one answers the serving question: *as you batch, where does the GPU's
-throughput (and its throughput/watt) overtake the ANE's?* - the crossover that
-decides which accelerator a serving deployment should target at a given batch size.
-
-METHODOLOGY - reused verbatim from device_compare_wattcomplete (see that file's
-docstring for the full rationale); this script imports its energy harness so the
-numbers are produced by the SAME code:
-
-  * idle-subtracted ACTIVE power; headline = total-package power from powermetrics'
-    own ``Combined Power (CPU + GPU + ANE)`` line (NOT a hand-summed rail total -
-    the GPU rail prints twice per sample block);
-  * median + CV% over the per-sample package totals (CV>35% is FLAGGED low-confidence);
-  * sustained loop driven until the sampler process EXITS (the fix that got CV to
-    1-25%); warmup before the window;
-  * accuracy (relerr vs an fp32/fp64 numpy reference) reported alongside; fp16 both
-    sides; forced device sync (compiled-net call on ANE, ``mx.eval`` on GPU).
-
-TRUE BATCHING ON BOTH SIDES: each workload is ONE compiled program with a real
-batch dimension B (NOT multi-stream). The ANE true-batches - dispatch amortizes
-over B - so a real batch dim is the fair apples-to-apples vs GPU batching. We sweep
-B in {1, 4, 16, 64, 256}; if an ANE workload fails to compile / OOMs at some B we
-report the cap as a finding (we do NOT silently drop it or fall back to multi-stream).
-
-WORKLOADS (4, serving-relevant):
-  1. vision    - a 3x3 conv stack -> GAP -> FC, image-classifier serving (N=B images,
-                 conv's native batch dim).
-  2. encoder   - a transformer-encoder block (attn + MLP + 2 layernorms) at S=128,
-                 batched over B sequences; embedding serving. Batched as a rank-3/4
-                 graph (layernorm folds B into rows [B*S, D]).
-  3. attention - the self-attention block alone at S=128, batched over B (rank-4
-                 q@k / softmax / @v). The decomposed-SDPA route, true-batched.
-  4. gemm      - the batched GEMM [B,M,K] @ [K,N] underlying serving, the throughput
-                 primitive.
-
-METRICS per (workload, B, device):
-  * throughput = items/s (images or sequences per second) and latency/call (ms);
-  * total-package ACTIVE power (idle-subtracted, median + CV%), sustained loop;
-  * throughput/watt = items/s / active_W;  energy/item = active_W * call_ms / B (mJ);
-  * accuracy = relerr vs fp32 reference.
-
-DELIVERABLE = the two crossovers per workload: the B where GPU THROUGHPUT overtakes
-ANE, and the B where GPU THROUGHPUT/WATT overtakes ANE (typically a larger B - the
-ANE's watt advantage persists past its throughput advantage). Printed explicitly.
-
-Run from repo root (energy needs passwordless sudo for powermetrics)::
-
-    PYTHONPATH=. python3 bench/device_serving_sweep.py
-
-Writes bench/results/device_serving_sweep_results.json. --quick = short window;
---batches "1,4,16" overrides the sweep; --window N overrides the per-loop seconds.
-"""
+"""Batched serving sweep: finds the batch size where GPU throughput / throughput-per-watt overtakes the ANE, across 4 serving workloads - ANE vs GPU (MLX). Run: PYTHONPATH=. python3 bench/device_serving_sweep.py"""
 from __future__ import annotations
 
 import argparse
@@ -93,25 +39,18 @@ RESULTS: dict[str, dict] = {}
 
 # one measured point: latency (min over reps) + sustained-loop energy
 def measure_point(wl, device, B, run_once, *, items_per_call, relerr_val, tag):
-    """Time one (device,B) point and run the reused energy harness on it.
-
-    items_per_call = the number of serving items processed by one run_once() call
-    (= B here, since the whole batch is one call). throughput = items/s, perf/watt
-    and energy/item are derived from the sustained-loop active package power."""
+    """Time one (device,B) point + run the energy harness. items_per_call = B."""
     lat, _out = min_latency_with_out(run_once, reps=20, warmup=6)
     thr = items_per_call / lat                                    # items/s
     point = {"device": device, "B": B, "latency_ms": lat * 1e3,
              "throughput_items_s": thr, "relerr": relerr_val}
-    # reuse the wattcomplete sustained-loop power harness verbatim
     e = wc.measure_energy(run_once, tag=tag, window=wc.WINDOW)
     if e is not None:
         apw = e.get("active_pkg_W", float("nan"))
         sane = apw == apw and apw > 0
-        # plausibility guard, same as wattcomplete's _attach_energy
         if device == "ANE" and e.get("ane_active_mW", 0.0) < 5.0 and not e["flags"]:
             e["flags"].append("ANE rail ~0 mW during ANE workload - likely a 100ms sampling miss")
-        # the loop's own per-iter time is the steady-state call time; throughput/watt
-        # and energy/item use it (the min-latency above is the headline call time).
+        # steady-state call time from the loop's per-iter time
         loop_items_s = items_per_call / (e["iter_ms"] / 1e3)
         if sane:
             e["throughput_items_s"] = loop_items_s
@@ -200,8 +139,7 @@ def wl_vision(batches):
 
 def _build_encoder_ane(B, S, D, H, Wq, bq, Wk, bk, Wv, bv, Wo, bo, W1, b1, W2, b2,
                        g1, bn1, g2, bn2):
-    """One batched transformer-encoder block as an aneforge graph (rank-4 attn,
-    layernorms folded to [B*S, D]). Returns the compiled Model. fp16 weights."""
+    """One batched transformer-encoder block as an aneforge graph; returns the compiled Model."""
     dh = D // H
     x = af.input((B, S, D))
     # pre-LN attention
@@ -438,8 +376,7 @@ def _series(points, device, key):
 
 
 def _crossover(ane, gpu):
-    """First B where GPU >= ANE (linear-interpolated in log2 B). Returns
-    (crossover_B or None, verdict_string)."""
+    """First B where GPU >= ANE (log2-B interpolated). Returns (crossover_B or None, verdict)."""
     ad = dict(ane); gd = dict(gpu)
     common = sorted(set(ad) & set(gd))
     if not common:
@@ -453,7 +390,6 @@ def _crossover(ane, gpu):
     for i in range(1, len(diffs)):
         b0, d0 = diffs[i - 1]; b1, d1 = diffs[i]
         if d0 < 0 <= d1:
-            # log2-B interpolation of the crossover point
             l0, l1 = np.log2(b0), np.log2(b1)
             frac = -d0 / (d1 - d0) if (d1 - d0) != 0 else 0.0
             bx = 2 ** (l0 + frac * (l1 - l0))

--- a/bench/encoder_serving_crosspath.py
+++ b/bench/encoder_serving_crosspath.py
@@ -1,58 +1,5 @@
 #!/usr/bin/env python3
-"""End-to-end encoder-block serving, cross-path: ANEForge (ANE) vs MLX (GPU).
-
-QUESTION
---------
-A single int4 matmul at batch is ~2x faster on the ANE than on the GPU's own
-4-bit path (cross_path_compress_bench.py). A sibling experiment
-(model_int4_bench.py) showed the per-matmul int4 LATENCY win dilutes to ~1.0x on
-whole models once norms / attention / residuals / the per-program dispatch floor
-are mixed in. This asks the cross-path version of that dilution question for one
-representative pre-LN transformer ENCODER block, swept over batch:
-
-  Does the ANE int4 advantage over the GPU int4 SURVIVE end-to-end on the full
-  block, or does the GPU win / tie once it is more than one matmul?
-  And does int4 help the ANE end-to-end here at all?
-
-BLOCK (Paper B Table 7 config)
-------------------------------
-Pre-LN transformer encoder block, D=768, H=12, Dff=3072, S=128, batch sweep
-B in {1,8,16,32,64}:
-    h1 = x  + MHSA(LayerNorm(x))            (q,k,v,out projections)
-    y  = h1 + FFN(LayerNorm(h1))            (up D->Dff, gelu, down Dff->D)
-The six linears (q,k,v,out,up,down) are the weight-bearing matmuls that int4
-compresses; norms / softmax / residuals / gelu are uncompressed.
-
-ATTENTION VARIANT
------------------
-We build attention as bmm + softmax (q@k^T, softmax, @v) in [B,H,S,dh], NOT the
-af.sdpa native-fused layer. af.sdpa is a graph CUT (host round-trip between e5rt
-sub-programs) and is batch-1 only; using it would (a) not batch and (b) make the
-comparison about the cut rather than about weight streaming. bmm+softmax keeps
-the whole block in ONE e5rt program so the timing isolates weight bandwidth +
-the single dispatch floor. (The MLX side uses the same bmm+softmax math.)
-
-VARIANTS TIMED (end-to-end block latency, median; throughput = B/latency)
-    ANE fp16            compress=None
-    ANE int4 (default)  compress="int4"  (atol 0.05 -> pessimistic on gaussian
-                        weights, usually falls back to int8/fp16)
-    ANE int4 (loose)    compress="int4", compress_atol=0.5  (forces the LUT)
-    ANE auto            compress="auto"
-    GPU fp16            mlx fp16
-    GPU int4            mlx 4-bit group-affine (group_size 64) on the six linears
-
-We tally constexpr_lut_to_dense nodes per ANE program so the reader knows whether
-int4 truly fired (default vs loose). Each int4 path is cosine-checked vs its own
-fp16 block so timing is on a correct computation. Random (untrained) weights are
-fine for LATENCY (op-mix / shape dependent); only the int4 accuracy gate is
-pessimistic on gaussian weights, which is exactly why we report the loose-gate
-row as the genuine int4-fired datapoint.
-
-Run (needs the 3.14 interp with BOTH aneforge + mlx):
-    PYTHONPATH=<repo> python3 \
-        bench/encoder_serving_crosspath.py
-Writes bench/results/encoder_serving_crosspath.json
-"""
+"""End-to-end encoder-block serving, cross-path (ANE vs MLX-GPU): does the ANE int4 win survive a full block? Run: PYTHONPATH=<repo> python3 bench/encoder_serving_crosspath.py"""
 from __future__ import annotations
 
 import json
@@ -67,7 +14,7 @@ import numpy as np
 import aneforge as af
 import mlx.core as mx
 
-# ---- config ---------------------------------------------------------------- #
+# config
 D, H, DFF, S = 768, 12, 3072, 128
 DH = D // H
 SCALE = 1.0 / (DH ** 0.5)
@@ -100,7 +47,7 @@ def median_ms(fn):
     return statistics.median(ts)
 
 
-# ---- shared weights (PyTorch [out,in] convention; identical for ANE & GPU) -- #
+# shared weights (PyTorch [out,in] convention; identical for ANE & GPU)
 def make_weights(rng):
     def lin(out, inp):
         return (rng.standard_normal((out, inp)) / np.sqrt(inp)).astype(np.float32)
@@ -117,10 +64,9 @@ def make_weights(rng):
     }
 
 
-# ---- ANE: pre-LN encoder block as one aneforge graph ----------------------- #
+# ANE: pre-LN encoder block as one aneforge graph
 def build_ane(w, B):
-    """Batched [B,S,D] pre-LN encoder block; attention in [B,H,S,dh] (bmm+softmax),
-    linears / LayerNorm on [B*S, D]. One fused e5rt program (no graph cut)."""
+    """Batched [B,S,D] pre-LN encoder block; attention bmm+softmax, one fused e5rt program."""
     x = af.input((B, S, D))
     xf = x.reshape(B * S, D)
     xn = xf.layer_norm(w["ln1w"], w["ln1b"], EPS)
@@ -138,8 +84,7 @@ def build_ane(w, B):
 
 
 def _lut_tally(build_dir):
-    """Count constexpr_lut_to_dense (int4-LUT) and the other weight encodings the
-    emitter actually chose, summed across all model.mil files under build_dir."""
+    """Count the weight encodings the emitter chose, summed across model.mil files."""
     counts = {"int4_lut": 0, "sparse": 0, "int8": 0, "fp16": 0}
     for mil in Path(build_dir).rglob("model.mil"):
         txt = mil.read_text()
@@ -162,10 +107,9 @@ def run_ane(w, B, x, label, compress, atol):
     return ms, np.asarray(y, np.float32), enc
 
 
-# ---- GPU: same block in MLX (fp16 and 4-bit group-affine) ------------------ #
+# GPU: same block in MLX (fp16 and 4-bit group-affine)
 def _mx_w(w):
-    """upload weights as mx float16; store linears transposed to [in,out] so
-    x[...,in] @ Wt[in,out] = (x @ W.T) matches the aneforge linear convention."""
+    """upload weights as mx float16; linears transposed to [in,out] for x @ Wt."""
     g = {}
     for kk, vv in w.items():
         g[kk] = mx.array(vv).astype(mx.float16)
@@ -175,8 +119,7 @@ def _mx_w(w):
 
 
 def _gpu_block(xm, g, lin):
-    """pre-LN encoder block in MLX. `lin(name, x)` does x @ W.T (+ bias) for the six
-    weight linears; norms/softmax/gelu/residuals are plain fp16."""
+    """pre-LN encoder block in MLX; `lin(name, x)` does x @ W.T (+ bias)."""
     B = xm.shape[0]
 
     def layernorm(t, gw, gb):
@@ -218,7 +161,7 @@ def run_gpu_fp16(g, B, xnp):
 
 def run_gpu_int4(g, B, xnp):
     xm = mx.array(xnp).astype(mx.float16)
-    # quantize the six linears (their [in,out] mx weight) 4-bit, group_size 64
+    # quantize the six linears 4-bit, group_size 64
     q4 = {}
     for nm in ("Wq", "Wk", "Wv", "Wo", "Wi", "Wd"):
         wq, sc, bi = mx.quantize(g[nm + "_t"], bits=4, group_size=GROUP)
@@ -238,7 +181,7 @@ def run_gpu_int4(g, B, xnp):
     return median_ms(run), out
 
 
-# ---- driver ---------------------------------------------------------------- #
+# driver
 def main():
     print("END-TO-END encoder-block serving, cross-path (ANE vs MLX-GPU)")
     print("=" * 78)

--- a/bench/fused_gpu_baseline.py
+++ b/bench/fused_gpu_baseline.py
@@ -1,32 +1,5 @@
 #!/usr/bin/env python3
-"""Fused-GPU (MLX) baseline (addresses the "own-tool vs MLX" confound).
-
-Peer-review blocker: the ANE is driven by our fused compiler (aneforge, one program)
-while the GPU baseline is *default* MLX, which runs some ops UNFUSED (e.g. layer_norm
-as several separate kernel passes). So the device map might reflect TOOLCHAIN
-(fused-vs-unfused) rather than SILICON. We fix it with measurement: re-run the
-fusion-sensitive workloads with the GPU ALSO fused via mx.compile (MLX graph
-capture/kernel fusion), and put default-MLX, fused-MLX, and the ANE side by side.
-
-Workloads (same shapes the paper uses, pulled from device_compare_wattcomplete.py):
-  * layer_norm  (197, 768)         - the canonical multi-pass op MLX runs unfused
-  * gelu        (197, 768)         - transcendental elementwise
-  * attention   (197, 768, 12)     - ViT self-attention block (qkv->softmax->out)
-  * conv stack  (64->256, 32x32, k3, depth 16)  - resnet-ish 3x3 stack
-
-For each: default-MLX vs mx.compile-fused-MLX vs ANE (aneforge), reporting
-latency (min over reps), idle-subtracted total-package active power + CV%, and
-GFLOP/s-or-items/s perf/W. Power harness imported from device_compare_wattcomplete.
-
-THE QUESTION: does fusing the GPU materially change any device-map verdict - does
-the GPU close the perf/watt gap, or flip any ANE win? We report it plainly either way.
-
-Run from repo root (energy needs passwordless sudo):
-
-    PYTHONPATH=. python3 bench/fused_gpu_baseline.py
-
-Writes bench/results/fused_gpu_baseline_results.json. --quick reduces the window.
-"""
+"""Fused-GPU (MLX) baseline: default-MLX vs mx.compile-fused-MLX vs ANE, to test whether fusing the GPU flips any device-map verdict. Run: PYTHONPATH=. python3 bench/fused_gpu_baseline.py"""
 from __future__ import annotations
 
 import argparse
@@ -123,7 +96,7 @@ def wl_layer_norm(shape=(197, 768), window=6.0):
             mu = mx.mean(xg, axis=-1, keepdims=True)
             var = mx.mean((xg - mu) ** 2, axis=-1, keepdims=True)
             return (xg - mu) * mx.rsqrt(var + 1e-5) * gg + bb
-        # default (unfused: each mx op a separate kernel launch)
+        # default (unfused)
         lat, out = _mlx_min_latency(lambda: ln(xg, gg, bb))
         e = wc.measure_energy(lambda: mx.eval(ln(xg, gg, bb)), tag="ln_gpu_default", window=window) if HAVE_SUDO else None
         _record(wl, "GPU default", lat_s=lat, out=out, ref=ref, items=items, energy=e)
@@ -270,10 +243,7 @@ def wl_conv_stack(Cin=64, Cout=256, H=32, W=32, k=3, depth=16, window=6.0):
         _record(wl, "ANE (aneforge)", lat_s=lat, out=np.asarray(out), ref=ref, flops=flops, energy=e)
 
 
-# 5-point stencil, 32 chained steps (256x256) - the largest perf/W gap (49x)   #
-# in the device map, and exactly the asymmetric-fusion case: default MLX runs   #
-# 32 separate conv kernels, the ANE fuses all 32 into one program. Re-test the  #
-# GPU with mx.compile fusing the whole 32-step chain so the comparison is fair. #
+# 5-point stencil, 32 chained steps - largest perf/W gap; asymmetric-fusion case
 def wl_stencil(H=256, W=256, steps=32, window=6.0):
     wl = f"stencil 5pt ({H}x{W}, steps={steps})"
     print(f"\n=== {wl} ===", flush=True)
@@ -283,7 +253,7 @@ def wl_stencil(H=256, W=256, steps=32, window=6.0):
     lap = np.array([[0, 1, 0], [1, -4, 1], [0, 1, 0]], dtype=np.float32)
     K = np.zeros((1, 1, 3, 3), dtype=np.float32)
     K[0, 0] = dt * lap
-    K[0, 0, 1, 1] += 1.0                      # identity + dt*Laplacian, one 3x3
+    K[0, 0, 1, 1] += 1.0                      # identity + dt*Laplacian
     flops = float(steps * 2 * 1 * 1 * 9 * H * W)
 
     def np_step(u):

--- a/bench/gemv_bandwidth_sweep.py
+++ b/bench/gemv_bandwidth_sweep.py
@@ -1,34 +1,5 @@
 #!/usr/bin/env python3
-"""GEMV weight-stream bandwidth sweep (corroborates the ~112 GB/s).
-
-Peer-review blocker: the paper's "~112 GB/s ANE weight-stream bandwidth" (the
-*second* bandwidth, distinct from the choked ~24 GB/s standalone-activation path)
-is inferred from a SINGLE GEMV point (M=1, K=N=4096, 466% of the drawn ~24 GB/s
-roof) with no climb-to-plateau. The same evidence standard the paper applies to
-the 24 GB/s elementwise number (flat-with-size plateau) must be applied here.
-
-This script sweeps the decode GEMV (M=1) on the ANE across K=N in
-{512,1024,2048,4096,6144,8192} (plus a few rectangular K!=N), and for each computes
-the ACHIEVED EFFECTIVE WEIGHT-STREAM BANDWIDTH:
-
-    eff_BW = (weight_bytes + input_bytes + output_bytes) / min_latency
-
-with weight_bytes = K*N*2 (fp16), input = K*2, output = N*2. The weight matrix
-dominates at M=1, so this is the weight-DMA bandwidth the decode GEMV actually
-drives. We report GB/s per K and ask: does it plateau ~112 GB/s (supporting the
-two-bandwidth claim) or vary (undermining it)?
-
-The same GEMV sweep is run on GPU (MLX fp16) and CPU (numpy/Accelerate fp32) for
-context. Power (idle-subtracted total-package, median + CV) is measured at the
-4096 and 8192 points via the rigorous harness imported from
-device_compare_wattcomplete.
-
-Run from repo root (energy needs passwordless sudo for powermetrics):
-
-    PYTHONPATH=. python3 bench/gemv_bandwidth_sweep.py
-
-Writes bench/results/gemv_bandwidth_sweep_results.json. --quick caps sizes.
-"""
+"""GEMV weight-stream bandwidth sweep: M=1 decode GEMV across K=N to test whether ANE effective bandwidth plateaus near the paper's ~112 GB/s. Run: PYTHONPATH=. python3 bench/gemv_bandwidth_sweep.py"""
 from __future__ import annotations
 
 import argparse
@@ -79,14 +50,14 @@ def sweep_gemv(K, N, *, reps, warmup, measure_pw):
     label = f"GEMV M=1, K={K}, N={N}"
     print(f"\n=== {label} === (weight {K*N*2/1e6:.1f} MB fp16)", flush=True)
     rng = np.random.default_rng(0)
-    # well-scaled so fp16 is meaningful; aneforge linear wants W as [out,in]=[N,K]
+    # aneforge linear wants W as [out,in]=[N,K]
     x32 = (rng.standard_normal((1, K)).astype(np.float32) / np.sqrt(K))
     W32 = (rng.standard_normal((N, K)).astype(np.float32) / np.sqrt(K))  # [out,in]
     ref = x32.astype(np.float64) @ W32.astype(np.float64).T              # [1,N]
     res = {"K": K, "N": N, "weight_MB": K * N * 2 / 1e6,
            "eff_bytes": eff_bytes(K, N), "devices": {}}
 
-    # ANE (aneforge fused single-program, fp16) ----------------------------- #
+    # ANE (aneforge fused single-program, fp16)
     if HAVE_ANE:
         try:
             net = af.compile(af.input((1, K)).linear(W32.astype(np.float16)))
@@ -118,7 +89,7 @@ def sweep_gemv(K, N, *, reps, warmup, measure_pw):
             res["devices"]["ANE"] = {"error": f"{type(e).__name__}: {e}"}
             print(f"  ANE  FAILED: {type(e).__name__}: {e}")
 
-    # GPU (MLX fp16) -------------------------------------------------------- #
+    # GPU (MLX fp16)
     if HAVE_MLX:
         try:
             xg = mx.array(x32.astype(np.float16))
@@ -151,7 +122,7 @@ def sweep_gemv(K, N, *, reps, warmup, measure_pw):
             res["devices"]["GPU"] = {"error": f"{type(e).__name__}: {e}"}
             print(f"  GPU  FAILED: {type(e).__name__}: {e}")
 
-    # CPU (numpy / Accelerate fp32) ----------------------------------------- #
+    # CPU (numpy / Accelerate fp32)
     try:
         Wt = W32.T.copy()    # [K,N]
         out_h = {}
@@ -160,7 +131,7 @@ def sweep_gemv(K, N, *, reps, warmup, measure_pw):
             out_h["o"] = x32 @ Wt
         lat = min_latency(run, reps=max(10, reps // 2), warmup=warmup)
         out = out_h["o"]
-        # CPU fp32 moves 4 B/elem for the weight; report its own effective BW
+        # CPU fp32 moves 4 B/elem; report its own effective BW
         cpu_bytes = K * N * 4 + K * 4 + N * 4
         d = {"dtype": "fp32", "lat_ms": lat * 1e3,
              "eff_GBps": cpu_bytes / lat / 1e9, "GFLOPs": gflops(K, N, lat),
@@ -194,10 +165,7 @@ def main() -> int:
               f"GPU {wc.IDLE.get('gpu',0):.0f} / CPU {wc.IDLE.get('cpu',0):.0f})")
 
     square = [512, 1024, 2048, 4096] if args.quick else [512, 1024, 2048, 4096, 6144, 8192]
-    # power measured at EVERY square point so the weight-stream tier carries a
-    # GB/s/W column (the only sweep that previously lacked one - closes the
-    # "watt-complete" asymmetry: the 24 GB/s activation path has GB/s/W in
-    # Table 4, the weight path did not). Each point adds one power window.
+    # power at every square point so the weight-stream tier carries a GB/s/W column
     pw_at = set(square)
 
     sweep = []
@@ -205,13 +173,13 @@ def main() -> int:
         sweep.append(sweep_gemv(KN, KN, reps=args.reps, warmup=args.warmup,
                                 measure_pw=(KN in pw_at)))
 
-    # a couple of rectangular K!=N points (same M=1 decode shape)
+    # rectangular K!=N points (same M=1 decode shape)
     rect = [] if args.quick else [(8192, 2048), (2048, 8192), (4096, 11008)]
     rect_res = []
     for (K, N) in rect:
         rect_res.append(sweep_gemv(K, N, reps=args.reps, warmup=args.warmup, measure_pw=False))
 
-    # -------- plateau analysis on the ANE square sweep -------------------- #
+    # plateau analysis on the ANE square sweep
     print("\n" + "=" * 90)
     print(" ANE WEIGHT-STREAM BANDWIDTH (square M=1 GEMV)")
     print("=" * 90)
@@ -232,7 +200,7 @@ def main() -> int:
     verdict = {}
     if ane_bw:
         bws = np.array([b for _, b in ane_bw])
-        # plateau = the large-K tail (>=2048), where small-size dispatch overhead is amortized
+        # plateau = large-K tail (>=2048), dispatch overhead amortized
         tail = np.array([b for k, b in ane_bw if k >= 2048])
         verdict = {
             "ane_bw_all_GBps": {str(k): round(b, 1) for k, b in ane_bw},

--- a/bench/model_int4_bench.py
+++ b/bench/model_int4_bench.py
@@ -1,53 +1,5 @@
 #!/usr/bin/env python3
-"""End-to-end int4 / auto weight-compression benchmark for real-model graphs.
-
-QUESTION
---------
-The per-matmul finding was that 4-bit LUT weight streaming gives a 1.3-1.8x
-latency win over fp16 on weight-bandwidth-bound matmuls at batch 1. This script
-asks whether that win CARRIES to whole models, where norms, attention, residuals
-and the fixed per-program dispatch floor dilute the weight-bandwidth fraction
-(exactly as int8's per-GEMV win did NOT carry to end-to-end LLM decode).
-
-WHAT IT MEASURES
-----------------
-For each model we build the full forward graph (correct ImageNet / ViT-B/16 /
-MiniLM-L6 architecture and shapes) and compile it THREE ways through the public
-``af.compile`` knob:
-
-    compress=None     fp16 baseline (byte-identical to the historical path)
-    compress="int4"   per-tensor 4-bit LUT, accuracy-gated (falls back int8/fp16)
-    compress="auto"   per-weight: sparse -> int4 -> int8 -> fp16 (most-aggressive
-                      encoding that stays within the accuracy budget)
-
-and reports, end-to-end (the WHOLE program, not a single matmul):
-
-  * latency  : median of `REPS` timed evals after `WARMUP` (ms) + the speedup
-               vs the fp16 baseline,
-  * cosine   : cosine similarity of the compressed output vs the fp16 baseline
-               output (accuracy retention of the end-to-end forward),
-  * size     : on-disk `weights.bin` bytes + fraction of the fp16 baseline.
-
-WEIGHT SOURCE
--------------
-This host has numpy + aneforge + the ANE dylib but NOT torch / torchvision /
-transformers, so the pretrained loaders (af.load_resnet18 / af.load / the ViT
-demo) cannot fetch real trained weights here. We therefore build each model's
-EXACT architecture and tensor shapes with deterministic random weights
-(seeded, He/Xavier-scaled). This is a faithful test of the latency + footprint
-question (those depend on op mix + shapes, not weight values) and of cosine
-RETENTION (compressed-vs-fp16 of the same graph). The one caveat is the int4
-ACCURACY GATE: random near-Gaussian weights are close to worst-case for 4-bit
-LUT palettization (no low-rank / clustered structure for the 16-entry codebook
-to exploit), so the int4 fallback-to-fp16 rate measured here is PESSIMISTIC
-relative to real trained weights. We report the realized cosine and footprint
-so the gate behaviour is visible either way. compress_atol is left at the
-library default (0.05 relative-L2 per tensor).
-
-Run:
-    PYTHONPATH=<repo> \
-      python3 bench/model_int4_bench.py
-"""
+"""End-to-end int4 / auto weight-compression benchmark: does the per-matmul 4-bit win carry to whole-model latency, cosine, and footprint? Run: PYTHONPATH=<repo> python3 bench/model_int4_bench.py"""
 from __future__ import annotations
 
 import json
@@ -72,8 +24,7 @@ def _rng():
 
 
 def W(rng, *shape, fan_in=None):
-    """Xavier-ish weight: scale by 1/sqrt(fan_in) so activations stay O(1) and the
-    fp16 baseline forward does not overflow (matters for the cosine reference)."""
+    """Xavier-ish weight: scale by 1/sqrt(fan_in) so activations stay O(1)."""
     fan = fan_in if fan_in is not None else shape[-1]
     return (rng.standard_normal(shape) / np.sqrt(fan)).astype(np.float32)
 
@@ -84,9 +35,7 @@ def B(rng, n):
 
 # model graph builders (full architecture, deterministic random weights)
 def build_resnet18(rng):
-    """torchvision ResNet-18 forward (ImageNet): conv-dominated. BatchNorm is folded
-    into the preceding conv (as the real loader does), so the graph is pure
-    conv/relu/pool/add/fc. Input [1,3,224,224] -> logits [1,1000]."""
+    """torchvision ResNet-18 forward (ImageNet): conv-dominated, BN folded into conv. [1,3,224,224] -> [1,1000]."""
     def conv_w(cout, cin, k):
         return W(rng, cout, cin, k, k, fan_in=cin * k * k)
 
@@ -111,9 +60,7 @@ def build_resnet18(rng):
 
 
 def build_vit_b16(rng, n_layers=12):
-    """ViT-B/16 encoder forward (12 layers x 768 dim x 12 heads, 197 tokens):
-    patch-embed conv + attention + MLP matmuls -> logits [1,1000]. Mixed conv +
-    matmul, matmul-dominated by parameter count (the MLP 768<->3072 projections)."""
+    """ViT-B/16 encoder forward (12 layers x 768 dim x 12 heads, 197 tokens) -> [1,1000]; matmul-dominated."""
     DIM, HEADS, PATCH, IMG = 768, 12, 16, 224
     NP = (IMG // PATCH) ** 2          # 196
     SEQ = NP + 1                       # 197
@@ -136,7 +83,7 @@ def build_vit_b16(rng, n_layers=12):
         seq = seq + y
 
     seq = seq.layer_norm(W(rng, DIM), B(rng, DIM), eps=1e-6)
-    # classifier on row 0 (CLS) via a one-hot picker matmul (same trick as vit_demo)
+    # classifier on CLS row via one-hot picker matmul
     sel = np.eye(1, SEQ, dtype=np.float32)
     cls_row = seq.transpose([1, 0]).linear(sel).transpose([1, 0])    # [1,768]
     out = cls_row.linear(W(rng, 1000, DIM), B(rng, 1000))
@@ -146,10 +93,7 @@ def build_vit_b16(rng, n_layers=12):
 
 
 def build_minilm(rng, S=64, L=6, DIM=384, HEADS=12, ff=1536):
-    """all-MiniLM-L6-v2 encoder (BERT-family) transformer stack: 6 post-norm layers
-    of MHA + LayerNorm + (Linear-GELU-Linear) MLP. Pure matmul + layer_norm (the
-    embedding lookup is host-side in the real loader; we feed the post-embed [S,DIM]
-    activation as the input, which is what runs on the ANE). Matmul-DOMINATED."""
+    """all-MiniLM-L6-v2 encoder: 6 post-norm MHA+LayerNorm+(Linear-GELU-Linear) layers; matmul-dominated."""
     eps = 1e-12
     h = af.input((S, DIM))
     for _ in range(L):
@@ -170,19 +114,14 @@ MODELS = {
 
 # bench harness
 def _encoding_tally(build_dir):
-    """Count which weight encodings the emitter actually chose, by scanning the
-    generated MIL. This makes the int4 accuracy-gate fallback VISIBLE: a request for
-    compress='int4' that finds a weight too lossy for the 16-entry LUT falls back to
-    int8 (constexpr_affine_dequantize) or fp16 (const). SegmentedModels write several
-    model.mil files (one per region); we sum across all of them under build_dir."""
+    """Count weight encodings from the generated MIL (makes the int4 gate fallback visible), summed across model.mil files."""
     counts = {"int4_lut": 0, "sparse": 0, "int8": 0, "fp16": 0}
     for mil in Path(build_dir).rglob("model.mil"):
         txt = mil.read_text()
         counts["int4_lut"] += txt.count("constexpr_lut_to_dense")
         counts["sparse"] += txt.count("constexpr_sparse_to_dense")
         counts["int8"] += txt.count("constexpr_affine_dequantize")
-        # fp16 weight constants are BLOBFILE-backed const() ops (exclude the many
-        # tiny inline const() scalars, which have no BLOBFILE).
+        # fp16 weight constants are BLOBFILE-backed const() ops
         counts["fp16"] += sum(1 for ln in txt.splitlines()
                               if "= const()" in ln and "BLOBFILE" in ln)
     return counts
@@ -206,7 +145,7 @@ def median_ms(net, inputs):
 
 def run_model(name, kind, builder):
     print(f"\n=== {name} ({kind}) ===")
-    # build inputs once (deterministic) so all three variants see identical feeds
+    # build inputs once so all variants see identical feeds
     rng = _rng()
     built = builder(rng)
     in_shapes = built[1]
@@ -217,17 +156,11 @@ def run_model(name, kind, builder):
 
     res = {"kind": kind, "n_ops": None, "fp16_ms": None, "variants": {}}
     fp16_out = None
-    # (label, compress, compress_atol). "int4_forced" loosens the accuracy gate to
-    # 0.30 so the 4-bit LUT actually FIRES on these random weights (the default 0.05
-    # gate rejects near-Gaussian weights -> falls back to int8/fp16, so plain "int4"
-    # here measures the FALLBACK, not the LUT). The forced row is the genuine
-    # int4-encoding end-to-end latency/footprint datapoint; its cosine shows the
-    # accuracy cost of accepting the lossy LUT.
+    # (label, compress, atol); int4_forced loosens the gate to 0.30 so the LUT fires on random weights
     plan = [("fp16", None, 0.05), ("int4", "int4", 0.05),
             ("int4_forced", "int4", 0.30), ("auto", "auto", 0.05)]
     for label, variant, atol in plan:
-        # rebuild the graph fresh per variant from the SAME seed: weight values are
-        # identical across variants, only the encoding differs.
+        # rebuild graph fresh per variant from the same seed; only the encoding differs
         rng_v = _rng()
         b = builder(rng_v)
         out_v = b[0]
@@ -244,7 +177,7 @@ def run_model(name, kind, builder):
         ms = median_ms(net, arrays)
         wb = os.path.getsize(os.path.join(d, "weights.bin"))
         n_ops = getattr(net, "n_ops", None)
-        enc = _encoding_tally(d)        # which weight encodings the emitter actually chose
+        enc = _encoding_tally(d)
         net.release()
 
         if variant is None:

--- a/bench/real_models_fp16.py
+++ b/bench/real_models_fp16.py
@@ -1,18 +1,5 @@
 #!/usr/bin/env python3
-"""fp16 GPU baselines for the real models (addresses the fp16-ANE-vs-fp32-GPU
-asymmetry in the real-model table).
-
-The single-stream real-model rows compared an fp16 ANE against an fp32 torch-MPS
-GPU, so the headline energy ratios (e.g. ViT-B/16 ~18x mJ/inference) were not
-like-for-like. This script re-runs ResNet-18, ViT-B/16, and MiniLM on the GPU in
-BOTH fp32 and fp16 (torch-MPS .half()), under the same watt-complete harness, so
-the fp16-vs-fp16 GPU/ANE energy ratio can be reported. It reuses the exact model
-builders from device_compare_wattcomplete.py.
-
-Run from repo root (energy needs passwordless sudo):
-    PYTHONPATH=. python3 bench/real_models_fp16.py --window 6
-Writes bench/results/real_models_fp16_results.json.
-"""
+"""fp16 GPU (fp32+fp16) vs ANE energy baselines for the real models. Run: PYTHONPATH=. python3 bench/real_models_fp16.py --window 6"""
 from __future__ import annotations
 
 import argparse
@@ -35,14 +22,12 @@ import device_compare as dc  # noqa: E402
 import device_compare_wattcomplete as wc  # noqa: E402
 
 HAVE_SUDO = dc.HAVE_SUDO
-# GPU-only: the ANE real-model numbers are unchanged and read from the committed
-# device-map JSON, so we never re-dispatch the ANE here (avoids session-state hangs
-# and keeps the ANE pairing identical to the headline table).
+# GPU-only: ANE numbers read from committed device-map JSON, never re-dispatched.
 HAVE_ANE = False
 min_latency_with_out = dc.min_latency_with_out
 relerr = dc.relerr
 
-# ANE real-model energy from the committed single-stream run (the paper's M5 table).
+# ANE real-model energy from the committed single-stream run (paper's M5 table).
 _ANE_DEVMAP = json.loads((Path(__file__).resolve().parent / "results" /
     "device_compare_wattcomplete_results_M5.json").read_text())
 def _ane_mJ(wl_substr):
@@ -103,8 +88,7 @@ def resnet18(window):
 
 
 def vit_b16(window):
-    """Full ViT-B/16 (torchvision, 12-layer) on GPU fp32 + fp16. GPU-only: the ANE
-    ViT-B/16 energy is read from the committed device-map run (the paper's table)."""
+    """Full ViT-B/16 on GPU fp32 + fp16; ANE energy read from committed device-map run."""
     import torch, torchvision as tv
     wl = "ViT-B/16 forward (1x3x224x224, 197 tokens)"
     print(f"\n=== {wl} ===", flush=True)

--- a/bench/roofline_analysis.py
+++ b/bench/roofline_analysis.py
@@ -1,36 +1,5 @@
 #!/usr/bin/env python3
-"""Capstone roofline analysis - unify the compute-ceiling and bandwidth-ceiling sweeps
-into a per-device roofline that mechanistically EXPLAINS the device map.
-
-Two measured ceilings already exist (we do NOT re-run them):
-  * COMPUTE roof  - peak GFLOP/s per device, from device_saturation_sweep_results.json
-                    ("peaks": GEMM/conv). GPU ~30.9/31.8 TFLOP/s; ANE ~10.2/18.8;
-                    CPU ~1.9 (fp32 AMX).
-  * BANDWIDTH roof - peak GB/s per device, from device_bandwidth_roofline_results.json
-                    (streaming archetype). GPU ~230, CPU ~130, ANE ~24 (the STANDALONE
-                    single-program path ceiling, flat from small - NOT silicon DMA).
-
-This script:
-  1. Computes arithmetic intensity (AI = FLOPs / bytes-moved) for each op archetype from
-     real FLOP and byte counts, showing the formula. fp16 = 2 B/elem; CPU fp32 = 4 B.
-  2. Pulls the two ceilings from the JSONs and computes each device's ridge point
-     (ridge = peak_compute / peak_bw, in FLOP/byte).
-  3. Places every archetype on EACH device's roofline:
-        applicable_roof(AI) = min(compute_roof, bw_roof * AI)
-        %roof = achieved / applicable_roof
-     where achieved is: the saturation sweep for compute-bound ops; AI x achieved_GB/s
-     (DERIVED) for bandwidth-bound ops; and a fresh MEASUREMENT for attention, a real
-     fused block, and a GEMV/decode point (the gaps not covered by the two sweeps).
-  4. Emits roofline_analysis_results.json + prints per-device tables and ASCII rooflines.
-
-Only the GAPS are measured here (attention achieved GFLOP/s per device, a real fused
-conv block achieved GFLOP/s on the ANE, a GEMV decode point). GEMM/conv/bandwidth peaks
-are READ from the existing JSONs.
-
-Run from repo root:
-    PYTHONPATH=. python3 bench/roofline_analysis.py
-    # --no-measure  : skip the gap measurements (uses analytic AIxBW placeholders, labeled)
-"""
+"""Per-device roofline analysis unifying compute and bandwidth ceilings. Run: PYTHONPATH=. python3 bench/roofline_analysis.py"""
 from __future__ import annotations
 
 import argparse
@@ -57,14 +26,13 @@ BW_JSON = TOOLS / "device_bandwidth_roofline_results.json"
 FP16 = 2  # bytes/elem
 FP32 = 4
 
-# Part 0 - pull the measured ceilings from the two JSONs
+# Part 0 - pull measured ceilings from the two JSONs
 def load_ceilings():
     sat = json.loads(SAT_JSON.read_text())
     bw = json.loads(BW_JSON.read_text())
 
     peaks = sat["peaks"]
-    # Compute roof (GFLOP/s). GEMM (square) and conv are reported separately; the ANE in
-    # particular has DIFFERENT compute roofs per op (conv >> square-matmul). Keep both.
+    # Compute roof (GFLOP/s): GEMM and conv kept separate (ANE conv >> square-matmul).
     compute = {}
     for dev in ("CPU", "GPU", "ANE"):
         compute[dev] = {
@@ -74,13 +42,11 @@ def load_ceilings():
             "conv_peak_at_C": peaks["conv"][dev]["peak_gflops_size"],
         }
 
-    # Bandwidth roof (GB/s) - use the STREAMING archetype peak (relu / x*2, byte_factor=2),
-    # the cleanest pure read+write traffic op. This is the standalone-op bandwidth ceiling.
+    # Bandwidth roof (GB/s): streaming archetype peak (pure read+write traffic).
     stream = bw["results"]["roofline"]["streaming (relu / x*2)"]["peak"]
     bandwidth = {dev.upper(): stream[dev.lower()]["gbps"] for dev in ("CPU", "GPU", "ANE")}
 
-    # achieved GB/s per device per archetype (the saturated tail of each curve) - used to
-    # DERIVE achieved GFLOP/s for the bandwidth-bound ops.
+    # achieved GB/s per device per archetype -> derive achieved GFLOP/s for bw-bound ops.
     arche_bw = {}
     for name, blk in bw["results"]["roofline"].items():
         arche_bw[name] = {dev.upper(): blk["peak"][dev.lower()]["gbps"]
@@ -97,10 +63,7 @@ def ai_matmul(M, K, N, bpe):
 
 
 def ai_conv3x3(B, Cin, Cout, H, W, bpe):
-    """3x3 same-pad conv. flops = 2*B*Cout*Cin*9*H*W.
-    bytes moved = input(B*Cin*H*W) + weights(Cout*Cin*9) + output(B*Cout*H*W), *bpe.
-    The reuse factor (why conv has decent AI): each input element participates in
-    ~9*Cout MACs, each weight in B*H*W MACs - so flops/bytes climbs with channels."""
+    """3x3 same-pad conv. flops=2*B*Cout*Cin*9*H*W; bytes=(in+weights+out)*bpe."""
     k = 3
     flops = 2.0 * B * Cout * Cin * k * k * H * W
     in_el = B * Cin * H * W
@@ -118,12 +81,10 @@ def ai_elementwise(reads, writes, flops_per_elem, n, bpe):
 
 
 def build_archetype_ai():
-    """Return a list of archetype dicts with AI computed from real counts + the formula
-    string, for fp16 (GPU/ANE) traffic. AI is dtype-dependent only through bytes-per-
-    element: CPU fp32 doubles the bytes/elem, halving AI; handled per device in placement."""
+    """Archetype dicts with fp16 AI from real counts + formula string (CPU fp32 halves AI in placement)."""
     rows = []
 
-    # ---- matmul: square N (compute archetype) + GEMV/decode (the key low-AI case) ----
+    # matmul: square N (compute) + GEMV/decode (low-AI case)
     for N in (512, 2048, 8192):
         f, b, ai = ai_matmul(N, N, N, FP16)
         rows.append({
@@ -133,7 +94,7 @@ def build_archetype_ai():
             "note": "AI = 2N^3 / (3N^2 * 2) = N/3. Grows with N -> large GEMM is compute-bound.",
             "represents": ["matmul(large)", "bmm", "linear"],
         })
-    # GEMV / M=1 decode matmul, K=4096, N=4096 (a transformer projection at decode)
+    # GEMV / M=1 decode matmul (transformer projection at decode)
     M, K, N = 1, 4096, 4096
     f, b, ai = ai_matmul(M, K, N, FP16)
     rows.append({
@@ -147,7 +108,7 @@ def build_archetype_ai():
         "represents": ["GEMV", "LLM decode matmul", "M=1 projection"],
     })
 
-    # ---- conv 3x3, the saturating config from the sweep (C=512,B=4,64x64) ----
+    # conv 3x3, saturating config from the sweep (C=512,B=4,64x64)
     f, b, ai = ai_conv3x3(B=4, Cin=512, Cout=512, H=64, W=64, bpe=FP16)
     rows.append({
         "archetype": "conv 3x3 (C=512,B=4,64x64)", "class": "compute",
@@ -156,7 +117,7 @@ def build_archetype_ai():
         "note": "reuse: each input elem in ~9*Cout MACs -> high AI, clears every ridge.",
         "represents": ["conv", "conv_transpose"],
     })
-    # a small conv too (C=64,B=16) to show AI is config-dependent but still high
+    # small conv (C=64,B=16): AI config-dependent but still high
     f, b, ai = ai_conv3x3(B=16, Cin=64, Cout=64, H=64, W=64, bpe=FP16)
     rows.append({
         "archetype": "conv 3x3 (C=64,B=16,64x64)", "class": "compute",
@@ -166,26 +127,26 @@ def build_archetype_ai():
         "represents": ["conv (small-channel)"],
     })
 
-    # ---- bandwidth-bound elementwise archetypes (AI from real op counts) ----
-    # relu/copy: 1 read + 1 write, ~1 flop (compare/max). ~0.2 FLOP/byte
+    # bandwidth-bound elementwise archetypes (AI from real op counts)
+    # relu/copy: 1R+1W, ~1 flop -> ~0.2 FLOP/byte
     f, b, ai = ai_elementwise(reads=1, writes=1, flops_per_elem=1, n=16_777_216, bpe=FP16)
     rows.append({"archetype": "relu / copy (1R+1W, ~1 flop)", "class": "memory",
                  "formula": "1 flop / (2 elem * 2B) = 0.25; counting copy as ~0 flop -> ~0.2",
                  "flops": f, "bytes_fp16": b, "ai_fp16": ai, "bw_archetype": "streaming (relu / x*2)",
                  "represents": ["relu", "abs", "copy", "reshape", "transpose", "add", "sub", "mul"]})
-    # gelu/silu: ~10 flops/elem (erf/tanh approx), 1R+1W -> ~2.5 FLOP/byte
+    # gelu/silu: ~10 flop/elem, 1R+1W -> ~2.5 FLOP/byte
     f, b, ai = ai_elementwise(reads=1, writes=1, flops_per_elem=10, n=16_777_216, bpe=FP16)
     rows.append({"archetype": "gelu / silu (~10 flop, 1R+1W)", "class": "memory",
                  "formula": "~10 flop / (2 elem * 2B) = 2.5 FLOP/byte",
                  "flops": f, "bytes_fp16": b, "ai_fp16": ai, "bw_archetype": "gelu (light compute)",
                  "represents": ["gelu", "silu", "erf", "tanh", "sigmoid", "exp"]})
-    # softmax: ~5 flops/elem (max,sub,exp,sum,div), 1R+1W effective -> ~1.2 FLOP/byte
+    # softmax: ~5 flop/elem, 1R+1W -> ~1.2 FLOP/byte
     f, b, ai = ai_elementwise(reads=1, writes=1, flops_per_elem=5, n=16_777_216, bpe=FP16)
     rows.append({"archetype": "softmax (~5 flop, 1R+1W)", "class": "memory",
                  "formula": "~5 flop / (2 elem * 2B) = 1.25 FLOP/byte",
                  "flops": f, "bytes_fp16": b, "ai_fp16": ai, "bw_archetype": "softmax",
                  "represents": ["softmax"]})
-    # layer_norm: ~10 flops/elem (mean,var,normalize,scale,shift), 1R+1W -> ~2.5 FLOP/byte
+    # layer_norm: ~10 flop/elem, 1R+1W -> ~2.5 FLOP/byte
     f, b, ai = ai_elementwise(reads=1, writes=1, flops_per_elem=10, n=16_777_216, bpe=FP16)
     rows.append({"archetype": "layer_norm (~10 flop, 1R+1W)", "class": "memory",
                  "formula": "~10 flop / (2 elem * 2B) = 2.5 FLOP/byte",
@@ -196,16 +157,13 @@ def build_archetype_ai():
 
 # Part 1b - attention block: blended AI (matmul-dominated)
 def attention_flops_bytes(S, D, H, bpe):
-    """One attention block QK^T + softmax + AV for [1,H,S,D] (per the af.sdpa shape).
-    QK^T: 2*H*S*S*D flops.  AV: 2*H*S*S*D flops.  softmax over H*S*S scores: ~5 flop each.
-    bytes moved (standalone, intermediates spill): Q,K,V in = 3*H*S*D; scores S^2*H
-    written+read for softmax = 2*H*S*S; out = H*S*D. *bpe."""
+    """QK^T + softmax + AV for [1,H,S,D]; standalone bytes (intermediates spill)."""
     qkt = 2.0 * H * S * S * D
     av = 2.0 * H * S * S * D
     sm = 5.0 * H * S * S
     flops = qkt + av + sm
     in_el = 3 * H * S * D
-    score_traffic = 2 * H * S * S  # write then read scores (standalone, not fused)
+    score_traffic = 2 * H * S * S  # write then read scores (standalone)
     out_el = H * S * D
     nbytes = (in_el + score_traffic + out_el) * bpe
     return flops, nbytes, flops / nbytes
@@ -243,8 +201,8 @@ def measure_gaps(no_measure):
         out["skipped"] = True
         return out
 
-    # ---------- ATTENTION block [1,H,S,D] ----------
-    S, D, H = 512, 64, 12   # S=512 seq, d_head=64, 12 heads (ViT-B-ish)
+    # ATTENTION block [1,H,S,D]
+    S, D, H = 512, 64, 12   # ViT-B-ish: 512 seq, d_head=64, 12 heads
     flops, _, _ = attention_flops_bytes(S, D, H, FP16)
     out["attention"]["config"] = {"S": S, "D": D, "H": H, "flops": flops}
     rng = np.random.default_rng(0)
@@ -296,9 +254,7 @@ def measure_gaps(no_measure):
     except Exception as e:
         out["attention"]["CPU"] = {"error": f"{type(e).__name__}: {e}"}
 
-    # ---------- REAL FUSED BLOCK on the ANE: a 3-conv stack fused into ONE program ----
-    # This is the fusion-lever evidence: 3 chained 3x3 convs, intermediates never leave
-    # the chip. Compare its achieved GFLOP/s to ONE standalone conv's (from the sweep).
+    # FUSED BLOCK on ANE: 3 chained 3x3 convs in one program (intermediates stay on-chip)
     if HAVE_ANE:
         try:
             import aneforge as af
@@ -318,13 +274,12 @@ def measure_gaps(no_measure):
             xf = rng.standard_normal((Bc, C, Hc, Wc)).astype(np.float16)
             net(xf)
             lat = _min_lat(lambda: net(xf))
-            # standalone bytes for ONE conv (input+wt+out) vs fused (read input once, write
-            # output once, 3x weights, intermediates stay on-chip): estimate effective AI.
+            # effective AI: fused (intermediates on-chip) vs 3 standalone dispatches
             f1, b_standalone_one, ai_one = ai_conv3x3(Bc, C, C, Hc, Wc, FP16)
             in_el = Bc * C * Hc * Wc; out_el = Bc * C * Hc * Wc
             w_el = 3 * C * C * k3 * k3
-            fused_bytes = (in_el + w_el + out_el) * FP16  # intermediates NOT counted (on-chip)
-            standalone_bytes_3 = 3 * b_standalone_one      # 3 separate dispatches spill each
+            fused_bytes = (in_el + w_el + out_el) * FP16  # intermediates not counted
+            standalone_bytes_3 = 3 * b_standalone_one      # each dispatch spills
             out["fused_block"]["ANE"] = {
                 "config": {"B": Bc, "C": C, "HxW": f"{Hc}x{Wc}", "n_conv": n_conv},
                 "dtype": "fp16", "lat_ms": lat * 1e3, "gflops": fused_flops / lat / 1e9,
@@ -338,11 +293,11 @@ def measure_gaps(no_measure):
         except Exception as e:
             out["fused_block"]["ANE"] = {"error": f"{type(e).__name__}: {e}"}
 
-    # ---------- GEMV / decode point (M=1) per device ----------
+    # GEMV / decode point (M=1) per device
     M, K, N = 1, 4096, 4096
     flops_gemv = 2.0 * M * K * N
     xg = (rng.standard_normal((M, K)) / np.sqrt(K)).astype(np.float16)
-    Wg = (rng.standard_normal((N, K)) / np.sqrt(K)).astype(np.float16)  # [out,in]
+    Wg = (rng.standard_normal((N, K)) / np.sqrt(K)).astype(np.float16)  # [out, in]
     if HAVE_ANE:
         try:
             import aneforge as af
@@ -378,8 +333,7 @@ def applicable_roof(ai, compute_roof, bw_roof):
 
 
 def _sat_achieved(sat, dev, archetype):
-    """Pull the size-specific achieved GFLOP/s straight from the saturation sweep JSON
-    for the exact size a compute archetype names (not the peak)."""
+    """Size-specific achieved GFLOP/s from the saturation sweep JSON (not the peak)."""
     if "square N=" in archetype:
         N = int(archetype.split("N=")[1].split()[0])
         for r in sat["gemm"]:
@@ -394,16 +348,16 @@ def _sat_achieved(sat, dev, archetype):
 
 
 def build_placement(arche, compute, bandwidth, arche_bw, gaps, sat):
-    """For each (op, device): AI (dtype-adjusted), applicable roof, achieved, %roof."""
+    """Per (op, device): AI (dtype-adjusted), applicable roof, achieved, %roof."""
     placement = {dev: [] for dev in ("CPU", "GPU", "ANE")}
     for dev in ("CPU", "GPU", "ANE"):
         bpe = FP32 if dev == "CPU" else FP16
         bw_roof = bandwidth[dev]
         for row in arche:
-            # AI for this device's dtype: recompute byte count with this bpe -> AI scales by 2/bpe
+            # AI scales by 2/bpe for this device's dtype
             ai = row["ai_fp16"] * (FP16 / bpe)
             cls = row["class"]
-            # pick compute roof: conv archetypes use conv peak, matmul archetypes use gemm peak
+            # conv archetypes use conv peak, matmul use gemm peak
             if "conv" in row["archetype"]:
                 comp_roof = compute[dev]["conv_peak_gflops"]
             else:
@@ -412,15 +366,15 @@ def build_placement(arche, compute, bandwidth, arche_bw, gaps, sat):
             achieved = None
             src = None
             if cls == "compute":
-                # size-SPECIFIC achieved from the saturation sweep (NOT the device peak)
+                # size-specific achieved from the saturation sweep (not the peak)
                 achieved = _sat_achieved(sat, dev, row["archetype"])
                 src = "saturation sweep (size-specific)"
             else:
-                # bandwidth-bound: achieved = AI * achieved_GB/s (DERIVED)
+                # bandwidth-bound: derived achieved = AI * achieved_GB/s
                 bwname = row.get("bw_archetype")
                 if bwname and bwname in arche_bw:
                     gbps = arche_bw[bwname][dev]
-                    achieved = ai * gbps  # GFLOP/s = (FLOP/byte) * (GB/s)
+                    achieved = ai * gbps  # GFLOP/s = FLOP/byte * GB/s
                     src = f"DERIVED: AI x achieved {gbps:.1f} GB/s ({bwname})"
             pct = (achieved / roof * 100.0) if (achieved and roof) else None
             placement[dev].append({
@@ -434,7 +388,7 @@ def build_placement(arche, compute, bandwidth, arche_bw, gaps, sat):
         D = gaps["attention"].get("config", {}).get("D", 64)
         Hh = gaps["attention"].get("config", {}).get("H", 12)
         _, _, ai_att = attention_flops_bytes(S, D, Hh, bpe)
-        comp_roof = compute[dev]["gemm_peak_gflops"]  # attention is matmul-dominated
+        comp_roof = compute[dev]["gemm_peak_gflops"]  # matmul-dominated
         roof = applicable_roof(ai_att, comp_roof, bw_roof)
         adev = gaps["attention"].get(dev, {})
         ach = adev.get("gflops")
@@ -459,8 +413,7 @@ def build_placement(arche, compute, bandwidth, arche_bw, gaps, sat):
 
 # ASCII roofline sketch
 def ascii_roofline(dev, compute, bandwidth, placement_rows, ridge):
-    """log-log ASCII: x=AI (FLOP/byte), y=GFLOP/s. Draw the roof (bw slope -> flat) and
-    plot each op as a point at its (AI, achieved)."""
+    """log-log ASCII roofline: x=AI (FLOP/byte), y=GFLOP/s, ops as points."""
     comp = compute[dev]["gemm_peak_gflops"]
     comp_conv = compute[dev]["conv_peak_gflops"]
     bw = bandwidth[dev]
@@ -478,7 +431,7 @@ def ascii_roofline(dev, compute, bandwidth, placement_rows, ridge):
         return int((y_hi - math.log10(g)) / (y_hi - y_lo) * (Hh - 1))
 
     grid = [[" "] * W for _ in range(Hh)]
-    # roof line: for AI from x_lo..x_hi, y = min(comp, bw*AI)
+    # roof line: y = min(comp, bw*AI)
     for c in range(W):
         ai = 10 ** (x_lo + c / (W - 1) * (x_hi - x_lo))
         y = min(comp, bw * ai)
@@ -527,7 +480,7 @@ def main():
     # ridge points
     ridges = {}
     for dev in ("CPU", "GPU", "ANE"):
-        # use the GEMM compute peak as the headline compute roof for the ridge
+        # GEMM compute peak as the headline roof for the ridge
         ridges[dev] = compute[dev]["gemm_peak_gflops"] / bandwidth[dev]
 
     print("=" * 88)

--- a/bench/whisper_encoder_ane/bench_energy.py
+++ b/bench/whisper_encoder_ane/bench_energy.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Energy: the whisper-tiny encoder on the ANE vs the Metal GPU (MPS), whole-package,
-idle-subtracted, via powermetrics. Same methodology as the project's headline numbers
-(bench/device_compare_wattcomplete.py): sample CPU+GPU+ANE rails at 500 ms, subtract a
-per-rail idle baseline, report milliJoules per encode.
-
-Needs passwordless sudo for powermetrics. Run from repo root:
-    PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_energy.py [--window 8]
-"""
+"""Whisper-tiny encoder energy (ANE vs Metal GPU), idle-subtracted via powermetrics. Run: PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_energy.py"""
 from __future__ import annotations
 
 import argparse

--- a/bench/whisper_encoder_ane/bench_latency.py
+++ b/bench/whisper_encoder_ane/bench_latency.py
@@ -1,14 +1,5 @@
 #!/usr/bin/env python3
-"""Latency: the whisper-tiny encoder on the ANE (decomposed mha, and af.sdpa) vs the
-same encoder in PyTorch on the CPU (fp32) and the Metal GPU (MPS, fp16).
-
-The ANE 'mha' and 'sdpa' rows are expected to match: at seq=1500 af.sdpa decomposes
-to the same matmul/softmax (the native fused-attention layer needs the smaller
-attention axis < 512). All four run identical weights.
-
-Run from repo root:
-    PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_latency.py [--reps 30]
-"""
+"""Whisper-tiny encoder latency (ANE vs PyTorch CPU/MPS). Run: PYTHONPATH=. python3 bench/whisper_encoder_ane/bench_latency.py"""
 from __future__ import annotations
 
 import argparse

--- a/bench/whisper_encoder_ane/encoder.py
+++ b/bench/whisper_encoder_ane/encoder.py
@@ -1,20 +1,4 @@
-"""A whisper-tiny encoder built two ways from one state dict: the HuggingFace
-reference, and the equivalent ANEForge graph that runs on the Apple Neural Engine.
-
-Weights are randomly initialised (fixed seed), so nothing is downloaded: latency and
-energy are weight-independent, and fidelity only needs the two graphs to share
-weights. Pass real whisper-tiny weights (same key names) to run the published
-checkpoint.
-
-Mapping notes:
-  - The whole transformer stack runs as 2-D [seq, d_model] (batch 1), which is what
-    af.mha / af.layer_norm expect.
-  - Whisper's conv1d stem maps to af.conv (2-D) with a singleton height axis. af.conv
-    pads symmetrically, so the time axis is zero-padded explicitly (_pad_time) and the
-    conv runs with pad=0, leaving the singleton axis alone.
-  - Whisper's k_proj has no bias (passed as None); attention scale is 1/sqrt(d_head),
-    which is af.mha's default.
-"""
+"""Whisper-tiny encoder built two ways from one state dict: the HuggingFace reference and the equivalent ANEForge graph for the Apple Neural Engine."""
 from __future__ import annotations
 
 import numpy as np

--- a/bench/whisper_encoder_ane/export_bundle.py
+++ b/bench/whisper_encoder_ane/export_bundle.py
@@ -1,12 +1,5 @@
 #!/usr/bin/env python3
-"""Compile the whisper-tiny encoder, persist its program (model.mil + weights.bin +
-the compiled bundle), and dump everything the standalone C++ runner needs: the exact
-fp16 input vectors, the port manifest (names + element counts), and the PyTorch
-reference output to score against.
-
-Run from repo root:
-    PYTHONPATH=. python3 bench/whisper_encoder_ane/export_bundle.py [--out DIR]
-"""
+"""Compile and persist the whisper-tiny encoder bundle plus the I/O the standalone C++ runner needs. Run: PYTHONPATH=. python3 bench/whisper_encoder_ane/export_bundle.py"""
 from __future__ import annotations
 
 import argparse

--- a/bench/whisper_encoder_ane/fidelity.py
+++ b/bench/whisper_encoder_ane/fidelity.py
@@ -1,11 +1,5 @@
 #!/usr/bin/env python3
-"""Fidelity gate: the ANEForge whisper-tiny encoder vs the PyTorch reference, same
-weights. Prints cosine similarity and relative error of the encoder output computed
-on the Apple Neural Engine.
-
-Run from repo root:
-    PYTHONPATH=. python3 bench/whisper_encoder_ane/fidelity.py
-"""
+"""Fidelity gate: ANEForge whisper-tiny encoder vs PyTorch reference (cosine + relative error). Run: PYTHONPATH=. python3 bench/whisper_encoder_ane/fidelity.py"""
 from __future__ import annotations
 
 import os

--- a/bench/whisper_encoder_ane/validate_real.py
+++ b/bench/whisper_encoder_ane/validate_real.py
@@ -1,16 +1,5 @@
 #!/usr/bin/env python3
-"""Fidelity on the real checkpoint: whisper-tiny's trained encoder weights and a real
-log-mel from Whisper's own feature extractor, ANEForge vs the PyTorch reference. This
-complements fidelity.py, which uses a randomly-initialised encoder.
-
-The trained encoder on real audio reaches cosine ~0.998 (vs ~1.0000 for random init):
-the ANE's gelu LUT and fp16 lose more on the sharp, high-dynamic-range activations a
-trained encoder produces on real log-mel. The drop needs both real weights and real
-input; neither alone shows it.
-
-Downloads openai/whisper-tiny (needs network). Run from repo root:
-    PYTHONPATH=. python3 bench/whisper_encoder_ane/validate_real.py
-"""
+"""Fidelity on the real checkpoint: trained whisper-tiny weights + real log-mel, ANEForge vs PyTorch reference. Run: PYTHONPATH=. python3 bench/whisper_encoder_ane/validate_real.py"""
 from __future__ import annotations
 
 import os

--- a/bench/whisper_encoder_ane/wer_proxy.py
+++ b/bench/whisper_encoder_ane/wer_proxy.py
@@ -1,18 +1,5 @@
 #!/usr/bin/env python3
-"""Does the encoder's fidelity gap change the transcript? Feed the ANE encoder output
-into the HF Whisper decoder on real speech and compare against the reference encoder's
-transcript. A word-error-rate proxy that skips the whisper.cpp C++ wiring: same
-decoder weights either way, only the encoder differs.
-
-On the canonical jfk.wav clip the encoder reaches cosine ~0.9998 (real speech is
-easier than the synthetic signal in validate_real.py) and the two transcripts are
-identical, so the feature error costs no accuracy here. This is one clip, not a full
-dataset WER; it answers "does the gap matter" for a real sample, not "what is the WER
-over LibriSpeech".
-
-Downloads openai/whisper-tiny and jfk.wav (needs network). Run from repo root:
-    PYTHONPATH=. python3 bench/whisper_encoder_ane/wer_proxy.py [--audio path.wav]
-"""
+"""WER proxy: does the encoder fidelity gap change the transcript? ANE vs reference encoder through the HF Whisper decoder. Run: PYTHONPATH=. python3 bench/whisper_encoder_ane/wer_proxy.py"""
 from __future__ import annotations
 
 import argparse

--- a/tests/_corpus.py
+++ b/tests/_corpus.py
@@ -1,21 +1,4 @@
-"""Shared harness for the aneforge correctness corpus.
-
-This is the GATE infrastructure: a graph-optimizer pass must keep the whole
-corpus green. Each test is a ``Case`` record::
-
-    Case(name, category, build_fn, ref_fn, inputs, tol, ...)
-
-where
-  - ``build_fn(*input_tensors) -> af.Tensor`` builds the graph (the ANE output),
-  - ``ref_fn(*input_arrays_fp32) -> np.ndarray`` is the numpy golden reference,
-  - ``inputs`` is a list of fp16 numpy arrays (also the af.input shapes), and
-  - ``tol`` is the per-case relative-error tolerance (or abs/exact mode).
-
-The key reuse hook is ``run_case(case, int8=False) -> np.ndarray``: it builds the
-graph, compiles it on the ANE, runs it on the case inputs, and returns the ANE
-output. A future optimizer can call ``run_case`` with optimization on/off and diff
-the two outputs against THIS corpus - same builds, same inputs, same goldens.
-"""
+"""Shared harness for the aneforge correctness corpus (the green-gate infrastructure)."""
 from __future__ import annotations
 
 import sys

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,31 +1,9 @@
-"""Pytest configuration for the on-device suites.
-
-The tests run each in their own forked subprocess (``--forked`` in pyproject's
-``addopts``). Process isolation matters here because every ``compile`` allocates an
-e5rt program against the ANE, and a single process accumulates them across a whole
-suite - the compile-heavy training and streaming tests alone build hundreds of
-programs, which can approach the per-PID program limit and cause sporadic
-late-suite failures. A fresh process per test resets that
-state, and the fork overhead is negligible next to the ANE compile time itself.
-
-These environment variables must be set before any test forks or loads the dispatch
-dylib, so they are set here at collection time (before the test modules import
-aneforge):
-  - OBJC_DISABLE_INITIALIZE_FORK_SAFETY: the dispatch path loads Apple Obj-C
-    frameworks; forking after they initialize trips Obj-C's fork-safety abort unless
-    this is set.
-  - KMP_DUPLICATE_LIB_OK: tolerate the duplicate OpenMP runtime that numpy/the dylib
-    can both pull in.
-  - OMP/MKL/OPENBLAS/VECLIB thread counts = 1: --forked calls os.fork() in a process
-    where numpy/torch may have started an OpenMP worker-thread pool. fork() does not
-    copy those worker threads, so the child inherits a broken pool, and the next
-    OpenMP op (e.g. torch CPU autograd in the grad-vs-torch CIFAR tests) faults inside
-    libomp (__kmp_fork_barrier) - a SIGSEGV that surfaced only late in the forked
-    suite. One OpenMP thread means there is no pool to break, so the fork is safe.
-"""
+"""Pytest config for the on-device suites: env vars set before tests fork/import aneforge."""
 import os
 
+# Must be set before any test forks or loads the dispatch dylib (Obj-C fork-safety; dup OpenMP).
 os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+# Single OpenMP thread: --forked os.fork() can't copy worker-thread pools, so disable them.
 for _thread_var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
   os.environ.setdefault(_thread_var, "1")

--- a/tests/op_smoketest.py
+++ b/tests/op_smoketest.py
@@ -1,11 +1,4 @@
-"""Smoke test for aneforge's op surface: build a one-op graph for each operation,
-compile it into an ANE program, run it, and check against a numpy reference.
-
-Covers the ops added from the e5rt conformance sweep
-(the reverse-engineering corpus). Run:
-
-    PYTHONPATH=. python3 tests/op_smoketest.py
-"""
+"""Smoke test for aneforge's op surface: one-op graph per op, compiled/run vs numpy."""
 import math
 import sys
 from pathlib import Path

--- a/tests/run_corpus.py
+++ b/tests/run_corpus.py
@@ -1,18 +1,4 @@
-"""Run the full aneforge correctness corpus on the ANE.
-
-This is the GATE for any future graph-optimizer pass: run it before and after a
-rewrite; the pass-rate and per-case relerr must not regress. Each case builds a
-graph, compiles it (``af.compile``), runs it on the M-series ANE, and asserts the
-output against a numpy golden reference within a per-category tolerance.
-
-    PYTHONPATH=. python3 tests/run_corpus.py
-
-Optimizer-diff reuse: import ALL_CASES and tests._corpus.run_case to run the same
-builds with optimization on/off and diff the two ANE outputs directly.
-
-Also pytest-compatible (the default suite skips it, so name the file):
-PYTHONPATH=. pytest tests/run_corpus.py
-"""
+"""Run the full aneforge correctness corpus on the ANE (the graph-optimizer GATE)."""
 from __future__ import annotations
 
 import sys

--- a/tests/test_attention_tiles.py
+++ b/tests/test_attention_tiles.py
@@ -1,9 +1,4 @@
-"""Attention query-tile autotune: heuristic by default, exact across counts, cached.
-
-The autotune only changes HOW the [H,S,T] score is fissioned, never the result, so the
-key safety property is that the tile count does not change the output. Uses a temp cache
-dir so the test sees no previously-tuned values.
-"""
+"""Attention query-tile autotune: heuristic by default, output-invariant across counts, cached."""
 import os
 import tempfile
 os.environ["ANEFORGE_CACHE_DIR"] = tempfile.mkdtemp()      # hermetic: no prior tuned values

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -1,3 +1,5 @@
+"""On-device autograd: VJP grad-checks, optimizers, and end-to-end training runs."""
+
 from pathlib import Path
 
 import numpy as np
@@ -23,15 +25,12 @@ def test_vjp_registry_and_topo():
 
 
 def _ane_grad(loss, params, loss_scale=1.0):
-  """Compile the backward graph (concatenated param grads), eval on ANE, return
-    a list of numpy grads (one per param) in fp32."""
+  """Compile concatenated param grads, eval on ANE, return per-param fp32 grads."""
   grads = agrad.backward(loss, params, loss_scale=loss_scale)
   flat = [grads[p].reshape(1, int(np.prod(p.shape))) for p in params]
   out = af.concat(flat, axis=1) if len(flat) > 1 else flat[0]
   net = af.compile(out)
   feed = []
-  # inputs in creation order: data inputs need values; here params are the only inputs
-  # (the harness builds graphs whose only inputs are the params)
   import aneforge._compile as _c
   order = [t for t in _c._topo(out) if t.op == "input"]
   order.sort(key=lambda t: t.attrs.get("idx", 0))
@@ -39,7 +38,6 @@ def _ane_grad(loss, params, loss_scale=1.0):
     feed.append(t.attrs["value"].astype(np.float16))
   res = net(*feed).reshape(-1) / loss_scale
   net.release()
-  # split by param sizes
   sizes = [int(np.prod(p.shape)) for p in params]
   outg, k = [], 0
   for p, s in zip(params, sizes):
@@ -56,7 +54,7 @@ def test_muls_grad():
 
 
 def _check(build, params, ref_grads, loss_scale=1.0, atol=3e-2):
-  """build() -> scalar loss using params; ref_grads: list of numpy fp32 grads."""
+  """Grad-check: build() -> scalar loss; compare ANE grads to ref_grads."""
   loss = build()
   ane = _ane_grad(loss, params, loss_scale)
   for ga, gr in zip(ane, ref_grads):
@@ -143,11 +141,7 @@ def _eval_grad_tensor(gt, params):
   return res
 
 
-# grad-checks for the conv/attention coverage vjps (transpose, reshape, concat, #
-# slice_by_size, relu, conv-grad-input, avg_pool, trainable conv2d, mha). Each  #
-# compares the on-ANE analytic gradient to a numpy/finite-difference reference  #
-# (torch is unavailable on this interpreter; numpy FD is the agreed reference). #
-# Require cos > 0.99 and relerr in the fp16 band.                               #
+# ---- conv/attention coverage vjp grad-checks (vs numpy/FD, cos > 0.99) ----
 
 def _ane_grad_shaped(loss, params, loss_scale=1.0):
   """Eval each param's analytic gradient on the ANE in its natural shape."""
@@ -323,11 +317,7 @@ def test_avg_pool_grad():
 
 
 def test_max_pool_grad():
-  # max_pool backward routes g to the argmax of each window, built without
-  # gather/scatter (upsample the pooled max back over each k*k block, mask the
-  # cells equal to it via greater+select). Non-overlapping windows (stride==k,
-  # pad==0). On random continuous inputs ties are rare; matches a numpy/torch
-  # max-pool backward within the fp16 band (cos > 0.99).
+  # max_pool backward routes g to each window's argmax (non-overlapping, stride==k)
   rng = np.random.default_rng(58)
   N, C, H, W, k = 2, 3, 8, 8, 2
   xv = rng.standard_normal((N, C, H, W)).astype(np.float32)
@@ -457,15 +447,11 @@ def test_adam_minimizes_quadratic():
 
 
 def test_cnn_trains_on_subset():
-  # conv -> relu -> avg_pool -> flatten -> linear -> softmax-CE, forward+backward
-  # on the ANE. The conv weight is a trainable parameter (built from primitives).
+  # conv -> relu -> avg_pool -> flatten -> linear -> softmax-CE, fwd+bwd on ANE
   d = np.load(Path(__file__).resolve().parent.parent / "examples" / "data" / "mnist_subset.npz")
   Xtr = d["Xtr"].astype(np.float32) / 255.0; ytr = d["ytr"].astype(np.int64)
   Xte = d["Xte"].astype(np.float32) / 255.0; yte = d["yte"].astype(np.int64)
-  # Cap the full-batch size: aneforge's trainable-conv im2col tensors grow with the
-  # batch, so the COMPILE cost scales with B - B=1000 hangs the M1/h13 compiler for
-  # minutes (it compiles fine on M5). 64 keeps the compile fast and is host-independent
-  # (identical on M1 and M5); we trade the headline accuracy for a quick, portable check.
+  # cap batch: trainable-conv compile cost scales with B; 64 keeps it fast/portable
   N = min(Xtr.shape[0], 64)
   Xtr = Xtr[:N]; ytr = ytr[:N]
   Xtr_img = Xtr.reshape(N, 1, 28, 28); Xte_img = Xte.reshape(-1, 1, 28, 28)
@@ -486,20 +472,16 @@ def test_cnn_trains_on_subset():
     tr.step()
   l1 = tr.loss(); acc1 = tr.accuracy(Xte_img, yte)
   tr.release()
-  # At the small batch the model can't reach the full-data ~0.95; assert it clearly
-  # LEARNS (loss collapses, test accuracy jumps well above its starting point).
+  # small batch can't hit ~0.95; assert it clearly LEARNS (loss drops, acc jumps)
   assert l1 < 0.4 * l0 and acc1 > acc0 + 0.3, (l0, l1, acc0, acc1)
 
 
 def test_cnn_maxpool_trains_on_subset():
-  # the avg_pool CNN with the pool swapped to max_pool: conv -> relu -> max_pool
-  # -> flatten -> linear -> softmax-CE, forward+backward on the ANE. Exercises the
-  # max_pool vjp (argmax routing via upsample + greater + select) in a full train.
+  # avg_pool CNN with pool swapped to max_pool; exercises the max_pool vjp in a train
   d = np.load(Path(__file__).resolve().parent.parent / "examples" / "data" / "mnist_subset.npz")
   Xtr = d["Xtr"].astype(np.float32) / 255.0; ytr = d["ytr"].astype(np.int64)
   Xte = d["Xte"].astype(np.float32) / 255.0; yte = d["yte"].astype(np.int64)
-  # Same 64-sample batch cap as the avg_pool test above: keeps the compile fast and
-  # host-independent, trading headline accuracy for a quick portable check.
+  # same 64-sample batch cap as the avg_pool test above (fast/portable compile)
   N = min(Xtr.shape[0], 64)
   Xtr = Xtr[:N]; ytr = ytr[:N]
   Xtr_img = Xtr.reshape(N, 1, 28, 28); Xte_img = Xte.reshape(-1, 1, 28, 28)
@@ -520,14 +502,12 @@ def test_cnn_maxpool_trains_on_subset():
     tr.step()
   l1 = tr.loss(); acc1 = tr.accuracy(Xte_img, yte)
   tr.release()
-  # At the small batch the model can't reach the full-data ~0.95; assert it clearly
-  # LEARNS (loss collapses, test accuracy jumps well above its starting point).
+  # small batch can't hit ~0.95; assert it clearly LEARNS (loss drops, acc jumps)
   assert l1 < 0.4 * l0 and acc1 > acc0 + 0.3, (l0, l1, acc0, acc1)
 
 
 def test_transformer_block_trains():
-  # mha + residual + MLP + residual, forward+backward on the ANE; attention is
-  # differentiable end to end. Loss drops well below the initial value on a toy task.
+  # mha + residual + MLP + residual, fwd+bwd on ANE; attention diff'able end to end
   rng = np.random.default_rng(0)
   S, D, n_heads = 8, 16, 4; dh = D // n_heads
   Xv = (rng.standard_normal((S, D)) * 0.5).astype(np.float32)
@@ -555,8 +535,7 @@ def test_transformer_block_trains():
 
 
 def test_layer_norm_trainable_affine_forward_matches_baked():
-  # passing parameter Tensors for gamma/beta composes normalize + learnable affine;
-  # the forward must equal the native baked-affine layer_norm with the same values.
+  # parameter gamma/beta forward must equal native baked-affine layer_norm
   rng = np.random.default_rng(70); M, D = 8, 16
   xv = rng.standard_normal((M, D)).astype(np.float32)
   gv = (rng.standard_normal(D) * 0.5 + 1.0).astype(np.float32)
@@ -613,9 +592,7 @@ def test_rms_norm_affine_param_trains():
 
 
 def test_charlm_trains_and_predicts():
-  # A small multi-layer causal char-LM trains end to end on the engine: one-hot
-  # embedding (matmul, not gather), causal-masked attention, RMSNorm + SwiGLU, and a
-  # next-token cross-entropy objective. Loss falls and next-char accuracy reaches ~1.0.
+  # small causal char-LM (one-hot embed, masked attn, RMSNorm+SwiGLU, next-tok CE)
   text = "ane trains a tiny language model. " * 2
   chars = sorted(set(text)); V = len(chars)
   stoi = {c: i for i, c in enumerate(chars)}
@@ -659,9 +636,7 @@ def test_charlm_trains_and_predicts():
 
 
 def test_charlm_generalizes_on_corpus():
-  # Trained on random windows of a structured corpus's TRAIN split, the char-LM
-  # predicts held-out VAL windows it never trained on, well above the unigram
-  # baseline - generalization (transferable structure), not memorization.
+  # char-LM predicts held-out VAL windows above the unigram baseline (generalizes)
   from collections import Counter
   rng = np.random.default_rng(0)
   animals, verbs, advs = ["cat", "dog", "bird"], ["runs", "jumps", "sleeps"], ["fast", "slow"]
@@ -717,10 +692,7 @@ def test_charlm_generalizes_on_corpus():
 
 
 def test_prenorm_transformer_block_trains():
-  # Pre-norm transformer block (layer_norm before attention and before the MLP),
-  # forward+backward on the ANE. The gradient flows THROUGH layer_norm to the
-  # trainable projections/MLP; norm affine (gamma/beta) is fixed at unit init.
-  # This is the end-to-end proof that layer_norm no longer blocks backprop.
+  # pre-norm transformer block; gradient flows THROUGH layer_norm (affine fixed)
   rng = np.random.default_rng(0)
   S, D, n_heads = 8, 16, 4; dh = D // n_heads
   Xv = (rng.standard_normal((S, D)) * 0.5).astype(np.float32)
@@ -750,9 +722,7 @@ def test_prenorm_transformer_block_trains():
 
 
 def test_llama_block_trains():
-  # LLaMA-style block: rms_norm (pre-norm) + attention + rms_norm + SwiGLU
-  # (silu gate). Exercises rms_norm and silu gradients end to end; trainable
-  # projections + the three SwiGLU weights. Norm affine (gamma) fixed at unit.
+  # LLaMA-style block: rms_norm + attention + rms_norm + SwiGLU (silu gate)
   rng = np.random.default_rng(1)
   S, D, n_heads = 8, 16, 4; dh = D // n_heads; FF = 4 * D
   Xv = (rng.standard_normal((S, D)) * 0.5).astype(np.float32)
@@ -822,9 +792,7 @@ def test_classifier_trains_synthetic():
 
 
 def test_mnist_mlp_trains():
-  # 784->128->10 GELU MLP, full-batch (N=1000), softmax-CE + Adam, forward+backward
-  # on the ANE. Train==test==1000 so the one forward-logits program serves both the
-  # train loss and the test accuracy (no different-shape recompile; Task 5/7 scope).
+  # 784->128->10 GELU MLP, full-batch, softmax-CE + Adam; train==test==1000 (no recompile)
   d = np.load(Path(__file__).resolve().parent.parent / "examples" / "data" / "mnist_subset.npz")
   Xtr = d["Xtr"].astype(np.float32) / 255.0; ytr = d["ytr"].astype(np.int64)
   Xte = d["Xte"].astype(np.float32) / 255.0; yte = d["yte"].astype(np.int64)
@@ -916,8 +884,7 @@ def test_on_ane_adam_update_matches_numpy():
 
 
 def test_on_ane_stack3_update_returns_three_arrays():
-  # The STACK multi-output path: a [3,n] update program returns the 3 correct
-  # arrays on the ANE after a host row-wise split (no _compile.py change).
+  # STACK multi-output path: [3,n] program -> 3 arrays after host row-wise split
   rng = np.random.default_rng(41)
   shp = (8, 6)
   wv, mv, vv, gv = [rng.standard_normal(shp).astype(np.float32) for _ in range(4)]
@@ -1007,8 +974,7 @@ def test_mlp_trains():
 
 
 def test_compile_multi_two_outputs():
-  # compile_multi lowers a graph with N output Tensors into ONE program with N
-  # named output ports; __call__ returns them by name, matching a numpy reference.
+  # compile_multi lowers N output Tensors into ONE program with N named output ports
   from aneforge import _compile as _c
   rng = np.random.default_rng(3)
   N, D = 8, 5
@@ -1029,8 +995,7 @@ def test_compile_multi_two_outputs():
 
 
 def test_resident_sgd_matches_host_reference():
-  # A fused fwd+bwd+SGD step holds both weights RESIDENT on-device across steps
-  # (host feeds only x,y,lr); the resident weights match a host SGD reference.
+  # fused fwd+bwd+SGD step keeps weights RESIDENT on-device; matches host SGD ref
   from aneforge import _compile as _c
   rng = np.random.default_rng(1)
   D, H, N, STEPS, LR = 6, 4, 12, 40, 0.02
@@ -1085,8 +1050,7 @@ def test_resident_adam_trains_subset_and_state_stays_resident():
   tr = agrad.Trainer(agrad.softmax_cross_entropy(logits, target), [P1, b1, P2, b2],
                      lr=0.01, loss_scale=1024.0, optimizer="adam", resident_state=True,
                      data_inputs={x: np.zeros((B, Dn), np.float32), target: np.zeros((B, K), np.float32)})
-  # the per-step feed touches ONLY data + lr -- no param/moment port is fed each
-  # step (state stays resident on-device). Verify structurally.
+  # structural: per-step feed touches ONLY data + lr; state stays resident
   state_ids = set()
   for e in tr._res_state:
     state_ids.add(id(e["p"]))
@@ -1101,17 +1065,11 @@ def test_resident_adam_trains_subset_and_state_stays_resident():
 
 
 def test_resident_cnn_trains_subset():
-  # the resident-state path (previously MLP-validated) also compiles + trains for
-  # a CNN: the whole step (primitive-built trainable-conv forward + backward +
-  # per-param Adam) is ONE fused multi-output program with state aliased
-  # on-device. Host feeds only the minibatch + lr each step.
+  # resident-state path for a CNN: whole step is ONE fused program, state aliased on-device
   d = np.load(Path(__file__).resolve().parent.parent / "examples" / "data" / "mnist_subset.npz")
   Xtr = d["Xtr"].astype(np.float32) / 255.0; ytr = d["ytr"].astype(np.int64)
   Xte = d["Xte"].astype(np.float32) / 255.0; yte = d["yte"].astype(np.int64)
-  # The resident path compiles ONE program at the fixed batch B below, so its compile
-  # cost is governed by B (modest, ~B=100), not the dataset size N. Unlike the
-  # full-batch CNN tests, N must stay >= B here (minibatches of B are sampled from N),
-  # so it is not capped - capping it below B would yield zero training steps.
+  # N not capped: resident compile cost is governed by fixed B, and N must stay >= B
   N = Xtr.shape[0]
   Xtr_img = Xtr.reshape(N, 1, 28, 28); Xte_img = Xte.reshape(-1, 1, 28, 28)
   K, Cout, k, pk = 10, 8, 3, 2
@@ -1143,9 +1101,7 @@ def test_resident_cnn_trains_subset():
 
 
 def test_resident_transformer_block_trains():
-  # the resident-state path also compiles + trains for a transformer block:
-  # mha + residual + MLP + residual, the whole step (forward + backward + eight-
-  # param Adam) is ONE fused multi-output program with state aliased on-device.
+  # resident-state path for a transformer block: whole step is ONE fused program
   rng = np.random.default_rng(0)
   S, D, n_heads = 8, 16, 4; dh = D // n_heads
   Xv = (rng.standard_normal((S, D)) * 0.5).astype(np.float32)
@@ -1173,7 +1129,7 @@ def test_resident_transformer_block_trains():
 
 
 def test_unrolled_trainer_resident_trains_and_state_stays_resident():
-  # K Adam steps unrolled into ONE program, optimizer state RESIDENT on-device.
+  # K Adam steps unrolled into ONE program, optimizer state RESIDENT on-device
   d = np.load(Path(__file__).resolve().parent.parent / "examples" / "data" / "mnist_subset.npz")
   Xtr = d["Xtr"].astype(np.float32) / 255.0; ytr = d["ytr"].astype(np.int64)
   Xte = d["Xte"].astype(np.float32) / 255.0; yte = d["yte"].astype(np.int64)
@@ -1187,8 +1143,7 @@ def test_unrolled_trainer_resident_trains_and_state_stays_resident():
   xs = [af.input((B, DIN)) for _ in range(K)]; ts = [af.input((B, C)) for _ in range(K)]
   tr = af.UnrolledTrainer(P, fwd, "ce", xs, ts, (Xtr, oh), lr=0.01, loss_scale=1024.0,
                           resident=True)
-  # structural: the per-dispatch feed touches ONLY data + lr ports; the param/m/v
-  # state ports are never fed (they stay resident on-device, aliased out->in).
+  # structural: per-dispatch feed touches ONLY data + lr; state ports stay resident
   assert tr.resident
   data_names = {n for n, _, _ in tr._res_data} | set(tr._res_lr_names)
   state_names = {tr._res_inm[id(t)] for t in (P + tr._m_in + tr._v_in)}
@@ -1200,8 +1155,7 @@ def test_unrolled_trainer_resident_trains_and_state_stays_resident():
 
 
 def test_unrolled_trainer_resident_matches_nonresident():
-  # resident and host-shuttle paths must produce the SAME trained weights (the only
-  # difference is WHERE state lives, not the math).
+  # resident and host-shuttle paths must produce the SAME trained weights
   rng = np.random.default_rng(1)
   B, K, DIN, H, C, N = 16, 4, 12, 10, 3, 256
   X = (rng.standard_normal((N, DIN)) * 0.5).astype(np.float32)

--- a/tests/test_blas.py
+++ b/tests/test_blas.py
@@ -1,40 +1,4 @@
-"""BLAS test corpus for aneforge: BLAS-1/2/3 operations expressed as aneforge
-graphs, each compiled + run on the Apple Neural Engine and validated against a
-numpy fp32 reference at fp16-appropriate tolerance.
-
-The point of this corpus is twofold:
-
-  1. CORRECTNESS - confirm that the classic dense-linear-algebra kernels lower to
-     the ANE and match numpy within fp16 round-off.
-  2. COST-MODEL DATA - every case carries a ``cost character`` tag in its
-     ``category`` field, one of:
-
-       floor      - tiny problem, dominated by per-dispatch fixed cost
-       bandwidth  - memory-bound (BLAS-1: O(n) flops over O(n) bytes, AI~1)
-       compute    - arithmetic-bound (BLAS-3 GEMM: O(n^3) over O(n^2) bytes)
-       reduction  - a sum/contraction collapse (dot/asum/nrm2/Gram diagonal);
-                    accuracy-sensitive because the accumulation length grows
-
-     so the corpus doubles as labelled validation data for a cost model.
-
-Run::
-
-    PYTHONPATH=. python3 tests/test_blas.py
-
-The shared harness (tests/_corpus.py) does build->compile->run->compare. We reuse
-its ``Case`` record, ``eval_case`` and the gate accounting, and add a BLAS-specific
-runner that also prints the cost-character distribution and an N/M size summary.
-
-API notes that shape these graphs (see aneforge/graph.py):
-  - scalar multiply is ``x * float`` (the ``muls`` op); binary +,-,*,/, maximum,
-    minimum need TWO graph Tensors. axpy/scal therefore fold the scalar into muls.
-  - ``x @ W`` with a numpy ``W`` is a streamed weight matmul (W stored as W.T);
-    ``x @ y`` with two Tensors is a bmm (activation x activation).
-  - reductions (sum/amax/...) keep dims (the reduced axis becomes 1). dot is
-    ``(x*y).sum(axis)``; asum is ``x.abs().sum(axis)``; nrm2 is
-    ``(x*x).sum(axis).sqrt()`` (axis convention: the reduced axis -> size 1).
-  - ger (rank-1 outer product) is a broadcast multiply u[M,1] * v[1,N] -> [M,N].
-"""
+"""BLAS-1/2/3 corpus: aneforge graphs run on the ANE vs numpy fp32, tagged with cost character."""
 from __future__ import annotations
 
 import numpy as np
@@ -50,12 +14,9 @@ def f16(*shape, scale=1.0):
 def fp32(a): return np.asarray(a, np.float32)
 
 
-# BLAS-1 : vector ops (bandwidth / floor bound; dot/asum/nrm2 are reductions)
-# aneforge has no rank-1 vector type; we carry vectors as [1, N] row tensors so
-# they fit the 2D activation layout. The cost character is unchanged.
+# BLAS-1: vector ops carried as [1, N] row tensors (no rank-1 vector type).
 
 def _axpy(N, tag):
-  # y = alpha*x + y  ->  (x * alpha) + y   (muls then add of two Tensors)
   alpha = 1.7
   x = f16(1, N); y = f16(1, N)
   def build(xt, yt): return (xt * alpha) + yt
@@ -64,7 +25,6 @@ def _axpy(N, tag):
 
 
 def _scal(N, tag):
-  # x = alpha*x  (pure muls; the cheapest BLAS-1, read+write one vector)
   alpha = 0.5
   x = f16(1, N)
   def build(xt): return xt * alpha
@@ -73,12 +33,7 @@ def _scal(N, tag):
 
 
 def _dot(N, tag, tol, abserr=None):
-  # dot = sum(x*y)  (a reduction; accumulation length N). The output is a single
-  # scalar from a sum of signed products, so it is cancellation-prone: the true
-  # value can be near zero while the absolute fp16 error stays small. For such
-  # near-zero scalars relerr (|err|/|value|) is the wrong metric, so small-N dots
-  # validate on an absolute tolerance instead (the accumulation is wide/fp32 on
-  # the ANE, so the abs error is governed by input fp16 round-off, ~1e-3).
+  # cancellation-prone scalar output: small-N dots validate on abserr, not relerr.
   x = f16(1, N, scale=0.5); y = f16(1, N, scale=0.5)
   def build(xt, yt): return (xt * yt).sum(1)
   def ref(xa, ya): return (xa * ya).sum(1, keepdims=True)
@@ -86,7 +41,6 @@ def _dot(N, tag, tol, abserr=None):
 
 
 def _asum(N, tag, tol):
-  # asum = sum(|x|)  (reduction; all-positive accumulands, length N)
   x = f16(1, N)
   def build(xt): return xt.abs().sum(1)
   def ref(xa): return np.abs(xa).sum(1, keepdims=True)
@@ -94,7 +48,6 @@ def _asum(N, tag, tol):
 
 
 def _nrm2(N, tag, tol):
-  # nrm2 = sqrt(sum(x^2))  (reduction then sqrt)
   x = f16(1, N, scale=0.3)
   def build(xt): return (xt * xt).sum(1).sqrt()
   def ref(xa): return np.sqrt((xa * xa).sum(1, keepdims=True))
@@ -102,19 +55,17 @@ def _nrm2(N, tag, tol):
 
 
 def _l2norm(N, tag, tol):
-  # the fused reduce_l2_norm op: x / sqrt(sum(x^2,axis)+eps). Bandwidth-ish
-  # (O(n) work, O(n) output) but contains a reduction; tagged reduction.
+  # fused reduce_l2_norm: contains a reduction, so tagged reduction.
   x = f16(1, N, scale=0.3)
   def build(xt): return xt.l2_norm(1)
   def ref(xa): return xa / np.sqrt((xa * xa).sum(1, keepdims=True) + 1e-12)
   return Case(f"l2norm_n{N}", tag, build, ref, [x], tol=tol)
 
 
-# BLAS-2 : matrix-vector (mixed; small=floor, large=bandwidth)
+# BLAS-2: matrix-vector.
 
 def _gemv(M, K, tag):
-  # y = A @ x, A[M,K], x[K].  Express as x_row[1,K] @ W with W=A.T (numpy weight
-  # path stores W as W.T, so x_row @ A.T == (A @ x) as a [1,M] row).
+  # y = A@x via x_row[1,K] @ A.T (numpy weight path stores W as W.T).
   A = f16(M, K, scale=0.3); x = f16(1, K)
   AT = A.T.astype(np.float16)
   def build(xt): return xt @ AT                      # [1,K] @ [K,M] -> [1,M]
@@ -123,7 +74,7 @@ def _gemv(M, K, tag):
 
 
 def _ger(M, N, tag):
-  # rank-1 outer product: u[M,1] * v[1,N] -> [M,N] (broadcast multiply).
+  # rank-1 outer product via broadcast multiply u[M,1] * v[1,N].
   u = f16(M, 1, scale=0.5); v = f16(1, N, scale=0.5)
   def build(ut, vt): return ut * vt
   def ref(ua, va): return ua * va
@@ -131,8 +82,7 @@ def _ger(M, N, tag):
 
 
 def _symv(M, K, tag):
-  # symmetric matrix-vector: y = S @ x with S = S^T. Same lowering as gemv;
-  # the symmetry is in the data, not the graph. Validates A@x on a symmetric A.
+  # symmetric matrix-vector: same lowering as gemv, symmetry is in the data.
   base = f16(M, K, scale=0.3)
   S = ((fp32(base) @ fp32(base).T) / K).astype(np.float16)  # [M,M] symmetric
   x = f16(1, M)
@@ -142,10 +92,10 @@ def _symv(M, K, tag):
   return Case(f"symv_{M}x{M}", tag, build, ref, [x], tol=0.02)
 
 
-# BLAS-3 : matrix-matrix (compute bound at size; floor when tiny)
+# BLAS-3: matrix-matrix.
 
 def _gemm(M, K, N, tag, tol, int8_ok=False):
-  # C = A @ B (activation A times streamed weight B). The canonical compute case.
+  # C = A @ B (activation A times streamed weight B).
   scale = 1.0 / max(1.0, K ** 0.5)        # keep products O(1) so fp16 is well-conditioned
   A = f16(M, K, scale=1.0); B = f16(K, N, scale=scale)
   def build(at): return at @ B
@@ -154,7 +104,7 @@ def _gemm(M, K, N, tag, tol, int8_ok=False):
 
 
 def _gemm_aa(M, K, N, tag, tol):
-  # activation x activation GEMM (bmm path), both operands are graph inputs.
+  # activation x activation GEMM (bmm path).
   scale = 1.0 / max(1.0, K ** 0.5)
   A = f16(M, K, scale=1.0); B = f16(K, N, scale=scale)
   def build(at, bt): return at @ bt
@@ -163,7 +113,7 @@ def _gemm_aa(M, K, N, tag, tol):
 
 
 def _syrk(M, K, tag, tol):
-  # C = A @ A^T (Gram matrix), A[M,K] activation. transpose + bmm.
+  # C = A @ A^T (Gram matrix) via transpose + bmm.
   scale = 1.0 / max(1.0, K ** 0.5)
   A = f16(M, K, scale=1.0) * np.float16(scale)
   def build(at): return at @ at.transpose([1, 0])    # [M,K] @ [K,M] -> [M,M]
@@ -171,11 +121,7 @@ def _syrk(M, K, tag, tol):
   return Case(f"syrk_{M}x{K}", tag, build, ref, [A], tol=tol)
 
 
-# case list
-# Sizes span regimes. Reduction tolerance loosens with accumulation length
-# (fp16 round-off on long sums); the cost-model knees referenced in the project
-# notes are K up to 2048 for matmul.
-
+# case list (reduction tolerance loosens with accumulation length)
 CASES = [
   # ---- BLAS-1 ---------------------------------------------------------- #
   # scal/axpy: read+write a vector, pure bandwidth; tiny N = floor.
@@ -216,7 +162,7 @@ CASES = [
 ]
 
 
-# runner - mirrors _corpus.run_corpus but adds cost-character + N/M summaries
+# runner - mirrors _corpus.run_corpus plus cost-character summaries
 
 def run_blas(cases, verbose: bool = True):
   all_results = []

--- a/tests/test_broad.py
+++ b/tests/test_broad.py
@@ -1,11 +1,4 @@
-"""Broader corpus part 2: multi-op COMPOSITIONS and BATCH variation at scale.
-
-test_shapes.py sweeps single ops across shapes; this sweeps realistic op
-*compositions* (attention block, MLP/FFN, conv->group_norm->relu residual) and
-batch/leading-dim variation at sizes larger than the existing small nn-block
-cases - where fusion + cross-op numerical interactions compound. Every case is
-validated against a numpy fp32 golden. Folded into ALL_CASES (run_corpus.py).
-"""
+"""Broader corpus part 2: multi-op compositions and batch variation at scale, vs numpy fp32."""
 from __future__ import annotations
 
 import numpy as np
@@ -117,12 +110,7 @@ def _deep_chain_case(D, depth):
       h = 0.5 * h * (1 + np.vectorize(erf)(h / np.sqrt(2))) if i % 2 == 0 else np.maximum(h, 0.0)
     return h
 
-  # A deep fp16 chain drifts vs fp32: each layer's activations are re-rounded to
-  # fp16 and the gelu/relu nonlinearity compounds it across layers (the wide matmul
-  # accumulator only helps WITHIN a matmul, not across them). Measured ~0.15 at
-  # depth 12, D=512 - an fp16-dataplane characteristic, not a bug. This case pins
-  # that the deep fused program compiles + runs within that drift band; a real
-  # regression would push it well past 0.2.
+  # tol=0.2: deep fp16 chain drifts ~0.15 (depth 12, D=512); a regression blows past 0.2.
   return Case(f"deep_chain_D{D}_d{depth}", "broad", build, ref, [x], tol=0.2)
 
 

--- a/tests/test_builder_guards.py
+++ b/tests/test_builder_guards.py
@@ -1,14 +1,4 @@
-"""Build-time guards on the graph builders (aneforge/graph.py).
-
-Invalid inputs should fail at graph BUILD time with a clear ValueError, not
-deep in the backend compiler: rms_norm requires a 2D [M,D] input (its lowering
-reshapes to [M,D,1,1]), and conv/conv_transpose share the ANE kernel-width
-tiling limit (kW <= 15).
-
-These are pure graph-construction tests (no ANE): nothing is compiled or run.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_builder_guards.py -q
-"""
+"""Build-time guards on the graph builders (rms_norm rank, conv/conv_transpose kW<=15)."""
 import numpy as np
 import pytest
 

--- a/tests/test_compile_breaker.py
+++ b/tests/test_compile_breaker.py
@@ -1,15 +1,4 @@
-"""The compile-failure backoff rate-limiter (aneforge/_circuit.py).
-
-A defensive backstop for the autotuner's burst of variant compiles: after a
-compile FAILURE, pace the next compile by a short interval (~15 s) so consecutive
-failures stay apart. The guard is a per-process rate limiter on consecutive
-failures; no failure-count cap is needed.
-
-These are pure unit tests (no ANE): a fake clock replaces _monotonic/_sleep so no
-real time passes.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_compile_breaker.py -q
-"""
+"""The compile-failure backoff rate-limiter (aneforge/_circuit.py)."""
 import warnings
 
 import pytest
@@ -32,7 +21,7 @@ class _Clock:
 
 @pytest.fixture(autouse=True)
 def _isolate(monkeypatch):
-  # fresh breaker state + a fake clock for every test
+  # fresh breaker state + fake clock per test
   clock = _Clock()
   monkeypatch.setattr(_circuit, "_monotonic", clock.now)
   monkeypatch.setattr(_circuit, "_sleep", clock.sleep)

--- a/tests/test_compile_targets.py
+++ b/tests/test_compile_targets.py
@@ -1,15 +1,4 @@
-"""compile(target=...) - gate lowering on the target ANE family.
-
-The gate runs once at the top of compile(): resolve the family, substitute below-floor
-ops that have an in-graph decomposition (sin/cos -> special.py), and raise a clear
-compile-time error on an op the family cannot run (instead of a dispatch-time crash).
-
-On the M5 dev host (family 5) everything is native, so target=None is a no-op fast path
-and existing compiles are byte-identical. The decompose path IS verifiable here, because
-the rewritten graph (sin -> mul/exp polynomial) is all-native and runs on the M5.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_compile_targets.py -q
-"""
+"""compile(target=...) - gate lowering on the target ANE family (decompose / reject / saturation / preflight)."""
 import numpy as np
 import pytest
 
@@ -17,8 +6,7 @@ import aneforge as af
 
 
 def test_compile_decomposes_sin_for_h13_and_runs():
-  # target='h13' (family 2) -> native sin is unavailable -> compile substitutes the
-  # special.py polynomial. The rewritten graph runs on this M5 and matches numpy.
+  # h13 lacks native sin -> compile substitutes the special.py polynomial; runs on M5
   xv = np.linspace(-1.0, 1.0, 64).astype(np.float16).reshape(1, 64)
   net = af.compile(af.input((1, 64)).sin(), target="h13")
   out = np.asarray(net(xv)).astype(np.float32)
@@ -46,7 +34,7 @@ def test_compile_rejects_below_mil_floor():
 
 
 def test_compile_default_target_is_native_noop_on_m5():
-  # no target -> detect host (M5/family 5) -> sin is native, no rewrite, runs as before
+  # no target -> host M5: sin native, no rewrite
   xv = np.linspace(-1.0, 1.0, 64).astype(np.float16).reshape(1, 64)
   net = af.compile(af.input((1, 64)).sin())
   out = np.asarray(net(xv)).astype(np.float32)
@@ -63,8 +51,7 @@ def _saturation_warnings(graph, target):
 
 
 def test_h13_last_axis_offset_slice_warns():
-  # a last-axis-offset slice routes through the H13 Q.4 fixed-point DMA that saturates
-  # at 4094 (=65504/16); on M1 this must warn loudly (it silently corrupts otherwise).
+  # last-axis-offset slice routes through the H13 Q.4 DMA that saturates at 4094; must warn
   g = af.input((1, 8)).slice_by_size([0, 2], [1, 4])   # last-axis begin=2 > 0
   assert _saturation_warnings(g, "h13")
 
@@ -83,10 +70,7 @@ def test_m5_offset_slice_does_not_warn():
 
 # --- cross_compile_check: static preflight pre-gate (family-cap CI keystone) ---
 def test_cross_compile_check_rejects_family_cap_violation_statically(monkeypatch):
-  # A conv with kW=14 fits A16 (<=15) but exceeds the A13 cap (<=13). cross_compile_check
-  # for h13 must reject it from preflight ALONE - not lean on the host cross-compiler,
-  # which may not enforce a different family's dim caps. The e5rt compiler must not even
-  # be reached for a statically-rejectable graph.
+  # conv kW=14 fits A16 (<=15) but exceeds A13 cap (<=13); preflight must reject without compiling
   from aneforge import _compile, _runtime
   g = af.conv(af.input((1, 3, 32, 32)), np.zeros((8, 3, 3, 14), np.float32), pad=0)
 
@@ -97,8 +81,7 @@ def test_cross_compile_check_rejects_family_cap_violation_statically(monkeypatch
 
 
 def test_cross_compile_check_passes_valid_graph_to_compiler(monkeypatch):
-  # A graph with no static violation must still flow through to the e5rt compiler and
-  # return its verdict (here stubbed to success) - the pre-gate is a filter, not a wall.
+  # no static violation -> flows through to the (stubbed) e5rt compiler verdict
   from aneforge import _compile, _runtime
   g = af.conv(af.input((1, 3, 32, 32)), np.zeros((8, 3, 3, 11), np.float32), pad=0)
   monkeypatch.setattr(_runtime, "compile_check", lambda *a, **k: 0)

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -72,13 +72,8 @@ def test_weight_int4_falls_back_when_inaccurate():
 
 
 def test_int4_gate_not_bypassed_by_fp16_norm_overflow():
-  """Regression: an fp16 weight whose self-norm OVERFLOWS fp16 must still be gated.
-    The rel-error denominator ||W|| was once computed in fp16, so a large-magnitude
-    weight gave ||W||=inf -> rel_error=0 -> the int4 gate was silently bypassed and a
-    too-lossy int4 weight emitted. The error metric must compute in fp32."""
-  # fp16 input (the natural case), values up to ~1785: each is fp16-representable but
-  # W.dot(W) ~ 2.7e8 overflows fp16 (max 65504). 16 LUT levels cannot represent 256
-  # spread values within a tight budget, so the gate MUST reject int4.
+  """Regression: an fp16 weight whose self-norm OVERFLOWS fp16 must still be gated (rel-error in fp32)."""
+  # values fp16-representable but W.dot(W)~2.7e8 overflows fp16; 16 LUT levels can't fit -> reject int4
   W = (np.arange(256, dtype=np.float32) * 7.0).reshape(1, 256).astype(np.float16)
   em = _compile._Emitter(int8=False, compress="int4", compress_atol=1e-3)
   em.weight("w", W, allow_int8=True, allow_int4=True)
@@ -285,13 +280,12 @@ def test_auto_falls_to_int8_then_fp16():
 
 @requires_ane
 def test_auto_none_byte_identical():
-  """compress="auto" picking fp16 on a real graph does not regress; AND compress=None
-    stays byte-identical to the historical default (re-confirms the byte-identity test)."""
+  """compress="auto" picking fp16 does not regress; compress=None stays byte-identical to default."""
   import aneforge as af
   from pathlib import Path
   import tempfile
   rng = np.random.default_rng(22)
-  # a tiny norm-like weight (rms_norm gamma): forced to fp16 (allow_int8=False, no int4/sparse)
+  # rms_norm gamma: forced to fp16 (allow_int8=False, no int4/sparse)
   g = rng.standard_normal((16,)).astype(np.float32)
   x = rng.standard_normal((1, 16)).astype(np.float32)
   base = af.compile(af.input((1, 16)).rms_norm(g), compress=None)
@@ -326,31 +320,26 @@ def test_auto_matmul_runs_on_ane():
   net.release()
 
 
-# Feature - family-aware compress="auto": only encodings that STREAM natively on
-# the target family are auto candidates (h13/M1 streams int4-LUT + sparse;
-# int8/blockwise fold to dense fp16 there - accuracy cost, no bandwidth win).
+# Feature - family-aware compress="auto": only natively-streaming encodings are auto candidates
 def test_native_streams_table():
   from aneforge import _targets as TG
-  # M1: int4-LUT + sparse stream (round-9: compress="sparse" -> constexpr_sparse_to_dense,
-  # live-measured ~1.6x on genuinely-sparse weights; distinct from the HAL kernel-format gate).
+  # M1: only int4-LUT + sparse stream
   assert TG.native_streams(TG.Family.A13) == frozenset({"int4", "sparse"})
-  # A14 (M2 silicon-measured): int4/int8/sparse stream, blockwise FOLDS (no win).
+  # A14 (M2): int4/int8/sparse stream, blockwise folds
   assert TG.native_streams(TG.Family.A14) == frozenset({"int4", "int8", "sparse"})
-  # A16 (M5): the broad set streams.
+  # A16 (M5): the broad set streams
   assert TG.native_streams(TG.Family.A16) == frozenset({"int4", "int8", "sparse", "blockwise"})
 
 
 def _sparse_int4able_weight():
-  """A weight that is BOTH >=50% zeros (sparse-eligible) and int4-representable
-    under a generous budget."""
+  """A weight both >=50% zeros (sparse-eligible) and int4-representable."""
   W = np.random.default_rng(30).standard_normal((32, 64)).astype(np.float32)
   W[np.abs(W) < 1.0] = 0.0                        # ~68% zeros
   return W
 
 
 def test_auto_on_h13_streams_sparse():
-  # sparse streams on h13 (round-9 table), so auto keeps the package-wide
-  # sparse-before-int4 precedence there; the h13 filter bites on int8/blockwise.
+  # sparse streams on h13, so auto keeps sparse-before-int4 precedence; filter bites on int8/blockwise
   em = _compile._Emitter(int8=False, compress="auto", compress_atol=0.5, family=2)
   em.weight("w", _sparse_int4able_weight(), allow_int8=True, allow_int4=True, allow_sparse=True)
   mil = "\n".join(em.lines)
@@ -359,8 +348,7 @@ def test_auto_on_h13_streams_sparse():
 
 
 def test_auto_on_h13_int4_reject_falls_to_fp16_not_int8():
-  # int4-unfit weight (256 widely-spread values vs a tight budget): on h13 int8
-  # would FOLD (accuracy loss, no bandwidth win) so auto must fall to fp16.
+  # int4-unfit weight: on h13 int8 would fold, so auto must fall to fp16
   W = (np.arange(256, dtype=np.float32) * 7.0).reshape(1, 256)
   em = _compile._Emitter(int8=False, compress="auto", compress_atol=1e-4, family=2)
   em.weight("w", W, allow_int8=True, allow_int4=True, allow_sparse=True)
@@ -388,10 +376,7 @@ def test_explicit_modes_not_filtered_by_family():
 
 @requires_ane
 def test_auto_target_h13_compiles_native_stream():
-  """End-to-end plumbing: af.compile(compress='auto', target='h13') routes the
-    family into the emitter - the sparse-eligible weight comes out sparse (a
-    native h13 stream, preferred over int4), int8/blockwise never appear (they
-    fold on h13), and the program still runs (sparse is family-2-native)."""
+  """End-to-end: compile(compress='auto', target='h13') -> sparse-eligible weight comes out sparse, runs."""
   import aneforge as af
   from pathlib import Path
   import tempfile

--- a/tests/test_conv_int8.py
+++ b/tests/test_conv_int8.py
@@ -1,19 +1,4 @@
-"""Conv per-channel int8 weights - round-9 fix.
-
-Round-8 found that ``af.conv`` emitted its weight with ``allow_int8=False``, so
-``compile(int8=True)`` / ``compress='int8'`` on a conv graph was a SILENT no-op
-(byte-identical fp16). Measured on h13/M1: per-channel int8 (``constexpr_affine_
-dequantize``) DOES route as a conv weight operand (no +0 bridge needed, unlike
-``constexpr_blockwise_shift_scale``), compiles+runs at cos~1.0 vs fp16 with the
-expected ~0.5-0.7% per-channel quant error, and ~halves the conv DRAM weight bytes.
-The fix enables it (``allow_int8=True``) and extends the auto-rewriter to conv.
-
-These tests lock in: (1) the conv int8 weight branch emits affine_dequantize and
-~halves the weight bytes; (2) compress=None stays byte-identical at opt=0 (the int8
-branch is gated on the compress knob, so enabling allow_int8 changes nothing there);
-(3) the per-node int8 override (auto-rewriter) tags conv; (4) on device, int8 conv
-runs cos~1.0 vs fp16 and within the per-channel int8 error vs an fp32 reference.
-"""
+"""Conv per-channel int8 weights - round-9 fix (allow_int8 on conv + auto-rewriter)."""
 from __future__ import annotations
 import numpy as np
 import pytest
@@ -59,8 +44,7 @@ def _npconv(x, w, pad):
 
 # MIL-level (no device): the int8 branch fires for conv and ~halves the bytes
 def test_conv_int8_emits_affine_dequantize():
-  """compress='int8' on a conv weight emits constexpr_affine_dequantize (the fix);
-    previously allow_int8=False fell through to a plain fp16 const (silent no-op)."""
+  """compress='int8' on a conv weight emits constexpr_affine_dequantize (the fix)."""
   W = (rng.standard_normal((64, 32, 3, 3)) * 0.2).astype(np.float16)
   em = C._Emitter(int8=False, compress="int8")
   em.weight("c_w", W, allow_int8=True, int8=None, allow_int4=True, allow_sparse=True)
@@ -69,8 +53,7 @@ def test_conv_int8_emits_affine_dequantize():
 
 
 def test_conv_int8_halves_weight_bytes():
-  """Per-channel int8 ~halves the conv DRAM weight bytes vs fp16 (residual = the
-    per-output-channel fp16 scale vector + blob descriptors)."""
+  """Per-channel int8 ~halves the conv DRAM weight bytes vs fp16."""
   W = (rng.standard_normal((64, 32, 3, 3)) * 0.2).astype(np.float16)
   fp16 = C._Emitter(int8=False, compress=None)
   fp16.weight("c_w", W, allow_int8=True, int8=None, allow_int4=True, allow_sparse=True)
@@ -81,9 +64,7 @@ def test_conv_int8_halves_weight_bytes():
 
 
 def test_conv_compress_none_byte_identical_at_opt0():
-  """Enabling allow_int8 must NOT change the compress=None (opt=0) lowering: the int8
-    branch is gated on the compress knob (use_int8), which compress=None never sets, so
-    the emitted MIL and blob bytes are byte-identical to the historical fp16 path."""
+  """Enabling allow_int8 must NOT change the compress=None (opt=0) lowering (byte-identical)."""
   W = (rng.standard_normal((32, 16, 3, 3)) * 0.2).astype(np.float16)
   new = C._Emitter(int8=False, compress=None)     # conv now passes allow_int8=True
   new.weight("c_w", W, allow_int8=True, int8=None, allow_int4=True, allow_sparse=True)
@@ -94,8 +75,7 @@ def test_conv_compress_none_byte_identical_at_opt0():
 
 
 def test_auto_rewriter_includes_conv():
-  """The per-node int8 auto-rewriter now treats conv as a weight-bearing candidate:
-    list_weight_nodes finds it and set_node_int8 tags it with int8=True."""
+  """The per-node int8 auto-rewriter treats conv as a weight-bearing candidate."""
   from aneforge._rewrite import set_node_int8, list_weight_nodes
   from aneforge._compile import _topo
   from aneforge._optimize import _has_weights, _int8_candidates

--- a/tests/test_corners.py
+++ b/tests/test_corners.py
@@ -1,13 +1,4 @@
-"""Adversarial / corner cases for the aneforge corpus - the part an optimizer is
-most likely to break:
-
-  - extreme-but-legal shapes (axis sizes near 1 and large, within [1, 65536]),
-  - very deep op chains fused into ONE program (30+ ops),
-  - graphs that MIX fused-MIL and netplist-bridge ops (conv -> ... -> argmax/sdpa
-    -> ... -> fc) so the SegmentedModel graph-cut path is exercised,
-  - multi-input graphs,
-  - the SAME graph compiled fp16 vs int8 (both within their own tol).
-"""
+"""Adversarial / corner cases for the aneforge corpus (extreme shapes, deep chains, graph cuts, multi-input, fp16-vs-int8)."""
 from __future__ import annotations
 
 import numpy as np
@@ -98,11 +89,7 @@ def _big_channel_conv():
 
 # very deep chain fused into one program
 def _deep_chain():
-  # 32 ops fused into ONE program. The sin/cos/tanh cycle (interleaved with a
-  # *1.4 rescale) is magnitude-PRESERVING: values stay O(1) so relerr stays a
-  # meaningful metric. (A contractive chain would collapse into the fp16
-  # denormal floor and make relative error explode - that is a test-design
-  # trap, not an aneforge bug.)
+  # 32 ops fused into ONE program; sin/cos/tanh + *1.4 is magnitude-preserving (O(1)) so relerr stays meaningful
   x = f16(4, 16, scale=1.0)
   n = 32
 
@@ -139,8 +126,7 @@ def _deep_chain():
 
 # mixed fused-MIL + netplist-bridge (graph cut -> SegmentedModel)
 def _conv_argmax_cut():
-  # conv -> relu -> reduce to [C,W] -> argmax (netplist cut). Exercises the
-  # SegmentedModel split: e5rt region feeds a native argmax sub-program.
+  # conv -> relu -> reduce -> argmax (netplist cut); exercises the SegmentedModel split
   W = f16(4, 3, 3, 3, scale=0.2)
   x = f16(1, 3, 8, 8)
 
@@ -176,8 +162,7 @@ def _np_conv(x, w, b=None, stride=1, pad=0):
 
 
 def _sdpa_sandwich():
-  # linear -> reshape to [1,H,S,D] -> af.sdpa (native cut) -> reshape -> linear.
-  # Exercises a netplist cut in the MIDDLE of a fused graph (region/cut/region).
+  # linear -> sdpa (native cut) -> linear; exercises a netplist cut in the MIDDLE of a fused graph
   H, S, Dh = 2, 6, 8
   D = H * Dh
   Wi = f16(D, D, scale=0.2)

--- a/tests/test_cost_model_analytic.py
+++ b/tests/test_cost_model_analytic.py
@@ -1,16 +1,4 @@
-"""Direction A: the measurement-free analytic per-chip cost model in aneforge/_cost.py.
-
-The compiler's own ``cycles -> roofline -> wall-time`` model was extracted (ANEForge
-reverse-engineering, from costmodel_curves.json) and is valid
-for all 28 chips from one extraction. Two anchors, both measured/fit on M1:
-  * latency roofline fit:  peak 3.25 TFLOP/s, BW 9.0 GB/s, dispatch overhead 0.22 ms
-    -> reproduces the 5 measured M1 convs within +/-17%.
-  * headline fp16 peak:    1.8 TFLOP/s measured, the project_peak anchor.
-Cross-chip throughput scales by ``cores * eff_freq(0.8*fmax)`` relative to M1:
-  M5 (H17s) ~5.5x, H17d (Ultra) ~22x, M11 ~0.1x.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_cost_model_analytic.py -q
-"""
+"""Measurement-free analytic per-chip cost model in aneforge/_cost.py."""
 import numpy as np
 
 import aneforge as af
@@ -25,10 +13,6 @@ def test_project_peak_m1_is_the_measured_anchor():
 
 
 def test_project_peak_m5_about_5x():
-  # Doc's back-of-envelope is ~5.5x/10 TFLOP/s using eff=0.84 (the LOW-freq end of the
-  # curve). project_peak reads efficiency at the actual operating clock (0.8*fmax),
-  # where M5's eff interpolates to ~0.746 -> a more conservative, physically-consistent
-  # ~4.9x / ~8.9 TFLOP/s. Same ballpark, consistent basis.
   p = _cost.project_peak("h17s")              # M5 == H17s
   assert 4.5 < p["rel_m1"] < 6.2
   assert 8.0 < p["tflops"] < 11.5
@@ -45,13 +29,13 @@ def test_project_peak_m11_about_tenth():
 
 
 def test_project_peak_unknown_arch_falls_back_to_family():
-  # h18 has no own cost curve; it folds to the A16 tier, must still resolve sanely.
+  # h18 has no own cost curve; folds to the A16 tier
   p = _cost.project_peak("h18")
   assert p["tflops"] > 1.8                    # an A16-tier chip beats M1
 
 
 # --- the latency roofline: reproduce the doc's +/-17% M1 conv validation ---------------
-# (workload, kH, kW, Cin, Cout, spatial, measured_ms) from the ANEForge measurements
+# (workload, kH, kW, Cin, Cout, spatial, measured_ms)
 _M1_CONVS = [
   ("3x3 C256@28",  3, 3, 256,  256, 28, 0.507),
   ("1x1 C512@32",  1, 1, 512,  512, 32, 0.444),
@@ -79,22 +63,15 @@ def test_m1_conv_latency_within_17pct():
 
 
 def test_m1_classifies_deep_narrow_as_slower():
-  # the non-obvious result: 1x1 C2048@8 (0.27 GMAC, memory-bound) is SLOWER than
-  # 3x3 C256@28 (0.46 GMAC, compute-bound) despite far less spatial work.
+  # memory-bound 1x1 C2048@8 slower than compute-bound 3x3 C256@28
   deep_narrow = _cost.estimate(_conv_graph(1, 1, 2048, 2048, 8), target="h13")
   compute_bound = _cost.estimate(_conv_graph(3, 3, 256, 256, 28), target="h13")
   assert deep_narrow > compute_bound
 
 
 # --- the M5 loop closure: per-chip measured {BW, floor, peak} anchors ------------------
-# The M1-anchored model over-predicted M5 ~2x (mean |err| 99%, max 211%): it scaled BW by
-# CLOCK (9.0 -> 14.9 GB/s) but M5's measured effective BW is 57 GB/s - BW tracks CORE
-# COUNT (16/4), not clock (m5_weight_stream.py / m5_bw_floor.py).
-# Fix: silicon-measured anchors per chip {h13: 9.0 GB/s/220us/3.25T, h17s: 57 GB/s/
-# 110us/8.9T}; unmeasured chips scale BW by core ratio and floor by clock from their
-# family's anchor (fam 5 -> h17s, else h13).
 _M5_CONVS = [
-  # (workload, kH, kW, Cin, Cout, spatial, M5 measured ms) - m5_roofline_validate.py
+  # (workload, kH, kW, Cin, Cout, spatial, M5 measured ms)
   ("3x3 C256@28",  3, 3, 256,  256,  28, 0.216),
   ("1x1 C512@32",  1, 1, 512,  512,  32, 0.178),
   ("3x3 C512@14",  3, 3, 512,  512,  14, 0.192),
@@ -111,7 +88,7 @@ def test_m5_anchor_constants():
 
 
 def test_m1_anchor_unchanged():
-  # the h13 path must stay the exact M1 fit (the +/-17% validation above depends on it)
+  # h13 path must stay the exact M1 fit (the +/-17% validation depends on it)
   c = _cost._analytic_constants("h13")
   assert abs(c["bw_bytes_per_us"] - 9.0e3) < 1e-6
   assert abs(c["floor_us"] - 220.0) < 1e-6
@@ -119,10 +96,6 @@ def test_m1_anchor_unchanged():
 
 
 def test_m5_conv_latency_loop_closed():
-  # the re-fit lands 4 of the 5 convs within 13% (mean |err| 12%) vs the old
-  # clock-scaled BW's mean 99% / max 211%. The one tail (1x1 C1024@16, -31%) is a
-  # floor-bound under-prediction: M5's measured dispatch floor spans 90-150 us and
-  # that conv sits in the band's slow end.
   QUOTED = {"3x3 C256@28", "1x1 C512@32", "1x1 C2048@8"}      # writeup: 214/170/265 us
   errs = {}
   for name, kH, kW, Cin, Cout, S, meas_ms in _M5_CONVS:
@@ -138,8 +111,7 @@ def test_unmeasured_chip_bw_core_scaled():
   # h17d (64 cores) takes the h17s (16-core) anchor scaled by core ratio, not clock
   c5, cd = _cost._analytic_constants("h17s"), _cost._analytic_constants("h17d")
   assert abs(cd["bw_bytes_per_us"] / c5["bw_bytes_per_us"] - 4.0) < 0.01     # 64/16
-  # h14 (M2 Pro / A14) is now its OWN silicon-measured anchor (~48 GB/s), distinct from
-  # h13's ~9 GB/s - not scaled off h13 anymore.
+  # h14 (M2 Pro / A14) is its own silicon-measured anchor (~48 GB/s)
   c1, c4 = _cost._analytic_constants("h13"), _cost._analytic_constants("h14")
   assert abs(c4["bw_bytes_per_us"] - 48.0e3) < 1.0           # 48 GB/s = 48e3 B/us
   assert c4["bw_bytes_per_us"] > 5 * c1["bw_bytes_per_us"]   # ~48 vs ~9 GB/s
@@ -159,23 +131,18 @@ def test_bigger_chip_not_slower():
 def test_default_path_unchanged_without_target():
   g = _conv_graph(3, 3, 256, 256, 28)
   default = _cost.estimate(g)
-  # default uses the bundled M5-measured ane_cost_model.json (or its documented
-  # defaults); it must NOT raise and must be a positive latency.
   assert default > 0.0
-  # passing target=None is identical to omitting it.
+  # target=None identical to omitting it
   assert _cost.estimate(g, target=None) == default
 
 
 def test_h14_midband_compute_ramp():
-  # M2/A14 grid: effective compute throughput ramps to peak with per-op FLOPs, so the
-  # plain roofline under-predicts mid-size ops badly (768^3 GEMM measured 596us, ~0.38x).
-  # The h14 anchor's util ramp lifts the mid-band toward measured; endpoints/other chips
-  # keep util=1. (papers H14_CALIBRATION_GRID.md; fit cuts grid mean-err 1.61x->1.20x.)
+  # h14 anchor's util ramp lifts the mid-band toward measured (768^3 GEMM measured 596us)
   W = np.zeros((768, 768), np.float32)
   gemm = af.input((768, 768)) @ W            # 768^3 GEMM, the worst mid-band point
   e_mid = _cost.estimate(gemm, target="h14")
   assert 350.0 < e_mid < 596.0               # ramped up from the ~224us no-ramp estimate
-  # the ramp is h14-only: h13/h17s constants carry no util_k (M1/M5 estimates unchanged)
+  # ramp is h14-only: h13/h17s constants carry no util_k
   assert "util_k" not in _cost._analytic_constants("h13")
   assert "util_k" not in _cost._analytic_constants("h17s")
   assert "util_k" in _cost._analytic_constants("h14g")
@@ -183,9 +150,7 @@ def test_h14_midband_compute_ramp():
 
 # --- estimate provenance: is a target's estimate silicon-anchored or extrapolated? ------
 def test_estimate_provenance_marks_silicon_measured_families():
-  # Three measured anchors: A13/h13 (M1), A14/h14 (M2 Pro), A16/h17s (M5). A target whose
-  # capability family owns a silicon anchor is "measured"; h16/h17* fold into the A16 tier
-  # so they ride the h17s silicon point.
+  # measured anchors: A13/h13 (M1), A14/h14 (M2 Pro), A16/h17s (M5); h16/h17* fold to A16 tier
   for arch in ("h13", "h14", "h17s", "h16", "h17d"):
     p = af.estimate_provenance(arch)
     assert p["measured"] is True
@@ -193,8 +158,7 @@ def test_estimate_provenance_marks_silicon_measured_families():
 
 
 def test_estimate_provenance_marks_extrapolated_targets():
-  # A15 has no M3 silicon yet -> extrapolated from the nearest measured anchor below it
-  # (the A14/h14 point). h11 (a sub-A13 reference target) extrapolates from h13.
+  # A15 has no M3 silicon -> extrapolated from h14; h11 extrapolates from h13
   p15 = af.estimate_provenance("h15")
   assert p15["measured"] is False
   assert p15["anchor"] == "h14"

--- a/tests/test_cross_chip_ops.py
+++ b/tests/test_cross_chip_ops.py
@@ -1,9 +1,4 @@
-"""Ops that M1 (A13) cannot run but newer Macs can. On M1 hardware we test the
-TWO things that are testable: (1) the op catalog correctly declares each op's
-cross-chip availability (walled/bridge on M1, native on the supporting family),
-and (2) aneforge GUARDS them on M1 - it refuses (clear arch-gate error) rather
-than silently miscompiling, and the same graph compiles when targeting a chip
-that supports it. The op cannot actually EXECUTE here (that needs the newer silicon)."""
+"""Cross-chip ops M1 can't run: catalog declares availability and aneforge guards them on M1."""
 from __future__ import annotations
 import pytest
 import aneforge as af
@@ -39,7 +34,7 @@ def test_catalog_declares_cross_chip(op):
 
 
 def test_catalog_capability_grows_m1_to_m5():
-  # M5 (family 5) runs at least as many native ops as M1 (family 2) - capability is a ladder.
+  # capability is a ladder: M5 native ops >= M1 native ops
   m1 = set(oc.ops_on("m1", "native"))
   m5 = set(oc.ops_on("m5", "native"))
   assert m1 <= m5, f"M1-native ops not all M5-native: {sorted(m1 - m5)}"
@@ -53,9 +48,7 @@ def test_catalog_capability_grows_m1_to_m5():
     ("sort", lambda: af.compile(af.sort(af.input((1, 16))))),          # compile-time family guard
 ])
 def test_m1_refuses_gated_op(name, mk, monkeypatch):
-  # Pin the M1 (h13) target so this asserts "M1 refuses" regardless of the host
-  # chip: on an M5 host the same ops compile, so relying on host detection would
-  # make the test pass only when run on M1.
+  # pin M1 (h13) so this asserts "M1 refuses" regardless of host chip
   monkeypatch.setenv("ANEFORGE_TARGET", "h13"); TG._cpu_brand.cache_clear()
   try:
     with pytest.raises(Exception) as ei:
@@ -80,14 +73,10 @@ def test_sort_compiles_for_m5_not_m1(monkeypatch):
 
 
 # --- regression: last-axis gather routes off the width axis (A13/A14 crop-DMA quirk) -----
-# The composed gather (slice_by_size + concat) returns WRONG ELEMENTS for a nonzero WIDTH
-# (last-axis) begin on A13/A14; gather transposes the axis off the last position so it is
-# exact on every family. Guards the M2/A14 gather-axis-1 fix (master 41ca47b).
 @requires_ane
 def test_gather_last_axis_matches_numpy():
   import numpy as np
-  # fp16-EXACT integer inputs (distinct values, well under 2048) so array_equal tests
-  # element SELECTION precisely - a wrong element is an integer mismatch fp16 can't mask.
+  # fp16-exact integer inputs so array_equal tests element selection precisely
   x2 = np.arange(8 * 16, dtype=np.float32).reshape(8, 16)
   idx2 = [3, 0, 15, 7, 7, 1]
   got2 = af.compile(af.gather(af.input((8, 16)), idx2, axis=1))(x2)
@@ -103,11 +92,6 @@ def test_gather_last_axis_matches_numpy():
 
 
 # --- regression: the width-slice hazard guard targets the confirmed patterns -------------
-# Two silicon-pinned modes (a2a323a refined the wrong-element mode; M2 silicon corrected the
-# saturation family bound): (1) WRONG ELEMENTS only when >=2 width-offset slices are
-# CONCATENATED (single slices select correctly - 180-config M2 sweep is exact); (2) magnitude
-# SATURATION (|v|>4094 -> inf) on a single width slice, confirmed on A13 AND A14 (M2 probe);
-# A15 pending M3. A16/M5 unaffected.
 def test_width_slice_guard_modes():
   import warnings
   from aneforge import _compile

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -1,26 +1,11 @@
-"""Cross-target compile validation: does a graph compile for another ANE family,
-checked from THIS host? (aneforge._compile.cross_compile_check)
-
-The e5rt compiler honors a ``TargetArchitecture`` option, and the compile step (produces
-a library) is separable from the device-load step. So on this M5 we can compile-check a
-graph for h13 (M1) etc. without an actual M1 - the keystone CI lever: validate that the
-op corpus compiles for every chip family on one box. (Numeric correctness still needs the
-real silicon; this is compile-level validation.)
-
-These tests reproduce the measured op-floor ladder through aneforge's own dylib:
-relu needs H13+ (the MIL hard floor); native sin/cos need A15+.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_cross_compile.py -q
-"""
+"""Cross-target compile validation: does a graph compile for another ANE family from this host?"""
 import pytest
 import aneforge as af
 from aneforge._compile import cross_compile_check
 from aneforge._targets import detect_family
 
 # cross_compile_check uses the HOST compiler, which can only emit ops the host's family
-# supports. A host below A15 (family 4) has no native-`sin` codegen, so cross-compiling a
-# native-sin graph fails for EVERY target (measured on M1/family-2: h13/h15/h17s all False).
-# Tests that cross-compile native A15+ ops therefore require an A15+/M5 host.
+# supports; native A15+ ops (e.g. sin) require an A15+/M5 host.
 _NEEDS_A15_HOST = pytest.mark.skipif(
   detect_family() < 4,
   reason="cross_compile_check can only emit native A15+ ops (e.g. sin) from an A15+/M5 host")
@@ -32,7 +17,7 @@ def test_relu_compiles_for_h13():
 
 
 def test_relu_rejected_below_the_mil_floor():
-  # "MIL is only supported for H13+ ANE architectures" - even relu fails on h11/h12
+  # MIL is only supported for H13+; even relu fails on h11/h12
   assert cross_compile_check(af.input((1, 64)).relu(), "h11") is False
   assert cross_compile_check(af.input((1, 64)).relu(), "h12") is False
 
@@ -54,17 +39,14 @@ def test_fused_graph_cross_compiles_for_m1():
 
 @_NEEDS_A15_HOST
 def test_a17_a18_and_m11_targets_compile():
-  # The compiler's 28-target table includes A17 (h17*), A18 (h18) and the M11
-  # efficiency ANE; all accept TargetArchitecture. h17s is the measured M5 target.
+  # A17 (h17*), A18 (h18), M11 all accept TargetArchitecture
   g = af.input((1, 64)).sin()           # A15+ op: native on every one of these
   for arch in ("h17s", "h17d", "h18", "m11"):
     assert cross_compile_check(g, arch) is True
 
 
 def test_sd15_group_norm_tiling_cross_compiles():
-  # The rank-4 tiled group_norm makes SD-1.5's big maps fit the per-axis cap. 640ch@64/G32
-  # (flat per-group 81920) tiles to D=20/H*W=4096 - under even the A13 16384 cap, so it
-  # must compile on every family including h13 (M1). 512ch@128/G32 -> H*W=16384 fits too.
+  # rank-4 tiled group_norm makes SD-1.5's big maps fit the per-axis cap (must compile on h13)
   import numpy as np
   for C, H, W, G in [(640, 64, 64, 32), (512, 128, 128, 32)]:
     g = af.input((1, C, H, W)).group_norm(np.ones(C, np.float16), np.zeros(C, np.float16), G)
@@ -73,9 +55,7 @@ def test_sd15_group_norm_tiling_cross_compiles():
 
 
 def test_unknown_arch_raises_not_silently_passes():
-  # e5rt silently falls back to the HOST target on an unknown TargetArchitecture
-  # string (measured: 'zzz' compiles), so cross_compile_check must gate the name -
-  # otherwise a typo'd CI matrix would validate nothing.
+  # e5rt silently falls back to the HOST target on unknown arch, so the name must be gated
   import pytest
   with pytest.raises(ValueError, match="unknown ANE target arch"):
     cross_compile_check(af.input((1, 64)).relu(), "h19")

--- a/tests/test_cross_compile_matrix.py
+++ b/tests/test_cross_compile_matrix.py
@@ -1,20 +1,4 @@
-"""Cross-compile the whole fused corpus for every ANE family, and gate that our static
-target model (aneforge._targets) agrees with what the real compiler does.
-
-This turns the cross-target lever into actual coverage: every fused corpus case (the op
-surface) is compiled for h13/h14/h15/h16s on this one M5 box (h16s stands in for the
-whole A16-ceiling capability tier - the h17*/h18 targets compile too but are
-capability-identical, core-count scaling only), and the per-(case, family)
-compile result is compared to the model's prediction (a raw graph compiles iff every op
-is native and nothing is oversize). Any disagreement is a bug in _OP_FLOOR / _LIMITS /
-preflight - this is how we keep the hand-curated model correct against the ground truth.
-
-Compile-level only (cross-target programs can't execute on this host); numeric
-correctness still needs the real silicon. Bridge/segmented cases are skipped (the
-cross-target checker is fused-route only).
-
-Run: PYTHONPATH=.:tests python3 -m pytest tests/test_cross_compile_matrix.py -q
-"""
+"""Cross-compile the fused corpus for every ANE family; gate that _targets agrees with the compiler."""
 import sys
 import warnings
 from pathlib import Path
@@ -32,8 +16,7 @@ ARCHS = [("h13", 2), ("h14", 3), ("h15", 4), ("h16s", 5)]
 
 
 def _model_compiles(graph, family: int) -> bool:
-  """The model's prediction for whether the RAW graph compiles at this family: every op
-    native (no decomposition needed) and nothing oversize."""
+  """Model prediction: raw graph compiles iff every op native and nothing oversize."""
   rep = T.preflight(graph, family)
   return not rep.reject and not rep.decompose and not rep.oversize
 
@@ -56,11 +39,7 @@ def test_model_matches_compiler(name, graph):
     for arch, fam in ARCHS:
       actual = cross_compile_check(graph, arch)
       predicted = _model_compiles(graph, fam)
-      # cross_compile_check uses the HOST compiler, which can only EMIT ops the host's
-      # family supports. When the model says a higher-family TARGET runs the op natively
-      # but the host is below that family, the host can't emit it - cross_compile
-      # rejects for a host reason, not because the target lacks the op. That's a host
-      # artifact (it would pass on an A15+/M5 host), so skip rather than flag the model.
+      # host artifact: host can't EMIT ops above its own family, so skip rather than flag the model
       if predicted and not actual and fam > host_family: continue
       assert actual == predicted, (
         f"{name} @ {arch} (family {fam}): compiler {'compiles' if actual else 'rejects'} "

--- a/tests/test_decoder_block.py
+++ b/tests/test_decoder_block.py
@@ -33,8 +33,7 @@ def test_causal_llama_block_matches_numpy(S, D, H, Dff):
 
 @requires_ane
 def test_kv_cache_decode_step():
-  # one autoregressive DECODE step: the new token attends to cached K/V (+ its own new k/v)
-  # via the decode-shape SDPA (seq_q=1, seq_kv=cache+1), in a full LLaMA block.
+  # one autoregressive decode step: new token attends to cached K/V via decode-shape SDPA
   rng = np.random.default_rng(0); D, H, Dff, Sc = 16, 2, 32, 5; dh = D // H
   W = {k: (rng.standard_normal(s) * 0.1).astype(np.float32) for k, s in
        {"Wq": (D, D), "Wk": (D, D), "Wv": (D, D), "Wo": (D, D),
@@ -75,7 +74,7 @@ def test_kv_cache_decode_step():
 
 @requires_ane
 def test_ane_generate_matches_numpy():
-  # end-to-end autoregressive generation on the ANE == a numpy reference (token-for-token).
+  # end-to-end autoregressive generation on the ANE == numpy reference (token-for-token)
   from examples.gpt_generate_ane import TinyDecoderANE
   m = TinyDecoderANE(seed=0)
   rms = lambda z, g, e=1e-5: z / np.sqrt((z ** 2).mean(-1, keepdims=True) + e) * g
@@ -103,7 +102,7 @@ def test_ane_generate_matches_numpy():
 
 @requires_ane
 def test_generate_fixed_cache_matches_per_step():
-  # fixed-max cache (ONE decode compile + runtime position mask) == per-step growing cache.
+  # fixed-max cache (one decode compile + runtime position mask) == per-step growing cache
   from examples.gpt_generate_ane import TinyDecoderANE
   m = TinyDecoderANE(seed=0)
   assert m.generate_fixed([3, 7, 1], 4, max_len=12) == m.generate([3, 7, 1], 4)
@@ -111,9 +110,7 @@ def test_generate_fixed_cache_matches_per_step():
 
 @requires_ane
 def test_generate_resident_matches_per_step():
-  # RESIDENT KV-cache (share_buffer: the masked positional write is in-graph and the cache
-  # output is aliased onto its own input, so the cache never round-trips to the host) ==
-  # the per-step growing cache. Productizes the zero-copy KV-cache crack.
+  # resident KV-cache (share_buffer: cache aliased onto its own input, no host round-trip)
   from examples.gpt_generate_ane import TinyDecoderANE
   m = TinyDecoderANE(seed=0)
   assert m.generate_resident([3, 7, 1], 4, max_len=12) == m.generate([3, 7, 1], 4)

--- a/tests/test_dispatch_floor_warning.py
+++ b/tests/test_dispatch_floor_warning.py
@@ -1,8 +1,4 @@
-"""compile() warns (DispatchFloorWarning) when a program is dispatch-floor-bound - its
-predicted ANE time is dominated by the fixed per-call dispatch/firmware round-trip, so the
-user knows to amortize via batching or op-chaining rather than looping per-sample. Must NOT
-fire for compute-bound programs, and must be filterable.
-"""
+"""compile() warns (DispatchFloorWarning) for dispatch-floor-bound programs, not compute-bound; filterable."""
 import warnings
 
 import numpy as np

--- a/tests/test_dynamic_conv.py
+++ b/tests/test_dynamic_conv.py
@@ -1,5 +1,4 @@
-"""af.dynamic_conv - native conv with a runtime-tensor (dynamic) weight, lowering to the
-ANE's dynamic-kernel path. Batch-1 only (B>=2 is unsupported, guarded at build)."""
+"""af.dynamic_conv: native conv with a runtime-tensor weight (batch-1 only)."""
 from __future__ import annotations
 import numpy as np
 import pytest
@@ -34,13 +33,12 @@ def _cos(a, b):
 
 
 def test_dynamic_conv_b2_guard_and_dtype():
-  # batch>=2 is unsupported -> rejected at build time
+  # batch>=2 rejected at build time
   with pytest.raises(ValueError, match="batch N=1"):
     af.dynamic_conv(af.input((2, 1, 8, 8)), af.input((8, 1, 3, 3)))
-  # a constant (numpy) weight is the wrong call - use af.conv
+  # constant numpy weight is the wrong call (use af.conv)
   with pytest.raises(TypeError, match="must be a Tensor"):
     af.dynamic_conv(af.input((1, 1, 8, 8)), np.ones((8, 1, 3, 3), np.float32))
-  # builds at B=1 with the right output shape
   assert af.dynamic_conv(af.input((1, 2, 8, 8)), af.input((4, 2, 3, 3))).shape == (1, 4, 6, 6)
 
 
@@ -55,7 +53,7 @@ def test_dynamic_conv_fed_weight():
 
 @requires_ane
 def test_dynamic_conv_hypernetwork():
-  # a code vector generates the conv kernel ON-ENGINE (linear -> reshape -> conv), one program
+  # code vector generates the conv kernel on-engine (linear -> reshape -> conv)
   xv = rng.standard_normal((1, 2, 8, 8)).astype(np.float16)
   cv = rng.standard_normal((1, 8)).astype(np.float16)
   Wgen = (rng.standard_normal((8, 4 * 2 * 3 * 3)) * 0.1).astype(np.float32)

--- a/tests/test_fft2.py
+++ b/tests/test_fft2.py
@@ -1,11 +1,4 @@
-"""2-D FFT on the ANE - aneforge.fft.fft2/ifft2 as ONE fused program per transform.
-
-The 2-D DFT of an [M,N] complex field is F_M @ X @ F_N^T - a handful of real GEMMs,
-so it fuses into a single e5rt program instead of host-looping the 1-D plan over
-M rows + N columns (M+N dispatches).
-
-Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_fft2.py -q
-"""
+"""2-D FFT on the ANE: aneforge.fft.fft2/ifft2 as one fused program per transform."""
 from __future__ import annotations
 import os
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
@@ -31,7 +24,7 @@ def test_fft2_matches_numpy(shape):
 
 
 def test_fft2_real_field():
-  # real input (imag fed as zeros) - the PDE/Poisson use case
+  # real input (imag fed as zeros): the PDE/Poisson use case
   rng = np.random.default_rng(3)
   f = rng.standard_normal((32, 32)).astype(np.float32)
   Xr, Xi = agfft.fft2(f, np.zeros_like(f))
@@ -40,7 +33,7 @@ def test_fft2_real_field():
 
 
 def test_ifft2_roundtrip():
-  # ifft2(fft2(x)) ~ x, which also pins the 1/(M*N) normalization
+  # ifft2(fft2(x)) ~ x; also pins the 1/(M*N) normalization
   rng = np.random.default_rng(7)
   xr = rng.standard_normal((32, 32)).astype(np.float32)
   xi = rng.standard_normal((32, 32)).astype(np.float32)
@@ -59,14 +52,13 @@ def test_ifft2_matches_numpy():
 
 
 def test_ifft2_large_magnitude_spectrum():
-  # A real PDE spectrum is LARGE (O(N^2) at the dominant modes): the inverse's
-  # 1/(M*N) scaling must be folded INTO the per-axis twiddles, or the intermediate
-  # after the first axis transform overflows fp16 (max 65504).
+  # large PDE spectrum: 1/(M*N) scaling must fold into the per-axis twiddles or the
+  # intermediate after the first axis overflows fp16 (max 65504).
   N = 64
   x = np.linspace(0.0, 2 * np.pi, N, endpoint=False)
   X, Y = np.meshgrid(x, x, indexing="ij")
   u = np.sin(X) * np.cos(2 * Y) + 0.3 * np.cos(2 * X) * np.cos(2 * Y)
-  spec = np.fft.fft2(u) * 8.0          # |values| up to ~1.6e4 - inside fp16 range
+  spec = np.fft.fft2(u) * 8.0          # |values| up to ~1.6e4, inside fp16 range
   br, bi = agfft.ifft2(spec.real.astype(np.float32), spec.imag.astype(np.float32))
   ref = np.fft.ifft2(spec)
   assert np.all(np.isfinite(br)) and np.all(np.isfinite(bi))
@@ -77,4 +69,4 @@ def test_fft2_plan_is_one_program_and_cached():
   p1 = agfft.fft2_plan(32, 32)
   p2 = agfft.fft2_plan(32, 32)
   assert p1 is p2                       # plan cache, like fft_plan
-  assert p1.model.n_ops > 0             # ONE compiled e5rt program, not a host loop
+  assert p1.model.n_ops > 0             # one compiled e5rt program, not a host loop

--- a/tests/test_fp16_cross_chip.py
+++ b/tests/test_fp16_cross_chip.py
@@ -1,16 +1,4 @@
-"""Direction B wiring: the cross-chip fp16 divergence predictor surfaced as WARNINGS in
-``cross_compile_check`` (preflight) and the A13/M1 conv-training loss_scale guard in
-``Trainer``. The predictor itself is unit-tested in test_targets.py; here we check it is
-correctly wired into the compile/train paths and never REJECTS or mutates (warn-only:
-the auto-cap was dropped after the M1 end-to-end run refuted it - a real CNN trains
-identically at loss_scale 128/1024/65536).
-
-cross_compile_check compiles on this M5 host for another family's TargetArchitecture, so
-these touch the dylib. The Trainer guard is host-static but the construction does
-compile tiny programs.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_fp16_cross_chip.py -q
-"""
+"""Cross-chip fp16 divergence predictor wired into cross_compile_check + Trainer (warn-only)."""
 import warnings
 
 import numpy as np
@@ -27,23 +15,21 @@ def _crosschip_warnings(rec):
 
 
 def test_cross_compile_check_warns_reduction_route(monkeypatch):
-  # host = M5 (A16); cross-compiling a reduction for h13 (A13) -> <=1-ULP route warning.
-  # Pin the simulated host family so the test is host-independent (passes on M1 too).
+  # host A16, cross-compiling a reduction for A13 -> <=1-ULP route warning; pin host family
   monkeypatch.setenv("ANEFORGE_TARGET", "h16s")
   TG._cpu_brand.cache_clear()
   g = af.input((1, 256)).sum((1,))
   with warnings.catch_warnings(record=True) as rec:
     warnings.simplefilter("always")
     ok = cross_compile_check(g, "h13")
-  assert ok is True                       # still compiles - warn-only
+  assert ok is True                       # still compiles, warn-only
   msgs = _crosschip_warnings(rec)
   assert len(msgs) == 1
   assert "ULP" in msgs[0]
 
 
 def test_cross_compile_check_same_family_no_warning(monkeypatch):
-  # cross-compiling for the host's own family (A16) must not warn.
-  # Pin host=A16 so this is host-independent (the host's own family == the target).
+  # cross-compiling for the host's own family (A16) must not warn; pin host=A16
   monkeypatch.setenv("ANEFORGE_TARGET", "h16s")
   TG._cpu_brand.cache_clear()
   g = af.input((1, 256)).sum((1,))
@@ -54,7 +40,7 @@ def test_cross_compile_check_same_family_no_warning(monkeypatch):
 
 
 def test_cross_compile_check_no_fp16_axis_no_warning(monkeypatch):
-  # an all-elementwise graph has no reduction/slice route axis -> no fp16 warning.
+  # all-elementwise graph has no reduction/slice route axis -> no fp16 warning
   monkeypatch.delenv("ANEFORGE_TARGET", raising=False)
   g = af.input((1, 64)).relu()
   with warnings.catch_warnings(record=True) as rec:
@@ -63,7 +49,7 @@ def test_cross_compile_check_no_fp16_axis_no_warning(monkeypatch):
   assert _crosschip_warnings(rec) == []
 
 
-# --- the A13 conv-training loss_scale saturation WARNING (Trainer; warn-only) ----------
+# --- A13 conv-training loss_scale saturation warning (Trainer; warn-only) ----------
 def _conv_trainer(loss_scale):
   w = ag.conv_param(np.random.randn(3, 2, 3, 3))     # kW=3 -> width-offset im2col
   x = af.input((2, 2, 6, 6))
@@ -74,12 +60,12 @@ def _conv_trainer(loss_scale):
 
 
 def test_trainer_warns_but_keeps_loss_scale_on_a13_conv(monkeypatch):
-  monkeypatch.setenv("ANEFORGE_TARGET", "h13")        # target the M1/A13 family
+  monkeypatch.setenv("ANEFORGE_TARGET", "h13")        # target the A13 family
   TG._cpu_brand.cache_clear()
   with warnings.catch_warnings(record=True) as rec:
     warnings.simplefilter("always")
     t = _conv_trainer(1024.0)
-  assert t.scale == 1024.0                             # warn-only: never mutated
+  assert t.scale == 1024.0                             # warn-only, never mutated
   assert any("saturat" in str(r.message) for r in rec)
 
 
@@ -88,14 +74,13 @@ def test_trainer_no_warning_below_onset_on_a13(monkeypatch):
   TG._cpu_brand.cache_clear()
   with warnings.catch_warnings(record=True) as rec:
     warnings.simplefilter("always")
-    t = _conv_trainer(256.0)                         # already clean in the repro
+    t = _conv_trainer(256.0)                         # below onset, already clean
   assert t.scale == 256.0
   assert not any("saturat" in str(r.message) for r in rec)
 
 
 def test_trainer_no_warning_on_a16(monkeypatch):
-  # M5/A16 takes the clean slice route -> silent even at a high loss_scale.
-  # Pin host=A16 so this is host-independent (passes on M1 too, which is otherwise A13).
+  # A16 takes the clean slice route -> silent even at high loss_scale; pin host=A16
   monkeypatch.setenv("ANEFORGE_TARGET", "h16s")
   TG._cpu_brand.cache_clear()
   with warnings.catch_warnings(record=True) as rec:
@@ -106,7 +91,7 @@ def test_trainer_no_warning_on_a16(monkeypatch):
 
 
 def test_trainer_a13_no_conv_unaffected(monkeypatch):
-  # A13 target but a plain (non-conv) graph: no width-offset slice -> silent.
+  # A13 target but plain (non-conv) graph: no width-offset slice -> silent
   monkeypatch.setenv("ANEFORGE_TARGET", "h13")
   TG._cpu_brand.cache_clear()
   p = ag.parameter(np.random.randn(4, 4))

--- a/tests/test_group_norm_tiling.py
+++ b/tests/test_group_norm_tiling.py
@@ -1,13 +1,4 @@
-"""group_norm rank-4 tiling (Direction C): the SD-1.5 large-feature-map wall.
-
-The native group_norm now lowers to [1,G,C/groups,H*W] and reduces the trailing two
-axes (instead of flattening to [1,G,(C/groups)*H*W]), so every internal axis stays under
-the ANE per-axis cap. This lets SD-1.5's 640ch@64 and 512ch@128 maps compile + run where
-the flattened extent (81920 / 262144) overflowed. These tests pin small-shape correctness,
-big-shape correctness vs fp32, and the relaxed construction guard.
-
-    PYTHONPATH=. python3 -m pytest tests/test_group_norm_tiling.py -q
-"""
+"""group_norm rank-4 tiling: keeps each internal axis under the ANE per-axis cap (SD-1.5 maps)."""
 from __future__ import annotations
 
 import numpy as np
@@ -63,8 +54,7 @@ def test_group_norm_small_shapes(C, H, W, G):
 @requires_ane
 @pytest.mark.parametrize("C,H,W,G", [(640, 64, 64, 32), (512, 128, 128, 32)])
 def test_group_norm_sd15_large_maps_run(C, H, W, G):
-  # flat per-group (C/G)*H*W = 81920 / 262144 used to overflow the per-axis cap; the
-  # rank-4 tiling keeps max(C/G, H*W) under it so these compile + run in fp16.
+  # flat (C/G)*H*W = 81920 / 262144 used to overflow the cap; rank-4 tiling keeps it under.
   got, ref = _run(C, H, W, G)
   assert np.abs(got - ref).max() < 0.03
 
@@ -73,11 +63,11 @@ def test_group_norm_sd15_large_maps_run(C, H, W, G):
 def test_group_norm_guard_allows_large_product_small_axes():
   # 640ch@64/G32: product 81920 > 65536 (old guard rejected) but max(C/G,H*W)=4096 fits.
   af.input((1, 640, 64, 64)).group_norm(np.ones(640, np.float16), np.zeros(640, np.float16), 32)
-  # 512ch@128/G32: product 262144, tiled axes D=16 / H*W=16384 both fit.
+  # 512ch@128/G32: product 262144 but tiled axes D=16 / H*W=16384 both fit.
   af.input((1, 512, 128, 128)).group_norm(np.ones(512, np.float16), np.zeros(512, np.float16), 32)
 
 
 def test_group_norm_guard_rejects_oversize_single_axis():
-  # A single tiled axis above 65536 still raises: H*W = 257*257 = 66049 > 65536.
+  # single tiled axis above 65536 still raises: H*W = 257*257 = 66049 > 65536
   with pytest.raises(ValueError, match="largest tiled axis"):
     af.input((1, 4, 257, 257)).group_norm(np.ones(4, np.float16), np.zeros(4, np.float16), 1)

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -1,11 +1,4 @@
-"""Tests for af.image_input - uint8 image input dequantised to fp16 ON the engine.
-
-Camera/decoded-video bytes feed the model directly; the uint8->fp16 cast + the
-``scale*x + bias`` normalisation run as in-graph ANE ops. Each test compiles+runs a
-real graph fed a uint8 array and checks it against a host-fp16 reference.
-
-    PYTHONPATH=. python3 -m pytest tests/test_image_input.py -q
-"""
+"""af.image_input - uint8 image input dequantised to fp16 on the engine."""
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_lapack.py
+++ b/tests/test_lapack.py
@@ -1,18 +1,4 @@
-"""LAPACK-on-the-ANE characterization corpus.
-
-LAPACK is built on three things the ANE cannot do: PIVOTING (data-dependent argmax +
-row swap), a SEQUENTIAL data-sized inner recurrence, and fp64. So LAPACK's *routines*
-do not port. But each LAPACK *problem* has a fixed-iteration / matmul-dominated method
-that IS static dataflow, and those UNROLL into a single on-ANE program (no host compute).
-
-This file is the map: for each LAPACK problem family it runs the ANE method fully on the
-engine, validates against the numpy fp64 reference on the SAME fp16-rounded system, and
-records the conditioning envelope. The families whose only method is a pivoted/recursive
-DIRECT factorization (full spectrum, pivoted LU/QR) are the documented walls - listed,
-not run. Accumulation is via matmul (the ANE's wide >=fp32 accumulator).
-
-Run: PYTHONPATH=. python3 tests/test_lapack.py
-"""
+"""LAPACK-on-the-ANE characterization corpus: per-family ANE method vs numpy fp64, with fp16 conditioning envelope."""
 from __future__ import annotations
 import os
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
@@ -154,8 +140,7 @@ CASES = [
 
 REACHABLE_UNBUILT: list = []   # QR / Cholesky / LU now built (above); nothing left in this tier
 
-# The genuine walls - they need data-dependent CONTROL FLOW or OUTPUT SIZE, which static
-# dataflow cannot express even with fixed iteration:
+# genuine walls: need data-dependent control flow or output size
 WALLED = [
     ("rank-revealing / adaptive-tolerance", "data-dependent OUTPUT SIZE (how many values > tol) - "
         "cannot emit a runtime-sized result; only all-n + a mask. The one irreducible wall."),

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -1,14 +1,4 @@
-"""Pytest coverage for the on-ANE linear-algebra kernels (aneforge.linalg).
-
-These kernels are fp16, fixed-iteration, and (for the factorizations) UNROLLED into one
-program, so they have shape- and conditioning-dependent envelopes. This suite validates
-each against the numpy/scipy reference within its envelope, and deliberately sweeps
-SHAPES (tall / wide / square) for the SVD/QR/LU family - the wide case is what hid the
-``svd`` Gram-matrix bug (it only ever formed A^T A, fine for tall A, a huge graph for wide
-A). Sizes are kept small: several kernels compile a deep unrolled graph.
-
-Run: PYTHONPATH=. .venv/bin/python -m pytest tests/test_linalg.py -q
-"""
+"""Pytest coverage for the on-ANE linear-algebra kernels (aneforge.linalg)."""
 from __future__ import annotations
 import os
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
@@ -144,8 +134,7 @@ def test_eigh_full_spectrum(cond):
 
 
 def test_eigh_iterate_matches_unrolled():
-  # iterate=True host-loops ONE compiled sweep; same rotations on the same engine as the
-  # unrolled one-program path, so at small n the two must agree to fp16 exactness.
+  # iterate path and unrolled path use the same rotations -> fp16-exact at small n
   A = _sym_gapped(8, 1e1, 19)
   un = L.eigh(f16(A), sweeps=8)
   it = L.eigh(f16(A), sweeps=8, iterate=True)
@@ -154,9 +143,7 @@ def test_eigh_iterate_matches_unrolled():
 
 
 def test_eigh_iterate_beyond_unrolled_ceiling():
-  # n=32 exceeds the ~n=20 cap of the unrolled program; only the iterate path reaches it
-  # (measured 1.4e-2 here; n=48 at ~1.2-1.8e-2 stays a documented probe - ~220s is too
-  # heavy for the gate).
+  # n=32 exceeds the ~n=20 unrolled cap; only the iterate path reaches it
   A = _sym_gapped(32, 1e1, 32)
   ref = np.sort(np.linalg.eigvalsh(A))
   assert relerr(L.eigh(f16(A), sweeps=10, iterate=True), ref) <= 3e-2
@@ -207,12 +194,8 @@ def test_lu_reconstruction(cond):
 
 
 def test_factorizations_large_entries():
-  # Entries ABOVE the A13/A14 slice-x16 saturation threshold (4094) but inside fp16 range:
-  # a direct [i,j] width-offset element slice would return +/-inf on that silicon (confirmed on
-  # BOTH: M2/A14 non-finite pre-fix at max|A|>=4500; M1/A13 a [0,3] slice of an 8000 element
-  # returns inf vs the routed accessor's exact 8000). The _els_routed accessor keeps every slice begin's
-  # last axis at 0, so chol/lu stay finite + accurate up to the kernels' intrinsic fp16 range.
-  # (qr/eigh/eigvals are NOT tested hot: they overflow fp16 intrinsically at max|A| ~ 1e2.)
+  # entries above the slice-x16 saturation threshold (4094) but inside fp16 range: the
+  # routed accessor keeps chol/lu finite where a direct width-offset slice returns inf
   for mx in (4500.0, 8000.0):
     A = _spd(6, 1e1, 31); A = A / np.abs(A).max() * mx
     Lc = L.cholesky(f16(A))

--- a/tests/test_new_ops.py
+++ b/tests/test_new_ops.py
@@ -1,5 +1,4 @@
-"""New forward ops (floor/ceil/round/sign/pow/comparisons/logical_not/reverse/tile/
-reduce_log_sum_exp) + their vjps. All confirmed native on M1 (h13)."""
+"""New forward ops (floor/ceil/round/sign/pow/comparisons/reverse/tile/reduce_log_sum_exp) + their vjps."""
 from __future__ import annotations
 import numpy as np
 import pytest

--- a/tests/test_nn_blocks.py
+++ b/tests/test_nn_blocks.py
@@ -1,11 +1,4 @@
-"""NN-block cases for the aneforge corpus: realistic network fragments an
-optimizer must not break - conv stacks, a transformer encoder block, a small
-CNN->GAP->fc classifier, group/batch norm, upsample+conv (SR-style), and
-conv_transpose.
-
-Each case ships its own numpy golden reference. ``CASES`` is imported by
-tests/run_corpus.py; this file also runs standalone.
-"""
+"""NN-block cases for the aneforge corpus: realistic network fragments vs numpy goldens."""
 from __future__ import annotations
 
 import numpy as np
@@ -370,8 +363,7 @@ def _space_depth_roundtrip():
   def ref(xa):
     return xa.astype(np.float32)
 
-  # the reorder is value-preserving; a sub-ULP fp16 residual (~1e-5) keeps it from
-  # being bit-exact, so gate on a tight relerr rather than exact equality.
+  # value-preserving reorder with a sub-ULP fp16 residual -> tight relerr, not exact
   return Case("space_depth_roundtrip", "nn", build, ref, [x], tol=1e-4)
 
 

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -1,32 +1,4 @@
-"""Numerical-computing corpus for aneforge - the "arbitrary sequences of ops" probe.
-
-Two halves:
-
-1. KERNELS - iterative / composed numerical kernels (power iteration, a CG step,
-   Horner polynomial eval, a PDE stencil, n-body normals, a Monte-Carlo reduction,
-   a Gram/SYRK product). Each is built as an aneforge graph, compiled + run on the
-   ANE, and validated against a numpy fp32 golden at an fp16-appropriate tolerance.
-   Tolerances are LOOSER where iteration compounds rounding - and where they are
-   loosened, the case docstring SAYS so and distinguishes "fp16 compounding" from
-   "wrong" (a wrong kernel blows past any sane tol; compounding stays O(few %)).
-
-2. LAPACK FEASIBILITY PROBES - corner probes (QR/Cholesky-style
-   orthonormalization, triangular back-substitution, a small linear solve). These
-   ask "what classical linear algebra actually fits the ANE's fp16 feed-forward
-   dataflow?" They are tagged works / arch-limited / fp16-unstable with evidence
-   (relerr vs scipy, or the compile/runtime error). A "no" here is the finding.
-
-Every case carries two extra tags beyond the harness ``Case`` fields:
-  - cost character: floor | bandwidth | compute | reduction | mixed
-  - feasibility:    works | arch-limited | fp16-unstable
-
-We reuse the shared harness (Case, eval_case, run_corpus) verbatim; the cost/
-feasibility tags are kept in a side table keyed by case name and printed by our
-own runner, so we don't touch _corpus.py.
-
-Run:
-    PYTHONPATH=. python3 tests/test_numerical.py
-"""
+"""Numerical-computing corpus for aneforge: composed kernels + LAPACK feasibility probes vs numpy goldens."""
 from __future__ import annotations
 
 import sys
@@ -50,8 +22,7 @@ rng = np.random.default_rng(1234)
 def f16(*shape, scale=1.0): return (rng.standard_normal(shape).astype(np.float32) * scale).astype(np.float16)
 
 
-# tag side-table: name -> (cost_character, feasibility)                        #
-# Populated as cases are constructed; printed by the runner.                   #
+# tag side-table: name -> (cost_character, feasibility); printed by the runner
 TAGS: dict[str, tuple[str, str]] = {}
 
 
@@ -175,8 +146,6 @@ def _horner():
   cvec = coeffs.reshape(1, D + 1)
 
   def build(xt, ct):
-    # ct is [1, D+1]; _col(ct, i) selects coeff i as a [1,1] tensor that
-    # broadcasts over the 32 lanes, so the whole recurrence stays fused.
     acc = None
     for i in range(D, -1, -1):
       ci = _col(ct, i)                  # [1,1] -> broadcasts over the 32 lanes
@@ -362,20 +331,9 @@ def _gram_syrk():
                 "compute", "works")
 
 
-# LAPACK FEASIBILITY PROBES - classify correctly, do not fake a pass.
-#
-# Background (from the reverse-engineering corpus RE of the MatrixDecomposition layer):
-#   * aneforge's __all__ exposes NO decomposition op. The hardware
-#     `MatrixDecomposition` unit exists in the netplist ISA (Type=NonQRGivens,
-#     a Givens-rotation orthogonalizer), and `MatrixDecomposition->MatMul`
-#     CARRIERS compile + run (matdecomp_matmul_fused.py), but the exact
-#     factorization COMPOSITE is `not_currently_callable`
-#     (ane_matdecomp_frontier_report.py: "carriers runtime-proven ... but exact
-#     composite evidence is absent"). So a *usable factorization* (extract Q/R/L)
-#     is NOT reachable from the public frontend or the cracked bridge today.
-#
-# We therefore probe what IS reachable - building factorizations out of the
-# available feed-forward ops - and tag each corner with evidence.
+# LAPACK FEASIBILITY PROBES - classify correctly, do not fake a pass. The native
+# MatrixDecomposition composite is not_currently_callable, so we probe what IS
+# reachable from feed-forward ops and tag each corner with evidence.
 
 def _qr_givens_probe():
   """QR via explicit Givens rotations on a small fixed matrix.

--- a/tests/test_op_coverage.py
+++ b/tests/test_op_coverage.py
@@ -1,7 +1,4 @@
-"""Per-op coverage: one case per exposed aneforge op. Each compiles +
-runs on the ANE; ops with a computable numpy reference are checked for correctness
-(cos > 0.99 / allclose), the rest assert a finite, correctly-shaped output. M1-walled
-bridge ops (per the op catalog) are xfail-skipped. ~100 ops."""
+"""Per-op coverage: one case per exposed aneforge op, run on the ANE and checked vs numpy or for finite shape."""
 from __future__ import annotations
 import math
 import numpy as np

--- a/tests/test_pde_ode.py
+++ b/tests/test_pde_ode.py
@@ -1,50 +1,4 @@
-"""Iterative-numerical-methods corpus for aneforge - PDE/ODE/root-finding/series.
-
-The question it maps is: *which iterative scientific methods fit the ANE's
-fixed-dataflow, feed-forward, fp16 engine, and which need control flow it lacks?*
-
-Three families:
-
-1. PDE / STENCILS (conv-based) - the marquee scientific-compute fit. The ANE is a
-   convolution engine, so explicit stencil sweeps (Jacobi, heat, wave, multigrid
-   smoothing) lower to native conv and run on its home turf. cost: COMPUTE.
-
-2. ODE INTEGRATORS & ROOT FINDERS - forward-Euler, RK4, Newton, fixed-point. These
-   are RECURRENCES advanced a FIXED number of steps, with the RHS / f / f' / g built
-   as aneforge ops. cost: MIXED (composed elementwise + small matmul/reduction).
-
-3. SERIES / SPECIAL-FUNCTION APPROX - exp/erf/log via Horner-form polynomial chains,
-   checked against numpy's exact special function. cost: FLOOR/FUSION (deep dependent
-   mul/add chain fused into one program).
-
-THE ARCHITECTURAL BOUNDARY (the finding). The ANE has NO data-dependent control
-flow: no in-graph loop, no convergence test, no adaptive timestep, no scalar
-feedback. Every method here is therefore built with a FIXED iteration count, fully
-unrolled into a static graph. Where a real method needs a *convergence test* (stop
-when ||residual|| < tol) or an *adaptive step* (shrink dt on local error), that form
-is ARCH-LIMITED and tagged as such, with a note on exactly what control flow is
-missing. The fixed-iteration version of the same method WORKS; the adaptive/
-convergent version does not. That split IS the capability map.
-
-On error: the iterative kernels COMPOUND fp16 rounding: the ANE iterate and
-the numpy-fp32 reference iterate are genuinely different trajectories, so they drift
-a little per step. Where a tol is loosened, the docstring says so and distinguishes
-*compounding* (O(few %), grows ~linearly in step count, stays bounded) from a *bug*
-(a wrong kernel blows past any sane tol by O(1)). We keep step counts modest so the
-compounding stays interpretable.
-
-Tags (side table, like test_numerical.py - we do not touch _corpus.py):
-  - cost character: floor | bandwidth | compute | reduction | mixed
-  - feasibility:    works | arch-limited
-
-Constants. aneforge has no scalar add/sub op (only scalar MULTIPLY via ``* float``),
-so additive constants are fed as extra graph inputs (a constant array supplied at run
-time) and indexed with a one-hot ``@`` select - exactly the pattern test_numerical.py
-uses for Horner coefficients. The reference applies the identical constants.
-
-Run:
-    PYTHONPATH=. python3 tests/test_pde_ode.py
-"""
+"""Iterative-numerical-methods corpus for aneforge: PDE/ODE/root-finding/series, fixed-iteration kernels vs numpy goldens."""
 from __future__ import annotations
 
 import math
@@ -608,14 +562,8 @@ def _log_series():
                 "floor/fusion", "works")
 
 
-# 4. ARCH-LIMITED PROBES - the control-flow boundary, made explicit
-#
-# The cases above all run the FIXED-iteration form (which works). The two probes
-# below document the boundary directly: they are the SAME methods but in the form a
-# real solver needs (run-to-convergence / adaptive). We cannot express the
-# data-dependent stop, so we encode the boundary as an xfail with the reason - the
-# corpus records WHY, not a silent omission. The xfail keeps the gate green while
-# making the architectural limit a visible result.
+# 4. ARCH-LIMITED PROBES - same methods in their convergent/adaptive form, xfail'd
+# because the data-dependent stop is inexpressible on the feed-forward engine.
 
 def _newton_to_convergence_archlimited():
   """Newton run-TO-CONVERGENCE (stop when |f(x)| < tol) - the form a real root

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -102,10 +102,7 @@ def test_canon_noop_keeps_identity():
   assert canonicalize(y) is y
 
 def test_graph_rewrite_deep_graph_no_recursion():
-  # Iterative-solver graphs (eigh/svd unrolls) are thousands of nodes deep; the
-  # walk must not blow Python's recursion limit (_topo is iterative for the same
-  # reason). 4000 deep >> sys.getrecursionlimit() (default 1000). The add_zero
-  # canon rule drops every node, so a stack-unsafe walk would RecursionError here.
+  # 4000-deep chain >> recursion limit: the walk must stay iterative (no RecursionError)
   x = af.input((10, 1)); y = x
   for _ in range(4000): y = y.adds(0.0)                # deep chain of no-op adds
   out = canonicalize(y)                                # must not RecursionError

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -1,22 +1,4 @@
-"""On-device validation of the optimizer's equivalence-route registry.
-
-The optimizer's coverage guarantee is: *every surfaced capability is either ROUTE-
-SELECTABLE (the autotuner picks its cheapest equivalent lowering by measured cost) or
-EXPLICITLY SINGLE-ROUTE.* This test proves the SELECTABLE half is accurate - every route
-the optimizer is willing to flip a bridge node to is mathematically equivalent on real
-ANE silicon, the same proof class as the metamorphic ``mha_vs_sdpa`` /
-``reduce_sum_vs_matmul`` transforms.
-
-For each route in the registry it compiles BOTH lowerings (the native bridge and the
-fused decomposition) on the device, runs them on identical inputs, and asserts they
-agree within fp16 op-noise. It also reconciles the three closed tables so they cannot
-drift: the route registry (``_capabilities.route_registry``), the executable builders
-(``_rewrite._BRIDGE_DECOMPOSERS``), and the optimizer's route-id detector
-(``_optimize._route_ids``).
-
-Run standalone:
-    PYTHONPATH=. python3 tests/test_routes.py
-"""
+"""On-device validation of the optimizer's equivalence-route registry: each selectable route's bridge and fused lowerings agree."""
 import sys
 from pathlib import Path
 
@@ -29,10 +11,7 @@ from aneforge import _capabilities as cap
 from aneforge._rewrite import _BRIDGE_DECOMPOSERS, decompose_bridge
 
 
-# fp16 op-noise ceiling: a single fused op sits at ~1e-3 relerr; a short chain (the
-# minmax decomposition is sub/divide) stays well under this. Same scale as the
-# metamorphic mha_vs_sdpa tol (0.06). A genuine semantic break is orders of magnitude
-# larger, so this never hides a real bug.
+# fp16 op-noise ceiling: well above per-op rounding, far below a semantic break
 _TOL = 5e-3
 
 

--- a/tests/test_sdpa_causal.py
+++ b/tests/test_sdpa_causal.py
@@ -1,6 +1,4 @@
-"""Native ANE causal SDPA: the fused-attention layer's optional additive-mask (5th) bottom.
-Validated against softmax(QK^T*scale + mask)*V at the bridge entry. The high-level af.sdpa
-is_causal path is not wired yet (it raises), so it is asserted to fail loudly, not silently."""
+"""Native ANE causal SDPA + additive-mask bottom and query-tiled decomposition, vs softmax(QK^T*scale + mask)*V."""
 from __future__ import annotations
 import math
 import numpy as np

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -1,17 +1,4 @@
-"""Broad shape / numerical-edge corpus - fp32-golden cases that sweep the
-shape-sensitive, numerically-risky ops across a wide range (including large and
-edge shapes), so shape-dependent and fp16-cancellation bugs surface in the gate.
-
-Motivation: the native-SDPA accuracy cliff at large sequence length (relerr ~1.0
-vs fp32 at S=4096) slipped through because every existing case used small,
-moderate shapes. Each case here validates the ANE output against a numpy fp32
-golden (the TRUE answer), not a sibling ANE implementation, so a native-layer or
-accumulation breakage shows up as a relerr failure rather than hiding.
-
-Documented hardware walls are marked ``xfail=<reason>`` so they record the limit
-without turning the gate red; an unexpected pass becomes XPASS (a limit to revisit)
-and an unexpected fail is a newly-caught bug. Folded into ALL_CASES (run_corpus.py).
-"""
+"""Broad shape / numerical-edge corpus: shape-sensitive, fp16-risky ops swept across wide shapes vs fp32 goldens."""
 from __future__ import annotations
 
 import numpy as np
@@ -127,9 +114,7 @@ def _softmax_case(N):
 
 
 def _reduce_case(N):
-  # pos=True offsets the input away from 0 so the reference mean isn't ~0; a
-  # zero-centered mean of N samples is a knife-edge for *relative* error (tiny
-  # denominator), which made this case sensitive to the module rng stream position.
+  # pos=True keeps the reference mean away from 0 (a ~0 mean makes relative error a knife-edge)
   x = f16(1, N, scale=1.0, pos=True)
   return Case(f"reduce_mean_N{N}", "shape",
               lambda xt: xt.mean((1,)),

--- a/tests/test_special_trig.py
+++ b/tests/test_special_trig.py
@@ -1,16 +1,4 @@
-"""sin/cos as fused fp16 polynomials + the cos-free _const fix (aneforge.special).
-
-Two things this guards:
-1. ``_const`` must NOT depend on cos. The native cos op is A15+ (family 4), so a
-   cos-based ``_const`` silently breaks EVERY special function on M1/H13 (family 2).
-   Switching to the F0-native ``exp(0)==1`` makes the whole module M1-capable.
-2. ``special.sin`` / ``special.cos`` give a portable trig path on chips where native
-   sin/cos do not exist. Domain is [-pi/2, pi/2] (documented, like every other
-   function in special.py). The decomposition uses only mul/sub/exp - native on M1 - so
-   it is validated here on the M5 against numpy; the same graph runs on M1.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_special_trig.py -q
-"""
+"""sin/cos as fused fp16 polynomials + the cos-free _const fix (aneforge.special)."""
 import numpy as np
 
 import aneforge as af

--- a/tests/test_spectral_sci.py
+++ b/tests/test_spectral_sci.py
@@ -1,45 +1,4 @@
-"""Spectral / signal / statistical scientific-kernel corpus for aneforge.
-
-The marquee probe: **can the Apple Neural Engine do an FFT?** The ANE has NO complex
-dtype - compute is fp16 real only. So every complex kernel here is emulated as a PAIR
-of real tensors ``(real, imag)`` with hand-expanded complex arithmetic
-``(a+bi)(c+di) = (ac-bd) + (ad+bc)i``. The question is whether that emulation is
-(1) *expressible* as an aneforge graph and (2) *numerically usable* in fp16, and if so,
-**to what transform size N** before fp16 precision (not structure) becomes the wall.
-
-Five families, each built as an aneforge graph, compiled + run on the ANE, validated
-against a numpy/scipy fp32 golden at an fp16-appropriate tolerance:
-
-1. SPECTRAL (the headline) - the DFT as a twiddle-matrix matmul (X = x @ W_N^T over
-   real/imag pairs) swept across N, plus a fully-unrolled radix-2 (DIT) butterfly FFT.
-   The verdict block at the end answers "is FFT viable on the ANE, and where/why does
-   it break?".
-2. SIGNAL - a FIR filter (1D conv) and autocorrelation (the cracked CrossCorrelation
-   bridge + a conv-based variant).
-3. MONTE CARLO - an MC integral and on-line mean/variance over a large sample
-   (host-drawn samples fed as inputs; see the RANDOMNESS NOTE below).
-4. N-BODY - pairwise forces among N points via a broadcast diff
-   ([N,1,3]-[1,N,3]) + reduction; small N.
-5. QUADRATURE - Simpson and Gauss-Legendre integration as a weighted reduction
-   (cumsum is unsupported on the ANE - a documented boundary).
-
-RANDOMNESS NOTE: aneforge's public API exposes NO RandomGenerator op (the e5rt
-``random_uniform`` surface is RE'd in the reverse-engineering corpus
-but is only promoted as a *fused backend consumer pattern*, not a callable frontend
-op). So the Monte-Carlo kernels draw their samples on the HOST (numpy) and feed them
-as graph inputs; the reference uses the SAME samples, making the comparison exact
-(deterministic), not a statistical tolerance. The ANE does the reduction/transform.
-
-Two tags per case beyond the harness ``Case`` fields (mirrors test_numerical.py):
-  - cost character: floor/fusion | bandwidth | compute | reduction | mixed
-  - feasibility:    works | arch-limited | fp16-limited
-
-We reuse the shared harness (Case, eval_case) verbatim and keep the tag side-table +
-spectral verdict block in our own runner, so we don't touch _corpus.py.
-
-Run:
-    PYTHONPATH=. python3 tests/test_spectral_sci.py
-"""
+"""Spectral / signal / statistical scientific-kernel corpus for aneforge (the 'can the ANE do an FFT?' probe), vs fp32 goldens."""
 from __future__ import annotations
 
 import sys
@@ -489,8 +448,7 @@ def _gauss_legendre(n: int, tol: float):
 
 # corpus assembly + runner
 
-# SPECTRAL: tolerances track the measured fp16 floor (flat ~3e-4..6e-4 in N because the
-# wide accumulator does not compound the twiddle sum). We give a little headroom per N.
+# SPECTRAL: tolerances track the measured fp16 floor (flat in N; wide accumulator)
 SPECTRAL = [
   _dft_matmul(8,    tol=0.004),
   _dft_matmul(16,   tol=0.004),

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,10 +1,4 @@
-"""Layer-streamed (gradient-checkpointed) training: aneforge/streaming.py.
-
-The whole point is that the per-layer forward/backward are compiled ONCE and reused for
-every layer, so an arbitrarily deep stack of identical layers trains with compile work
-that does not grow with depth. The gradients must stay bit-exact versus a monolithic
-backward, which is what these tests check.
-"""
+"""Layer-streamed (gradient-checkpointed) training (aneforge/streaming.py): streamed grads match a monolithic backward."""
 import numpy as np
 
 import aneforge as af

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -1,8 +1,4 @@
-"""Synthetic cases for the aneforge corpus: random elementwise+activation chains,
-numpy-style broadcasts, reshape/transpose chains that cancel, reductions along
-various axes, and matmul/bmm rectangles. These stress the algebraic identities a
-graph optimizer is most likely to touch.
-"""
+"""Synthetic cases for the aneforge corpus: op-chains, broadcasts, cancelling reshapes, reductions, matmul/bmm rectangles."""
 from __future__ import annotations
 
 import numpy as np

--- a/tests/test_targets.py
+++ b/tests/test_targets.py
@@ -1,10 +1,4 @@
-"""Per-chip ANE target capability core (aneforge._targets).
-
-Host-independent: every fact here is the measured per-family capability data from the
-M1/M5 reverse-engineering (MinimumFamily op floors + the ZinIrHalParameters numeric limits +
-the "MIL is only supported for H13+ ANE architectures" hard floor). No hardware needed
-to run these - family is passed explicitly. Detection + cross-compile are separate.
-"""
+"""Per-chip ANE target capability core (aneforge._targets): host-independent per-family op gating + numeric limits."""
 import pytest
 
 from aneforge import _targets as T

--- a/tests/test_train_cifar.py
+++ b/tests/test_train_cifar.py
@@ -42,12 +42,8 @@ def test_conv2d_pad_grad_matches_torch():
   x = af.input(x_np.shape); x.attrs["value"] = x_np
   w = af.conv_param(w_np)
   y = af.conv2d(x, w, pad=1)
-  # Reduce only over the batch dim. A full mean over all 4 dims divides the
-  # gradient by N*Cout*H*W (=1280), pushing input-grad magnitudes down to ~1e-4
-  # where the ANE's fp16 MAC accumulator loses relative precision in the
-  # transposed-conv input-grad path (cosine drops to ~0.95 even though the math
-  # is correct). Mean-over-batch keeps grads in fp16's normal range so the
-  # comparison is meaningful while still exercising the padded backward + a mean.
+  # mean over batch only: a full 4-dim mean shrinks grads to ~1e-4 where fp16 loses
+  # precision; mean-over-batch keeps them in fp16's normal range
   loss = (y * y).mean((0,))
   grads = agrad.backward(loss, [x, w], loss_scale=1.0)
   gx_ane = _eval(grads[x])

--- a/tests/test_tune_guards.py
+++ b/tests/test_tune_guards.py
@@ -1,23 +1,4 @@
-"""Unit tests for the autotuner's accuracy-reference guards and the cost-curve
-load error - all WITHOUT touching the ANE (the measurement seams `measure` /
-`_measure_with_ref` / `build_variant` are monkeypatched, the same fake-dependency
-style as test_compile_breaker.py):
-
-  1. tune(): if NO lossless variant compiles there is no fp16 baseline, so a lossy
-     variant must never become its own accuracy reference - lossy variants are
-     skipped and a warning is emitted. With a lossless baseline, behavior is
-     unchanged.
-  2. tune_precision(): a graph `_fp32_reference` cannot emulate falls back to the
-     fp16 baseline's own measured output as the reference (baseline relerr 0.0 by
-     definition; target_error enforced as divergence from the baseline; ref_kind
-     reported). If the baseline ALSO fails, no reference of any kind exists -
-     warn and prefer the cheapest lossless variant, never silently select.
-  3. _cost._curves(): a missing/unparseable bundled costmodel_curves.json raises a
-     RuntimeError naming the file (a broken installation), not a KeyError blaming
-     the arch name.
-
-Run: PYTHONPATH=. python3 -m pytest tests/test_tune_guards.py -q
-"""
+"""Autotuner accuracy-reference guards and cost-curve load errors, with the measurement seams monkeypatched (no ANE)."""
 import warnings
 
 import numpy as np

--- a/tests/test_vjp_sweep.py
+++ b/tests/test_vjp_sweep.py
@@ -1,9 +1,4 @@
-"""Finite-difference VJP sweep over unary/elementwise ops.
-
-Checks aneforge's on-ANE autograd gradients against numerical (central-difference)
-gradients for a spread of ops (exp, sqrt, inverse, erf, clip, l2_norm, ...). Each op is
-its own parametrized case. Moved here from the standalone op_validation/vjp_sweep.py script.
-"""
+"""Finite-difference VJP sweep: on-ANE autograd gradients vs central differences over unary/elementwise ops."""
 import math
 
 import numpy as np

--- a/tests/test_zero_copy_io.py
+++ b/tests/test_zero_copy_io.py
@@ -1,8 +1,4 @@
-"""Zero-copy I/O views (Program/Model.input_view/output_view) must produce identical
-results to the copy path (__call__/eval), while skipping the per-call host<->device
-memcpy. The win scales with I/O size (negligible for tiny tensors, ~30% for large ones);
-this test pins only the correctness invariant.
-"""
+"""Zero-copy I/O views (input_view/output_view) produce identical results to the copy path (__call__/eval)."""
 import warnings
 
 import numpy as np


### PR DESCRIPTION
Applies the same tinygrad-terse pass to `bench/` and `tests/`. **Zero code/behavior change.**

## What
Across 70 files (23 `bench/`, 47 `tests/`): module docstrings collapsed to one line, long in-body explanatory/methodology comment blocks trimmed (kept short `# why` notes, threshold rationales, and section markers). **Net −1,476 lines** (+326 / −1,802). No test names, assertions, thresholds, marks, or string literals touched.

## Safety
Every changed file is **CODE-IDENTICAL** to `main` under a docstring-stripped AST comparison — mechanical proof that only docstrings/comments changed, no logic moved. And because `tests/` is the behavior oracle:

- full on-device suite (`--forked`, Apple Silicon): **563 passed, 0 failed**
- `compileall` clean; `ruff check` clean

Completes the docs-thinning arc alongside #37 (core) and #38 (examples): terse, self-documenting code across the whole repo; narrative lives in `docs/`.