### PR TITLE
Refactor: dedup + dead-code removal from the expert review (net -895 lines)

### DIFF
--- a/aneforge/_bridges/_netplist.py
+++ b/aneforge/_bridges/_netplist.py
@@ -36,15 +36,17 @@ def ensure_invoker(name: str) -> Path:
   return binp
 
 
-def invoke_netplist(invoker, net_plist, *, weights=(), inputs=(), outputs=(), repeats=1, warmup=None, extra=()):
+def invoke_netplist(invoker, net_plist, *, weights=(), inputs=(), outputs=(), repeats: int | None = 1, warmup=None, extra=()):
   """Shared Path-A dispatch: build the invoker command and run it. `inputs`/
     `outputs` are `(name, path)` pairs (caller writes inputs, reads outputs).
-    Raises on non-zero return or non-`ok` status; returns the status dict."""
+    `repeats`/`warmup` are omitted from the command when None (the rank_invoker
+    does not accept them). Raises on non-zero return or non-`ok` status;
+    returns the status dict."""
   cmd = [str(invoker), "--net-plist", str(net_plist)]
   for w in weights: cmd += ["--weights", str(w)]
   for name, path in inputs: cmd += ["--input", f"{name}={path}"]
   for name, path in outputs: cmd += ["--output", f"{name}={path}"]
-  cmd += ["--repeats", str(repeats)]
+  if repeats is not None: cmd += ["--repeats", str(repeats)]
   if warmup is not None: cmd += ["--warmup", str(warmup)]
   cmd += list(extra)
   proc = subprocess.run(cmd, capture_output=True, text=True)
@@ -53,7 +55,11 @@ def invoke_netplist(invoker, net_plist, *, weights=(), inputs=(), outputs=(), re
     raise RuntimeError(
       f"{name} failed (rc={proc.returncode}):\n"
       f"stdout: {proc.stdout}\nstderr: {proc.stderr}")
-  info = json.loads(proc.stdout.strip().splitlines()[-1])
+  # Prefer JSON lines (the layer_invoker may emit non-JSON noise before the
+  # status line); fall back to the last line for invokers that print only JSON.
+  json_lines = [ln for ln in proc.stdout.splitlines() if ln.strip().startswith("{")]
+  if not json_lines: raise RuntimeError(f"no JSON from {name}:\n{proc.stdout}\n{proc.stderr}")
+  info = json.loads(json_lines[-1])
   if info.get("status") != "ok": raise RuntimeError(f"{name} non-ok status: {info}")
   return info
 

--- a/aneforge/_bridges/ane_cost_volume_fused.py
+++ b/aneforge/_bridges/ane_cost_volume_fused.py
@@ -4,7 +4,6 @@ See docs/developer/bridges.md."""
 from __future__ import annotations
 
 import json
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any
@@ -22,7 +21,7 @@ def cost_volume_fused(aux: np.ndarray, ref: np.ndarray,
   ref = np.asarray(ref, dtype=np.float16).reshape(-1)
   Wa, Wr = aux.size, ref.size
   R = int(disparity_range)
-  from ._netplist import write_model, ensure_invoker
+  from ._netplist import write_model, ensure_invoker, invoke_netplist
 
   with tempfile.TemporaryDirectory(prefix="ane_costvol_") as d:
     wd = Path(d)
@@ -34,20 +33,12 @@ def cost_volume_fused(aux: np.ndarray, ref: np.ndarray,
     )
     aux.tofile(wd / "in_aux.f16")
     ref.tofile(wd / "in_ref.f16")
-    cmd = [
-      str(ensure_invoker("sdpa_invoker")),
-      "--net-plist", str(wd / "net.plist"),
-      "--weights", str(wd / "weights.0"),
-      "--input", f"aux={wd / 'in_aux.f16'}",
-      "--input", f"ref={wd / 'in_ref.f16'}",
-      "--output", f"y={wd / 'out_y.f16'}",
-      "--repeats", "1", "--warmup", "0",
-    ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-      raise RuntimeError(f"cost_volume invoker failed:\n{proc.stderr}\n{proc.stdout}")
-    info = json.loads(proc.stdout.strip().splitlines()[-1])
-    if info.get("status") != "ok": raise RuntimeError(f"cost_volume non-ok: {info}")
+    invoke_netplist(
+      ensure_invoker("sdpa_invoker"), wd / "net.plist",
+      weights=[wd / "weights.0"],
+      inputs=[("aux", wd / "in_aux.f16"), ("ref", wd / "in_ref.f16")],
+      outputs=[("y", wd / "out_y.f16")], warmup=0,
+    )
     y = np.frombuffer((wd / "out_y.f16").read_bytes(), dtype=np.float16)
     return y.reshape(R + 1, Wa).copy()
 

--- a/aneforge/_bridges/ane_cross_correlation_fused.py
+++ b/aneforge/_bridges/ane_cross_correlation_fused.py
@@ -4,7 +4,6 @@ See docs/developer/bridges.md."""
 from __future__ import annotations
 
 import json
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -21,7 +20,7 @@ def cross_correlation_fused(x: np.ndarray, template: np.ndarray) -> np.ndarray:
   H, W = x.shape
   Th, Tw = template.shape
   out_h, out_w = H - Th + 1, W - Tw + 1
-  from ._netplist import write_model, ensure_invoker
+  from ._netplist import write_model, ensure_invoker, invoke_netplist
 
   with tempfile.TemporaryDirectory(prefix="ane_xcorr_") as d:
     wd = Path(d)
@@ -33,20 +32,12 @@ def cross_correlation_fused(x: np.ndarray, template: np.ndarray) -> np.ndarray:
     )
     x.tofile(wd / "in_x.f16")
     template.reshape(-1).astype(np.float16).tofile(wd / "in_t.f16")
-    cmd = [
-      str(ensure_invoker("sdpa_invoker")),
-      "--net-plist", str(wd / "net.plist"),
-      "--weights", str(wd / "weights.0"),
-      "--input", f"x={wd / 'in_x.f16'}",
-      "--input", f"template={wd / 'in_t.f16'}",
-      "--output", f"y={wd / 'out_y.f16'}",
-      "--repeats", "1", "--warmup", "0",
-    ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-      raise RuntimeError(f"cross_correlation invoker failed:\n{proc.stderr}\n{proc.stdout}")
-    info = json.loads(proc.stdout.strip().splitlines()[-1])
-    if info.get("status") != "ok": raise RuntimeError(f"cross_correlation non-ok: {info}")
+    invoke_netplist(
+      ensure_invoker("sdpa_invoker"), wd / "net.plist",
+      weights=[wd / "weights.0"],
+      inputs=[("x", wd / "in_x.f16"), ("template", wd / "in_t.f16")],
+      outputs=[("y", wd / "out_y.f16")], warmup=0,
+    )
     y = np.frombuffer((wd / "out_y.f16").read_bytes(), dtype=np.float16)
     return y.reshape(out_h, out_w).copy()
 

--- a/aneforge/_bridges/ane_cross_product_fused.py
+++ b/aneforge/_bridges/ane_cross_product_fused.py
@@ -4,7 +4,6 @@ See docs/developer/bridges.md."""
 from __future__ import annotations
 
 import json
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -17,27 +16,19 @@ def cross_product_fused(x: np.ndarray, z: np.ndarray) -> np.ndarray:
   """Return `cross(x, z)` (length-3 fp16) for two 3-vectors, on the ANE."""
   x = np.asarray(x, dtype=np.float16).reshape(3)
   z = np.asarray(z, dtype=np.float16).reshape(3)
-  from ._netplist import write_model, ensure_invoker
+  from ._netplist import write_model, ensure_invoker, invoke_netplist
 
   with tempfile.TemporaryDirectory(prefix="ane_xprod_") as d:
     wd = Path(d)
     write_model("cross_product", wd)
     (wd / "in_x.f16").write_bytes(x.tobytes())
     (wd / "in_z.f16").write_bytes(z.tobytes())
-    cmd = [
-      str(ensure_invoker("sdpa_invoker")),
-      "--net-plist", str(wd / "net.plist"),
-      "--weights", str(wd / "weights.0"),
-      "--input", f"x={wd / 'in_x.f16'}",
-      "--input", f"z={wd / 'in_z.f16'}",
-      "--output", f"y={wd / 'out_y.f16'}",
-      "--repeats", "1", "--warmup", "0",
-    ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    if proc.returncode != 0:
-      raise RuntimeError(f"cross_product invoker failed:\n{proc.stderr}\n{proc.stdout}")
-    info = json.loads(proc.stdout.strip().splitlines()[-1])
-    if info.get("status") != "ok": raise RuntimeError(f"cross_product non-ok: {info}")
+    invoke_netplist(
+      ensure_invoker("sdpa_invoker"), wd / "net.plist",
+      weights=[wd / "weights.0"],
+      inputs=[("x", wd / "in_x.f16"), ("z", wd / "in_z.f16")],
+      outputs=[("y", wd / "out_y.f16")], warmup=0,
+    )
     return np.frombuffer((wd / "out_y.f16").read_bytes(), dtype=np.float16).copy()
 
 

--- a/aneforge/_bridges/ane_dynamic_slice_fused.py
+++ b/aneforge/_bridges/ane_dynamic_slice_fused.py
@@ -4,7 +4,6 @@ See docs/developer/bridges.md."""
 from __future__ import annotations
 
 import struct
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -28,14 +27,11 @@ def dynamic_slice_fused(x: np.ndarray, start: int, *, slice_size: int = 2) -> np
   g.write_model("dynamic_slice_const_u16", d, width=4, height=1, channels=1)
   (d / "weights.1").write_bytes(struct.pack("<H", int(start)))
   (d / "in_x.f16").write_bytes(x.tobytes())
-  cmd = [
-    str(g.ensure_invoker("sdpa_invoker")), "--net-plist", str(d / "net.plist"),
-    "--weights", str(d / "weights.0"), "--weights", str(d / "weights.1"),
-    "--input", f"x={d / 'in_x.f16'}", "--output", f"y={d / 'out.f16'}",
-    "--repeats", "1", "--warmup", "0",
-  ]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(f"dynamic_slice invoker failed:\n{p.stderr}")
+  g.invoke_netplist(
+    g.ensure_invoker("sdpa_invoker"), d / "net.plist",
+    weights=[d / "weights.0", d / "weights.1"],
+    inputs=[("x", d / "in_x.f16")], outputs=[("y", d / "out.f16")], warmup=0,
+  )
   return np.frombuffer((d / "out.f16").read_bytes(), dtype=np.float16)
 
 

--- a/aneforge/_bridges/ane_fps_fused.py
+++ b/aneforge/_bridges/ane_fps_fused.py
@@ -4,7 +4,6 @@ See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -28,13 +27,11 @@ def fps_fused(points: np.ndarray, centroid_count: int, *, metric: str = "L1") ->
     width=N, centroid_count=int(centroid_count), distance_metric=metric, output_channels=3,
   )
   (d / "points.f16").write_bytes(np.ascontiguousarray(pts_cw, dtype=np.float16).tobytes())
-  cmd = [
-    str(g.ensure_invoker("sdpa_invoker")), "--net-plist", str(d / "net.plist"), "--weights", str(d / "weights.0"),
-    "--input", f"points={d / 'points.f16'}", "--output", f"y={d / 'out.f16'}",
-    "--repeats", "1", "--warmup", "0",
-  ]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(f"fps invoker failed:\n{p.stderr}")
+  g.invoke_netplist(
+    g.ensure_invoker("sdpa_invoker"), d / "net.plist",
+    weights=[d / "weights.0"], inputs=[("points", d / "points.f16")],
+    outputs=[("y", d / "out.f16")], warmup=0,
+  )
   y = np.frombuffer((d / "out.f16").read_bytes(), dtype=np.float16)
   return y.reshape(3, centroid_count).T  # (k, 3)
 

--- a/aneforge/_bridges/ane_input_view_fused.py
+++ b/aneforge/_bridges/ane_input_view_fused.py
@@ -4,7 +4,6 @@ See docs/developer/bridges.md."""
 from __future__ import annotations
 
 import plistlib
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -37,13 +36,11 @@ def input_view_fused(x: np.ndarray, offset: int, size: int, *, dimension: str = 
     plistlib.dump(pl, f, sort_keys=True)
   (d / "weights.0").write_bytes(b"")
   (d / "in_x.f16").write_bytes(x.tobytes())
-  cmd = [
-    str(g.ensure_invoker("sdpa_invoker")), "--net-plist", str(d / "net.plist"), "--weights", str(d / "weights.0"),
-    "--input", f"x={d / 'in_x.f16'}", "--output", f"y={d / 'out.f16'}",
-    "--repeats", "1", "--warmup", "0",
-  ]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(f"input_view invoker failed:\n{p.stderr}")
+  g.invoke_netplist(
+    g.ensure_invoker("sdpa_invoker"), d / "net.plist",
+    weights=[d / "weights.0"], inputs=[("x", d / "in_x.f16")],
+    outputs=[("y", d / "out.f16")], warmup=0,
+  )
   return np.frombuffer((d / "out.f16").read_bytes(), dtype=np.float16)
 
 

--- a/aneforge/_bridges/ane_radius_search_fused.py
+++ b/aneforge/_bridges/ane_radius_search_fused.py
@@ -3,7 +3,6 @@ See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
-import subprocess
 import tempfile
 from pathlib import Path
 
@@ -31,13 +30,12 @@ def radius_search_fused(points: np.ndarray, centroids: np.ndarray, radius: float
   )
   (d / "points.f16").write_bytes(np.ascontiguousarray(pts_cw, dtype=np.float16).tobytes())
   (d / "centroids.f16").write_bytes(np.ascontiguousarray(cent_cw, dtype=np.float16).tobytes())
-  cmd = [
-    str(g.ensure_invoker("sdpa_invoker")), "--net-plist", str(d / "net.plist"), "--weights", str(d / "weights.0"),
-    "--input", f"centroids={d / 'centroids.f16'}", "--input", f"points={d / 'points.f16'}",
-    "--output", f"y={d / 'out.f16'}", "--repeats", "1", "--warmup", "0",
-  ]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(f"radius_search invoker failed:\n{p.stderr}")
+  g.invoke_netplist(
+    g.ensure_invoker("sdpa_invoker"), d / "net.plist",
+    weights=[d / "weights.0"],
+    inputs=[("centroids", d / "centroids.f16"), ("points", d / "points.f16")],
+    outputs=[("y", d / "out.f16")], warmup=0,
+  )
   raw = (d / "out.f16").read_bytes()
   # output is [Np rows x Nc cols], 2 bytes per W-cell; low byte = membership flag
   arr = np.frombuffer(raw, dtype=np.uint8).reshape(Np, Nc * 2)

--- a/aneforge/_bridges/ane_rank_fused.py
+++ b/aneforge/_bridges/ane_rank_fused.py
@@ -4,88 +4,34 @@ See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
-import json
-import subprocess
 import tempfile
 import plistlib
 from pathlib import Path
 
 import numpy as np
 
-from ._netplist import bin_dir
-
-_INVOKER_BIN = bin_dir() / "rank_invoker"
-_INVOKER_SRC = Path(__file__).resolve().parents[1] / "_invokers" / "rank_invoker.mm"
-
-
-def _ensure_invoker() -> Path:
-  if (
-    _INVOKER_BIN.exists()
-    and _INVOKER_SRC.exists()
-    and _INVOKER_BIN.stat().st_mtime >= _INVOKER_SRC.stat().st_mtime
-  ):
-    return _INVOKER_BIN
-  _INVOKER_BIN.parent.mkdir(parents=True, exist_ok=True)
-  cmd = [
-    "xcrun", "clang++", "-O2", "-Wall", "-Wextra",
-    "-fobjc-arc", "-std=gnu++17",
-    "-framework", "Foundation", "-framework", "IOSurface",
-    str(_INVOKER_SRC), "-o", str(_INVOKER_BIN),
-  ]
-  proc = subprocess.run(cmd, capture_output=True, text=True)
-  if proc.returncode != 0: raise RuntimeError(f"failed to build rank invoker:\n{proc.stderr}")
-  return _INVOKER_BIN
+from ._netplist import build_plist, ensure_invoker, input_entry, invoke_netplist, output_entry
 
 
 # Minimal netplist scaffolding: single op, single input x, output y.
 
-def _input_entry(unit, sym, *, width, height=1, channels=1):
-  return {
-    "BatchSize": 1, "InputChannels": channels, "InputDepth": 1,
-    "InputHeight": height, "InputInterleave": 1, "InputName": sym,
-    "InputType": "Float16", "InputWidth": width, "Name": unit,
-    "OperationName": "op0",
-  }
-
-
-def _output_entry(sym, unit):
-  return {
-    "Name": unit, "OperationName": "op0", "OutputInterleave": 1,
-    "OutputName": sym, "OutputType": "Float16",
-  }
-
-
 def _build_plist(layer_type: str, params: dict, *, width, height, channels):
-  net = f"network_{layer_type.lower()}-1"
   unit = {
     "Bottom": ["x"], "InputType": ["Float16"], "Name": "op-1",
     "OutputChannels": channels, "OutputType": "Float16",
     "Type": layer_type, "Params": params,
   }
-  network = {
-    "op-1": unit, "Units": ["op-1"], "Weights": ["weights.0"],
-    "y": {"Bottom": "op-1", "OutputInterleave": 1,
-          "OutputName": "y", "OutputType": "Float16"},
-  }
-  return {
-    "Version": "1.0.10",
-    "Networks": [net],
-    "ProcedureList": [{
-      "Name": net.replace("network_", "procedure_"),
-      "InputList": [_input_entry("op-1", "x", width=width,
-                                 height=height, channels=channels)],
-      "OperationList": [{"NetworkName": net, "OperationName": "op0"}],
-      "OutputList": [_output_entry("y", "op-1")],
-    }],
-    net: network,
-  }
+  return build_plist(
+    f"network_{layer_type.lower()}-1", "op-1",
+    [input_entry("x", width=width, height=height, channels=channels, entry_name="op-1")],
+    [output_entry("y", "op-1")], {"op-1": unit})
 
 
 def _run(layer_type: str, params: dict, x: np.ndarray, *,
          channels: int, width: int, height: int = 1,
          return_details: bool = False):
   """Run x ([C,H,W] fp16), decoding output with the runtime-reported strides."""
-  invoker = _ensure_invoker()
+  invoker = ensure_invoker("rank_invoker")
   x = np.asarray(x, dtype=np.float16)
   with tempfile.TemporaryDirectory(prefix=f"ane_{layer_type.lower()}_") as ws:
     ws = Path(ws)
@@ -95,18 +41,11 @@ def _run(layer_type: str, params: dict, x: np.ndarray, *,
       plistlib.dump(plist, f, fmt=plistlib.FMT_BINARY)
     (ws / "weights.0").write_bytes(b"\x00" * 1024)
     (ws / "in_x.f16").write_bytes(x.tobytes())
-    cmd = [
-      str(invoker), "--net-plist", str(ws / "net.plist"),
-      "--weights", str(ws / "weights.0"),
-      "--input", f"x={ws / 'in_x.f16'}",
-      "--output-raw", f"y={ws / 'out_y.bin'}",
-      "--output-bytes", "65536",
-    ]
-    proc = subprocess.run(cmd, capture_output=True, text=True)
-    line = [l for l in proc.stdout.splitlines() if l.strip().startswith("{")]
-    if not line: raise RuntimeError(f"no JSON from invoker:\n{proc.stdout}\n{proc.stderr}")
-    info = json.loads(line[-1])
-    if info.get("status") != "ok": raise RuntimeError(f"invoker status={info.get('status')}: {info}")
+    info = invoke_netplist(
+      invoker, ws / "net.plist",
+      weights=[ws / "weights.0"], inputs=[("x", ws / "in_x.f16")],
+      repeats=None, warmup=None,
+      extra=["--output-raw", f"y={ws / 'out_y.bin'}", "--output-bytes", "65536"])
     oi = info["live_outputs"][0]
     ps, rs = oi["PlaneStride"], oi["RowStride"]
     ch, hh, wd = oi["Channels"], oi["Height"], oi["Width"]

--- a/aneforge/_bridges/ane_rearrange_fused.py
+++ b/aneforge/_bridges/ane_rearrange_fused.py
@@ -12,7 +12,7 @@ from typing import Any
 
 import numpy as np
 
-from ._netplist import ensure_invoker, invoke_netplist
+from ._netplist import build_plist, ensure_invoker, input_entry, invoke_netplist, output_entry
 
 # The native netplist Type token for each public layer name.
 _LAYER_TYPES = {
@@ -23,31 +23,6 @@ _LAYER_TYPES = {
   "SpaceToBatch",
   "BatchToSpace",
 }
-
-
-def _in_entry(sym: str, w: int, h: int, c: int, unit: str, b: int = 1) -> dict:
-  return {
-    "BatchSize": b,
-    "InputChannels": c,
-    "InputDepth": 1,
-    "InputHeight": h,
-    "InputInterleave": 1,
-    "InputName": sym,
-    "InputType": "Float16",
-    "InputWidth": w,
-    "Name": unit,
-    "OperationName": "op0",
-  }
-
-
-def _out_entry(sym: str, unit: str) -> dict:
-  return {
-    "Name": unit,
-    "OperationName": "op0",
-    "OutputInterleave": 1,
-    "OutputName": sym,
-    "OutputType": "Float16",
-  }
 
 
 def build_netplist(
@@ -66,7 +41,6 @@ def build_netplist(
   if layer not in _LAYER_TYPES:
     raise ValueError(f"unknown layer {layer!r}; expected one of {sorted(_LAYER_TYPES)}")
   unit_name = f"{layer.lower()}-1"
-  net_name = f"network_{unit_name}"
   unit = {
     "Bottom": ["x"],
     "InputType": ["Float16"],
@@ -76,25 +50,11 @@ def build_netplist(
     "Params": {"FactorX": factor_x, "FactorY": factor_y, "FactorZ": factor_z},
     "Type": layer,
   }
-  network = {
-    unit_name: unit,
-    "Units": [unit_name],
-    "Weights": ["weights.0"],
-    "y": {"Bottom": unit_name, "OutputInterleave": 1, "OutputName": "y", "OutputType": "Float16"},
-  }
-  return {
-    "Version": "1.0.10",
-    "Networks": [net_name],
-    "ProcedureList": [
-      {
-        "Name": f"procedure_{unit_name}",
-        "InputList": [_in_entry("x", in_width, in_height, in_channels, unit_name, in_batch)],
-        "OperationList": [{"NetworkName": net_name, "OperationName": "op0"}],
-        "OutputList": [_out_entry("y", unit_name)],
-      }
-    ],
-    net_name: network,
-  }
+  return build_plist(
+    f"network_{unit_name}", unit_name,
+    [input_entry("x", width=in_width, height=in_height, channels=in_channels,
+                 entry_name=unit_name, batch_size=in_batch)],
+    [output_entry("y", unit_name)], {unit_name: unit})
 
 
 def _run_netplist(plist: dict, x: np.ndarray) -> tuple[np.ndarray, dict[str, Any]]:

--- a/aneforge/_bridges/ane_sdpa_fused.py
+++ b/aneforge/_bridges/ane_sdpa_fused.py
@@ -6,40 +6,13 @@ from __future__ import annotations
 
 import math
 import plistlib
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Optional
 
 import numpy as np
 
-from ._netplist import bin_dir, invoke_netplist
-
-
-_INVOKER_BIN = bin_dir() / "sdpa_invoker"
-_INVOKER_SRC = Path(__file__).resolve().parents[1] / "_invokers" / "sdpa_invoker.mm"
-
-
-def _ensure_invoker() -> Path:
-  """Build the SDPA invoker once if missing/stale."""
-  if (
-    _INVOKER_BIN.exists()
-    and _INVOKER_SRC.exists()
-    and _INVOKER_BIN.stat().st_mtime >= _INVOKER_SRC.stat().st_mtime
-  ):
-    return _INVOKER_BIN
-  _INVOKER_BIN.parent.mkdir(parents=True, exist_ok=True)
-  cmd = [
-    "xcrun", "clang++", "-O2", "-Wall", "-Wextra",
-    "-fobjc-arc", "-std=gnu++17",
-    "-framework", "Foundation",
-    "-framework", "IOSurface",
-    str(_INVOKER_SRC),
-    "-o", str(_INVOKER_BIN),
-  ]
-  proc = subprocess.run(cmd, capture_output=True, text=True)
-  if proc.returncode != 0: raise RuntimeError(f"failed to build sdpa invoker:\n{proc.stderr}")
-  return _INVOKER_BIN
+from ._netplist import ensure_invoker, invoke_netplist
 
 
 def _write_netplist(
@@ -128,7 +101,7 @@ def sdpa_fused(
   K_ane = np.ascontiguousarray(K.transpose(0, 2, 1, 3))
   V_ane = np.ascontiguousarray(V.transpose(0, 2, 1, 3))
 
-  invoker = _ensure_invoker()
+  invoker = ensure_invoker("sdpa_invoker")
 
   with tempfile.TemporaryDirectory(prefix="ane_sdpa_") as workdir_str:
     workdir = Path(workdir_str)

--- a/aneforge/_bridges/lrn_fused.py
+++ b/aneforge/_bridges/lrn_fused.py
@@ -4,57 +4,30 @@ KernelChannel internally. See docs/developer/bridges.md for the conventions."""
 
 from __future__ import annotations
 
-import json
 import plistlib
-import subprocess
 import tempfile
 from pathlib import Path
 
 import numpy as np
 
-from ._netplist import bin_dir
-
-_INVOKER = bin_dir() / "layer_invoker"
-_INVOKER_SRC = Path(__file__).resolve().parents[1] / "_invokers" / "layer_invoker.mm"
+from ._netplist import build_plist, ensure_invoker, input_entry, invoke_netplist, output_entry
 
 
 def fp16_bits(value: float) -> int:
   return int(np.array(value, dtype=np.float16).view(np.uint16).item())
 
 
-def _ensure_invoker() -> Path:
-  if _INVOKER.exists() and _INVOKER.stat().st_mtime >= _INVOKER_SRC.stat().st_mtime:
-    return _INVOKER
-  _INVOKER.parent.mkdir(parents=True, exist_ok=True)
-  cmd = ["xcrun", "clang++", "-O2", "-fobjc-arc", "-std=gnu++17",
-         "-framework", "Foundation", "-framework", "IOSurface",
-         str(_INVOKER_SRC), "-o", str(_INVOKER)]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(p.stderr)
-  return _INVOKER
-
-
 def _plist(channels, height, width, kernel_channel, alpha_bits, beta, k) -> dict:
-  net = "network_lrn-1"
   unit = {"Bottom": ["x"], "InputType": ["Float16"], "Name": "op-1",
           "OutputChannels": channels, "OutputType": "Float16",
           "Type": "LocalResponseNormalization",
           "Params": {"Type": "Channel", "KernelWidth": 1, "KernelHeight": 1,
                      "KernelChannel": kernel_channel, "Alpha": alpha_bits,
                      "Beta": beta, "K": k}}
-  inp = {"BatchSize": 1, "InputChannels": channels, "InputDepth": 1,
-         "InputHeight": height, "InputInterleave": 1, "InputName": "x",
-         "InputType": "Float16", "InputWidth": width, "Name": "op-1",
-         "OperationName": "op0"}
-  return {"Version": "1.0.10", "Networks": [net],
-          "ProcedureList": [{"Name": "procedure_lrn-1", "InputList": [inp],
-              "OperationList": [{"NetworkName": net, "OperationName": "op0"}],
-              "OutputList": [{"Name": "op-1", "OperationName": "op0",
-                              "OutputInterleave": 1, "OutputName": "y",
-                              "OutputType": "Float16"}]}],
-          net: {"op-1": unit, "Units": ["op-1"], "Weights": ["weights.0"],
-                "y": {"Bottom": "op-1", "OutputInterleave": 1,
-                      "OutputName": "y", "OutputType": "Float16"}}}
+  return build_plist(
+    "network_lrn-1", "op-1",
+    [input_entry("x", width=width, height=height, channels=channels, entry_name="op-1")],
+    [output_entry("y", "op-1")], {"op-1": unit})
 
 
 def lrn_fused(x: np.ndarray, *, alpha: float = 1.0, beta: float = 0.75,
@@ -70,7 +43,7 @@ def lrn_fused(x: np.ndarray, *, alpha: float = 1.0, beta: float = 0.75,
   if x.ndim != 4: raise ValueError("x must be (B,C,H,W)")
   B, C, H, W = x.shape
   if B != 1: raise ValueError("B=1 only")
-  invoker = _ensure_invoker()
+  invoker = ensure_invoker("layer_invoker")
   # ANE divides parsed alpha by KernelChannel; pre-multiply to recover `alpha`.
   alpha_bits = fp16_bits(alpha * C)
   x5 = x.reshape(1, C, 1, H, W)
@@ -81,15 +54,11 @@ def lrn_fused(x: np.ndarray, *, alpha: float = 1.0, beta: float = 0.75,
                     fmt=plistlib.FMT_BINARY)
     (cd / "weights.0").write_bytes(b"\x00" * 1024)
     (cd / "in_x.bin").write_bytes(x5.astype(np.float16).tobytes())
-    cmd = [str(invoker), "--net-plist", str(cd / "net.plist"),
-           "--weights", str(cd / "weights.0"), "--input", f"x={cd / 'in_x.bin'}",
-           "--output", f"y={cd / 'out_y.bin'}",
-           "--raw-output", f"y={cd / 'out_raw.bin'}", "--repeats", "1"]
-    p = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    lines = [l for l in p.stdout.splitlines() if l.strip().startswith("{")]
-    if not lines: raise RuntimeError(f"no JSON from invoker:\n{p.stdout}\n{p.stderr}")
-    info = json.loads(lines[-1])
-    if info.get("status") != "ok": raise RuntimeError(f"lrn invoker failed: {info}")
+    invoke_netplist(
+      invoker, cd / "net.plist",
+      weights=[cd / "weights.0"], inputs=[("x", cd / "in_x.bin")],
+      outputs=[("y", cd / "out_y.bin")], warmup=0,
+      extra=["--raw-output", f"y={cd / 'out_raw.bin'}"])
     raw = (cd / "out_y.bin").read_bytes()
     return np.frombuffer(raw[:C * H * W * 2], dtype=np.float16).reshape(C, H, W)
 

--- a/aneforge/_bridges/minmax_norm_fused.py
+++ b/aneforge/_bridges/minmax_norm_fused.py
@@ -4,18 +4,13 @@ fp16 bit pattern. See docs/developer/bridges.md."""
 
 from __future__ import annotations
 
-import json
 import plistlib
-import subprocess
 import tempfile
 from pathlib import Path
 
 import numpy as np
 
-from ._netplist import bin_dir
-
-_INVOKER = bin_dir() / "layer_invoker"
-_INVOKER_SRC = Path(__file__).resolve().parents[1] / "_invokers" / "layer_invoker.mm"
+from ._netplist import build_plist, ensure_invoker, input_entry, invoke_netplist, output_entry
 
 _AXIS = {"Width": 3, "Height": 2, "Channel": 1}
 
@@ -24,37 +19,15 @@ def fp16_bits(value: float) -> int:
   return int(np.array(value, dtype=np.float16).view(np.uint16).item())
 
 
-def _ensure_invoker() -> Path:
-  if _INVOKER.exists() and _INVOKER.stat().st_mtime >= _INVOKER_SRC.stat().st_mtime:
-    return _INVOKER
-  _INVOKER.parent.mkdir(parents=True, exist_ok=True)
-  cmd = ["xcrun", "clang++", "-O2", "-fobjc-arc", "-std=gnu++17",
-         "-framework", "Foundation", "-framework", "IOSurface",
-         str(_INVOKER_SRC), "-o", str(_INVOKER)]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(p.stderr)
-  return _INVOKER
-
-
 def _plist(channels: int, height: int, width: int, dimension: str, eps_bits: int) -> dict:
-  net = "network_minmax-1"
   unit = {"Bottom": ["x"], "InputType": ["Float16"], "Name": "op-1",
           "OutputChannels": channels, "OutputType": "Float16",
           "Type": "MinMaxNormalization",
           "Params": {"Dimension": dimension, "Epsilon": eps_bits}}
-  inp = {"BatchSize": 1, "InputChannels": channels, "InputDepth": 1,
-         "InputHeight": height, "InputInterleave": 1, "InputName": "x",
-         "InputType": "Float16", "InputWidth": width, "Name": "op-1",
-         "OperationName": "op0"}
-  return {"Version": "1.0.10", "Networks": [net],
-          "ProcedureList": [{"Name": "procedure_minmax-1", "InputList": [inp],
-              "OperationList": [{"NetworkName": net, "OperationName": "op0"}],
-              "OutputList": [{"Name": "op-1", "OperationName": "op0",
-                              "OutputInterleave": 1, "OutputName": "y",
-                              "OutputType": "Float16"}]}],
-          net: {"op-1": unit, "Units": ["op-1"], "Weights": ["weights.0"],
-                "y": {"Bottom": "op-1", "OutputInterleave": 1,
-                      "OutputName": "y", "OutputType": "Float16"}}}
+  return build_plist(
+    "network_minmax-1", "op-1",
+    [input_entry("x", width=width, height=height, channels=channels, entry_name="op-1")],
+    [output_entry("y", "op-1")], {"op-1": unit})
 
 
 def minmax_norm_fused(x: np.ndarray, *, dimension: str = "Width",
@@ -74,7 +47,7 @@ def minmax_norm_fused(x: np.ndarray, *, dimension: str = "Width",
   if x.ndim != 4: raise ValueError("x must be (B,C,H,W)")
   B, C, H, W = x.shape
   if B != 1: raise ValueError("B=1 only")
-  invoker = _ensure_invoker()
+  invoker = ensure_invoker("layer_invoker")
   x5 = x.reshape(1, C, 1, H, W)
   with tempfile.TemporaryDirectory(prefix="ane_mm_") as d:
     cd = Path(d)
@@ -83,16 +56,11 @@ def minmax_norm_fused(x: np.ndarray, *, dimension: str = "Width",
                     fmt=plistlib.FMT_BINARY)
     (cd / "weights.0").write_bytes(b"\x00" * 1024)
     (cd / "in_x.bin").write_bytes(x5.astype(np.float16).tobytes())
-    cmd = [str(invoker), "--net-plist", str(cd / "net.plist"),
-           "--weights", str(cd / "weights.0"), "--input", f"x={cd / 'in_x.bin'}",
-           "--output", f"y={cd / 'out_y.bin'}",
-           "--raw-output", f"y={cd / 'out_raw.bin'}", "--repeats", "1"]
-    p = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    lines = [l for l in p.stdout.splitlines() if l.strip().startswith("{")]
-    if not lines: raise RuntimeError(f"no JSON from invoker:\n{p.stdout}\n{p.stderr}")
-    info = json.loads(lines[-1])
-    if info.get("status") != "ok":
-      raise RuntimeError(f"minmax invoker failed (dimension={dimension}): {info}")
+    invoke_netplist(
+      invoker, cd / "net.plist",
+      weights=[cd / "weights.0"], inputs=[("x", cd / "in_x.bin")],
+      outputs=[("y", cd / "out_y.bin")], warmup=0,
+      extra=["--raw-output", f"y={cd / 'out_raw.bin'}"])
     raw = (cd / "out_y.bin").read_bytes()
     return np.frombuffer(raw[:C * H * W * 2], dtype=np.float16).reshape(C, H, W)
 

--- a/aneforge/_bridges/scaled_elementwise_fused.py
+++ b/aneforge/_bridges/scaled_elementwise_fused.py
@@ -3,18 +3,13 @@ selects the op; `Params.Scale` is a fp16 bit pattern. See docs/developer/bridges
 
 from __future__ import annotations
 
-import json
 import plistlib
-import subprocess
 import tempfile
 from pathlib import Path
 
 import numpy as np
 
-from ._netplist import bin_dir
-
-_INVOKER = bin_dir() / "layer_invoker"
-_INVOKER_SRC = Path(__file__).resolve().parents[1] / "_invokers" / "layer_invoker.mm"
+from ._netplist import build_plist, ensure_invoker, input_entry, invoke_netplist, output_entry
 
 _OP = {"Add": np.add, "Mult": np.multiply, "Sub": np.subtract,
        "Min": np.minimum, "Max": np.maximum}
@@ -24,40 +19,16 @@ def fp16_bits(value: float) -> int:
   return int(np.array(value, dtype=np.float16).view(np.uint16).item())
 
 
-def _ensure_invoker() -> Path:
-  if _INVOKER.exists() and _INVOKER.stat().st_mtime >= _INVOKER_SRC.stat().st_mtime:
-    return _INVOKER
-  _INVOKER.parent.mkdir(parents=True, exist_ok=True)
-  cmd = ["xcrun", "clang++", "-O2", "-fobjc-arc", "-std=gnu++17",
-         "-framework", "Foundation", "-framework", "IOSurface",
-         str(_INVOKER_SRC), "-o", str(_INVOKER)]
-  p = subprocess.run(cmd, capture_output=True, text=True)
-  if p.returncode != 0: raise RuntimeError(p.stderr)
-  return _INVOKER
-
-
 def _plist(width: int, op_type: str, scale_bits: int) -> dict:
-  net = "network_scaled_ew-1"
   unit = {"Bottom": ["x", "z"], "InputType": ["Float16", "Float16"],
           "Name": "op-1", "OutputChannels": 1, "OutputType": "Float16",
           "Type": "ScaledElementWise",
           "Params": {"Type": op_type, "Scale": scale_bits}}
-
-  def _in(sym):
-    return {"BatchSize": 1, "InputChannels": 1, "InputDepth": 1,
-            "InputHeight": 1, "InputInterleave": 1, "InputName": sym,
-            "InputType": "Float16", "InputWidth": width, "Name": "op-1",
-            "OperationName": "op0"}
-  return {"Version": "1.0.10", "Networks": [net],
-          "ProcedureList": [{"Name": "procedure_scaled_ew-1",
-              "InputList": [_in("x"), _in("z")],
-              "OperationList": [{"NetworkName": net, "OperationName": "op0"}],
-              "OutputList": [{"Name": "op-1", "OperationName": "op0",
-                              "OutputInterleave": 1, "OutputName": "y",
-                              "OutputType": "Float16"}]}],
-          net: {"op-1": unit, "Units": ["op-1"], "Weights": ["weights.0"],
-                "y": {"Bottom": "op-1", "OutputInterleave": 1,
-                      "OutputName": "y", "OutputType": "Float16"}}}
+  return build_plist(
+    "network_scaled_ew-1", "op-1",
+    [input_entry("x", width=width, entry_name="op-1"),
+     input_entry("z", width=width, entry_name="op-1")],
+    [output_entry("y", "op-1")], {"op-1": unit})
 
 
 def scaled_elementwise_fused(x: np.ndarray, z: np.ndarray, *,
@@ -73,7 +44,7 @@ def scaled_elementwise_fused(x: np.ndarray, z: np.ndarray, *,
   z = np.asarray(z, dtype=np.float16).reshape(-1)
   if x.shape != z.shape: raise ValueError("x and z must share shape")
   W = x.shape[0]
-  invoker = _ensure_invoker()
+  invoker = ensure_invoker("layer_invoker")
   with tempfile.TemporaryDirectory(prefix="ane_se_") as d:
     cd = Path(d)
     with (cd / "net.plist").open("wb") as f:
@@ -81,16 +52,12 @@ def scaled_elementwise_fused(x: np.ndarray, z: np.ndarray, *,
     (cd / "weights.0").write_bytes(b"\x00" * 1024)
     (cd / "in_x.bin").write_bytes(x.reshape(1, 1, 1, 1, W).tobytes())
     (cd / "in_z.bin").write_bytes(z.reshape(1, 1, 1, 1, W).tobytes())
-    cmd = [str(invoker), "--net-plist", str(cd / "net.plist"),
-           "--weights", str(cd / "weights.0"),
-           "--input", f"x={cd / 'in_x.bin'}", "--input", f"z={cd / 'in_z.bin'}",
-           "--output", f"y={cd / 'out_y.bin'}",
-           "--raw-output", f"y={cd / 'out_raw.bin'}", "--repeats", "1"]
-    p = subprocess.run(cmd, capture_output=True, text=True, timeout=120)
-    lines = [l for l in p.stdout.splitlines() if l.strip().startswith("{")]
-    if not lines: raise RuntimeError(f"no JSON from invoker:\n{p.stdout}\n{p.stderr}")
-    info = json.loads(lines[-1])
-    if info.get("status") != "ok": raise RuntimeError(f"scaled_elementwise invoker failed: {info}")
+    invoke_netplist(
+      invoker, cd / "net.plist",
+      weights=[cd / "weights.0"],
+      inputs=[("x", cd / "in_x.bin"), ("z", cd / "in_z.bin")],
+      outputs=[("y", cd / "out_y.bin")], warmup=0,
+      extra=["--raw-output", f"y={cd / 'out_raw.bin'}"])
     raw = (cd / "out_y.bin").read_bytes()
     return np.frombuffer(raw[:W * 2], dtype=np.float16)
 

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -25,11 +25,12 @@ _BUILD_INFO = (
 )
 
 
-def _topo(out: Tensor) -> list[Tensor]:
-  # iterative post-order DFS so deep unrolled graphs don't hit the recursion limit.
+def _topo_multi(*outs: Tensor) -> list[Tensor]:
+  # iterative post-order DFS over one-or-more roots so deep unrolled graphs don't hit
+  # the recursion limit. Single-root order is identical to seeding from just that root.
   seen: set[int] = set()
   order: list[Tensor] = []
-  stack: list = [(out, False)]
+  stack: list = [(o, False) for o in reversed(outs)]
   while stack:
     t, processed = stack.pop()
     if processed:
@@ -41,6 +42,10 @@ def _topo(out: Tensor) -> list[Tensor]:
     for src in t.srcs:
       if id(src) not in seen: stack.append((src, False))
   return order
+
+
+def _topo(out: Tensor) -> list[Tensor]:
+  return _topo_multi(out)
 
 
 # --------------------------------------------------------------------------- #
@@ -329,6 +334,28 @@ def _e_bmm(em, t, n, s):
       f'x = {s[0]}, y = {s[1]})[name = string("{n}")];')
 
 
+# shared const/param preambles - byte-identical MIL across the conv & pool emitters.
+def _const_pt(em, n):
+  em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
+
+
+def _const_i32_pair(em, n, suf, v):
+  em.line(f'tensor<int32, [2]> {n}_{suf} = const()[name = string("{n}_{suf}"), val = tensor<int32, [2]>([{v}, {v}])];')
+
+
+def _const_pad4(em, n, p):
+  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
+
+
+def _emit_conv_params(em, n, p, st, dl, g):   # pt, st, pd, dl, g (conv/dynamic_conv/conv_transpose)
+  _const_pt(em, n); _const_i32_pair(em, n, "st", st); _const_pad4(em, n, p); _const_i32_pair(em, n, "dl", dl)
+  em.line(f'int32 {n}_g = const()[name = string("{n}_g"), val = int32({g})];')
+
+
+def _emit_pool_params(em, n, k, st, p):       # pt, ks, st, pd (max_pool/avg_pool)
+  _const_pt(em, n); _const_i32_pair(em, n, "ks", k); _const_i32_pair(em, n, "st", st); _const_pad4(em, n, p)
+
+
 @op("conv")
 def _e_conv(em, t, n, s):
   a = t.attrs
@@ -336,11 +363,7 @@ def _e_conv(em, t, n, s):
   # conv operand directly, no +0 bridge); per-node `int8` attr overrides the global flag.
   w = em.weight(f"{n}_w", a["weight"], allow_int8=True, int8=a.get("int8"), allow_int4=True, allow_sparse=True)
   p, st, dl, g = a["pad"], a["stride"], a["dilation"], a["groups"]
-  em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
-  em.line(f'tensor<int32, [2]> {n}_st = const()[name = string("{n}_st"), val = tensor<int32, [2]>([{st}, {st}])];')
-  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
-  em.line(f'tensor<int32, [2]> {n}_dl = const()[name = string("{n}_dl"), val = tensor<int32, [2]>([{dl}, {dl}])];')
-  em.line(f'int32 {n}_g = const()[name = string("{n}_g"), val = int32({g})];')
+  _emit_conv_params(em, n, p, st, dl, g)
   em.line(f'{em.ty(t.shape)} {n} = conv(dilations = {n}_dl, groups = {n}_g, pad = {n}_pd, '
       f'pad_type = {n}_pt, strides = {n}_st, weight = {w}, x = {s[0]})[name = string("{n}")];')
   if "bias" in a:
@@ -355,11 +378,7 @@ def _e_dynamic_conv(em, t, n, s):
   # by construction (batch>=2 dynamic-weight conv is unsupported).
   a = t.attrs
   p, st, dl, g = a["pad"], a["stride"], a["dilation"], a["groups"]
-  em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
-  em.line(f'tensor<int32, [2]> {n}_st = const()[name = string("{n}_st"), val = tensor<int32, [2]>([{st}, {st}])];')
-  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
-  em.line(f'tensor<int32, [2]> {n}_dl = const()[name = string("{n}_dl"), val = tensor<int32, [2]>([{dl}, {dl}])];')
-  em.line(f'int32 {n}_g = const()[name = string("{n}_g"), val = int32({g})];')
+  _emit_conv_params(em, n, p, st, dl, g)
   em.line(f'{em.ty(t.shape)} {n} = conv(dilations = {n}_dl, groups = {n}_g, pad = {n}_pd, '
       f'pad_type = {n}_pt, strides = {n}_st, weight = {s[1]}, x = {s[0]})[name = string("{n}")];')
 
@@ -367,10 +386,7 @@ def _e_dynamic_conv(em, t, n, s):
 @op("max_pool")
 def _e_max_pool(em, t, n, s):
   k, st, p = t.attrs["k"], t.attrs["stride"], t.attrs["pad"]
-  em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
-  em.line(f'tensor<int32, [2]> {n}_ks = const()[name = string("{n}_ks"), val = tensor<int32, [2]>([{k}, {k}])];')
-  em.line(f'tensor<int32, [2]> {n}_st = const()[name = string("{n}_st"), val = tensor<int32, [2]>([{st}, {st}])];')
-  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
+  _emit_pool_params(em, n, k, st, p)
   em.line(f'bool {n}_cm = const()[name = string("{n}_cm"), val = bool(false)];')
   em.line(f'{em.ty(t.shape)} {n} = max_pool(ceil_mode = {n}_cm, kernel_sizes = {n}_ks, pad = {n}_pd, '
       f'pad_type = {n}_pt, strides = {n}_st, x = {s[0]})[name = string("{n}")];')
@@ -379,10 +395,7 @@ def _e_max_pool(em, t, n, s):
 @op("avg_pool")
 def _e_avg_pool(em, t, n, s):
   k, st, p = t.attrs["k"], t.attrs["stride"], t.attrs["pad"]
-  em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
-  em.line(f'tensor<int32, [2]> {n}_ks = const()[name = string("{n}_ks"), val = tensor<int32, [2]>([{k}, {k}])];')
-  em.line(f'tensor<int32, [2]> {n}_st = const()[name = string("{n}_st"), val = tensor<int32, [2]>([{st}, {st}])];')
-  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
+  _emit_pool_params(em, n, k, st, p)
   em.line(f'bool {n}_ep = const()[name = string("{n}_ep"), val = bool(false)];')
   em.line(f'bool {n}_cm = const()[name = string("{n}_cm"), val = bool(false)];')
   em.line(f'{em.ty(t.shape)} {n} = avg_pool(ceil_mode = {n}_cm, exclude_padding_from_average = {n}_ep, '
@@ -394,11 +407,7 @@ def _e_conv_transpose(em, t, n, s):
   a = t.attrs
   w = em.weight(f"{n}_w", a["weight"], allow_int8=False)         # [Cin, Cout, kH, kW]; int4 unverified here -> fp16
   p, st, dl, g = a["pad"], a["stride"], a["dilation"], a["groups"]
-  em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')
-  em.line(f'tensor<int32, [2]> {n}_st = const()[name = string("{n}_st"), val = tensor<int32, [2]>([{st}, {st}])];')
-  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
-  em.line(f'tensor<int32, [2]> {n}_dl = const()[name = string("{n}_dl"), val = tensor<int32, [2]>([{dl}, {dl}])];')
-  em.line(f'int32 {n}_g = const()[name = string("{n}_g"), val = int32({g})];')
+  _emit_conv_params(em, n, p, st, dl, g)
   em.line(f'{em.ty(t.shape)} {n} = conv_transpose(dilations = {n}_dl, groups = {n}_g, pad = {n}_pd, '
       f'pad_type = {n}_pt, strides = {n}_st, weight = {w}, x = {s[0]})[name = string("{n}")];')
   if "bias" in a:
@@ -913,19 +922,7 @@ class MultiModel:
 def compile_multi(outs, build_dir=None) -> MultiModel:
   """Lower a multi-output graph into one fused program with N named output ports (the
     multi-output `compile`, for the resident training step). fp16 only; no opt/compress."""
-  seen: set[int] = set()
-  order: list[Tensor] = []
-  stack: list = [(o, False) for o in reversed(outs)]    # iterative post-order (deep-graph safe)
-  while stack:
-    t, processed = stack.pop()
-    if processed:
-      order.append(t)
-      continue
-    if id(t) in seen: continue
-    seen.add(id(t))
-    stack.append((t, True))
-    for src in t.srcs:
-      if id(src) not in seen: stack.append((src, False))
+  order = _topo_multi(*outs)
   if any(t.op in NETPLIST_OPS for t in order):
     raise NotImplementedError("compile_multi: native-SDPA/netplist ops not supported")
   bad = sorted({t.op for t in order if t.op != "input" and t.op not in _EMIT})
@@ -938,14 +935,8 @@ def compile_multi(outs, build_dir=None) -> MultiModel:
   for t in order:
     if t.op != "input": _EMIT[t.op](em, t, t._name, [src._name for src in t.srcs])
 
-  sig = ", ".join(f"{_sig_ty(em, t)} {t._name}" for t in inputs)
   out_vars = ", ".join(o._name for o in outs)
-  mil = (f"program(1.3)\n{_BUILD_INFO}\n{{\n    func main<ios18>({sig}) {{\n"
-     + "\n".join(em.lines) + f"\n    }} -> ({out_vars});\n}}\n")
-  d = Path(build_dir) if build_dir else Path(tempfile.mkdtemp(prefix="aneforge_"))
-  d.mkdir(parents=True, exist_ok=True)
-  (d / "model.mil").write_text(mil)
-  (d / "weights.bin").write_bytes(em.blob.build())
+  d = _emit_program_dir(em, inputs, out_vars, None, build_dir)
   prog = E5RT.compile(mil_path=d / "model.mil", cache_dir=str(d / "cache"),
             inputs={t._name: t.shape for t in inputs},
             outputs={o._name: o.shape for o in outs}, device_mask=ANE_MASK,

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -19,7 +19,7 @@ from pathlib import Path
 
 import numpy as np
 
-from ._compile import compile as _raw_compile, _topo
+from ._compile import compile as _raw_compile, _topo as _raw_topo
 from ._cost import estimate, precision_risk
 from .graph import Tensor
 
@@ -30,6 +30,24 @@ _ACCURACY_TOL = 5e-3
 # A lossy variant must beat the baseline by this factor to be chosen, so a measurement-noise
 # "win" never costs accuracy for no real speedup.
 _MIN_LOSSY_SPEEDUP = 1.10
+
+
+# A tune re-walks the immutable graph via _topo from every candidate detector and each
+# _apply_variant/_estimate_variant call. The graph is never mutated during a tune
+# (_apply_variant builds a NEW DAG; compile only writes node._name, which topo ignores - order
+# depends ONLY on .srcs), so memoizing post-order per root only avoids recompute, never changes
+# the order. Each entry stores its root Tensor and is identity-checked on read: the stored
+# Tensor keeps its id alive, so a reused id can never return a stale order. Capped to bound it.
+_TOPO_MEMO: dict[int, tuple] = {}
+
+
+def _topo(out):
+  hit = _TOPO_MEMO.get(id(out))
+  if hit is not None and hit[0] is out: return hit[1]
+  order = _raw_topo(out)
+  if len(_TOPO_MEMO) >= 256: _TOPO_MEMO.clear()
+  _TOPO_MEMO[id(out)] = (out, order)
+  return order
 
 
 # --------------------------------------------------------------------------- #
@@ -281,6 +299,19 @@ def _apply_variant(out, cfg):
   return new_out, bool(cfg.get("int8", False))
 
 
+def _route_configs(routes) -> list:
+  """Coordinate-descent route enumeration shared by _route_variants and _variants:
+    opt=0 baseline (all native) + each single route flip + all-decomposed = K+1 configs,
+    linear NOT 2^K. Config values are JSON-friendly lists (a cached config must compare
+    equal after a JSON round-trip - the cache premise)."""
+  configs = [{"int8": False, "decomp": [], "lossy": False}]   # opt=0 baseline (all native)
+  for i in routes:
+    configs.append({"int8": False, "decomp": [i], "lossy": False})
+  if len(routes) > 1:
+    configs.append({"int8": False, "decomp": list(routes), "lossy": False})
+  return configs
+
+
 def _variants(out):
   """Legal variant configs (each a buildable/cacheable compile-config). Axes:
       - GLOBAL int8: {False, True}, LOSSY (accuracy-gated).
@@ -288,15 +319,7 @@ def _variants(out):
         Enumerated by COORDINATE DESCENT: baseline + each single flip + all-decomposed =
         K+1 variants, linear NOT 2^K.
     """
-  # config values are JSON-friendly lists (a cached config must compare equal after a JSON
-  # round-trip - the cache premise).
-  routes = _route_ids(out)
-  configs = [{"int8": False, "decomp": [], "lossy": False}]   # opt=0 baseline (all native)
-  if routes:
-    for i in routes:
-      configs.append({"int8": False, "decomp": [i], "lossy": False})
-    if len(routes) > 1:
-      configs.append({"int8": False, "decomp": list(routes), "lossy": False})
+  configs = _route_configs(_route_ids(out))
   if _has_weights(out):
     configs.append({"int8": True, "decomp": [], "lossy": True})   # PRIMARY: global int8
   cf = _constfold_candidates(out)
@@ -314,13 +337,7 @@ def _route_variants(out):
     numerics. (Shape-dependent equivalence is handled upstream: af.sdpa decomposes above the
     native accuracy limit, so a routable native sdpa node only exists where the route is
     lossless.)"""
-  routes = _route_ids(out)
-  configs = [{"int8": False, "decomp": [], "lossy": False}]      # all-native baseline
-  for i in routes:
-    configs.append({"int8": False, "decomp": [i], "lossy": False})
-  if len(routes) > 1:
-    configs.append({"int8": False, "decomp": list(routes), "lossy": False})
-  return configs
+  return _route_configs(_route_ids(out))
 
 
 def _compile_routes(out, int8: bool, build_dir=None):

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -50,6 +50,13 @@ def _topo(out: Tensor, stop: set | None = None) -> list[Tensor]:
   return order
 
 
+def _value_input(arr, shape) -> Tensor:
+  """A fed value-leaf: input holding `arr` reshaped to `shape` in attrs['value']."""
+  t = graph.input(shape)
+  t.attrs["value"] = np.asarray(arr, np.float32).reshape(shape)
+  return t
+
+
 def _const_like(t: Tensor, c: float) -> Tensor:
   """Constant `c` shaped like `t`, built from existing ops (no const-tensor op).
     `(t - t)` not `(t * 0.0)`: mul-by-zero on a reduce output trips an ANECCompile
@@ -222,13 +229,19 @@ def _vjp_silu(t, g):
 
 # normalization vjps: gamma (a per-channel const) is re-injected as a fed
 # value-input; closed-form grad_x. See docs/developer/autograd.md.
+def _layer_norm_backward(x, gn, ax, eps):
+  """Closed-form LayerNorm grad_x over axes `ax`: rstd*(gn - mean(gn) - n*mean(gn*n)),
+    gn = upstream*gamma. Shared by layer_norm / channel_layer_norm / group_norm."""
+  xc = x - x.mean(ax)                                          # x - mean
+  rstd = xc.square().mean(ax).adds(eps).rsqrt()               # 1/std
+  n = xc * rstd                                                # normalized
+  return (gn - gn.mean(ax) - n * (gn * n).mean(ax)) * rstd
+
+
 def _gamma_input(t):
   """gamma from a norm node's attrs, shaped [1,...,1,D] as a fed value-input."""
-  gamma = np.asarray(t.attrs["gamma"], np.float32)
   gshape = (1,) * (len(t.shape) - 1) + (t.shape[-1],)
-  gt = graph.input(gshape)
-  gt.attrs["value"] = gamma.reshape(gshape)
-  return gt
+  return _value_input(t.attrs["gamma"], gshape)
 
 
 @vjp("rms_norm")
@@ -244,26 +257,16 @@ def _vjp_rms_norm(t, g):
 @vjp("layer_norm")
 def _vjp_layer_norm(t, g):
   x = t.srcs[0]; last = (len(x.shape) - 1,)
-  eps = float(t.attrs["eps"]); gn = g * _gamma_input(t)        # g * gamma (beta drops out)
-  xc = x - x.mean(last)                                        # x - mean
-  rstd = xc.square().mean(last).adds(eps).rsqrt()              # 1/std  [..,1]
-  n = xc * rstd                                                # normalized
-  grad = gn - gn.mean(last) - n * (gn * n).mean(last)          # gn - mean(gn) - n*mean(gn*n)
-  return [grad * rstd]
+  gn = g * _gamma_input(t)                                     # g * gamma (beta drops out)
+  return [_layer_norm_backward(x, gn, last, float(t.attrs["eps"]))]
 
 
 @vjp("channel_layer_norm")
 def _vjp_channel_layer_norm(t, g):
-  x = t.srcs[0]; ax = (1,)                                     # LayerNorm over the channel axis
-  eps = float(t.attrs["eps"]); C = x.shape[1]
-  gamma = np.asarray(t.attrs["gamma"], np.float32)            # per-channel gamma as [1,C,1,1]
-  gt = graph.input((1, C, 1, 1)); gt.attrs["value"] = gamma.reshape(1, C, 1, 1)
+  x = t.srcs[0]; ax = (1,); C = x.shape[1]                    # LayerNorm over the channel axis
+  gt = _value_input(t.attrs["gamma"], (1, C, 1, 1))           # per-channel gamma as [1,C,1,1]
   gn = g * gt                                                  # g * gamma (beta drops out)
-  xc = x - x.mean(ax)                                          # x - channel mean
-  rstd = xc.square().mean(ax).adds(eps).rsqrt()              # 1/std  [N,1,1,S]
-  n = xc * rstd                                                # normalized
-  grad = gn - gn.mean(ax) - n * (gn * n).mean(ax)            # same LayerNorm backward, over C
-  return [grad * rstd]
+  return [_layer_norm_backward(x, gn, ax, float(t.attrs["eps"]))]
 
 
 # unary math / activation vjps: closed-form derivatives from existing ops; the
@@ -320,9 +323,8 @@ def _vjp_leaky_relu(t, g):
 @vjp("prelu")
 def _vjp_prelu(t, g):
   x = t.srcs[0]; C = x.shape[1]
-  alpha = np.asarray(t.attrs["alpha"], np.float32)
   ashape = (1, C) + (1,) * (len(x.shape) - 2)
-  at = graph.input(ashape); at.attrs["value"] = alpha.reshape(ashape)
+  at = _value_input(t.attrs["alpha"], ashape)
   ab = at + _const_like(x, 0.0)                     # broadcast per-channel alpha to x's shape
   return [g * graph.select(x.greater(_const_like(x, 0.0)), _ones_like(x), ab)]
 
@@ -397,14 +399,10 @@ def _vjp_group_norm(t, g):
   x = t.srcs[0]                                     # [N, C, H, W]
   N, C, H, W = x.shape
   G = int(t.attrs["groups"]); eps = float(t.attrs["eps"]); M = (C // G) * H * W
-  gamma = np.asarray(t.attrs["gamma"], np.float32)
-  gt = graph.input((1, C, 1, 1)); gt.attrs["value"] = gamma.reshape(1, C, 1, 1)
+  gt = _value_input(t.attrs["gamma"], (1, C, 1, 1))
   gn = (g * gt).reshape(N, G, M)                    # (g*gamma) grouped
-  xc = x.reshape(N, G, M); xc = xc - xc.mean((2,))  # per-group center
-  rstd = xc.square().mean((2,)).adds(eps).rsqrt()   # per-group 1/std
-  n = xc * rstd
-  grad = gn - gn.mean((2,)) - n * (gn * n).mean((2,))   # LN backward within group
-  return [(grad * rstd).reshape(N, C, H, W)]
+  xg = x.reshape(N, G, M)                           # per-group view
+  return [_layer_norm_backward(xg, gn, (2,), eps).reshape(N, C, H, W)]
 
 
 # structural vjps (transpose / reshape): pure index re-arrangements, fp16-exact;
@@ -738,7 +736,7 @@ class Adam:
 _A13_CONV_WGRAD_LOSS_SCALE_MAX = 512.0
 
 
-def _has_conv_wgrad(params, objective) -> bool:
+def _has_conv_wgrad(params) -> bool:
   """True iff a param is a trainable conv weight with kW>1 (only those hit the
     A13 width-offset saturation path)."""
   for p in params:
@@ -747,7 +745,7 @@ def _has_conv_wgrad(params, objective) -> bool:
   return False
 
 
-def _guard_a13_conv_loss_scale(params, objective, loss_scale: float) -> float:
+def _guard_a13_conv_loss_scale(params, loss_scale: float) -> float:
   """On A13/M1 with a trainable conv weight, warn when loss_scale could push
     backward activations past 4094 (width-offset im2col saturation). WARN only;
     returns loss_scale unchanged. Other families unaffected."""
@@ -757,7 +755,7 @@ def _guard_a13_conv_loss_scale(params, objective, loss_scale: float) -> float:
   except Exception:
     return loss_scale
   if int(fam) != int(TG.Family.A13): return loss_scale
-  if not _has_conv_wgrad(params, objective): return loss_scale
+  if not _has_conv_wgrad(params): return loss_scale
   if loss_scale >= _A13_CONV_WGRAD_LOSS_SCALE_MAX:
     import warnings
     warnings.warn(
@@ -792,7 +790,7 @@ class Trainer:
     from . import _compile as _c
     self.params = list(params)
     # A13/M1 conv weight-grad saturation guard (before scale is consumed).
-    loss_scale = _guard_a13_conv_loss_scale(self.params, objective, float(loss_scale))
+    loss_scale = _guard_a13_conv_loss_scale(self.params, float(loss_scale))
     self.data = dict(data_inputs or {})       # {input Tensor: numpy value}
     self.scale = float(loss_scale)
     self.lr = float(lr)

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -363,17 +363,17 @@ class Tensor:
            {"gamma": gamma, "beta": beta, "groups": num_groups, "eps": float(eps)})
 
   # -- spatial ----------------------------------------------------------- #
-  def max_pool(self, k: int, stride: int | None = None, pad: int = 0) -> "Tensor":
+  def _pool(self, op: str, k: int, stride: int | None, pad: int) -> "Tensor":
     stride = stride or k
     N, C, H, W = self.shape
     out = (N, C, (H + 2 * pad - k) // stride + 1, (W + 2 * pad - k) // stride + 1)
-    return Tensor(out, "max_pool", [self], {"k": k, "stride": stride, "pad": pad})
+    return Tensor(out, op, [self], {"k": k, "stride": stride, "pad": pad})
+
+  def max_pool(self, k: int, stride: int | None = None, pad: int = 0) -> "Tensor":
+    return self._pool("max_pool", k, stride, pad)
 
   def avg_pool(self, k: int, stride: int | None = None, pad: int = 0) -> "Tensor":
-    stride = stride or k
-    N, C, H, W = self.shape
-    out = (N, C, (H + 2 * pad - k) // stride + 1, (W + 2 * pad - k) // stride + 1)
-    return Tensor(out, "avg_pool", [self], {"k": k, "stride": stride, "pad": pad})
+    return self._pool("avg_pool", k, stride, pad)
 
   def upsample(self, scale: int = 2) -> "Tensor":
     """Nearest-neighbour upsample [N,C,H,W] -> [N,C,scale*H,scale*W]."""
@@ -449,6 +449,27 @@ def _binary(a: Tensor, b, kind: str) -> Tensor:
   return Tensor(_broadcast(a.shape, b.shape), kind, [a, b])
 
 
+def _check_kw(kW: int, op: str, weight_shape) -> None:
+  """ANE conv tiles along kernel WIDTH: kW>=16 fails ANECCompile (kH unconstrained)."""
+  if kW <= 15:
+    return
+  if weight_shape is None:                                 # dynamic_conv (runtime weight)
+    raise ValueError(f"{op}: kernel width kW={kW} exceeds the ANE limit (<=15); "
+            f"kernel height kH is unconstrained.")
+  raise ValueError(
+    f"{op}: kernel width kW={kW} exceeds the ANE limit (kW must be <=15); "
+    f"got weight {weight_shape}. Kernel height kH is unconstrained.")
+
+
+def _conv_attrs(weight, stride: int, pad: int, dilation: int, groups: int,
+        bias) -> "dict[str, Any]":
+  attrs: dict[str, Any] = {"weight": weight, "stride": stride, "pad": pad,
+              "dilation": dilation, "groups": groups}
+  if bias is not None:
+    attrs["bias"] = np.asarray(bias).astype(np.float32)
+  return attrs
+
+
 def conv(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: int = 1,
     groups: int = 1, bias=None) -> Tensor:
   """2D conv. `x`: [N,Cin,H,W]; `weight`: [Cout, Cin/groups, kH, kW]; `bias`: [Cout]."""
@@ -457,18 +478,11 @@ def conv(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: int = 1,
     raise ValueError(f"conv expects 4D input [N,Cin,H,W], got {x.shape}")
   N, Cin, H, W = x.shape
   Cout, _, kH, kW = weight.shape
-  # ANE conv tiles along kernel WIDTH: kW>=16 fails ANECCompile (kH unconstrained).
-  if kW > 15:
-    raise ValueError(
-      f"conv: kernel width kW={kW} exceeds the ANE limit (kW must be <=15); "
-      f"got weight {weight.shape}. Kernel height kH is unconstrained.")
+  _check_kw(kW, "conv", weight.shape)
   Hout = (H + 2 * pad - dilation * (kH - 1) - 1) // stride + 1
   Wout = (W + 2 * pad - dilation * (kW - 1) - 1) // stride + 1
-  attrs: dict[str, Any] = {"weight": weight, "stride": stride, "pad": pad,
-              "dilation": dilation, "groups": groups}
-  if bias is not None:
-    attrs["bias"] = np.asarray(bias).astype(np.float32)
-  return Tensor((N, Cout, Hout, Wout), "conv", [x], attrs)
+  return Tensor((N, Cout, Hout, Wout), "conv", [x],
+         _conv_attrs(weight, stride, pad, dilation, groups, bias))
 
 
 def dynamic_conv(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0,
@@ -492,9 +506,7 @@ def dynamic_conv(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0,
       f"is unsupported on the ANE dynamic-kernel path. Use af.conv / conv2d for batched convolution.")
   if Cin_g * groups != Cin:
     raise ValueError(f"dynamic_conv: weight Cin/groups={Cin_g} x groups={groups} != input Cin={Cin}")
-  if kW > 15:
-    raise ValueError(f"dynamic_conv: kernel width kW={kW} exceeds the ANE limit (<=15); "
-            f"kernel height kH is unconstrained.")
+  _check_kw(kW, "dynamic_conv", None)
   Hout = (H + 2 * pad - dilation * (kH - 1) - 1) // stride + 1
   Wout = (W + 2 * pad - dilation * (kW - 1) - 1) // stride + 1
   return Tensor((N, Cout, Hout, Wout), "dynamic_conv", [x, weight],
@@ -511,18 +523,11 @@ def conv_transpose(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: i
     raise ValueError(f"conv_transpose expects 4D [N,Cin,H,W], got {x.shape}")
   N, Cin, H, W = x.shape
   _, Cout, kH, kW = weight.shape
-  # Same kernel-WIDTH limit as conv: kW>=16 fails ANECCompile (kH unconstrained).
-  if kW > 15:
-    raise ValueError(
-      f"conv_transpose: kernel width kW={kW} exceeds the ANE limit (kW must be <=15); "
-      f"got weight {weight.shape}. Kernel height kH is unconstrained.")
+  _check_kw(kW, "conv_transpose", weight.shape)
   Hout = (H - 1) * stride - 2 * pad + dilation * (kH - 1) + 1
   Wout = (W - 1) * stride - 2 * pad + dilation * (kW - 1) + 1
-  attrs: dict[str, Any] = {"weight": weight, "stride": stride, "pad": pad,
-              "dilation": dilation, "groups": groups}
-  if bias is not None:
-    attrs["bias"] = np.asarray(bias).astype(np.float32)
-  return Tensor((N, Cout, Hout, Wout), "conv_transpose", [x], attrs)
+  return Tensor((N, Cout, Hout, Wout), "conv_transpose", [x],
+         _conv_attrs(weight, stride, pad, dilation, groups, bias))
 
 
 def batch_norm(x: Tensor, gamma, beta, mean, var, eps: float = 1e-5) -> Tensor:
@@ -995,6 +1000,34 @@ def _heads(t: Tensor, n: int, dh: int) -> Tensor:           # [S, D] -> [H, S, d
   return t.reshape(t.shape[0], n, dh).transpose([1, 0, 2])
 
 
+def _seq_slice(t: Tensor, axis: int, start: int, n: int) -> Tensor:
+  begin = [0] * len(t.shape); begin[axis] = start
+  size = list(t.shape); size[axis] = n
+  return t.slice_by_size(begin, size)
+
+
+def _tiled_attention(qh: Tensor, kt: Tensor, vh: Tensor, scale: float, n_tiles: int,
+           seq_axis: int, mask: "Tensor | None" = None) -> Tensor:
+  """Query-tiled softmax((q @ kt) * scale) @ v in `n_tiles` chunks (exact; ~3x faster
+    at large seq; `n_tiles==1` is one shot). Query seq runs along `seq_axis` (1 for 3D
+    [H,S,dh], 2 for 4D); tiles concat there. `mask` (sdpa) is sliced along the same axis."""
+  if n_tiles == 1:
+    scores = (qh @ kt) * scale
+    if mask is not None:
+      scores = scores + mask
+    return scores.softmax(-1) @ vh
+  Sq = qh.shape[seq_axis]
+  tile = -(-Sq // n_tiles)                                  # ceil -> near-even chunks
+  out_tiles = []
+  for start in range(0, Sq, tile):
+    n = min(tile, Sq - start)
+    st = (_seq_slice(qh, seq_axis, start, n) @ kt) * scale
+    if mask is not None:
+      st = st + _seq_slice(mask, seq_axis, start, n)
+    out_tiles.append(st.softmax(-1) @ vh)
+  return concat(out_tiles, axis=seq_axis)
+
+
 def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
   """Multi-head self-attention on `x` [S, D]. Weights [out,in]; biases [D] or None.
     Builds split-heads -> per-head SDPA -> concat -> output-proj from graph ops."""
@@ -1010,12 +1043,7 @@ def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
   # Exact and ~3x faster at large S (same fission as af.sdpa). Count from af.tune_attention.
   from . import _optimize as _opt
   n_tiles = _opt.attention_tiles(S, n_heads, dh)
-  if n_tiles == 1:
-    o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
-  else:
-    tile = -(-S // n_tiles)                                 # ceil -> near-even chunks
-    o = concat([((qh.slice_by_size([0, s, 0], [n_heads, min(tile, S-s), dh]) @ kt)
-                 * scale).softmax(-1) @ vh for s in range(0, S, tile)], axis=1)  # [H, S, dh]
+  o = _tiled_attention(qh, kt, vh, scale, n_tiles, seq_axis=1)  # [H, S, dh]
   o = o.transpose([1, 0, 2]).reshape(S, D)
   return o.linear(Wo, bo)
 
@@ -1037,12 +1065,7 @@ def cross_attention(x: Tensor, context: Tensor, Wq, Wk, Wv, Wo, n_heads: int,
   # (exact). Gated on score area so small-T cross-attention (SD T=77) stays single-shot.
   from . import _optimize as _opt
   n_tiles = _opt.attention_tiles(S, n_heads, dh, T=T) if (S >= 768 and T >= 512) else 1
-  if n_tiles == 1:
-    o = ((qh @ kt) * scale).softmax(-1) @ vh                # [H, S, dh]
-  else:
-    tile = -(-S // n_tiles)                                 # ceil -> near-even chunks
-    o = concat([((qh.slice_by_size([0, s, 0], [n_heads, min(tile, S-s), dh]) @ kt)
-                 * scale).softmax(-1) @ vh for s in range(0, S, tile)], axis=1)  # [H, S, dh]
+  o = _tiled_attention(qh, kt, vh, scale, n_tiles, seq_axis=1)  # [H, S, dh]
   o = o.transpose([1, 0, 2]).reshape(S, D)
   return o.linear(Wo, bo)
 
@@ -1111,23 +1134,7 @@ def sdpa(q: Tensor, k: Tensor, v: Tensor, scale: float | None = None,
     kt = k.transpose([0, 1, 3, 2])
     from . import _optimize as _opt
     n_tiles = _opt.attention_tiles(q.shape[2], q.shape[1], q.shape[3], T=k.shape[2])
-    if n_tiles == 1:
-      scores = q @ kt * float(_scale)
-      if attn_mask is not None:
-        scores = scores + attn_mask
-      return scores.softmax(-1) @ v
-    Sq = q.shape[2]
-    tile = -(-Sq // n_tiles)                            # ceil -> near-even chunks
-    out_tiles = []
-    for start in range(0, Sq, tile):
-      n = min(tile, Sq - start)
-      qt = q.slice_by_size([0, 0, start, 0], [q.shape[0], q.shape[1], n, q.shape[3]])
-      st = qt @ kt * float(_scale)
-      if attn_mask is not None:
-        st = st + attn_mask.slice_by_size(
-          [0, 0, start, 0], [attn_mask.shape[0], attn_mask.shape[1], n, attn_mask.shape[3]])
-      out_tiles.append(st.softmax(-1) @ v)
-    return concat(out_tiles, axis=2)
+    return _tiled_attention(q, kt, v, float(_scale), n_tiles, seq_axis=2, mask=attn_mask)
   if attn_mask is not None:                       # runtime mask rides the 5th bottom (stays native)
     return Tensor(q.shape, "sdpa", [q, k, v, attn_mask], {"scale": float(_scale), "masked": True})
   return Tensor(q.shape, "sdpa", [q, k, v], {"scale": float(_scale), "causal": bool(is_causal)})

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -57,6 +57,33 @@ def _solve_once(out, *feeds):
   return y
 
 
+def _run_multi(outs, *feeds):
+  """compile_multi a list of output graphs, run once, return outputs in `outs` order."""
+  from aneforge._compile import compile_multi
+  net = compile_multi(outs)
+  out = net(*feeds)
+  vals = [out[name] for _, name in net.output_ports]
+  net.release()
+  return vals
+
+
+def _mgs_qr_graph(X, height: int, ones):
+  """Modified Gram-Schmidt thin QR of an in-graph matrix X [height, n] -> (Q, R) graphs.
+    `ones` is a [height,1] fp16 const for the matmul dot (wide accum). Shared by qr/eigvals."""
+  n = X.shape[1]
+  Q, Rcols, z = [], [], None
+  dot = lambda a, b: (a * b).transpose([1, 0]) @ ones        # [1,height]@[height,1] = [1,1]
+  for j in range(n):
+    v = X.slice_by_size([0, j], [height, 1]); rcol = []
+    for i in range(j):
+      rij = dot(Q[i], v); rcol.append(rij); v = v - rij * Q[i]
+    d2 = dot(v, v); rjj = d2.sqrt(); rcol.append(rjj)
+    Q.append(v * d2.rsqrt())                                  # q_j = v / ||v||
+    z = rjj - rjj if z is None else z                        # exact-zero [1,1]
+    Rcols.append(af.concat(rcol + [z] * (n - j - 1), axis=0))   # R column j -> [n,1]
+  return af.concat(Q, axis=1), af.concat(Rcols, axis=1)
+
+
 # =========================================================================== #
 # 1. CONJUGATE GRADIENT  (SPD A, fixed K iterations)                           #
 # =========================================================================== #
@@ -451,28 +478,10 @@ def _els_routed(Xt, n: int):
 def qr(A):
   """Thin QR A = Q R by modified Gram-Schmidt, FULLY on the ANE (one program). Returns
     (Q, R); Q orthonormal columns, R upper-triangular. Small-n."""
-  from aneforge._compile import compile_multi
   A16 = np.asarray(A, f16); m, n = A16.shape; onem = np.ones((m, 1), f16)
-  At = af.input((m, n))
-  dot = lambda a, b: (a * b).transpose([1, 0]) @ onem        # [1,m]@[m,1] = [1,1]
-  Q, Rcols = [], []
-  z = None
-  for j in range(n):
-    v = At.slice_by_size([0, j], [m, 1])
-    rcol = []
-    for i in range(j):
-      rij = dot(Q[i], v); rcol.append(rij); v = v - rij * Q[i]
-    rjj = dot(v, v).sqrt(); rcol.append(rjj)
-    Q.append(v * dot(v, v).rsqrt())                        # q_j = v / ||v||
-    z = rjj - rjj if z is None else z                      # exact-zero [1,1]
-    Rcols.append(af.concat(rcol + [z] * (n - j - 1), axis=0))   # R column j -> [n,1]
-  net = compile_multi([af.concat(Q, axis=1), af.concat(Rcols, axis=1)])
-  nm = dict(net.output_ports)
-  out = net(A16)
-  Qv = np.asarray(out[nm[net.output_tensors[0]]], np.float32)
-  Rv = np.asarray(out[nm[net.output_tensors[1]]], np.float32)
-  net.release()
-  return Qv, Rv
+  Qg, Rg = _mgs_qr_graph(af.input((m, n)), m, onem)
+  Qv, Rv = _run_multi([Qg, Rg], A16)
+  return np.asarray(Qv, np.float32), np.asarray(Rv, np.float32)
 
 
 def cholesky(A):
@@ -495,7 +504,6 @@ def cholesky(A):
 def lu(A):
   """Unpivoted LU (A = L U, L unit-lower, U upper) by Doolittle, FULLY on the ANE.
     Returns (L, U). Small-n; UNPIVOTED, valid when no leading pivot underflows."""
-  from aneforge._compile import compile_multi
   A16 = np.asarray(A, f16); n = A16.shape[0]
   At = af.input((n, n)); el = _els_routed(At, n)
   z = el(0, 0) - el(0, 0); one = z.adds(1.0)
@@ -509,13 +517,8 @@ def lu(A):
       s = el(k, i)
       for t in range(i): s = s - L[(k, t)] * U[(t, i)]
       L[(k, i)] = s / U[(i, i)]
-  net = compile_multi([_grid(L, n, z), _grid(U, n, z)])
-  nm = dict(net.output_ports)
-  out = net(A16)
-  Lv = np.asarray(out[nm[net.output_tensors[0]]], np.float32)
-  Uv = np.asarray(out[nm[net.output_tensors[1]]], np.float32)
-  net.release()
-  return Lv, Uv
+  Lv, Uv = _run_multi([_grid(L, n, z), _grid(U, n, z)], A16)
+  return np.asarray(Lv, np.float32), np.asarray(Uv, np.float32)
 
 
 def lu_pivoted(A):
@@ -585,21 +588,8 @@ def eigvals(A, iters: int = 60):
     ~2e-3 (real)/~2e-2 (complex). Unshifted QR is linear, so clusters need more iters."""
   A16 = np.asarray(A, f16); n = A16.shape[0]; onen = np.ones((n, 1), f16)
   M = af.input((n, n))
-
-  def _qr_graph(X):                                      # modified Gram-Schmidt -> (Q, R)
-    Q, Rcols, z = [], [], None
-    for j in range(n):
-      v = X.slice_by_size([0, j], [n, 1]); rcol = []
-      for i in range(j):
-        rij = (Q[i] * v).transpose([1, 0]) @ onen; rcol.append(rij); v = v - rij * Q[i]
-      rjj = ((v * v).transpose([1, 0]) @ onen).sqrt(); rcol.append(rjj)
-      Q.append(v * ((v * v).transpose([1, 0]) @ onen).rsqrt())
-      z = rjj - rjj if z is None else z
-      Rcols.append(af.concat(rcol + [z] * (n - j - 1), axis=0))
-    return af.concat(Q, axis=1), af.concat(Rcols, axis=1)
-
   for _ in range(iters):
-    Q, R = _qr_graph(M); M = R @ Q                     # RQ; unrolls into one program
+    Q, R = _mgs_qr_graph(M, n, onen); M = R @ Q        # RQ; unrolls into one program
   Mv = _solve_once(M, A16)
   evs, i = [], 0
   while i < n:

--- a/bench/_mil.py
+++ b/bench/_mil.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+"""Shared MIL-opcode helpers for the bench/ scripts (not run on its own)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def mil_encoding_tally(build_dir):
+    """Count weight encodings from the generated MIL (makes the int4 gate fallback visible), summed across model.mil files."""
+    counts = {"int4_lut": 0, "sparse": 0, "int8": 0, "fp16": 0}
+    for mil in Path(build_dir).rglob("model.mil"):
+        txt = mil.read_text()
+        counts["int4_lut"] += txt.count("constexpr_lut_to_dense")
+        counts["sparse"] += txt.count("constexpr_sparse_to_dense")
+        counts["int8"] += txt.count("constexpr_affine_dequantize")
+        # fp16 weight constants are BLOBFILE-backed const() ops
+        counts["fp16"] += sum(1 for ln in txt.splitlines()
+                              if "= const()" in ln and "BLOBFILE" in ln)
+    return counts

--- a/bench/device_bandwidth_roofline.py
+++ b/bench/device_bandwidth_roofline.py
@@ -45,19 +45,6 @@ def _shape_for(nelem: int, dlast: int = 4096) -> tuple[int, int]:
     return (r, d)
 
 
-def _ane_min_latency_with_out(net, xf):
-    best = float("inf")
-    out = None
-    for _ in range(6):
-        net(xf)
-    for _ in range(20):
-        import time
-        t0 = time.perf_counter()
-        out = net(xf)
-        best = min(best, time.perf_counter() - t0)
-    return best, out
-
-
 def run_archetype(name, byte_factor, build_ane, build_mlx, build_cpu,
                   ref_fn, sizes, want_acc=True):
     """Run one archetype across all sizes/devices. byte_factor: traffic = factor*N*dt."""
@@ -88,7 +75,7 @@ def run_archetype(name, byte_factor, build_ane, build_mlx, build_cpu,
         if HAVE_ANE and build_ane is not None:
             try:
                 net, xf = build_ane(x32, R, D)
-                lat, out = _ane_min_latency_with_out(net, xf)
+                lat, out = dc.min_latency_with_out(lambda: net(xf), reps=20, warmup=6)
                 gbps = byte_factor * N * 2 / lat / 1e9
                 row["ane_gbps"] = gbps
                 row["ane_lat_ms"] = lat * 1e3
@@ -262,40 +249,26 @@ def measure_peak_power(specs, sizes):
     for (name, bf, build_ane, build_mlx, build_cpu, _ref, _acc) in specs:
         rec = RESULTS["roofline"][name]
         rec["power"] = {}
-        # ANE
-        if HAVE_ANE and build_ane is not None and "ane_err" not in rec["sizes"][-1]:
-            net, xf = build_ane(x32, R, D)
-            e = wc.measure_energy(lambda: net(xf), tag=f"bw_{abs(hash(name))%9999}_ane",
-                                  window=wc.WINDOW)
+        # (key, gated, builder, run-from-build-result, bytes/elem multiplier)
+        arms = (
+            ("ane", HAVE_ANE and build_ane is not None and "ane_err" not in rec["sizes"][-1],
+             build_ane, lambda b: (lambda: b[0](b[1])), 2),
+            ("gpu", HAVE_MLX and build_mlx is not None and "gpu_err" not in rec["sizes"][-1],
+             build_mlx, lambda b: b[0], 2),
+            ("cpu", build_cpu is not None, build_cpu, lambda b: b[0], 4),
+        )
+        for key, gated, builder, run_of, mult in arms:
+            if not gated:
+                continue
+            e = wc.measure_energy(run_of(builder(x32, R, D)),
+                                  tag=f"bw_{abs(hash(name))%9999}_{key}", window=wc.WINDOW)
             if e:
                 apw = e.get("active_pkg_W", float("nan"))
                 if apw == apw and apw > 0:
-                    gbps = bf * N * 2 / (e["iter_ms"] / 1e3) / 1e9
+                    gbps = bf * N * mult / (e["iter_ms"] / 1e3) / 1e9
                     e["gbps_loop"] = gbps
                     e["gbps_per_W"] = gbps / apw
-                rec["power"]["ane"] = e
-        # GPU
-        if HAVE_MLX and build_mlx is not None and "gpu_err" not in rec["sizes"][-1]:
-            fn, _ = build_mlx(x32, R, D)
-            e = wc.measure_energy(fn, tag=f"bw_{abs(hash(name))%9999}_gpu", window=wc.WINDOW)
-            if e:
-                apw = e.get("active_pkg_W", float("nan"))
-                if apw == apw and apw > 0:
-                    gbps = bf * N * 2 / (e["iter_ms"] / 1e3) / 1e9
-                    e["gbps_loop"] = gbps
-                    e["gbps_per_W"] = gbps / apw
-                rec["power"]["gpu"] = e
-        # CPU
-        if build_cpu is not None:
-            fn, _ = build_cpu(x32, R, D)
-            e = wc.measure_energy(fn, tag=f"bw_{abs(hash(name))%9999}_cpu", window=wc.WINDOW)
-            if e:
-                apw = e.get("active_pkg_W", float("nan"))
-                if apw == apw and apw > 0:
-                    gbps = bf * N * 4 / (e["iter_ms"] / 1e3) / 1e9
-                    e["gbps_loop"] = gbps
-                    e["gbps_per_W"] = gbps / apw
-                rec["power"]["cpu"] = e
+                rec["power"][key] = e
         p = rec["power"]
         def _s(d):
             ee = p.get(d, {})

--- a/bench/device_compare.py
+++ b/bench/device_compare.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
-"""Shared device-comparison harness (timing/precision/energy helpers + workload builders) imported by the other bench/ scripts - ANE vs GPU (MLX) vs CPU. Not run on its own."""
+"""Shared device-comparison helpers (timing/precision + device runners + numpy conv/torch/HF reference helpers) imported by the other bench/ scripts - ANE vs GPU (MLX) vs CPU. Not run on its own."""
 from __future__ import annotations
 
 import os
-import re
 import subprocess
 import sys
 import time
@@ -22,7 +21,7 @@ import numpy as np
 HAVE_ANE = HAVE_MLX = HAVE_TORCH = HAVE_TV = HAVE_HF = False
 ANE_ERR = MLX_ERR = ""
 try:
-    import aneforge as af
+    import aneforge as af  # noqa: F401
     HAVE_ANE = True
 except Exception as e:  # pragma: no cover
     ANE_ERR = f"{type(e).__name__}: {e}"
@@ -42,9 +41,6 @@ try:
 except Exception:
     pass
 
-_RAIL = {"ane": re.compile(r"ANE Power:\s*([\d.]+)\s*mW"),
-         "cpu": re.compile(r"CPU Power:\s*([\d.]+)\s*mW"),
-         "gpu": re.compile(r"GPU Power:\s*([\d.]+)\s*mW")}
 HAVE_SUDO = subprocess.run(["sudo", "-n", "true"], capture_output=True).returncode == 0
 
 
@@ -70,64 +66,6 @@ def relerr(got: np.ndarray, ref: np.ndarray) -> float:
     return float(np.linalg.norm(got - ref) / rn) if rn > 0 else float(np.linalg.norm(got - ref))
 
 
-def measure_energy(run_once, *, seconds: float, tag: str) -> dict | None:
-    """Sustained-loop powermetrics average around run_once(). Returns active-W
-    and per-rail mW, or None if energy can't be trusted (no sudo)."""
-    if not HAVE_SUDO:
-        return None
-    for _ in range(3):
-        run_once()
-    samples = max(15, int(seconds / 0.1) + 5)
-    log = Path(f"/tmp/pm_devcmp_{tag}.log")
-    pm = subprocess.Popen(
-        ["sudo", "-n", "powermetrics", "--samplers", "ane_power,cpu_power,gpu_power",
-         "--sample-rate", "100", "--sample-count", str(samples)],
-        stdout=open(log, "w"), stderr=subprocess.DEVNULL)
-    time.sleep(0.3)
-    t0 = time.perf_counter()
-    n = 0
-    while time.perf_counter() - t0 < seconds:
-        run_once()
-        n += 1
-    dt = time.perf_counter() - t0
-    pm.wait()
-    txt = log.read_text()
-    out = {"iter_ms": dt / n * 1e3, "iters": n}
-    active = 0.0
-    for rail, rx in _RAIL.items():
-        v = [float(m) for m in rx.findall(txt)]
-        mw = (sum(v) / len(v)) if v else float("nan")
-        out[rail + "_mW"] = mw
-        if not np.isnan(mw):
-            active += mw
-    out["active_W"] = active / 1000.0
-    return out
-
-
-# result accumulation
-
-RESULTS: dict[str, dict] = {}   # workload -> {"rows": [...], "note": str, ...}
-
-
-def add_row(workload: str, device: str, dtype: str, lat_s: float | None,
-            throughput: str | None, rerr: float | None):
-    RESULTS.setdefault(workload, {"rows": []})
-    RESULTS[workload]["rows"].append({
-        "device": device, "dtype": dtype,
-        "latency_ms": (lat_s * 1e3) if lat_s is not None else None,
-        "throughput": throughput, "relerr": rerr,
-    })
-
-
-def note(workload: str, text: str):
-    RESULTS.setdefault(workload, {"rows": []})
-    RESULTS[workload]["note"] = text
-
-
-def gflops(flops: float, lat_s: float) -> str:
-    return f"{flops / lat_s / 1e9:.1f} GFLOP/s"
-
-
 # device runners (each returns (latency_s, output_array) or None if unavailable)
 
 def cpu_run(build_out, reps=30):
@@ -149,117 +87,12 @@ def mlx_run(build_mx, reps=30):
     return lat, np.array(o, copy=False)
 
 
-# WORKLOADS
-
-def w_gemm(M, K, N, tag):
-    """GEMM x[M,K] @ W[K,N]. aneforge linear wants W as [out,in]=[N,K]."""
-    wl = f"GEMM {tag} (M={M},K={K},N={N})"
-    print(f"\n=== {wl} ===", flush=True)
-    rng = np.random.default_rng(0)
-    x32 = rng.standard_normal((M, K)).astype(np.float32) / np.sqrt(K)
-    W32 = rng.standard_normal((N, K)).astype(np.float32) / np.sqrt(K)  # [out,in]
-    ref = x32.astype(np.float64) @ W32.astype(np.float64).T
-    flops = 2 * M * K * N
-    note(wl, f"{flops/1e9:.3f} GFLOP. ref = fp64 numpy.")
-
-    if HAVE_ANE:
-        try:
-            xin = af.input((M, K))
-            net = af.compile(xin.linear(W32.astype(np.float16)))
-            xf16 = x32.astype(np.float16)
-            lat, out = min_latency_with_out(lambda: net(xf16))
-            add_row(wl, "ANE", "fp16", lat, gflops(flops, lat), relerr(out, ref))
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-    if HAVE_MLX:
-        xg32, Wg32 = mx.array(x32), mx.array(W32.T)
-        lat, out = mlx_run(lambda: xg32 @ Wg32)
-        add_row(wl, "GPU", "fp32", lat, gflops(flops, lat), relerr(out, ref))
-        xg16, Wg16 = mx.array(x32.astype(np.float16)), mx.array(W32.T.astype(np.float16))
-        lat, out = mlx_run(lambda: xg16 @ Wg16)
-        add_row(wl, "GPU", "fp16", lat, gflops(flops, lat), relerr(out, ref))
-
-    # CPU fp32 (Accelerate BLAS - the reference-speed device)
-    lat, out = cpu_run(lambda: x32 @ W32.T)
-    add_row(wl, "CPU", "fp32", lat, gflops(flops, lat), relerr(out, ref))
-    # numpy has no fp16 BLAS GEMM (upcasts, pathologically slow): only run it at the floor size
-    if M * K * N <= 64 * 256 * 256:
-        xh, Wh = x32.astype(np.float16), W32.T.astype(np.float16)
-        lat, out = cpu_run(lambda: (xh @ Wh), reps=5)  # numpy upcasts internally
-        add_row(wl, "CPU", "fp16*", lat, gflops(flops, lat), relerr(out, ref))
-
-
 def min_latency_with_out(fn, reps=30, warmup=8):
     holder = {}
     def wrap():
         holder["o"] = fn()
     lat = min_latency(wrap, reps=reps, warmup=warmup)
     return lat, holder["o"]
-
-
-def w_conv(Cin, Cout, H, W, k, depth, tag, energy=False):
-    """conv stack: `depth` chained Cout-channel kxk same-pad convs (ResNet-ish)."""
-    wl = f"conv {tag} (C={Cout},{H}x{W},k={k},depth={depth})"
-    print(f"\n=== {wl} ===", flush=True)
-    rng = np.random.default_rng(1)
-    pad = k // 2
-    x32 = (rng.standard_normal((1, Cin, H, W)).astype(np.float32))
-    # He init (sqrt(2/fan_in)) keeps a deep ReLU stack's activations O(1) (avoids fp16 underflow)
-    Ws = [rng.standard_normal((Cout, (Cin if d == 0 else Cout), k, k)).astype(np.float32)
-          * np.sqrt(2.0 / ((Cin if d == 0 else Cout) * k * k)) for d in range(depth)]
-    flops = sum(2 * (Cin if d == 0 else Cout) * Cout * k * k * H * W for d in range(depth))
-    note(wl, f"{flops/1e9:.3f} GFLOP, same-pad, He init (O(1) activations). ref = fp32 numpy.")
-
-    _ref = _np_conv_stack(x32, Ws, pad)
-
-    if HAVE_ANE:
-        try:
-            xin = af.input((1, Cin, H, W))
-            h = xin
-            for w in Ws:
-                h = af.conv(h, w.astype(np.float16), stride=1, pad=pad).relu()
-            net = af.compile(h)
-            xf = x32.astype(np.float16)
-            lat, out = min_latency_with_out(lambda: net(xf))
-            refr = _np_conv_stack(x32, Ws, pad, relu=True)
-            add_row(wl, "ANE", "fp16", lat, gflops(flops, lat), relerr(out, refr))
-            if energy:
-                e = measure_energy(lambda: net(xf), seconds=5.0, tag="conv_ane")
-                if e:
-                    RESULTS[wl]["energy_ane"] = e
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-    if HAVE_MLX:
-        # MLX NHWC; weight [Cout,kH,kW,Cin]
-        def mk(dt):
-            xg = mx.array(np.transpose(x32, (0, 2, 3, 1)).astype(dt))
-            Wg = [mx.array(np.transpose(w, (0, 2, 3, 1)).astype(dt)) for w in Ws]
-            return xg, Wg
-        for dt, name in ((np.float32, "fp32"), (np.float16, "fp16")):
-            xg, Wg = mk(dt)
-            def run():
-                hh = xg
-                for w in Wg:
-                    hh = mx.maximum(mx.conv2d(hh, w, stride=1, padding=pad), 0)
-                return hh
-            lat, out = mlx_run(run)
-            outn = np.transpose(np.array(out, copy=False), (0, 3, 1, 2))
-            refr = _np_conv_stack(x32, Ws, pad, relu=True)
-            add_row(wl, "GPU", name, lat, gflops(flops, lat), relerr(outn, refr))
-            if energy and dt == np.float16:
-                e = measure_energy(lambda: mx.eval(run()), seconds=5.0, tag="conv_gpu")
-                if e:
-                    RESULTS[wl]["energy_gpu"] = e
-
-    # CPU fp32 (numpy naive) - only for the SMALL conv; the big stack is too slow on CPU
-    if depth * Cout * H * W <= 256 * 32 * 32 * 4:
-        refr = _np_conv_stack(x32, Ws, pad, relu=True)
-        lat, _ = cpu_run(lambda: _np_conv_stack(x32, Ws, pad, relu=True), reps=5)
-        add_row(wl, "CPU", "fp32", lat, gflops(flops, lat), 0.0)
-    else:
-        note(wl, RESULTS[wl]["note"] + " CPU skipped (naive conv too slow at this size).")
 
 
 def _np_conv_stack(x, Ws, pad, relu=False):
@@ -287,250 +120,6 @@ def _np_conv2d(x, w, pad):
     return out
 
 
-def w_dft(Nn):
-    """DFT as matmul: y = F @ x, F[j,k] = exp(-2pi i jk/N). Real-valued split."""
-    wl = f"DFT-as-matmul (N={Nn})"
-    print(f"\n=== {wl} ===", flush=True)
-    rng = np.random.default_rng(2)
-    x = rng.standard_normal(Nn).astype(np.float64)
-    n = np.arange(Nn)
-    ang = -2 * np.pi * np.outer(n, n) / Nn
-    Fr, Fi = np.cos(ang), np.sin(ang)            # real/imag of the DFT matrix
-    ref_r = Fr @ x
-    ref_i = Fi @ x
-    flops = 2 * (2 * Nn * Nn)                     # two real matvecs
-    note(wl, f"{flops/1e9:.3f} GFLOP. Split-real DFT matrix; ref = fp64. "
-             f"Oscillatory matrix => cancellation, the fp16 stress case.")
-
-    # represent as [1,N] @ [N,N] for each of Fr,Fi
-    x1 = x.reshape(1, Nn)
-    if HAVE_ANE:
-        try:
-            xin = af.input((1, Nn))
-            netr = af.compile(xin.linear(Fr.astype(np.float16)))
-            neti = af.compile(xin.linear(Fi.astype(np.float16)))
-            xf = x1.astype(np.float16)
-            lat = min_latency(lambda: (netr(xf), neti(xf)))
-            yr, yi = netr(xf).ravel(), neti(xf).ravel()
-            err = (relerr(yr, ref_r) + relerr(yi, ref_i)) / 2
-            add_row(wl, "ANE", "fp16", lat, gflops(flops, lat), err)
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-    if HAVE_MLX:
-        for dt, name in ((np.float32, "fp32"), (np.float16, "fp16")):
-            xg = mx.array(x1.astype(dt))
-            Frg, Fig = mx.array(Fr.T.astype(dt)), mx.array(Fi.T.astype(dt))
-            lat, _ = mlx_run(lambda: (xg @ Frg) + (xg @ Fig))
-            yr = np.array(xg @ Frg, copy=False).ravel()
-            yi = np.array(xg @ Fig, copy=False).ravel()
-            err = (relerr(yr, ref_r) + relerr(yi, ref_i)) / 2
-            add_row(wl, "GPU", name, lat, gflops(flops, lat), err)
-
-    lat, _ = cpu_run(lambda: (Fr.astype(np.float32) @ x.astype(np.float32),
-                              Fi.astype(np.float32) @ x.astype(np.float32)))
-    yr = (Fr.astype(np.float32) @ x.astype(np.float32))
-    yi = (Fi.astype(np.float32) @ x.astype(np.float32))
-    err = (relerr(yr, ref_r) + relerr(yi, ref_i)) / 2
-    add_row(wl, "CPU", "fp32", lat, gflops(flops, lat), err)
-
-
-def w_stencil(H, W, steps):
-    """2D 5-point Laplacian stencil step, expressed as a 3x3 conv (the natural
-    ANE form). u_{t+1} = u_t + dt * laplacian(u_t), `steps` chained."""
-    wl = f"stencil 5pt ({H}x{W}, steps={steps})"
-    print(f"\n=== {wl} ===", flush=True)
-    rng = np.random.default_rng(3)
-    u0 = rng.standard_normal((1, 1, H, W)).astype(np.float32)
-    dt = 0.1
-    lap = np.array([[0, 1, 0], [1, -4, 1], [0, 1, 0]], dtype=np.float32)
-    K = np.zeros((1, 1, 3, 3), dtype=np.float32)
-    K[0, 0] = dt * lap
-    K[0, 0, 1, 1] += 1.0                  # identity + dt*lap fused into one 3x3
-    flops = steps * 2 * 1 * 1 * 9 * H * W
-    note(wl, f"{flops/1e9:.4f} GFLOP. Heat-eqn step as identity+dt*Laplacian 3x3 conv; "
-             f"ref = fp64 numpy. Smooth/diffusive => fp16-friendly.")
-
-    def np_step(u):
-        u = u.astype(np.float64)
-        for _ in range(steps):
-            u = _np_conv2d(u.astype(np.float32), K, 1).astype(np.float64)
-        return u
-    ref = np_step(u0)
-
-    if HAVE_ANE:
-        try:
-            xin = af.input((1, 1, H, W))
-            h = xin
-            for _ in range(steps):
-                h = af.conv(h, K.astype(np.float16), stride=1, pad=1)
-            net = af.compile(h)
-            uf = u0.astype(np.float16)
-            lat, out = min_latency_with_out(lambda: net(uf))
-            add_row(wl, "ANE", "fp16", lat, gflops(flops, lat), relerr(out, ref))
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-    if HAVE_MLX:
-        for d, name in ((np.float32, "fp32"), (np.float16, "fp16")):
-            xg = mx.array(np.transpose(u0, (0, 2, 3, 1)).astype(d))
-            Kg = mx.array(np.transpose(K, (0, 2, 3, 1)).astype(d))
-            def run():
-                h = xg
-                for _ in range(steps):
-                    h = mx.conv2d(h, Kg, stride=1, padding=1)
-                return h
-            lat, out = mlx_run(run)
-            outn = np.transpose(np.array(out, copy=False), (0, 3, 1, 2))
-            add_row(wl, "GPU", name, lat, gflops(flops, lat), relerr(outn, ref))
-
-    lat, _ = cpu_run(lambda: np_step(u0), reps=5)
-    add_row(wl, "CPU", "fp32", lat, gflops(flops, lat), relerr(np_step(u0), ref))
-
-
-def w_nbody(Np):
-    """N-body pairwise step: for N particles in 3D, compute pairwise displacement
-    norms (the O(N^2) cost core). Expressed as Gram-matrix math:
-    D2[i,j] = |p_i|^2 + |p_j|^2 - 2 p_i.p_j  -> the 2 p p^T term is the GEMM."""
-    wl = f"N-body pairwise (N={Np})"
-    print(f"\n=== {wl} ===", flush=True)
-    rng = np.random.default_rng(4)
-    P = rng.standard_normal((Np, 3)).astype(np.float64)
-    G = P @ P.T                                   # [N,N] Gram = the GEMM core
-    sq = np.sum(P * P, axis=1)
-    ref = sq[:, None] + sq[None, :] - 2 * G       # squared distances
-    flops = 2 * Np * Np * 3
-    note(wl, f"{flops/1e9:.4f} GFLOP (Gram core). Pairwise sq-distance via P@P^T; "
-             f"ref = fp64. Small inner dim (3) => mostly dispatch/bandwidth-bound.")
-
-    P32 = P.astype(np.float32)
-    if HAVE_ANE:
-        try:
-            # P @ P^T : linear wants W=[out,in]=[N,3] => W=P (so x@P.T = P@P.T)
-            xin = af.input((Np, 3))
-            net = af.compile(xin.linear(P32.astype(np.float16)))
-            pf = P32.astype(np.float16)
-            lat, out = min_latency_with_out(lambda: net(pf))
-            sqf = np.sum(P32 * P32, axis=1)
-            d2 = sqf[:, None] + sqf[None, :] - 2 * out.astype(np.float64)
-            add_row(wl, "ANE", "fp16", lat, gflops(flops, lat), relerr(d2, ref))
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-    if HAVE_MLX:
-        for d, name in ((np.float32, "fp32"), (np.float16, "fp16")):
-            Pg = mx.array(P32.astype(d))
-            lat, out = mlx_run(lambda: Pg @ Pg.T)
-            G2 = np.array(out, copy=False).astype(np.float64)
-            sqf = np.sum(P32 * P32, axis=1)
-            d2 = sqf[:, None] + sqf[None, :] - 2 * G2
-            add_row(wl, "GPU", name, lat, gflops(flops, lat), relerr(d2, ref))
-
-    lat, _ = cpu_run(lambda: P32 @ P32.T)
-    G2 = (P32 @ P32.T).astype(np.float64)
-    sqf = np.sum(P32 * P32, axis=1)
-    d2 = sqf[:, None] + sqf[None, :] - 2 * G2
-    add_row(wl, "CPU", "fp32", lat, gflops(flops, lat), relerr(d2, ref))
-
-
-def w_vit_attention(SEQ=197, DIM=768, HEADS=12):
-    """One ViT self-attention block (qkv proj -> MHA -> out proj), vit_demo shape.
-    Random weights; ANE uses af.mha (decomposed softmax SDPA, fused e5rt)."""
-    wl = f"ViT attention block (S={SEQ},D={DIM},H={HEADS})"
-    print(f"\n=== {wl} ===", flush=True)
-    rng = np.random.default_rng(5)
-    dh = DIM // HEADS
-    sc = 1.0 / np.sqrt(DIM)
-    def mkw(o, i): return (rng.standard_normal((o, i)).astype(np.float32) * sc)
-    def mkb(o): return (rng.standard_normal(o).astype(np.float32) * 0.01)
-    Wq, Wk, Wv, Wo = mkw(DIM, DIM), mkw(DIM, DIM), mkw(DIM, DIM), mkw(DIM, DIM)
-    bq, bk, bv, bo = mkb(DIM), mkb(DIM), mkb(DIM), mkb(DIM)
-    x = rng.standard_normal((SEQ, DIM)).astype(np.float32)
-
-    # fp64 reference
-    def ref_attn(xx, dt):
-        xx = xx.astype(dt)
-        def lin(a, W, b): return a @ W.astype(dt).T + b.astype(dt)
-        q = lin(xx, Wq, bq).reshape(SEQ, HEADS, dh).transpose(1, 0, 2)
-        k = lin(xx, Wk, bk).reshape(SEQ, HEADS, dh).transpose(1, 0, 2)
-        v = lin(xx, Wv, bv).reshape(SEQ, HEADS, dh).transpose(1, 0, 2)
-        s = (q @ k.transpose(0, 2, 1)) * (1.0 / np.sqrt(dh))
-        s = s - s.max(-1, keepdims=True)
-        a = np.exp(s); a = a / a.sum(-1, keepdims=True)
-        o = (a @ v).transpose(1, 0, 2).reshape(SEQ, DIM)
-        return lin(o, Wo, bo)
-    ref = ref_attn(x, np.float64)
-    flops = 4 * 2 * SEQ * DIM * DIM + 2 * 2 * HEADS * SEQ * SEQ * dh
-    note(wl, f"{flops/1e9:.3f} GFLOP. 4 proj GEMMs + attention scores/context. "
-             f"ref = fp64. softmax is fp16-stable (wide accum).")
-
-    if HAVE_ANE:
-        try:
-            xin = af.input((SEQ, DIM))
-            y = af.mha(xin, Wq.astype(np.float16), bq, Wk.astype(np.float16), bk,
-                       Wv.astype(np.float16), bv, Wo.astype(np.float16), bo, HEADS)
-            net = af.compile(y)
-            xf = x.astype(np.float16)
-            lat, out = min_latency_with_out(lambda: net(xf))
-            add_row(wl, "ANE", "fp16", lat, None, relerr(out, ref))
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-    if HAVE_MLX:
-        for d, name in ((np.float32, "fp32"), (np.float16, "fp16")):
-            xg = mx.array(x.astype(d))
-            Wqg, Wkg, Wvg, Wog = (mx.array(w.T.astype(d)) for w in (Wq, Wk, Wv, Wo))
-            bqg, bkg, bvg, bog = (mx.array(b.astype(d)) for b in (bq, bk, bv, bo))
-            def run():
-                q = (xg @ Wqg + bqg).reshape(SEQ, HEADS, dh).transpose(1, 0, 2)
-                k = (xg @ Wkg + bkg).reshape(SEQ, HEADS, dh).transpose(1, 0, 2)
-                v = (xg @ Wvg + bvg).reshape(SEQ, HEADS, dh).transpose(1, 0, 2)
-                s = (q @ k.transpose(0, 2, 1)) * (1.0 / np.sqrt(dh))
-                a = mx.softmax(s, axis=-1)
-                o = (a @ v).transpose(1, 0, 2).reshape(SEQ, DIM)
-                return o @ Wog + bog
-            lat, out = mlx_run(run)
-            add_row(wl, "GPU", name, lat, None, relerr(np.array(out, copy=False), ref))
-
-    lat, _ = cpu_run(lambda: ref_attn(x, np.float32), reps=10)
-    add_row(wl, "CPU", "fp32", lat, None, relerr(ref_attn(x, np.float32), ref))
-
-
-def w_resnet18():
-    """ResNet-18 ImageNet forward (af.load_resnet18). ANE vs torch-CPU/MPS."""
-    wl = "ResNet-18 forward (1x3x224x224)"
-    print(f"\n=== {wl} ===", flush=True)
-    if not HAVE_TV:
-        note(wl, "skipped - torchvision unavailable.")
-        return
-    rng = np.random.default_rng(6)
-    img = rng.standard_normal((1, 3, 224, 224)).astype(np.float32)
-
-    # torch CPU fp32 reference
-    import torch
-    tv = __import__("torchvision")
-    m = tv.models.resnet18(weights="IMAGENET1K_V1").eval()
-    with torch.no_grad():
-        ref = m(torch.from_numpy(img)).numpy()[0].astype(np.float64)
-    note(wl, "ref = torch-CPU fp32. ANE = aneforge fused conv graph (BN folded).")
-
-    lat_cpu, _ = cpu_run(lambda: _torch_fwd(m, img, "cpu"), reps=5)
-    add_row(wl, "CPU(torch)", "fp32", lat_cpu, None, 0.0)
-
-    if torch.backends.mps.is_available():
-        mm = m.to("mps")
-        lat, out = min_latency_with_out(lambda: _torch_fwd(mm, img, "mps"), reps=15, warmup=5)
-        add_row(wl, "GPU(MPS)", "fp32", lat, None, relerr(out, ref))
-
-    if HAVE_ANE:
-        try:
-            clf = af.load_resnet18()
-            lat, out = min_latency_with_out(lambda: clf(img), reps=15, warmup=5)
-            add_row(wl, "ANE", "fp16", lat, None, relerr(out, ref))
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
-
-
 def _torch_fwd(model, img, dev):
     import torch
     with torch.no_grad():
@@ -539,43 +128,6 @@ def _torch_fwd(model, img, dev):
         if dev == "mps":
             torch.mps.synchronize()
         return o.detach().to("cpu").numpy()[0]
-
-
-def w_minilm():
-    """MiniLM sentence encoder (af.load). ANE fused encoder vs torch-CPU/MPS."""
-    wl = "MiniLM encoder (1 sentence)"
-    print(f"\n=== {wl} ===", flush=True)
-    if not HAVE_HF:
-        note(wl, "skipped - transformers unavailable.")
-        return
-    NAME = "sentence-transformers/all-MiniLM-L6-v2"
-    text = "The Apple Neural Engine is a specialized accelerator for matrix math."
-    note(wl, "ref = HF torch-CPU fp32 (mean-pooled, L2-normed). ANE = af.load.")
-    try:
-        from transformers import AutoModel, AutoTokenizer
-        import torch
-        tok = AutoTokenizer.from_pretrained(NAME)
-        hf = AutoModel.from_pretrained(NAME).eval()
-        ids = tok(text, return_tensors="pt")
-        with torch.no_grad():
-            hs = hf(**ids).last_hidden_state[0].numpy()
-        ref = hs.mean(0)
-        ref = (ref / np.linalg.norm(ref)).astype(np.float64)
-        lat_cpu, _ = cpu_run(lambda: _hf_embed(hf, ids), reps=5)
-        add_row(wl, "CPU(torch)", "fp32", lat_cpu, None, 0.0)
-    except Exception as e:
-        print(f"  CPU ref: {type(e).__name__}: {e}")
-        return
-
-    if HAVE_ANE:
-        try:
-            enc = af.load(NAME)
-            enc(text)  # warm/compile
-            lat, _ = min_latency_with_out(lambda: enc(text), reps=15, warmup=3)
-            out = enc(text)[0].astype(np.float64)
-            add_row(wl, "ANE", "fp16", lat, None, relerr(out, ref))
-        except Exception as e:
-            print(f"  ANE: {type(e).__name__}: {e}")
 
 
 def _hf_embed(hf, ids):

--- a/bench/encoder_serving_crosspath.py
+++ b/bench/encoder_serving_crosspath.py
@@ -14,6 +14,8 @@ import numpy as np
 import aneforge as af
 import mlx.core as mx
 
+from _mil import mil_encoding_tally as _lut_tally
+
 # config
 D, H, DFF, S = 768, 12, 3072, 128
 DH = D // H
@@ -81,19 +83,6 @@ def build_ane(w, B):
     ff = yn.linear(w["Wi"], w["bi"]).gelu().linear(w["Wd"], w["bd"])
     out = (h1 + ff).reshape(B, S, D)
     return out
-
-
-def _lut_tally(build_dir):
-    """Count the weight encodings the emitter chose, summed across model.mil files."""
-    counts = {"int4_lut": 0, "sparse": 0, "int8": 0, "fp16": 0}
-    for mil in Path(build_dir).rglob("model.mil"):
-        txt = mil.read_text()
-        counts["int4_lut"] += txt.count("constexpr_lut_to_dense")
-        counts["sparse"] += txt.count("constexpr_sparse_to_dense")
-        counts["int8"] += txt.count("constexpr_affine_dequantize")
-        counts["fp16"] += sum(1 for ln in txt.splitlines()
-                              if "= const()" in ln and "BLOBFILE" in ln)
-    return counts
 
 
 def run_ane(w, B, x, label, compress, atol):

--- a/bench/model_int4_bench.py
+++ b/bench/model_int4_bench.py
@@ -12,6 +12,8 @@ import numpy as np
 
 import aneforge as af
 
+from _mil import mil_encoding_tally as _encoding_tally
+
 SEED = 0
 WARMUP = 8
 REPS = 30
@@ -113,20 +115,6 @@ MODELS = {
 
 
 # bench harness
-def _encoding_tally(build_dir):
-    """Count weight encodings from the generated MIL (makes the int4 gate fallback visible), summed across model.mil files."""
-    counts = {"int4_lut": 0, "sparse": 0, "int8": 0, "fp16": 0}
-    for mil in Path(build_dir).rglob("model.mil"):
-        txt = mil.read_text()
-        counts["int4_lut"] += txt.count("constexpr_lut_to_dense")
-        counts["sparse"] += txt.count("constexpr_sparse_to_dense")
-        counts["int8"] += txt.count("constexpr_affine_dequantize")
-        # fp16 weight constants are BLOBFILE-backed const() ops
-        counts["fp16"] += sum(1 for ln in txt.splitlines()
-                              if "= const()" in ln and "BLOBFILE" in ln)
-    return counts
-
-
 def cosine(a, b):
     a, b = np.asarray(a, np.float64).ravel(), np.asarray(b, np.float64).ravel()
     return float(a @ b / (np.linalg.norm(a) * np.linalg.norm(b) + 1e-30))

--- a/tests/_corpus.py
+++ b/tests/_corpus.py
@@ -10,7 +10,7 @@ from typing import Callable
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # repo root -> import aneforge
-import aneforge as af  # noqa: E402
+import aneforge as af
 
 
 @dataclass
@@ -49,19 +49,25 @@ def run_case(case: Case, int8: bool = False) -> np.ndarray:
 
 
 def compare(out: np.ndarray, ref: np.ndarray, case: Case, int8: bool = False):
-  """Return (passed: bool, metric_str, tol_used) for one (out, ref) pair."""
+  """Return (passed: bool, metric_str, tol_used, relerr) for one (out, ref) pair.
+
+    ``relerr`` is the numeric relative error when a relerr metric applies, else None
+    (carried on the record so runners need not re-parse the metric string)."""
   out = np.asarray(out, np.float32)
   ref = np.asarray(ref, np.float32)
-  if out.shape != ref.shape: return False, f"shape {out.shape} != ref {ref.shape}", 0.0
+  if out.shape != ref.shape: return False, f"shape {out.shape} != ref {ref.shape}", 0.0, None
   if case.exact:
     ok = bool(np.array_equal(out, ref))
-    return ok, f"exact={ok}", 0.0
+    return ok, f"exact={ok}", 0.0, None
   if case.abserr is not None:
     err = float(np.abs(out - ref).max())
-    return err < case.abserr, f"abserr {err:.5g}", case.abserr
+    return err < case.abserr, f"abserr {err:.5g}", case.abserr, None
   tol = case.int8_tol if int8 else case.tol
   relerr = float(np.abs(out - ref).max() / (np.abs(ref).max() + 1e-6))
-  return relerr < tol, f"relerr {relerr:.5g}", tol
+  metric = f"relerr {relerr:.5g}"
+  # Carry the *printed-precision* value so runners that aggregate it match the old
+  # behaviour of re-parsing ``float(metric.split()[1])`` exactly.
+  return relerr < tol, metric, tol, float(metric.split()[1])
 
 
 def eval_case(case: Case):
@@ -73,13 +79,13 @@ def eval_case(case: Case):
   ref = None
   for variant, int8 in variants:
     rec = {"name": case.name, "category": case.category, "variant": variant,
-           "metric": "", "tol": 0.0, "err": ""}
+           "metric": "", "tol": 0.0, "err": "", "relerr": None}
     try:
       if ref is None:
         ref = case.ref_fn(*[np.asarray(a, np.float32) for a in case.inputs])
       out = run_case(case, int8=int8)
-      passed, metric, tol = compare(out, ref, case, int8=int8)
-      rec["metric"], rec["tol"] = metric, tol
+      passed, metric, tol, relerr = compare(out, ref, case, int8=int8)
+      rec["metric"], rec["tol"], rec["relerr"] = metric, tol, relerr
       if case.xfail:
         rec["status"] = "XPASS" if passed else "XFAIL"
         rec["err"] = case.xfail
@@ -95,30 +101,48 @@ def eval_case(case: Case):
   return results
 
 
-def run_corpus(cases, verbose: bool = True):
+def _default_header():
+  return f"{'case':36s} {'var':5s} {'status':6s}  detail"
+
+
+def _default_row(rec):
+  return f"{rec['name']:36s} {rec['variant']:5s} {rec['status']:6s}  {rec['metric']}"
+
+
+def run_corpus(cases, verbose: bool = True, *, columns=None, verdict=None,
+               sep_width: int = 78, annotate=None):
   """Run all cases, print a pass/fail table, return (results, exit_code).
 
     Gating rule: PASS and XFAIL are green; FAIL, ERROR, and XPASS are red.
     (XPASS = an xfail-marked case unexpectedly passed -> the marker is stale.)
+
+    Customisation hooks (used by the per-domain runners so they need not re-implement
+    the eval/count/gate skeleton):
+      columns   : (header_str, row_fn(rec)->str) overriding the printed table layout.
+      annotate  : annotate(case, rec) called per record before it is printed, to stamp
+                  extra fields (e.g. cost/feasibility tags) onto the record.
+      verdict   : verdict(all_results, relerrs) printed after the summary stats and
+                  before the GATE line (a domain-specific findings block).
+      sep_width : width of the '-'/'=' separator rules.
     """
+  header_fn, row_fn = columns or (_default_header, _default_row)
   all_results = []
   relerrs = []
   if verbose:
-    print(f"{'case':36s} {'var':5s} {'status':6s}  detail")
-    print("-" * 78)
+    print(header_fn())
+    print("-" * sep_width)
   for case in cases:
     for rec in eval_case(case):
+      if annotate is not None: annotate(case, rec)
       all_results.append(rec)
-      tag = f"{rec['name']:36s} {rec['variant']:5s} {rec['status']:6s}  {rec['metric']}"
-      if rec["err"]: tag += f"  [{rec['err']}]"
+      line = row_fn(rec)
+      if rec["err"]: line += f"  [{rec['err']}]"
       if verbose:
-        print(tag)
+        print(line)
         if rec.get("traceback"):
           print("    " + rec["traceback"].replace("\n", "\n    "))
-      m = rec["metric"]
-      if m.startswith("relerr "):
-        try: relerrs.append(float(m.split()[1]))
-        except ValueError: pass
+      if rec.get("relerr") is not None:
+        relerrs.append(rec["relerr"])
 
   n_pass = sum(r["status"] == "PASS" for r in all_results)
   n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
@@ -128,12 +152,14 @@ def run_corpus(cases, verbose: bool = True):
   total = len(all_results)
   red = n_fail + n_err + n_xpass
 
-  print("\n" + "=" * 78)
+  print("\n" + "=" * sep_width)
   print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
         f"FAIL {n_fail}   ERROR {n_err}   XPASS {n_xpass}")
   if relerrs:
     print(f"relerr across {len(relerrs)} numeric variants: "
           f"min {min(relerrs):.2e}  median {np.median(relerrs):.2e}  max {max(relerrs):.2e}")
+  if verdict is not None:
+    verdict(all_results, relerrs)
   print(f"GATE: {'GREEN' if red == 0 else 'RED'}  "
         f"({n_pass + n_xfail}/{total} green, {red} red)")
   return all_results, (0 if red == 0 else 1)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,0 +1,48 @@
+"""Shared test helpers (plain importable module, NOT a test file).
+
+  Consolidates fixtures that had drifted across the suite: the fp16 random-input
+  factory, the one-hot static-index column selector, and the ANE-availability skip
+  marker. Importing this module has no side effects beyond importing numpy/pytest.
+  """
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import aneforge as af
+
+
+def f16(rng, *shape, scale=1.0, pos=False):
+  """Random fp16 tensor of the given shape, drawn from ``rng`` (a numpy Generator).
+
+    Superset of the per-file variants: ``scale`` multiplies a standard normal; when
+    ``pos`` is set the values are made strictly positive via ``abs(.) + 0.5`` (the
+    behaviour of the files that took a ``pos`` flag).
+    """
+  a = rng.standard_normal(shape).astype(np.float32) * scale
+  if pos:
+    a = np.abs(a) + 0.5
+  return a.astype(np.float16)
+
+
+def onehot_select(t: af.Tensor, i: int, w: int | None = None) -> af.Tensor:
+  """Select element ``i`` of a ``[1, W]`` tensor as a ``[1, 1]`` tensor via a matmul
+    against a folded one-hot column selector (a static-index trick that stays fused -
+    no dynamic_slice/gather, so it does not cut the graph)."""
+  W = w or t.shape[-1]
+  sel = np.zeros((W, 1), np.float16)
+  sel[i, 0] = 1.0
+  return t @ sel.astype(np.float16)
+
+
+def ane_available() -> bool:
+  """True iff the ANE/e5rt dispatch dylib can be located (device tests can run)."""
+  try:
+    from aneforge._runtime import _find_dylib
+    _find_dylib()
+    return True
+  except Exception:
+    return False
+
+
+requires_ane = pytest.mark.skipif(not ane_available(), reason="ANE/e5rt dylib unavailable")

--- a/tests/run_corpus.py
+++ b/tests/run_corpus.py
@@ -7,14 +7,14 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))          # tests/  -> _corpus
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))      # repo root -> aneforge
 
-import aneforge  # noqa: F401,E402  (importing the package sets KMP_DUPLICATE_LIB_OK before numpy loads)
+import aneforge  # noqa: F401  (importing the package sets KMP_DUPLICATE_LIB_OK before numpy loads)
 
-from _corpus import run_corpus, eval_case  # noqa: E402
-import test_nn_blocks  # noqa: E402
-import test_synthetic  # noqa: E402
-import test_corners  # noqa: E402
-import test_shapes  # noqa: E402
-import test_broad  # noqa: E402
+from _corpus import run_corpus, eval_case
+import test_nn_blocks
+import test_synthetic
+import test_corners
+import test_shapes
+import test_broad
 
 ALL_CASES = (test_nn_blocks.CASES + test_synthetic.CASES + test_corners.CASES
              + test_shapes.CASES + test_broad.CASES)

--- a/tests/test_blas.py
+++ b/tests/test_blas.py
@@ -3,13 +3,11 @@ from __future__ import annotations
 
 import numpy as np
 
-from _corpus import Case, eval_case  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16
 
 rng = np.random.default_rng(1234)
 
-
-def f16(*shape, scale=1.0):
-  return (rng.standard_normal(shape).astype(np.float32) * scale).astype(np.float16)
 
 def fp32(a): return np.asarray(a, np.float32)
 
@@ -18,7 +16,7 @@ def fp32(a): return np.asarray(a, np.float32)
 
 def _axpy(N, tag):
   alpha = 1.7
-  x = f16(1, N); y = f16(1, N)
+  x = f16(rng, 1, N); y = f16(rng, 1, N)
   def build(xt, yt): return (xt * alpha) + yt
   def ref(xa, ya): return alpha * xa + ya
   return Case(f"axpy_n{N}", tag, build, ref, [x, y], tol=0.01)
@@ -26,7 +24,7 @@ def _axpy(N, tag):
 
 def _scal(N, tag):
   alpha = 0.5
-  x = f16(1, N)
+  x = f16(rng, 1, N)
   def build(xt): return xt * alpha
   def ref(xa): return alpha * xa
   return Case(f"scal_n{N}", tag, build, ref, [x], tol=0.01)
@@ -34,21 +32,21 @@ def _scal(N, tag):
 
 def _dot(N, tag, tol, abserr=None):
   # cancellation-prone scalar output: small-N dots validate on abserr, not relerr.
-  x = f16(1, N, scale=0.5); y = f16(1, N, scale=0.5)
+  x = f16(rng, 1, N, scale=0.5); y = f16(rng, 1, N, scale=0.5)
   def build(xt, yt): return (xt * yt).sum(1)
   def ref(xa, ya): return (xa * ya).sum(1, keepdims=True)
   return Case(f"dot_n{N}", tag, build, ref, [x, y], tol=tol, abserr=abserr)
 
 
 def _asum(N, tag, tol):
-  x = f16(1, N)
+  x = f16(rng, 1, N)
   def build(xt): return xt.abs().sum(1)
   def ref(xa): return np.abs(xa).sum(1, keepdims=True)
   return Case(f"asum_n{N}", tag, build, ref, [x], tol=tol)
 
 
 def _nrm2(N, tag, tol):
-  x = f16(1, N, scale=0.3)
+  x = f16(rng, 1, N, scale=0.3)
   def build(xt): return (xt * xt).sum(1).sqrt()
   def ref(xa): return np.sqrt((xa * xa).sum(1, keepdims=True))
   return Case(f"nrm2_n{N}", tag, build, ref, [x], tol=tol)
@@ -56,7 +54,7 @@ def _nrm2(N, tag, tol):
 
 def _l2norm(N, tag, tol):
   # fused reduce_l2_norm: contains a reduction, so tagged reduction.
-  x = f16(1, N, scale=0.3)
+  x = f16(rng, 1, N, scale=0.3)
   def build(xt): return xt.l2_norm(1)
   def ref(xa): return xa / np.sqrt((xa * xa).sum(1, keepdims=True) + 1e-12)
   return Case(f"l2norm_n{N}", tag, build, ref, [x], tol=tol)
@@ -66,7 +64,7 @@ def _l2norm(N, tag, tol):
 
 def _gemv(M, K, tag):
   # y = A@x via x_row[1,K] @ A.T (numpy weight path stores W as W.T).
-  A = f16(M, K, scale=0.3); x = f16(1, K)
+  A = f16(rng, M, K, scale=0.3); x = f16(rng, 1, K)
   AT = A.T.astype(np.float16)
   def build(xt): return xt @ AT                      # [1,K] @ [K,M] -> [1,M]
   def ref(xa): return (fp32(A) @ fp32(xa).reshape(K)).reshape(1, M)
@@ -75,7 +73,7 @@ def _gemv(M, K, tag):
 
 def _ger(M, N, tag):
   # rank-1 outer product via broadcast multiply u[M,1] * v[1,N].
-  u = f16(M, 1, scale=0.5); v = f16(1, N, scale=0.5)
+  u = f16(rng, M, 1, scale=0.5); v = f16(rng, 1, N, scale=0.5)
   def build(ut, vt): return ut * vt
   def ref(ua, va): return ua * va
   return Case(f"ger_{M}x{N}", tag, build, ref, [u, v], tol=0.01)
@@ -83,9 +81,9 @@ def _ger(M, N, tag):
 
 def _symv(M, K, tag):
   # symmetric matrix-vector: same lowering as gemv, symmetry is in the data.
-  base = f16(M, K, scale=0.3)
+  base = f16(rng, M, K, scale=0.3)
   S = ((fp32(base) @ fp32(base).T) / K).astype(np.float16)  # [M,M] symmetric
-  x = f16(1, M)
+  x = f16(rng, 1, M)
   ST = S.T.astype(np.float16)  # == S, symmetric
   def build(xt): return xt @ ST                      # [1,M] @ [M,M] -> [1,M]
   def ref(xa): return (fp32(S) @ fp32(xa).reshape(M)).reshape(1, M)
@@ -97,7 +95,7 @@ def _symv(M, K, tag):
 def _gemm(M, K, N, tag, tol, int8_ok=False):
   # C = A @ B (activation A times streamed weight B).
   scale = 1.0 / max(1.0, K ** 0.5)        # keep products O(1) so fp16 is well-conditioned
-  A = f16(M, K, scale=1.0); B = f16(K, N, scale=scale)
+  A = f16(rng, M, K, scale=1.0); B = f16(rng, K, N, scale=scale)
   def build(at): return at @ B
   def ref(aa): return fp32(aa) @ fp32(B)
   return Case(f"gemm_{M}x{K}x{N}", tag, build, ref, [A], tol=tol, int8_ok=int8_ok)
@@ -106,7 +104,7 @@ def _gemm(M, K, N, tag, tol, int8_ok=False):
 def _gemm_aa(M, K, N, tag, tol):
   # activation x activation GEMM (bmm path).
   scale = 1.0 / max(1.0, K ** 0.5)
-  A = f16(M, K, scale=1.0); B = f16(K, N, scale=scale)
+  A = f16(rng, M, K, scale=1.0); B = f16(rng, K, N, scale=scale)
   def build(at, bt): return at @ bt
   def ref(aa, ba): return fp32(aa) @ fp32(ba)
   return Case(f"gemm_aa_{M}x{K}x{N}", tag, build, ref, [A, B], tol=tol)
@@ -115,7 +113,7 @@ def _gemm_aa(M, K, N, tag, tol):
 def _syrk(M, K, tag, tol):
   # C = A @ A^T (Gram matrix) via transpose + bmm.
   scale = 1.0 / max(1.0, K ** 0.5)
-  A = f16(M, K, scale=1.0) * np.float16(scale)
+  A = f16(rng, M, K, scale=1.0) * np.float16(scale)
   def build(at): return at @ at.transpose([1, 0])    # [M,K] @ [K,M] -> [M,M]
   def ref(aa): return fp32(aa) @ fp32(aa).T
   return Case(f"syrk_{M}x{K}", tag, build, ref, [A], tol=tol)
@@ -162,66 +160,40 @@ CASES = [
 ]
 
 
-# runner - mirrors _corpus.run_corpus plus cost-character summaries
+# runner - _corpus.run_corpus with a tag column plus cost-character summaries
+
+def _header():
+  return f"{'case':28s} {'tag':10s} {'var':5s} {'status':6s}  detail"
+
+
+def _row(rec):
+  return (f"{rec['name']:28s} {rec['category']:10s} {rec['variant']:5s} "
+          f"{rec['status']:6s}  {rec['metric']}")
+
 
 def run_blas(cases, verbose: bool = True):
-  all_results = []
-  relerrs = []
-  by_tag: dict[str, list[float]] = {}
-  if verbose:
-    print(f"{'case':28s} {'tag':10s} {'var':5s} {'status':6s}  detail")
-    print("-" * 84)
-  for case in cases:
-    for rec in eval_case(case):
-      all_results.append(rec)
-      line = (f"{rec['name']:28s} {rec['category']:10s} {rec['variant']:5s} "
-              f"{rec['status']:6s}  {rec['metric']}")
-      if rec["err"]: line += f"  [{rec['err']}]"
-      if verbose:
-        print(line)
-        if rec.get("traceback"):
-          print("    " + rec["traceback"].replace("\n", "\n    "))
-      m = rec["metric"]
-      if m.startswith("relerr "):
-        try:
-          e = float(m.split()[1])
-          relerrs.append(e)
-          by_tag.setdefault(rec["category"], []).append(e)
-        except ValueError:
-          pass
+  def verdict(all_results, relerrs):
+    by_tag: dict[str, list[float]] = {}
+    for r in all_results:
+      if r.get("relerr") is not None:
+        by_tag.setdefault(r["category"], []).append(r["relerr"])
+    print("\ncost-character distribution (relerr ranges per tag):")
+    print(f"  {'tag':10s} {'cases':5s}  {'min':>9s} {'median':>9s} {'max':>9s}")
+    # count cases (not variants) per tag, including non-numeric (exception) ones
+    tag_case_count: dict[str, int] = {}
+    for c in cases:
+      tag_case_count[c.category] = tag_case_count.get(c.category, 0) + 1
+    for tag in sorted(tag_case_count):
+      es = by_tag.get(tag, [])
+      if es:
+        print(f"  {tag:10s} {tag_case_count[tag]:5d}  {min(es):9.2e} "
+              f"{np.median(es):9.2e} {max(es):9.2e}")
+      else:
+        print(f"  {tag:10s} {tag_case_count[tag]:5d}  {'(no numeric variants)':>29s}")
+    print()  # blank line before the GATE line (was the leading \n of the gate print)
 
-  n_pass = sum(r["status"] == "PASS" for r in all_results)
-  n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
-  n_fail = sum(r["status"] == "FAIL" for r in all_results)
-  n_err = sum(r["status"] == "ERROR" for r in all_results)
-  n_xpass = sum(r["status"] == "XPASS" for r in all_results)
-  total = len(all_results)
-  red = n_fail + n_err + n_xpass
-
-  print("\n" + "=" * 84)
-  print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
-        f"FAIL {n_fail}   ERROR {n_err}   XPASS {n_xpass}")
-  if relerrs:
-    print(f"relerr across {len(relerrs)} numeric variants: "
-          f"min {min(relerrs):.2e}  median {np.median(relerrs):.2e}  max {max(relerrs):.2e}")
-
-  print("\ncost-character distribution (relerr ranges per tag):")
-  print(f"  {'tag':10s} {'cases':5s}  {'min':>9s} {'median':>9s} {'max':>9s}")
-  # count cases (not variants) per tag, including non-numeric (exception) ones
-  tag_case_count: dict[str, int] = {}
-  for c in cases:
-    tag_case_count[c.category] = tag_case_count.get(c.category, 0) + 1
-  for tag in sorted(tag_case_count):
-    es = by_tag.get(tag, [])
-    if es:
-      print(f"  {tag:10s} {tag_case_count[tag]:5d}  {min(es):9.2e} "
-            f"{np.median(es):9.2e} {max(es):9.2e}")
-    else:
-      print(f"  {tag:10s} {tag_case_count[tag]:5d}  {'(no numeric variants)':>29s}")
-
-  print(f"\nGATE: {'GREEN' if red == 0 else 'RED'}  "
-        f"({n_pass + n_xfail}/{total} green, {red} red)")
-  return all_results, (0 if red == 0 else 1)
+  return run_corpus(cases, verbose, columns=(_header, _row), verdict=verdict,
+                    sep_width=84)
 
 
 if __name__ == "__main__":

--- a/tests/test_broad.py
+++ b/tests/test_broad.py
@@ -5,9 +5,11 @@ import numpy as np
 
 import aneforge as af
 from _corpus import Case
-from test_shapes import f16, np_conv, np_group_norm, np_softmax
-
-rng = np.random.default_rng(11)
+from _helpers import f16
+# Reuse test_shapes' generator so the drawn random inputs (and goldens) stay byte-identical
+# to before, when f16 was imported from test_shapes and closed over test_shapes.rng (seed 7).
+# (test_broad's own seed-11 rng was never used - f16 always drew from test_shapes.rng.)
+from test_shapes import np_conv, np_group_norm, np_softmax, rng
 
 
 def _lin(z, W, b):
@@ -19,11 +21,11 @@ def _lin(z, W, b):
 # ---- multi-head attention block at scale -------------------------------------
 def _mha_case(S, D, H):
   dh = D // H
-  Wq, bq = f16(D, D, scale=1/np.sqrt(D)), f16(D, scale=0.1)
-  Wk, bk = f16(D, D, scale=1/np.sqrt(D)), f16(D, scale=0.1)
-  Wv, bv = f16(D, D, scale=1/np.sqrt(D)), f16(D, scale=0.1)
-  Wo, bo = f16(D, D, scale=1/np.sqrt(D)), f16(D, scale=0.1)
-  x = f16(S, D, scale=1.0)
+  Wq, bq = f16(rng, D, D, scale=1/np.sqrt(D)), f16(rng, D, scale=0.1)
+  Wk, bk = f16(rng, D, D, scale=1/np.sqrt(D)), f16(rng, D, scale=0.1)
+  Wv, bv = f16(rng, D, D, scale=1/np.sqrt(D)), f16(rng, D, scale=0.1)
+  Wo, bo = f16(rng, D, D, scale=1/np.sqrt(D)), f16(rng, D, scale=0.1)
+  x = f16(rng, S, D, scale=1.0)
 
   def build(xt):
     return af.mha(xt, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads=H)
@@ -40,9 +42,9 @@ def _mha_case(S, D, H):
 
 # ---- MLP / FFN at large width (batch via leading dim) ------------------------
 def _mlp_case(N, Din, Dff, Dout):
-  W1, b1 = f16(Dff, Din, scale=1/np.sqrt(Din)), f16(Dff, scale=0.1)
-  W2, b2 = f16(Dout, Dff, scale=1/np.sqrt(Dff)), f16(Dout, scale=0.1)
-  x = f16(N, Din, scale=1.0)
+  W1, b1 = f16(rng, Dff, Din, scale=1/np.sqrt(Din)), f16(rng, Dff, scale=0.1)
+  W2, b2 = f16(rng, Dout, Dff, scale=1/np.sqrt(Dff)), f16(rng, Dout, scale=0.1)
+  x = f16(rng, N, Din, scale=1.0)
 
   def build(xt):
     return xt.linear(W1, b1).gelu().linear(W2, b2)
@@ -58,10 +60,10 @@ def _mlp_case(N, Din, Dff, Dout):
 
 # ---- conv -> group_norm -> relu -> conv residual (UNet-like) at scale --------
 def _conv_block_case(C, HW):
-  g = f16(C, pos=True); b = f16(C, scale=0.1)
-  W1 = f16(C, C, 3, 3, scale=1/np.sqrt(C*9))
-  W2 = f16(C, C, 3, 3, scale=1/np.sqrt(C*9))
-  x = f16(1, C, HW, HW, scale=1.0)
+  g = f16(rng, C, pos=True); b = f16(rng, C, scale=0.1)
+  W1 = f16(rng, C, C, 3, 3, scale=1/np.sqrt(C*9))
+  W2 = f16(rng, C, C, 3, 3, scale=1/np.sqrt(C*9))
+  x = f16(rng, 1, C, HW, HW, scale=1.0)
 
   def build(xt):
     h = af.conv(xt, W1, pad=1)
@@ -79,7 +81,7 @@ def _conv_block_case(C, HW):
 
 # ---- batched matmul at scale -------------------------------------------------
 def _bmm_case(B, M, K, N):
-  a = f16(B, M, K, scale=1.0); b = f16(B, K, N, scale=1/np.sqrt(K))
+  a = f16(rng, B, M, K, scale=1.0); b = f16(rng, B, K, N, scale=1/np.sqrt(K))
 
   def build(at, bt):
     return at @ bt
@@ -92,8 +94,8 @@ def _bmm_case(B, M, K, N):
 
 # ---- wide deep fused chain (fusion at scale) ---------------------------------
 def _deep_chain_case(D, depth):
-  Ws = [f16(D, D, scale=1/np.sqrt(D)) for _ in range(depth)]
-  x = f16(8, D, scale=1.0)
+  Ws = [f16(rng, D, D, scale=1/np.sqrt(D)) for _ in range(depth)]
+  x = f16(rng, 8, D, scale=1.0)
 
   def build(xt):
     h = xt
@@ -116,7 +118,7 @@ def _deep_chain_case(D, depth):
 
 # ---- composition ops: native op arch-gated, function reachable by decomposition --
 def _cumsum_case(M, N):
-  x = f16(M, N, scale=1.0)
+  x = f16(rng, M, N, scale=1.0)
   return Case(f"cumsum_{M}x{N}", "broad",
               lambda xt: xt.cumsum(),
               lambda xa: np.cumsum(xa.astype(np.float32), axis=-1),
@@ -124,7 +126,7 @@ def _cumsum_case(M, N):
 
 
 def _gather_case(M, N, idx, axis):
-  x = f16(M, N, scale=1.0)
+  x = f16(rng, M, N, scale=1.0)
   return Case(f"gather_ax{axis}_{M}x{N}", "broad",
               lambda xt: af.gather(xt, idx, axis=axis),
               lambda xa: np.take(xa.astype(np.float32), idx, axis=axis),

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -1,5 +1,5 @@
 import numpy as np
-import pytest
+from _helpers import requires_ane
 from aneforge import _blob
 
 
@@ -106,16 +106,6 @@ def test_weight_int4_used_when_accurate():
 
 
 # Task 4 - on-device tests: int4-LUT runs on the ANE + weights.bin is smaller
-def _ane_available():
-  try:
-    from aneforge._runtime import _find_dylib
-    _find_dylib()
-    return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane_available(), reason="ANE/e5rt dylib unavailable")
 
 
 @requires_ane

--- a/tests/test_conv_int8.py
+++ b/tests/test_conv_int8.py
@@ -2,19 +2,12 @@
 from __future__ import annotations
 import numpy as np
 import pytest
+from _helpers import requires_ane
 import aneforge as af
 from aneforge import _compile as C
 from aneforge.graph import conv, input as ainput
 
 
-def _ane():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane(), reason="ANE/e5rt dylib unavailable")
 rng = np.random.default_rng(0)
 
 

--- a/tests/test_corners.py
+++ b/tests/test_corners.py
@@ -3,16 +3,11 @@ from __future__ import annotations
 
 import numpy as np
 
-from _corpus import Case, run_corpus  # noqa: E402
-import aneforge as af  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16
+import aneforge as af
 
 rng = np.random.default_rng(23)
-
-
-def f16(*shape, scale=1.0, pos=False):
-  a = rng.standard_normal(shape).astype(np.float32) * scale
-  if pos: a = np.abs(a) + 0.5
-  return a.astype(np.float16)
 
 
 def np_relu(x):
@@ -29,7 +24,7 @@ def np_softmax(x, axis=-1):
 # extreme-but-legal shapes
 def _tall_skinny():
   # [4096, 1]: huge leading axis, trailing axis == 1
-  x = f16(4096, 1)
+  x = f16(rng, 4096, 1)
 
   def build(xt):
     return (xt * 2.0).relu() + xt
@@ -43,8 +38,8 @@ def _tall_skinny():
 def _wide_vector_matmul():
   # contract a wide K dimension: [1, 4096] @ [4096, 8]
   K = 4096
-  x = f16(1, K, scale=0.05)
-  W = f16(K, 8, scale=0.02)
+  x = f16(rng, 1, K, scale=0.05)
+  W = f16(rng, K, 8, scale=0.02)
 
   def build(xt):
     return xt @ W
@@ -58,7 +53,7 @@ def _wide_vector_matmul():
 
 def _singleton_reduce():
   # reduce over an axis of size 1 (no-op reduction) mixed with a real one
-  x = f16(1, 1, 64)
+  x = f16(rng, 1, 1, 64)
 
   def build(xt):
     return xt.sum(0).mean(2)   # axis-0 size1, then real reduce over 64
@@ -72,8 +67,8 @@ def _singleton_reduce():
 def _big_channel_conv():
   # 1x1 conv with a large channel count (256->256)
   C = 256
-  W = f16(C, C, 1, 1, scale=0.03)
-  x = f16(1, C, 4, 4, scale=0.5)
+  W = f16(rng, C, C, 1, 1, scale=0.03)
+  x = f16(rng, 1, C, 4, 4, scale=0.5)
 
   def build(xt):
     return af.conv(xt, W).relu()
@@ -90,7 +85,7 @@ def _big_channel_conv():
 # very deep chain fused into one program
 def _deep_chain():
   # 32 ops fused into ONE program; sin/cos/tanh + *1.4 is magnitude-preserving (O(1)) so relerr stays meaningful
-  x = f16(4, 16, scale=1.0)
+  x = f16(rng, 4, 16, scale=1.0)
   n = 32
 
   def build(xt):
@@ -127,8 +122,8 @@ def _deep_chain():
 # mixed fused-MIL + netplist-bridge (graph cut -> SegmentedModel)
 def _conv_argmax_cut():
   # conv -> relu -> reduce -> argmax (netplist cut); exercises the SegmentedModel split
-  W = f16(4, 3, 3, 3, scale=0.2)
-  x = f16(1, 3, 8, 8)
+  W = f16(rng, 4, 3, 3, 3, scale=0.2)
+  x = f16(rng, 1, 3, 8, 8)
 
   def build(xt):
     h = af.conv(xt, W, pad=1).relu()     # [1,4,8,8]
@@ -165,9 +160,9 @@ def _sdpa_sandwich():
   # linear -> sdpa (native cut) -> linear; exercises a netplist cut in the MIDDLE of a fused graph
   H, S, Dh = 2, 6, 8
   D = H * Dh
-  Wi = f16(D, D, scale=0.2)
-  Wo = f16(D, D, scale=0.2)
-  x = f16(S, D, scale=0.5)
+  Wi = f16(rng, D, D, scale=0.2)
+  Wo = f16(rng, D, D, scale=0.2)
+  x = f16(rng, S, D, scale=0.5)
 
   def build(xt):
     h = xt.linear(Wi)                          # [S, D]
@@ -193,7 +188,7 @@ def _sdpa_sandwich():
 
 # multi-input graphs
 def _multi_input():
-  a = f16(4, 8); b = f16(4, 8); c = f16(8, 5, scale=0.3)
+  a = f16(rng, 4, 8); b = f16(rng, 4, 8); c = f16(rng, 8, 5, scale=0.3)
 
   def build(at, bt, ct):
     h = (at + bt).relu()
@@ -208,8 +203,8 @@ def _multi_input():
 
 def _multi_input_residual():
   # two image inputs combined, conv, with a third bias-vector input
-  x1 = f16(1, 3, 8, 8); x2 = f16(1, 3, 8, 8)
-  W = f16(6, 3, 3, 3, scale=0.2)
+  x1 = f16(rng, 1, 3, 8, 8); x2 = f16(rng, 1, 3, 8, 8)
+  W = f16(rng, 6, 3, 3, 3, scale=0.2)
 
   def build(t1, t2):
     h = af.maximum(t1, t2)
@@ -225,8 +220,8 @@ def _multi_input_residual():
 # same graph fp16 vs int8 (int8_ok cases below are run both ways)
 def _int8_linear_deep():
   D = 64
-  Ws = [f16(D, D, scale=0.12) for _ in range(3)]
-  x = f16(8, D, scale=0.5)
+  Ws = [f16(rng, D, D, scale=0.12) for _ in range(3)]
+  x = f16(rng, 8, D, scale=0.5)
 
   def build(xt):
     h = xt

--- a/tests/test_cross_chip_ops.py
+++ b/tests/test_cross_chip_ops.py
@@ -1,19 +1,10 @@
 """Cross-chip ops M1 can't run: catalog declares availability and aneforge guards them on M1."""
 from __future__ import annotations
 import pytest
+from _helpers import requires_ane
 import aneforge as af
 from aneforge import _op_catalog as oc
 import aneforge._targets as TG
-
-
-def _ane():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane(), reason="ANE/e5rt dylib unavailable")
 
 
 # --- (1) catalog correctly declares M1-can't / M5-can for the gated ops -----------------

--- a/tests/test_cross_compile_matrix.py
+++ b/tests/test_cross_compile_matrix.py
@@ -6,11 +6,11 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))      # tests/ -> import corpus
-import run_corpus  # noqa: E402
-from _corpus import _build_graph  # noqa: E402
+import run_corpus
+from _corpus import _build_graph
 
-from aneforge import _targets as T  # noqa: E402
-from aneforge._compile import _lower_fused_to_dir, cross_compile_check  # noqa: E402
+from aneforge import _targets as T
+from aneforge._compile import _lower_fused_to_dir, cross_compile_check
 
 ARCHS = [("h13", 2), ("h14", 3), ("h15", 4), ("h16s", 5)]
 

--- a/tests/test_decoder_block.py
+++ b/tests/test_decoder_block.py
@@ -3,18 +3,9 @@ from __future__ import annotations
 import math
 import numpy as np
 import pytest
+from _helpers import requires_ane
 from examples.llama_block_causal import build_causal_llama_block, numpy_reference
 import aneforge as af
-
-
-def _ane():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane(), reason="ANE/e5rt dylib unavailable")
 
 
 @requires_ane

--- a/tests/test_dynamic_conv.py
+++ b/tests/test_dynamic_conv.py
@@ -2,17 +2,10 @@
 from __future__ import annotations
 import numpy as np
 import pytest
+from _helpers import requires_ane
 import aneforge as af
 
 
-def _ane():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane(), reason="ANE/e5rt dylib unavailable")
 rng = np.random.default_rng(0)
 
 

--- a/tests/test_group_norm_tiling.py
+++ b/tests/test_group_norm_tiling.py
@@ -3,20 +3,9 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from _helpers import requires_ane
 
 import aneforge as af
-
-
-def _ane_available():
-  try:
-    from aneforge._runtime import _find_dylib
-    _find_dylib()
-    return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane_available(), reason="ANE/e5rt dylib unavailable")
 
 
 def _np_gn(x, gamma, beta, groups, eps=1e-5):

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -3,20 +3,11 @@ from __future__ import annotations
 
 import numpy as np
 import pytest
+from _helpers import requires_ane
 
 import aneforge as af
 
 
-def _ane_available():
-  try:
-    from aneforge._runtime import _find_dylib
-    _find_dylib()
-    return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane_available(), reason="ANE/e5rt dylib unavailable")
 rng = np.random.default_rng(0)
 
 

--- a/tests/test_new_ops.py
+++ b/tests/test_new_ops.py
@@ -2,18 +2,11 @@
 from __future__ import annotations
 import numpy as np
 import pytest
+from _helpers import requires_ane
 import aneforge as af
 from aneforge import autograd as agrad
 
 
-def _ane_available():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane_available(), reason="ANE/e5rt dylib unavailable")
 rng = np.random.default_rng(0)
 
 

--- a/tests/test_nn_blocks.py
+++ b/tests/test_nn_blocks.py
@@ -3,16 +3,11 @@ from __future__ import annotations
 
 import numpy as np
 
-from _corpus import Case, run_corpus  # noqa: E402
-import aneforge as af  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16
+import aneforge as af
 
 rng = np.random.default_rng(7)
-
-
-def f16(*shape, scale=1.0, pos=False):
-  a = rng.standard_normal(shape).astype(np.float32) * scale
-  if pos: a = np.abs(a) + 0.5
-  return a.astype(np.float16)
 
 
 # numpy reference primitives
@@ -116,9 +111,9 @@ def np_upsample_nn(x, scale):
 
 # cases
 def _conv_stack():
-  W1 = f16(8, 3, 3, 3, scale=0.2); b1 = f16(8, scale=0.1)
-  W2 = f16(16, 8, 3, 3, scale=0.2); b2 = f16(16, scale=0.1)
-  x = f16(1, 3, 16, 16)
+  W1 = f16(rng, 8, 3, 3, 3, scale=0.2); b1 = f16(rng, 8, scale=0.1)
+  W2 = f16(rng, 16, 8, 3, 3, scale=0.2); b2 = f16(rng, 16, scale=0.1)
+  x = f16(rng, 1, 3, 16, 16)
 
   def build(xt):
     h = af.conv(xt, W1, pad=1, bias=b1).relu()
@@ -134,10 +129,10 @@ def _conv_stack():
 
 
 def _cnn_classifier():
-  W1 = f16(8, 3, 3, 3, scale=0.2); b1 = f16(8, scale=0.1)
-  W2 = f16(16, 8, 3, 3, scale=0.2); b2 = f16(16, scale=0.1)
-  Wfc = f16(16, 10, scale=0.2)  # [in=16, out=10] for x @ W
-  x = f16(1, 3, 16, 16)
+  W1 = f16(rng, 8, 3, 3, 3, scale=0.2); b1 = f16(rng, 8, scale=0.1)
+  W2 = f16(rng, 16, 8, 3, 3, scale=0.2); b2 = f16(rng, 16, scale=0.1)
+  Wfc = f16(rng, 16, 10, scale=0.2)  # [in=16, out=10] for x @ W
+  x = f16(rng, 1, 3, 16, 16)
 
   def build(xt):
     h = af.conv(xt, W1, pad=1, bias=b1).relu()
@@ -156,15 +151,15 @@ def _cnn_classifier():
 
 def _transformer_encoder():
   S, D, H, Dff = 8, 16, 2, 32
-  Wq = f16(D, D, scale=0.2); bq = f16(D, scale=0.1)
-  Wk = f16(D, D, scale=0.2); bk = f16(D, scale=0.1)
-  Wv = f16(D, D, scale=0.2); bv = f16(D, scale=0.1)
-  Wo = f16(D, D, scale=0.2); bo = f16(D, scale=0.1)
-  g1 = f16(D, pos=True); b1 = f16(D, scale=0.1)
-  g2 = f16(D, pos=True); b2 = f16(D, scale=0.1)
-  Wg = f16(2 * Dff, D, scale=0.15); bg = f16(2 * Dff, scale=0.1)   # GEGLU
-  Wp = f16(D, Dff, scale=0.15); bp = f16(D, scale=0.1)             # FFN out
-  x = f16(S, D, scale=1.0)
+  Wq = f16(rng, D, D, scale=0.2); bq = f16(rng, D, scale=0.1)
+  Wk = f16(rng, D, D, scale=0.2); bk = f16(rng, D, scale=0.1)
+  Wv = f16(rng, D, D, scale=0.2); bv = f16(rng, D, scale=0.1)
+  Wo = f16(rng, D, D, scale=0.2); bo = f16(rng, D, scale=0.1)
+  g1 = f16(rng, D, pos=True); b1 = f16(rng, D, scale=0.1)
+  g2 = f16(rng, D, pos=True); b2 = f16(rng, D, scale=0.1)
+  Wg = f16(rng, 2 * Dff, D, scale=0.15); bg = f16(rng, 2 * Dff, scale=0.1)   # GEGLU
+  Wp = f16(rng, D, Dff, scale=0.15); bp = f16(rng, D, scale=0.1)             # FFN out
+  x = f16(rng, S, D, scale=1.0)
 
   def build(xt):
     h = xt.layer_norm(g1, b1)
@@ -200,9 +195,9 @@ def _transformer_encoder():
 
 def _rms_norm_block():
   D = 32
-  g = f16(D, pos=True)
-  Wp = f16(D, D, scale=0.2)
-  x = f16(6, D)
+  g = f16(rng, D, pos=True)
+  Wp = f16(rng, D, D, scale=0.2)
+  x = f16(rng, 6, D)
 
   def build(xt):
     return (xt.rms_norm(g) @ Wp).silu()
@@ -217,9 +212,9 @@ def _rms_norm_block():
 
 def _group_norm_block():
   C = 8
-  g = f16(C, pos=True); b = f16(C, scale=0.1)
-  W = f16(C, C, 3, 3, scale=0.2)
-  x = f16(1, C, 12, 12)
+  g = f16(rng, C, pos=True); b = f16(rng, C, scale=0.1)
+  W = f16(rng, C, C, 3, 3, scale=0.2)
+  x = f16(rng, 1, C, 12, 12)
 
   def build(xt):
     h = xt.group_norm(g, b, num_groups=4)
@@ -234,10 +229,10 @@ def _group_norm_block():
 
 def _batch_norm_block():
   C = 8
-  g = f16(C, pos=True); b = f16(C, scale=0.1)
-  m = f16(C, scale=0.5); v = f16(C, pos=True)
-  W = f16(16, C, 3, 3, scale=0.2)
-  x = f16(1, C, 12, 12)
+  g = f16(rng, C, pos=True); b = f16(rng, C, scale=0.1)
+  m = f16(rng, C, scale=0.5); v = f16(rng, C, pos=True)
+  W = f16(rng, 16, C, 3, 3, scale=0.2)
+  x = f16(rng, 1, C, 12, 12)
 
   def build(xt):
     h = af.batch_norm(xt, g, b, m, v, eps=1e-3)
@@ -252,8 +247,8 @@ def _batch_norm_block():
 
 def _upsample_conv_sr():
   Cin, Cout = 4, 3
-  W = f16(Cout, Cin, 3, 3, scale=0.2); b = f16(Cout, scale=0.1)
-  x = f16(1, Cin, 8, 8)
+  W = f16(rng, Cout, Cin, 3, 3, scale=0.2); b = f16(rng, Cout, scale=0.1)
+  x = f16(rng, 1, Cin, 8, 8)
 
   def build(xt):
     h = xt.upsample(scale=2)
@@ -270,8 +265,8 @@ def _pixel_shuffle_sr():
   # SR-style sub-pixel conv: conv to C*r*r channels, then pixel_shuffle.
   r = 2
   Cin, Cmid = 4, 3
-  W = f16(Cmid * r * r, Cin, 3, 3, scale=0.2); b = f16(Cmid * r * r, scale=0.1)
-  x = f16(1, Cin, 8, 8)
+  W = f16(rng, Cmid * r * r, Cin, 3, 3, scale=0.2); b = f16(rng, Cmid * r * r, scale=0.1)
+  x = f16(rng, 1, Cin, 8, 8)
 
   def build(xt):
     h = af.conv(xt, W, pad=1, bias=b)
@@ -288,8 +283,8 @@ def _pixel_shuffle_sr():
 
 def _conv_transpose_decoder():
   Cin, Cout = 4, 3
-  W = f16(Cin, Cout, 2, 2, scale=0.2)  # [Cin, Cout, kH, kW]
-  x = f16(1, Cin, 8, 8)
+  W = f16(rng, Cin, Cout, 2, 2, scale=0.2)  # [Cin, Cout, kH, kW]
+  x = f16(rng, 1, Cin, 8, 8)
 
   def build(xt):
     return af.conv_transpose(xt, W, stride=2).relu()
@@ -303,8 +298,8 @@ def _conv_transpose_decoder():
 # new primitives: norms / vision / einsum
 def _instance_norm_block():
   C = 8
-  g = f16(C, scale=0.5, pos=True); b = f16(C, scale=0.3)
-  x = f16(1, C, 8, 8)
+  g = f16(rng, C, scale=0.5, pos=True); b = f16(rng, C, scale=0.3)
+  x = f16(rng, 1, C, 8, 8)
 
   def build(xt):
     return af.instance_norm(xt, g, b).relu()
@@ -341,8 +336,8 @@ def _lrn_block():
 
 def _einsum_native_block():
   B, C, H, W1, W2 = 1, 4, 3, 6, 5
-  Wb = f16(B, W1, H, W2, scale=0.3)
-  x = f16(B, C, H, W1)
+  Wb = f16(rng, B, W1, H, W2, scale=0.3)
+  x = f16(rng, B, C, H, W1)
 
   def build(xt):
     return af.einsum_native("nchw,nwhu->nchu", xt, Wb).relu()
@@ -354,7 +349,7 @@ def _einsum_native_block():
 
 
 def _space_depth_roundtrip():
-  x = f16(1, 4, 8, 8)
+  x = f16(rng, 1, 4, 8, 8)
 
   def build(xt):
     h = af.space_to_depth(xt, 2)      # (1, 16, 4, 4)
@@ -368,7 +363,7 @@ def _space_depth_roundtrip():
 
 
 def _crop_resize_block():
-  x = f16(1, 3, 8, 8)
+  x = f16(rng, 1, 3, 8, 8)
 
   def build(xt):
     h = af.crop(xt, 1, 1, 1, 1)               # (1,3,6,6)
@@ -386,7 +381,7 @@ def _crop_resize_block():
 
 
 def _upsample_bilinear_block():
-  x = f16(1, 3, 4, 4)
+  x = f16(rng, 1, 3, 4, 4)
 
   def build(xt):
     return af.upsample_bilinear(xt, 2)        # half-pixel bilinear

--- a/tests/test_numerical.py
+++ b/tests/test_numerical.py
@@ -7,19 +7,17 @@ from pathlib import Path
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # tests/ -> import _corpus
-from _corpus import Case, eval_case  # noqa: E402
-import aneforge as af  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16, onehot_select as _col
+import aneforge as af
 
 try:
-  import scipy.linalg as sla  # noqa: E402
+  import scipy.linalg as sla
   HAVE_SCIPY = True
 except Exception:  # noqa: BLE001
   HAVE_SCIPY = False
 
 rng = np.random.default_rng(1234)
-
-
-def f16(*shape, scale=1.0): return (rng.standard_normal(shape).astype(np.float32) * scale).astype(np.float16)
 
 
 # tag side-table: name -> (cost_character, feasibility); printed by the runner
@@ -50,7 +48,7 @@ def _power_iteration():
   A = (rng.standard_normal((N, N)).astype(np.float32) * 0.25)
   A = (A + A.T)  # symmetric -> real dominant eigenvector, clean power iteration
   A = A.astype(np.float16)
-  x0 = f16(1, N)
+  x0 = f16(rng, 1, N)
 
   def build(xt):
     h = xt
@@ -93,7 +91,7 @@ def _cg_step():
   M = (rng.standard_normal((N, N)).astype(np.float32) * 0.2)
   A = (M @ M.T + N * np.eye(N)).astype(np.float32)   # SPD, well-conditioned
   Ah = A.astype(np.float16)
-  x = f16(1, N); r = f16(1, N); p = f16(1, N)
+  x = f16(rng, 1, N); r = f16(rng, 1, N); p = f16(rng, 1, N)
 
   def _dot(u, v):                                    # [1,N].[1,N] -> [1,1]
     return (u * v).sum(1)
@@ -163,14 +161,6 @@ def _horner():
                 "floor/fusion", "works")
 
 
-def _col(t: af.Tensor, i: int) -> af.Tensor:
-  """Select column i of a [1, W] tensor as a [1,1] tensor by matmul against a
-    one-hot column selector (a folded constant weight); stays fused, no graph cut."""
-  W = t.shape[1]
-  sel = np.zeros((W, 1), np.float16); sel[i, 0] = 1.0
-  return t @ sel.astype(np.float16)                   # [1,W] @ [W,1] -> [1,1]
-
-
 def _stencil_laplacian():
   """2D 5-point Laplacian (PDE diffusion step) as a fixed-kernel conv.
 
@@ -188,7 +178,7 @@ def _stencil_laplacian():
   K[0, 0] = dt * lap
   K[0, 0, 1, 1] += 1.0          # identity center -> u + dt*Lap(u)
   Kf = K.astype(np.float16)
-  u = f16(1, 1, 32, 32, scale=1.0)
+  u = f16(rng, 1, 1, 32, 32, scale=1.0)
 
   def build(ut): return af.conv(ut, Kf, pad=1)
 
@@ -219,7 +209,7 @@ def _nbody_normals():
     adding it would just chain an l2_norm in a *separate* e5rt segment; we keep the
     probe focused on the bridge numerics.
     """
-  e1 = f16(3); e2 = f16(3)
+  e1 = f16(rng, 3); e2 = f16(rng, 3)
 
   def build(a, b): return af.cross_product(a, b)
 
@@ -244,7 +234,7 @@ def _mc_reduction():
     error is fp16 *input* rounding of the 8192 samples. tol=0.03.
     """
   Nn = 8192
-  s = f16(1, Nn, scale=1.0)
+  s = f16(rng, 1, Nn, scale=1.0)
 
   def build(st):
     g = st.square()                 # g(x) = x^2
@@ -290,7 +280,7 @@ def _lrn_local():
     """
   C, H, W = 8, 4, 4
   alpha, beta, k = 1.0, 0.75, 1.0
-  x = f16(1, C, H, W, scale=1.0)
+  x = f16(rng, 1, C, H, W, scale=1.0)
 
   def build(xt): return af.lrn(xt, alpha=alpha, beta=beta, k=k)
 
@@ -321,7 +311,7 @@ def _gram_syrk():
     (wide accumulator keeps it tight).
     """
   M, K = 24, 16
-  X = f16(M, K, scale=0.3)
+  X = f16(rng, M, K, scale=0.3)
 
   def build(xt): return xt @ xt.transpose([1, 0])     # [M,K] @ [K,M] -> [M,M]
 
@@ -356,7 +346,7 @@ def _qr_givens_probe():
     passes, so it is recorded as WORKS-for-the-step. cost MIXED.
     """
   N = 8
-  A = f16(N, 2, scale=0.5)   # two columns a1, a2 as [N,2]
+  A = f16(rng, N, 2, scale=0.5)   # two columns a1, a2 as [N,2]
 
   def build(at):
     a1 = at.transpose([1, 0])              # [2,N]; take rows via one-hot selects
@@ -455,7 +445,7 @@ def _triangular_solve_probe():
   Lm = np.tril(rng.standard_normal((N, N)).astype(np.float32) * 0.3)
   Lm[np.diag_indices(N)] = np.abs(Lm[np.diag_indices(N)]) + 1.0   # strong diagonal
   Lflat = Lm.astype(np.float16).reshape(1, N * N)
-  b = f16(1, N)
+  b = f16(rng, 1, N)
 
   def lelem(t, i):
     sel = np.zeros((N * N, 1), np.float16); sel[i, 0] = 1.0
@@ -503,7 +493,7 @@ def _linear_solve_probe():
   A2 = (rng.standard_normal((2, 2)).astype(np.float32) * 0.5)
   A2 = (A2 + 2.0 * np.eye(2)).astype(np.float16)   # well-conditioned 2x2
   Aflat = A2.reshape(1, 4)
-  rhs = f16(1, 2)
+  rhs = f16(rng, 1, 2)
 
   def el(t, i, w):
     sel = np.zeros((w, 1), np.float16); sel[i, 0] = 1.0
@@ -548,6 +538,19 @@ LAPACK_PROBES = [
 CASES = KERNELS + LAPACK_PROBES
 
 
+def _header():
+  return f"{'case':32s} {'var':4s} {'status':6s} {'cost':18s} {'feasible':13s} detail"
+
+
+def _row(rec):
+  return (f"{rec['name']:32s} {rec['variant']:4s} {rec['status']:6s} "
+          f"{rec['cost']:18s} {rec['feasibility']:13s} {rec['metric']}")
+
+
+def _annotate(case, rec):
+  rec["cost"], rec["feasibility"] = TAGS.get(case.name, ("?", "?"))
+
+
 def run_numerical(cases, verbose: bool = True):
   """Mirror of _corpus.run_corpus, extended to print the cost/feasibility tags
     and a LAPACK-probe verdict block. Returns (results, exit_code).
@@ -557,82 +560,43 @@ def run_numerical(cases, verbose: bool = True):
     arch-limited still "passes" if its tiny fixed-N instance is numerically correct;
     the tag carries the *generalization* verdict.
     """
-  all_results = []
-  relerrs = []
-  if verbose:
-    print(f"{'case':32s} {'var':4s} {'status':6s} {'cost':18s} {'feasible':13s} detail")
+  def verdict(all_results, relerrs):
+    # ------- LAPACK feasibility verdict block ----------------------------- #
+    print("\n" + "-" * 100)
+    print("WHAT NUMERICAL COMPUTING FITS THE ANE (fp16 feed-forward dataflow)")
     print("-" * 100)
-  for case in cases:
-    cost, feas = TAGS.get(case.name, ("?", "?"))
-    for rec in eval_case(case):
-      rec["cost"], rec["feasibility"] = cost, feas
-      all_results.append(rec)
-      line = (f"{rec['name']:32s} {rec['variant']:4s} {rec['status']:6s} "
-              f"{cost:18s} {feas:13s} {rec['metric']}")
-      if rec["err"]:
-        line += f"  [{rec['err']}]"
-      if verbose:
-        print(line)
-        if rec.get("traceback"):
-          print("    " + rec["traceback"].replace("\n", "\n    "))
-      m = rec["metric"]
-      if m.startswith("relerr "):
-        try:
-          relerrs.append(float(m.split()[1]))
-        except ValueError:
-          pass
+    for c in LAPACK_PROBES:
+      recs = [r for r in all_results if r["name"] == c.name]
+      st = recs[0]["status"] if recs else "?"
+      metric = recs[0]["metric"] if recs else ""
+      cost, feas = TAGS[c.name]
+      numeric = "tiny-N instance PASSES" if st == "PASS" else f"instance {st}"
+      print(f"  {c.name:32s} -> {feas:13s} ({numeric}; {metric})")
+    print("\n  Summary verdict:")
+    print("    WORKS (feed-forward, fp16-clean): power iteration, CG step, Horner,")
+    print("      stencil/conv PDE step, n-body cross-product normals, MC mean/variance,")
+    print("      Gram/SYRK. The ANE is strong on composed elementwise + GEMM + conv +")
+    print("      reductions; the wide accumulator keeps reductions clean.")
+    print("    ARCH-LIMITED (the LAPACK corners): QR/Cholesky/LU/triangular-solve are")
+    print("      expressible ONLY by per-N static unrolling (no in-graph loop or scalar")
+    print("      feedback), so they do not scale to data-sized problems. The native")
+    print("      MatrixDecomposition (NonQRGivens) unit's factorization COMPOSITE is")
+    print("      not_currently_callable (carriers compile, the factorization does not),")
+    print("      and the frontend exposes no decomposition/solve op at all.")
+    print("    fp16 is NOT the wall: the unrolled tiny-N factorizations pass at")
+    print("      relerr < 1e-3, and condition-number sweeps (Cholesky to cond~1e4,")
+    print("      2x2 solve to cond~1.3e3) stay < 1% - the wide accumulator absorbs the")
+    print("      sequential sqrt/div re-rounding. The ceiling is ARCHITECTURAL (the")
+    print("      missing loop), not numerical. (Only true det->0 singularity would")
+    print("      break it, and that breaks fp32 too.)")
+    print("    => The ANE fits VECTOR/MATRIX numerical kernels with bounded, static")
+    print("       dataflow (iterative methods, stencils, GEMM-heavy linear algebra),")
+    print("       NOT pivoted/recursive direct factorizations that need data-sized")
+    print("       iteration.")
+    print()  # blank line before the GATE line
 
-  n_pass = sum(r["status"] == "PASS" for r in all_results)
-  n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
-  n_fail = sum(r["status"] == "FAIL" for r in all_results)
-  n_err = sum(r["status"] == "ERROR" for r in all_results)
-  n_xpass = sum(r["status"] == "XPASS" for r in all_results)
-  total = len(all_results)
-  red = n_fail + n_err + n_xpass
-
-  print("\n" + "=" * 100)
-  print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
-        f"FAIL {n_fail}   ERROR {n_err}   XPASS {n_xpass}")
-  if relerrs:
-    print(f"relerr across {len(relerrs)} numeric variants: "
-          f"min {min(relerrs):.2e}  median {np.median(relerrs):.2e}  max {max(relerrs):.2e}")
-
-  # ------- LAPACK feasibility verdict block ----------------------------- #
-  print("\n" + "-" * 100)
-  print("WHAT NUMERICAL COMPUTING FITS THE ANE (fp16 feed-forward dataflow)")
-  print("-" * 100)
-  for c in LAPACK_PROBES:
-    recs = [r for r in all_results if r["name"] == c.name]
-    st = recs[0]["status"] if recs else "?"
-    metric = recs[0]["metric"] if recs else ""
-    cost, feas = TAGS[c.name]
-    numeric = "tiny-N instance PASSES" if st == "PASS" else f"instance {st}"
-    print(f"  {c.name:32s} -> {feas:13s} ({numeric}; {metric})")
-  print("\n  Summary verdict:")
-  print("    WORKS (feed-forward, fp16-clean): power iteration, CG step, Horner,")
-  print("      stencil/conv PDE step, n-body cross-product normals, MC mean/variance,")
-  print("      Gram/SYRK. The ANE is strong on composed elementwise + GEMM + conv +")
-  print("      reductions; the wide accumulator keeps reductions clean.")
-  print("    ARCH-LIMITED (the LAPACK corners): QR/Cholesky/LU/triangular-solve are")
-  print("      expressible ONLY by per-N static unrolling (no in-graph loop or scalar")
-  print("      feedback), so they do not scale to data-sized problems. The native")
-  print("      MatrixDecomposition (NonQRGivens) unit's factorization COMPOSITE is")
-  print("      not_currently_callable (carriers compile, the factorization does not),")
-  print("      and the frontend exposes no decomposition/solve op at all.")
-  print("    fp16 is NOT the wall: the unrolled tiny-N factorizations pass at")
-  print("      relerr < 1e-3, and condition-number sweeps (Cholesky to cond~1e4,")
-  print("      2x2 solve to cond~1.3e3) stay < 1% - the wide accumulator absorbs the")
-  print("      sequential sqrt/div re-rounding. The ceiling is ARCHITECTURAL (the")
-  print("      missing loop), not numerical. (Only true det->0 singularity would")
-  print("      break it, and that breaks fp32 too.)")
-  print("    => The ANE fits VECTOR/MATRIX numerical kernels with bounded, static")
-  print("       dataflow (iterative methods, stencils, GEMM-heavy linear algebra),")
-  print("       NOT pivoted/recursive direct factorizations that need data-sized")
-  print("       iteration.")
-
-  print(f"\nGATE: {'GREEN' if red == 0 else 'RED'}  "
-        f"({n_pass + n_xfail}/{total} green, {red} red)")
-  return all_results, (0 if red == 0 else 1)
+  return run_corpus(cases, verbose, columns=(_header, _row), annotate=_annotate,
+                    verdict=verdict, sep_width=100)
 
 
 if __name__ == "__main__":

--- a/tests/test_op_coverage.py
+++ b/tests/test_op_coverage.py
@@ -3,17 +3,10 @@ from __future__ import annotations
 import math
 import numpy as np
 import pytest
+from _helpers import requires_ane
 import aneforge as af
 
 
-def _ane():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane(), reason="ANE/e5rt dylib unavailable")
 rng = np.random.default_rng(0)
 sig = lambda z: 1.0 / (1.0 + np.exp(-z))
 

--- a/tests/test_pde_ode.py
+++ b/tests/test_pde_ode.py
@@ -8,14 +8,11 @@ from pathlib import Path
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))  # tests/ -> import _corpus
-from _corpus import Case, eval_case  # noqa: E402
-import aneforge as af  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16, onehot_select as _col
+import aneforge as af
 
 rng = np.random.default_rng(7)
-
-
-def f16(*shape, scale=1.0):
-  return (rng.standard_normal(shape).astype(np.float32) * scale).astype(np.float16)
 
 
 # tag side-table: name -> (cost_character, feasibility)
@@ -25,16 +22,6 @@ TAGS: dict[str, tuple[str, str]] = {}
 def tagged(case: Case, cost: str, feasibility: str) -> Case:
   TAGS[case.name] = (cost, feasibility)
   return case
-
-
-def _col(t: af.Tensor, i: int, w: int | None = None) -> af.Tensor:
-  """Select scalar element i of a [1, W] tensor as a [1,1] tensor via a one-hot
-    matmul (a folded constant weight). Same static-index trick as test_numerical.py;
-    stays fused, no dynamic_slice graph cut."""
-  W = w or t.shape[-1]
-  sel = np.zeros((W, 1), np.float16)
-  sel[i, 0] = 1.0
-  return t @ sel.astype(np.float16)
 
 
 # 1. PDE / STENCILS  (conv-based - the ANE's home turf)
@@ -63,7 +50,7 @@ def _jacobi_iteration():
   H = W = 24; K = 5
   nbr = np.array([[0, 1, 0], [1, 0, 1], [0, 1, 0]], np.float32)
   Kw = (0.25 * nbr).reshape(1, 1, 3, 3).astype(np.float16)
-  u0 = f16(1, 1, H, W, scale=1.0)
+  u0 = f16(rng, 1, 1, H, W, scale=1.0)
 
   def build(ut):
     h = ut
@@ -105,7 +92,7 @@ def _heat_step_2d():
   K[0, 0] = r * lap
   K[0, 0, 1, 1] += 1.0
   Kf = K.astype(np.float16)
-  u0 = f16(1, 1, H, W, scale=1.0)
+  u0 = f16(rng, 1, 1, H, W, scale=1.0)
 
   def build(ut): return af.conv(ut, Kf, pad=1)
 
@@ -141,8 +128,8 @@ def _wave_step_2d():
   K[0, 0] = (C * C) * lap
   K[0, 0, 1, 1] += 2.0                  # + 2*I  -> conv gives 2 u^n + C^2 Lap u^n
   Kf = K.astype(np.float16)
-  un = f16(1, 1, H, W, scale=1.0)       # u^n
-  unm1 = f16(1, 1, H, W, scale=1.0)     # u^{n-1}
+  un = f16(rng, 1, 1, H, W, scale=1.0)       # u^n
+  unm1 = f16(rng, 1, 1, H, W, scale=1.0)     # u^{n-1}
 
   def build(un_t, unm1_t): return af.conv(un_t, Kf, pad=1) - unm1_t
 
@@ -182,7 +169,7 @@ def _multigrid_smooth():
   K[0, 0] = omega * 0.25 * nbr
   K[0, 0, 1, 1] += (1.0 - omega)
   Kf = K.astype(np.float16)
-  u0 = f16(1, 1, H, W, scale=1.0)
+  u0 = f16(rng, 1, 1, H, W, scale=1.0)
 
   def build(ut): return af.conv(ut, Kf, pad=1)
 
@@ -220,7 +207,7 @@ def _forward_euler():
   A = (rng.standard_normal((N, N)).astype(np.float32) * 0.3)
   A = (A - A.T)                       # skew-symmetric -> norm-preserving, stable
   Ah = A.astype(np.float16)
-  y0 = f16(1, N, scale=1.0)
+  y0 = f16(rng, 1, N, scale=1.0)
 
   def build(yt):
     h = yt
@@ -263,7 +250,7 @@ def _rk4_step():
 
   def f_np(y): return -y + 0.1 * y * y
 
-  y0 = f16(1, N, scale=0.5)
+  y0 = f16(rng, 1, N, scale=0.5)
 
   def build(yt):
     y = yt
@@ -685,6 +672,19 @@ ARCH_LIMITED = [
 CASES = PDE_STENCILS + ODE_ROOT + SERIES + ARCH_LIMITED
 
 
+def _header():
+  return f"{'case':32s} {'var':4s} {'status':6s} {'cost':22s} {'feasible':13s} detail"
+
+
+def _row(rec):
+  return (f"{rec['name']:32s} {rec['variant']:4s} {rec['status']:6s} "
+          f"{rec['cost']:22s} {rec['feasibility']:13s} {rec['metric']}")
+
+
+def _annotate(case, rec):
+  rec["cost"], rec["feasibility"] = TAGS.get(case.name, ("?", "?"))
+
+
 def run_pde_ode(cases, verbose: bool = True):
   """Mirror of _corpus.run_corpus, extended to print cost/feasibility tags and an
     iterative-methods capability verdict block. Returns (results, exit_code).
@@ -694,104 +694,66 @@ def run_pde_ode(cases, verbose: bool = True):
     their tag carries the capability verdict. A fixed-iteration kernel that drifts
     past tol would FAIL (red) - that is how compounding-vs-bug is policed.
     """
-  all_results = []
-  relerrs = []
-  if verbose:
-    print(f"{'case':32s} {'var':4s} {'status':6s} {'cost':22s} {'feasible':13s} detail")
+  def verdict(all_results, relerrs):
+    # ------- iterative-methods capability verdict block ------------------- #
+    print("\n" + "-" * 110)
+    print("WHICH ITERATIVE NUMERICAL METHODS FIT THE ANE (fixed feed-forward dataflow)")
     print("-" * 110)
-  for case in cases:
-    cost, feas = TAGS.get(case.name, ("?", "?"))
-    for rec in eval_case(case):
-      rec["cost"], rec["feasibility"] = cost, feas
-      all_results.append(rec)
-      line = (f"{rec['name']:32s} {rec['variant']:4s} {rec['status']:6s} "
-              f"{cost:22s} {feas:13s} {rec['metric']}")
-      if rec["err"]: line += f"  [{rec['err']}]"
-      if verbose:
-        print(line)
-        if rec.get("traceback"):
-          print("    " + rec["traceback"].replace("\n", "\n    "))
-      m = rec["metric"]
-      if m.startswith("relerr "):
-        try:
-          relerrs.append(float(m.split()[1]))
-        except ValueError:
-          pass
+    print("  PDE / STENCILS (conv-based) - the marquee fit:")
+    for c in PDE_STENCILS:
+      recs = [r for r in all_results if r["name"] == c.name]
+      st = recs[0]["status"] if recs else "?"
+      print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; {recs[0]['metric'] if recs else ''})")
+    print("  ODE INTEGRATORS & ROOT FINDERS (fixed-step recurrences):")
+    for c in ODE_ROOT:
+      recs = [r for r in all_results if r["name"] == c.name]
+      st = recs[0]["status"] if recs else "?"
+      print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; {recs[0]['metric'] if recs else ''})")
+    print("  SERIES / SPECIAL FUNCTIONS (Horner chains vs exact):")
+    for c in SERIES:
+      recs = [r for r in all_results if r["name"] == c.name]
+      st = recs[0]["status"] if recs else "?"
+      print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; {recs[0]['metric'] if recs else ''})")
+    print("  ARCH-LIMITED (convergent/adaptive forms - control flow the ANE lacks):")
+    for c in ARCH_LIMITED:
+      recs = [r for r in all_results if r["name"] == c.name]
+      st = recs[0]["status"] if recs else "?"
+      print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; xfail = inexpressible stop)")
 
-  n_pass = sum(r["status"] == "PASS" for r in all_results)
-  n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
-  n_fail = sum(r["status"] == "FAIL" for r in all_results)
-  n_err = sum(r["status"] == "ERROR" for r in all_results)
-  n_xpass = sum(r["status"] == "XPASS" for r in all_results)
-  total = len(all_results)
-  red = n_fail + n_err + n_xpass
+    print("\n  Summary verdict:")
+    print("    WORKS (fixed-iteration, fully unrolled into a static graph):")
+    print("      - PDE stencil sweeps: Jacobi (K sweeps), explicit heat step, leapfrog")
+    print("        wave step, damped-Jacobi multigrid smoothing. These lower to native")
+    print("        conv - the ANE's home turf - and are fp16-clean (wide accumulator).")
+    print("      - ODE integrators: forward-Euler & RK4 advanced a FIXED #steps; the RHS")
+    print("        is aneforge ops. Error is fp16 COMPOUNDING (~few %, bounded), not a bug.")
+    print("      - Root finders: Newton (scalar via sqrt-iter, vector via 2x2 closed-form")
+    print("        Jacobian) & fixed-point x=g(x), all FIXED iteration count.")
+    print("      - Special functions: exp/erf/log via Horner series, accurate to a few %")
+    print("        vs the EXACT function on a bounded argument interval.")
+    print("    ARCH-LIMITED (needs control flow the feed-forward engine lacks):")
+    print("      - RUN-TO-CONVERGENCE (stop when ||residual|| < tol): variable iteration")
+    print("        count = data-dependent loop/branch. Must fix K up front; a fixed graph")
+    print("        cannot match an adaptive reference for the hard lanes.")
+    print("      - ADAPTIVE TIMESTEP (shrink dt on local error): data-dependent step size")
+    print("        and step count. A fixed coarse step diverges on stiff lanes.")
+    print("      - REGIME SWITCHES in special functions (erf/log argument reduction, big-x")
+    print("        asymptotics): a runtime branch on the argument; one fixed series only")
+    print("        covers a bounded interval.")
+    print("      - MULTIGRID V-CYCLE RECURSION / coarse solve: the inter-grid transfers")
+    print("        are convs/pools (expressible), but the recursion depth + coarse solve")
+    print("        are control-flow / data-sized. Only the single smoothing sweep fits.")
+    print("    => The ANE fits iterative scientific methods whose ITERATION STRUCTURE is")
+    print("       STATIC AND KNOWN AT COMPILE TIME (fixed sweeps/steps, unrolled). It does")
+    print("       NOT fit methods whose iteration count or step size is decided AT RUNTIME")
+    print("       from the data (convergence tests, adaptive stepping, regime switches),")
+    print("       which need the in-graph loop/branch the feed-forward dataflow lacks.")
+    print("       fp16 is not the wall here (compounding stays bounded over modest step")
+    print("       counts); the wall is the missing data-dependent control flow.")
+    print()  # blank line before the GATE line
 
-  print("\n" + "=" * 110)
-  print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
-        f"FAIL {n_fail}   ERROR {n_err}   XPASS {n_xpass}")
-  if relerrs:
-    print(f"relerr across {len(relerrs)} numeric variants: "
-          f"min {min(relerrs):.2e}  median {np.median(relerrs):.2e}  max {max(relerrs):.2e}")
-
-  # ------- iterative-methods capability verdict block ------------------- #
-  print("\n" + "-" * 110)
-  print("WHICH ITERATIVE NUMERICAL METHODS FIT THE ANE (fixed feed-forward dataflow)")
-  print("-" * 110)
-  print("  PDE / STENCILS (conv-based) - the marquee fit:")
-  for c in PDE_STENCILS:
-    recs = [r for r in all_results if r["name"] == c.name]
-    st = recs[0]["status"] if recs else "?"
-    print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; {recs[0]['metric'] if recs else ''})")
-  print("  ODE INTEGRATORS & ROOT FINDERS (fixed-step recurrences):")
-  for c in ODE_ROOT:
-    recs = [r for r in all_results if r["name"] == c.name]
-    st = recs[0]["status"] if recs else "?"
-    print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; {recs[0]['metric'] if recs else ''})")
-  print("  SERIES / SPECIAL FUNCTIONS (Horner chains vs exact):")
-  for c in SERIES:
-    recs = [r for r in all_results if r["name"] == c.name]
-    st = recs[0]["status"] if recs else "?"
-    print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; {recs[0]['metric'] if recs else ''})")
-  print("  ARCH-LIMITED (convergent/adaptive forms - control flow the ANE lacks):")
-  for c in ARCH_LIMITED:
-    recs = [r for r in all_results if r["name"] == c.name]
-    st = recs[0]["status"] if recs else "?"
-    print(f"    {c.name:30s} {TAGS[c.name][1]:13s} ({st}; xfail = inexpressible stop)")
-
-  print("\n  Summary verdict:")
-  print("    WORKS (fixed-iteration, fully unrolled into a static graph):")
-  print("      - PDE stencil sweeps: Jacobi (K sweeps), explicit heat step, leapfrog")
-  print("        wave step, damped-Jacobi multigrid smoothing. These lower to native")
-  print("        conv - the ANE's home turf - and are fp16-clean (wide accumulator).")
-  print("      - ODE integrators: forward-Euler & RK4 advanced a FIXED #steps; the RHS")
-  print("        is aneforge ops. Error is fp16 COMPOUNDING (~few %, bounded), not a bug.")
-  print("      - Root finders: Newton (scalar via sqrt-iter, vector via 2x2 closed-form")
-  print("        Jacobian) & fixed-point x=g(x), all FIXED iteration count.")
-  print("      - Special functions: exp/erf/log via Horner series, accurate to a few %")
-  print("        vs the EXACT function on a bounded argument interval.")
-  print("    ARCH-LIMITED (needs control flow the feed-forward engine lacks):")
-  print("      - RUN-TO-CONVERGENCE (stop when ||residual|| < tol): variable iteration")
-  print("        count = data-dependent loop/branch. Must fix K up front; a fixed graph")
-  print("        cannot match an adaptive reference for the hard lanes.")
-  print("      - ADAPTIVE TIMESTEP (shrink dt on local error): data-dependent step size")
-  print("        and step count. A fixed coarse step diverges on stiff lanes.")
-  print("      - REGIME SWITCHES in special functions (erf/log argument reduction, big-x")
-  print("        asymptotics): a runtime branch on the argument; one fixed series only")
-  print("        covers a bounded interval.")
-  print("      - MULTIGRID V-CYCLE RECURSION / coarse solve: the inter-grid transfers")
-  print("        are convs/pools (expressible), but the recursion depth + coarse solve")
-  print("        are control-flow / data-sized. Only the single smoothing sweep fits.")
-  print("    => The ANE fits iterative scientific methods whose ITERATION STRUCTURE is")
-  print("       STATIC AND KNOWN AT COMPILE TIME (fixed sweeps/steps, unrolled). It does")
-  print("       NOT fit methods whose iteration count or step size is decided AT RUNTIME")
-  print("       from the data (convergence tests, adaptive stepping, regime switches),")
-  print("       which need the in-graph loop/branch the feed-forward dataflow lacks.")
-  print("       fp16 is not the wall here (compounding stays bounded over modest step")
-  print("       counts); the wall is the missing data-dependent control flow.")
-
-  print(f"\nGATE: {'GREEN' if red == 0 else 'RED'}  "
-        f"({n_pass + n_xfail}/{total} green, {red} red)")
-  return all_results, (0 if red == 0 else 1)
+  return run_corpus(cases, verbose, columns=(_header, _row), annotate=_annotate,
+                    verdict=verdict, sep_width=110)
 
 
 if __name__ == "__main__":

--- a/tests/test_sdpa_causal.py
+++ b/tests/test_sdpa_causal.py
@@ -3,17 +3,10 @@ from __future__ import annotations
 import math
 import numpy as np
 import pytest
+from _helpers import requires_ane
 import aneforge as af
 
 
-def _ane():
-  try:
-    from aneforge._runtime import _find_dylib; _find_dylib(); return True
-  except Exception:
-    return False
-
-
-requires_ane = pytest.mark.skipif(not _ane(), reason="ANE/e5rt dylib unavailable")
 rng = np.random.default_rng(0)
 
 
@@ -108,7 +101,7 @@ def test_af_mha_query_tiled():
   # verify the tiled path is exact against a numpy multi-head-attention reference.
   S, D, H = 1500, 256, 8                          # S >= 512 -> tiles the query
   dh = D // H
-  w = lambda *s: (rng.standard_normal(s) * 0.05).astype(np.float16)   # noqa: E731
+  w = lambda *s: (rng.standard_normal(s) * 0.05).astype(np.float16)
   Wq, bq, Wk, Wv, bv, Wo, bo = w(D, D), w(D), w(D, D), w(D, D), w(D), w(D, D), w(D)
   x = rng.standard_normal((S, D)).astype(np.float16)
   out = np.asarray(af.compile(af.mha(af.input((S, D)), Wq, bq, Wk, None, Wv, bv, Wo, bo, H))(x))
@@ -130,7 +123,7 @@ def test_af_cross_attention_query_tiled():
   # against a numpy cross-attention reference. (Small-T stays single-shot; same result.)
   S, T, D, H = 768, 512, 256, 8                   # S>=768 and T>=512 -> tiles the query
   dh = D // H
-  w = lambda *s: (rng.standard_normal(s) * 0.05).astype(np.float16)   # noqa: E731
+  w = lambda *s: (rng.standard_normal(s) * 0.05).astype(np.float16)
   Wq, Wk, Wv, Wo = w(D, D), w(D, D), w(D, D), w(D, D)
   x = rng.standard_normal((S, D)).astype(np.float16)
   ctx = rng.standard_normal((T, D)).astype(np.float16)

--- a/tests/test_shapes.py
+++ b/tests/test_shapes.py
@@ -5,14 +5,9 @@ import numpy as np
 
 import aneforge as af
 from _corpus import Case
+from _helpers import f16
 
 rng = np.random.default_rng(7)
-
-
-def f16(*shape, scale=1.0, pos=False):
-  a = rng.standard_normal(shape).astype(np.float32) * scale
-  if pos: a = np.abs(a) + 0.5
-  return a.astype(np.float16)
 
 
 # ---- numpy fp32 golden references --------------------------------------------
@@ -60,7 +55,7 @@ def np_softmax(x, axis=-1):
 # ---- A. SDPA across sequence length (the native-accuracy envelope) -----------
 def _sdpa_case(S, H=4, D=64):
   sc = 1.0 / D ** 0.5
-  q, k, v = f16(1, H, S, D), f16(1, H, S, D), f16(1, H, S, D)
+  q, k, v = f16(rng, 1, H, S, D), f16(rng, 1, H, S, D), f16(rng, 1, H, S, D)
   return Case(f"sdpa_S{S}", "shape",
               lambda qt, kt, vt: af.sdpa(qt, kt, vt),
               lambda qa, ka, va: np_sdpa(qa, ka, va, sc),
@@ -69,7 +64,7 @@ def _sdpa_case(S, H=4, D=64):
 
 # ---- B. matmul contraction across K (wide accumulator should hold) -----------
 def _matmul_case(K, N=256):
-  x = f16(1, K, scale=1.0); W = f16(N, K, scale=1.0 / np.sqrt(K))
+  x = f16(rng, 1, K, scale=1.0); W = f16(rng, N, K, scale=1.0 / np.sqrt(K))
   return Case(f"matmul_K{K}", "shape",
               lambda xt: xt.linear(W, None),
               lambda xa: xa.astype(np.float32) @ W.astype(np.float32).T,
@@ -79,7 +74,7 @@ def _matmul_case(K, N=256):
 # ---- C. conv across channels x spatial ---------------------------------------
 def _conv_case(C, HW, Cout=None):
   Cout = Cout or C
-  x = f16(1, C, HW, HW, scale=1.0); W = f16(Cout, C, 3, 3, scale=1.0 / np.sqrt(C * 9))
+  x = f16(rng, 1, C, HW, HW, scale=1.0); W = f16(rng, Cout, C, 3, 3, scale=1.0 / np.sqrt(C * 9))
   return Case(f"conv_C{C}_{HW}x{HW}", "shape",
               lambda xt: af.conv(xt, W, pad=1),
               lambda xa: np_conv(xa, W, pad=1),
@@ -88,7 +83,7 @@ def _conv_case(C, HW, Cout=None):
 
 # ---- D. group_norm across feature-map (documented large-map wall) ------------
 def _gn_case(C, HW, groups, xfail=""):
-  g = f16(C, pos=True); b = f16(C, scale=0.1); x = f16(1, C, HW, HW)
+  g = f16(rng, C, pos=True); b = f16(rng, C, scale=0.1); x = f16(rng, 1, C, HW, HW)
   return Case(f"group_norm_C{C}_{HW}x{HW}", "shape",
               lambda xt: xt.group_norm(g, b, num_groups=groups),
               lambda xa: np_group_norm(xa, g, b, groups),
@@ -97,7 +92,7 @@ def _gn_case(C, HW, groups, xfail=""):
 
 # ---- E. layer_norm across width ----------------------------------------------
 def _ln_case(D):
-  g = f16(D, pos=True); b = f16(D, scale=0.1); x = f16(8, D)
+  g = f16(rng, D, pos=True); b = f16(rng, D, scale=0.1); x = f16(rng, 8, D)
   return Case(f"layer_norm_D{D}", "shape",
               lambda xt: xt.layer_norm(g, b),
               lambda xa: np_layer_norm(xa, g, b),
@@ -106,7 +101,7 @@ def _ln_case(D):
 
 # ---- F. softmax / reduction over a long axis (fp16 accumulation) -------------
 def _softmax_case(N):
-  x = f16(4, N, scale=2.0)
+  x = f16(rng, 4, N, scale=2.0)
   return Case(f"softmax_N{N}", "shape",
               lambda xt: xt.softmax(-1),
               lambda xa: np_softmax(xa, -1),
@@ -115,7 +110,7 @@ def _softmax_case(N):
 
 def _reduce_case(N):
   # pos=True keeps the reference mean away from 0 (a ~0 mean makes relative error a knife-edge)
-  x = f16(1, N, scale=1.0, pos=True)
+  x = f16(rng, 1, N, scale=1.0, pos=True)
   return Case(f"reduce_mean_N{N}", "shape",
               lambda xt: xt.mean((1,)),
               lambda xa: xa.astype(np.float32).mean(1, keepdims=True),  # ANE keeps the reduced dim

--- a/tests/test_spectral_sci.py
+++ b/tests/test_spectral_sci.py
@@ -7,14 +7,11 @@ from pathlib import Path
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))   # tests/ -> import _corpus
-from _corpus import Case, eval_case  # noqa: E402
-import aneforge as af  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16, onehot_select
+import aneforge as af
 
 rng = np.random.default_rng(20260529)
-
-
-def f16(*shape, scale=1.0):
-  return (rng.standard_normal(shape).astype(np.float32) * scale).astype(np.float16)
 
 
 # tag side-table: name -> (cost_character, feasibility)
@@ -57,7 +54,7 @@ def _dft_matmul(N: int, tol: float):
   W = np.exp(-2j * np.pi * k * n / N)                  # [N,N] DFT matrix
   Wr = np.ascontiguousarray(np.real(W)).astype(np.float16)
   Wi = np.ascontiguousarray(np.imag(W)).astype(np.float16)
-  xr = f16(1, N); xi = f16(1, N)
+  xr = f16(rng, 1, N); xi = f16(rng, 1, N)
 
   def build(rt, it):
     a = rt @ Wr.T.astype(np.float16)                # xr @ Wr^T
@@ -113,15 +110,11 @@ def _fft_butterfly_radix2(N: int, tol: float):
 
   order = [_bitrev(i, bits) for i in range(N)]
 
-  def _lane(t, i):                                     # [1,N] -> [1,1] (one-hot select)
-    s = np.zeros((N, 1), np.float16); s[i, 0] = 1.0
-    return t @ s.astype(np.float16)
-
-  xr = f16(1, N); xi = f16(1, N)
+  xr = f16(rng, 1, N); xi = f16(rng, 1, N)
 
   def build(rt, it):
-    re = [_lane(rt, order[i]) for i in range(N)]
-    im = [_lane(it, order[i]) for i in range(N)]
+    re = [onehot_select(rt, order[i], N) for i in range(N)]  # [1,N] -> [1,1] one-hot select
+    im = [onehot_select(it, order[i], N) for i in range(N)]
     size = 2
     while size <= N:
       half = size // 2
@@ -160,7 +153,7 @@ def _rfft_power_spectrum(N: int, tol: float):
   W = np.exp(-2j * np.pi * k * n / N)
   Wr = np.ascontiguousarray(np.real(W)).astype(np.float16)
   Wi = np.ascontiguousarray(np.imag(W)).astype(np.float16)
-  x = f16(1, N)
+  x = f16(rng, 1, N)
 
   def build(xt):
     Xr = xt @ Wr.T.astype(np.float16)
@@ -189,8 +182,8 @@ def _fir_filter(L: int, K: int, tol: float):
     cost: COMPUTE (a real conv - the ANE's home turf).
     feasibility: WORKS.
     """
-  sig = f16(1, 1, 1, L)
-  taps = f16(1, 1, 1, K, scale=0.5)
+  sig = f16(rng, 1, 1, 1, L)
+  taps = f16(rng, 1, 1, 1, K, scale=0.5)
 
   def build(st):
     return af.conv(st, taps, pad=0)                 # [1,1,1,L-K+1], valid
@@ -219,7 +212,7 @@ def _autocorr_crosscorr(H: int, W: int, Th: int, Tw: int, tol: float):
     cost: MIXED (cut) - one native sub-program (graph cut), no surrounding fusion.
     feasibility: WORKS (cross_correlation is RE-recovered and runtime-proven).
     """
-  x = f16(H, W)
+  x = f16(rng, H, W)
   tmpl = np.ascontiguousarray(x[:Th, :Tw]).astype(np.float16)   # patch -> autocorr-style
 
   def build(xt, tt):
@@ -254,7 +247,7 @@ def _autocorr_conv(L: int, Lk: int, tol: float):
     feasibility: WORKS (small lag window; wide windows are arch-limited by the conv
       backend).
     """
-  sig = f16(1, 1, 1, L)
+  sig = f16(rng, 1, 1, 1, L)
   kern = np.ascontiguousarray(sig[0, 0, 0, :Lk]).astype(np.float16).reshape(1, 1, 1, Lk)
 
   def build(st):
@@ -336,7 +329,7 @@ def _nbody_spring(N: int, tol: float):
       O(N^2) in the intermediate, reduction over j).
     feasibility: WORKS (small N).
     """
-  P = f16(N, 3, scale=1.0)
+  P = f16(rng, N, 3, scale=1.0)
 
   def build(pt):
     pi = pt.reshape(N, 1, 3)
@@ -495,6 +488,19 @@ QUADRATURE = [
 CASES = SPECTRAL + SIGNAL + MONTECARLO + NBODY + QUADRATURE
 
 
+def _header():
+  return f"{'case':30s} {'var':4s} {'status':6s} {'cost':14s} {'feasible':13s} detail"
+
+
+def _row(rec):
+  return (f"{rec['name']:30s} {rec['variant']:4s} {rec['status']:6s} "
+          f"{rec['cost']:14s} {rec['feasibility']:13s} {rec['metric']}")
+
+
+def _annotate(case, rec):
+  rec["cost"], rec["feasibility"] = TAGS.get(case.name, ("?", "?"))
+
+
 def run_spectral(cases, verbose: bool = True):
   """Mirror of _corpus.run_corpus, extended to print cost/feasibility tags and a
     SPECTRAL verdict block. Returns (results, exit_code).
@@ -504,104 +510,65 @@ def run_spectral(cases, verbose: bool = True):
     "passes" if its tiny fixed-N instance is numerically correct; the tag carries the
     *generalization* verdict.
     """
-  all_results = []
-  relerrs = []
-  dft_curve: list[tuple[int, str]] = []     # (N, relerr_str) for the verdict block
-  if verbose:
-    print(f"{'case':30s} {'var':4s} {'status':6s} {'cost':14s} {'feasible':13s} detail")
+  def verdict(all_results, relerrs):
+    dft_curve = [(int(r["name"].split("_N")[1]), r["metric"].split()[1])
+                 for r in all_results
+                 if r.get("relerr") is not None and r["name"].startswith("dft_matmul_N")]
+    # ------- SPECTRAL verdict block (the marquee finding) ----------------- #
+    print("\n" + "-" * 104)
+    print("CAN THE ANE DO AN FFT?  (complex emulated as real/imag tensor pairs)")
     print("-" * 104)
-  for case in cases:
-    cost, feas = TAGS.get(case.name, ("?", "?"))
-    for rec in eval_case(case):
-      rec["cost"], rec["feasibility"] = cost, feas
-      all_results.append(rec)
-      line = (f"{rec['name']:30s} {rec['variant']:4s} {rec['status']:6s} "
-          f"{cost:14s} {feas:13s} {rec['metric']}")
-      if rec["err"]:
-        line += f"  [{rec['err']}]"
-      if verbose:
-        print(line)
-        if rec.get("traceback"):
-          print("    " + rec["traceback"].replace("\n", "\n    "))
-      m = rec["metric"]
-      if m.startswith("relerr "):
-        try:
-          relerrs.append(float(m.split()[1]))
-        except ValueError:
-          pass
-        if rec["name"].startswith("dft_matmul_N"):
-          dft_curve.append((int(rec["name"].split("_N")[1]), m.split()[1]))
+    if dft_curve:
+      print("  DFT-as-matmul precision vs transform size N (fp16 weights, wide accumulator):")
+      for N, e in sorted(dft_curve):
+        print(f"    N={N:<5d} relerr {e}")
+      print("    => relerr is essentially FLAT in N (no compounding): the ANE matmul")
+      print("       accumulator is wide (>=fp32), so the length-N twiddle sum is not")
+      print("       re-rounded per term. fp16 is NOT the wall for the transform.")
+    bf = [r for r in all_results if r["name"].startswith("fft_butterfly")]
+    if bf:
+      bfst = ", ".join(f"{r['name'].split('_N')[1]}:{r['status']}({r['metric']})" for r in bf)
+      print(f"  Radix-2 butterfly FFT (fully unrolled): {bfst}")
+    print("\n  VERDICT:")
+    print("    YES - both a dense DFT (twiddle-matrix matmul) and a radix-2 butterfly FFT")
+    print("    are EXPRESSIBLE and CORRECT on the ANE via complex-as-real-pairs")
+    print("    arithmetic ((a+bi)(c+di) = (ac-bd)+(ad+bc)i over paired real tensors).")
+    print("    * DFT-matmul: fp16-CLEAN to at least N=2048 (relerr ~ few e-4, flat in N).")
+    print("      The limiter is NOT precision but the O(N^2) twiddle-matrix size/bandwidth")
+    print("      - it is a naive DFT, so cost grows quadratically; precision does not.")
+    print("    * Butterfly FFT: correct for small fixed N, but expressible ONLY as a")
+    print("      per-N STATIC UNROLL (the ANE is feed-forward: no in-graph loop, no scalar")
+    print("      feedback, and bit-reversal needs a folded one-hot since there is no")
+    print("      gather). So its O(N log N) advantage is not realizable as a graph at")
+    print("      useful N - the wall is ARCHITECTURAL (static unroll), not fp16.")
+    print("    BOTTOM LINE: the ANE has no complex dtype, but FFT/DFT is viable through")
+    print("    real-pair emulation; for practical sizes the dense DFT-matmul is the")
+    print("    right tool (fp16-robust, fuses), and a true scaling FFT is blocked by the")
+    print("    missing loop/gather, not by numerics.")
 
-  n_pass = sum(r["status"] == "PASS" for r in all_results)
-  n_xfail = sum(r["status"] == "XFAIL" for r in all_results)
-  n_fail = sum(r["status"] == "FAIL" for r in all_results)
-  n_err = sum(r["status"] == "ERROR" for r in all_results)
-  n_xpass = sum(r["status"] == "XPASS" for r in all_results)
-  total = len(all_results)
-  red = n_fail + n_err + n_xpass
+    # ------- other capability findings ------------------------------------ #
+    print("\n" + "-" * 104)
+    print("OTHER SCIENTIFIC-KERNEL FINDINGS")
+    print("-" * 104)
+    print("  SIGNAL    : FIR filter (1D conv) and 2D autocorrelation (CrossCorrelation")
+    print("              bridge + conv-of-self) WORK, fp16-clean. ANE conv == cross-")
+    print("              correlation (no kernel flip); CrossCorrelation needs the template")
+    print("              strictly smaller than the map (same-size fails ANECCompile).")
+    print("  MONTECARLO: map+reduction estimators (integral, mean/variance) WORK; the wide")
+    print("              accumulator keeps large-M reductions clean. Caveat: aneforge")
+    print("              exposes NO on-device RNG, so samples are host-drawn and fed in")
+    print("              (reference uses the same samples -> exact, not statistical).")
+    print("  N-BODY    : pairwise broadcast-diff ([N,1,3]-[1,N,3]) + reduction WORKS for")
+    print("              small N (linear forces fp16-clean; 1/r potential is fp16-limited")
+    print("              near coincident points and grows O(N^2) in the intermediate).")
+    print("  QUADRATURE: definite integrals as a weighted reduction (Simpson, Gauss-")
+    print("              Legendre) WORK to ~1e-5. BOUNDARY: cumsum/prefix-scan is NOT")
+    print("              expressible (no scan op, no in-graph loop), so cumulative/")
+    print("              indefinite integrals do not fit.")
+    print()  # blank line before the GATE line
 
-  print("\n" + "=" * 104)
-  print(f"variants run: {total}   PASS {n_pass}   XFAIL {n_xfail}   "
-          f"FAIL {n_fail}   ERROR {n_err}   XPASS {n_xpass}")
-  if relerrs:
-    print(f"relerr across {len(relerrs)} numeric variants: "
-              f"min {min(relerrs):.2e}  median {np.median(relerrs):.2e}  max {max(relerrs):.2e}")
-
-  # ------- SPECTRAL verdict block (the marquee finding) ----------------- #
-  print("\n" + "-" * 104)
-  print("CAN THE ANE DO AN FFT?  (complex emulated as real/imag tensor pairs)")
-  print("-" * 104)
-  if dft_curve:
-    print("  DFT-as-matmul precision vs transform size N (fp16 weights, wide accumulator):")
-    for N, e in sorted(dft_curve):
-      print(f"    N={N:<5d} relerr {e}")
-    print("    => relerr is essentially FLAT in N (no compounding): the ANE matmul")
-    print("       accumulator is wide (>=fp32), so the length-N twiddle sum is not")
-    print("       re-rounded per term. fp16 is NOT the wall for the transform.")
-  bf = [r for r in all_results if r["name"].startswith("fft_butterfly")]
-  if bf:
-    bfst = ", ".join(f"{r['name'].split('_N')[1]}:{r['status']}({r['metric']})" for r in bf)
-    print(f"  Radix-2 butterfly FFT (fully unrolled): {bfst}")
-  print("\n  VERDICT:")
-  print("    YES - both a dense DFT (twiddle-matrix matmul) and a radix-2 butterfly FFT")
-  print("    are EXPRESSIBLE and CORRECT on the ANE via complex-as-real-pairs")
-  print("    arithmetic ((a+bi)(c+di) = (ac-bd)+(ad+bc)i over paired real tensors).")
-  print("    * DFT-matmul: fp16-CLEAN to at least N=2048 (relerr ~ few e-4, flat in N).")
-  print("      The limiter is NOT precision but the O(N^2) twiddle-matrix size/bandwidth")
-  print("      - it is a naive DFT, so cost grows quadratically; precision does not.")
-  print("    * Butterfly FFT: correct for small fixed N, but expressible ONLY as a")
-  print("      per-N STATIC UNROLL (the ANE is feed-forward: no in-graph loop, no scalar")
-  print("      feedback, and bit-reversal needs a folded one-hot since there is no")
-  print("      gather). So its O(N log N) advantage is not realizable as a graph at")
-  print("      useful N - the wall is ARCHITECTURAL (static unroll), not fp16.")
-  print("    BOTTOM LINE: the ANE has no complex dtype, but FFT/DFT is viable through")
-  print("    real-pair emulation; for practical sizes the dense DFT-matmul is the")
-  print("    right tool (fp16-robust, fuses), and a true scaling FFT is blocked by the")
-  print("    missing loop/gather, not by numerics.")
-
-  # ------- other capability findings ------------------------------------ #
-  print("\n" + "-" * 104)
-  print("OTHER SCIENTIFIC-KERNEL FINDINGS")
-  print("-" * 104)
-  print("  SIGNAL    : FIR filter (1D conv) and 2D autocorrelation (CrossCorrelation")
-  print("              bridge + conv-of-self) WORK, fp16-clean. ANE conv == cross-")
-  print("              correlation (no kernel flip); CrossCorrelation needs the template")
-  print("              strictly smaller than the map (same-size fails ANECCompile).")
-  print("  MONTECARLO: map+reduction estimators (integral, mean/variance) WORK; the wide")
-  print("              accumulator keeps large-M reductions clean. Caveat: aneforge")
-  print("              exposes NO on-device RNG, so samples are host-drawn and fed in")
-  print("              (reference uses the same samples -> exact, not statistical).")
-  print("  N-BODY    : pairwise broadcast-diff ([N,1,3]-[1,N,3]) + reduction WORKS for")
-  print("              small N (linear forces fp16-clean; 1/r potential is fp16-limited")
-  print("              near coincident points and grows O(N^2) in the intermediate).")
-  print("  QUADRATURE: definite integrals as a weighted reduction (Simpson, Gauss-")
-  print("              Legendre) WORK to ~1e-5. BOUNDARY: cumsum/prefix-scan is NOT")
-  print("              expressible (no scan op, no in-graph loop), so cumulative/")
-  print("              indefinite integrals do not fit.")
-
-  print(f"\nGATE: {'GREEN' if red == 0 else 'RED'}  "
-          f"({n_pass + n_xfail}/{total} green, {red} red)")
-  return all_results, (0 if red == 0 else 1)
+  return run_corpus(cases, verbose, columns=(_header, _row), annotate=_annotate,
+                    verdict=verdict, sep_width=104)
 
 
 if __name__ == "__main__":

--- a/tests/test_synthetic.py
+++ b/tests/test_synthetic.py
@@ -3,21 +3,16 @@ from __future__ import annotations
 
 import numpy as np
 
-from _corpus import Case, run_corpus  # noqa: E402
-import aneforge as af  # noqa: E402
+from _corpus import Case, run_corpus
+from _helpers import f16
+import aneforge as af
 
 rng = np.random.default_rng(11)
 
 
-def f16(*shape, scale=1.0, pos=False):
-  a = rng.standard_normal(shape).astype(np.float32) * scale
-  if pos: a = np.abs(a) + 0.5
-  return a.astype(np.float16)
-
-
 # random op-chain (elementwise + activations), broadcasts
 def _elementwise_chain():
-  a = f16(4, 8); b = f16(4, 8); c = f16(4, 8, pos=True)
+  a = f16(rng, 4, 8); b = f16(rng, 4, 8); c = f16(rng, 4, 8, pos=True)
 
   def build(at, bt, ct):
     h = (at + bt) * ct
@@ -37,7 +32,7 @@ def _elementwise_chain():
 
 
 def _activation_zoo():
-  x = f16(4, 8)
+  x = f16(rng, 4, 8)
 
   def build(xt):
     h = xt.silu() + xt.gelu()
@@ -59,7 +54,7 @@ def _activation_zoo():
 
 def _broadcast_rowvec():
   # [M, D] + [1, D] and * [1, D]: classic numpy broadcast the optimizer must keep.
-  x = f16(6, 12); row = f16(1, 12); col_scale = 2.0
+  x = f16(rng, 6, 12); row = f16(rng, 1, 12); col_scale = 2.0
 
   def build(xt, rt):
     h = xt + rt
@@ -76,7 +71,7 @@ def _broadcast_rowvec():
 
 def _broadcast_3d():
   # [B, M, D] + [1, 1, D]
-  x = f16(2, 5, 8); bias = f16(1, 1, 8)
+  x = f16(rng, 2, 5, 8); bias = f16(rng, 1, 1, 8)
 
   def build(xt, bt):
     return (xt + bt).silu()
@@ -94,7 +89,7 @@ def np_relu(x):
 
 # reshape/transpose chains that cancel back to identity
 def _reshape_cancel():
-  x = f16(2, 3, 4)
+  x = f16(rng, 2, 3, 4)
 
   def build(xt):
     h = xt.reshape(6, 4).reshape(2, 3, 4)
@@ -111,7 +106,7 @@ def _reshape_cancel():
 
 def _transpose_matmul():
   # transpose then matmul (column-major-ish feed)
-  x = f16(4, 6); W = f16(4, 5, scale=0.3)  # x.T is [6,4] @ [4,5]
+  x = f16(rng, 4, 6); W = f16(rng, 4, 5, scale=0.3)  # x.T is [6,4] @ [4,5]
 
   def build(xt):
     return xt.transpose([1, 0]) @ W
@@ -124,7 +119,7 @@ def _transpose_matmul():
 
 # reductions along various axes
 def _reduce_axes():
-  x = f16(3, 4, 5)
+  x = f16(rng, 3, 4, 5)
 
   def build(xt):
     s = xt.sum(2)                 # [3,4,1]
@@ -140,7 +135,7 @@ def _reduce_axes():
 
 
 def _reduce_minmax():
-  x = f16(4, 16)
+  x = f16(rng, 4, 16)
 
   def build(xt):
     return af.maximum(xt.amax(1), xt.amin(1) * -1.0)
@@ -152,7 +147,7 @@ def _reduce_minmax():
 
 
 def _reduce_then_normalize():
-  x = f16(5, 10)
+  x = f16(rng, 5, 10)
 
   def build(xt):
     mu = xt.mean(1)            # [5,1]
@@ -171,7 +166,7 @@ def _reduce_then_normalize():
 
 # matmul / bmm rectangles
 def _matmul_rect():
-  x = f16(7, 13); W = f16(13, 5, scale=0.3)
+  x = f16(rng, 7, 13); W = f16(rng, 13, 5, scale=0.3)
 
   def build(xt):
     return xt @ W
@@ -183,7 +178,7 @@ def _matmul_rect():
 
 
 def _bmm_rect():
-  a = f16(3, 6, 9, scale=0.5); b = f16(3, 9, 4, scale=0.5)
+  a = f16(rng, 3, 6, 9, scale=0.5); b = f16(rng, 3, 9, 4, scale=0.5)
 
   def build(at, bt):
     return at @ bt
@@ -196,9 +191,9 @@ def _bmm_rect():
 
 def _linear_chain():
   D0, D1, D2 = 12, 20, 7
-  W1 = f16(D1, D0, scale=0.2); b1 = f16(D1, scale=0.1)
-  W2 = f16(D2, D1, scale=0.2); b2 = f16(D2, scale=0.1)
-  x = f16(5, D0)
+  W1 = f16(rng, D1, D0, scale=0.2); b1 = f16(rng, D1, scale=0.1)
+  W2 = f16(rng, D2, D1, scale=0.2); b2 = f16(rng, D2, scale=0.1)
+  x = f16(rng, 5, D0)
 
   def build(xt):
     return xt.linear(W1, b1).relu().linear(W2, b2)
@@ -212,7 +207,7 @@ def _linear_chain():
 
 # new primitives: extra activations / reductions / structural / select
 def _extra_activation_zoo():
-  x = f16(4, 8)
+  x = f16(rng, 4, 8)
 
   def build(xt):
     h = xt.softsign() + xt.atan()
@@ -235,7 +230,7 @@ def _extra_activation_zoo():
 
 
 def _inverse_recip():
-  x = f16(4, 8, pos=True)  # strictly positive -> reciprocal is well-defined
+  x = f16(rng, 4, 8, pos=True)  # strictly positive -> reciprocal is well-defined
 
   def build(xt):
     return xt.inverse() + xt.sqrt().inverse()
@@ -247,7 +242,7 @@ def _inverse_recip():
 
 
 def _extra_reductions():
-  x = f16(4, 8)
+  x = f16(rng, 4, 8)
 
   def build(xt):
     return xt.l1_norm(1) + xt.sum_square(1)
@@ -259,7 +254,7 @@ def _extra_reductions():
 
 
 def _log_sum_reduce():
-  x = f16(4, 8, pos=True)
+  x = f16(rng, 4, 8, pos=True)
 
   def build(xt):
     return xt.log_sum(1)
@@ -271,7 +266,7 @@ def _log_sum_reduce():
 
 
 def _squeeze_expand_roundtrip():
-  x = f16(1, 4, 1, 8)
+  x = f16(rng, 1, 4, 1, 8)
 
   def build(xt):
     h = xt.squeeze([0, 2])            # (4, 8)
@@ -287,7 +282,7 @@ def _squeeze_expand_roundtrip():
 
 
 def _slice_by_size_window():
-  x = f16(4, 8)
+  x = f16(rng, 4, 8)
 
   def build(xt):
     return xt.slice_by_size([1, 2], [2, 5]).relu()
@@ -299,7 +294,7 @@ def _slice_by_size_window():
 
 
 def _stack_split():
-  a = f16(4, 8); b = f16(4, 8)
+  a = f16(rng, 4, 8); b = f16(rng, 4, 8)
 
   def build(at, bt):
     st = af.stack([at, bt], 0)        # (2, 4, 8)
@@ -314,7 +309,7 @@ def _stack_split():
 
 
 def _select_greater():
-  a = f16(4, 8); b = f16(4, 8)
+  a = f16(rng, 4, 8); b = f16(rng, 4, 8)
 
   def build(at, bt):
     return af.select(at.greater(bt), at, bt)   # elementwise max via select


### PR DESCRIPTION
Acts on the adversarially-verified findings from the fan-out refactor review (29 confirmed). Prioritized by **line-count savings**. **Behavior-preserving** — full on-device suite passed at each risky stage.

## Net −895 lines (47 files), by impact

**Big savers (dead code + dispatch duplication):**
- **bench −479** — deleted dead `device_compare.py` workload builders / legacy energy impl (kept the shared helpers the 8 importers use); moved the MIL opcode-tally to `bench/_mil.py`; table-drove `measure_peak_power` + dropped a duplicate latency helper.
- **bridges −257** — migrated 13 native bridges onto the shared `_netplist` helpers (`ensure_invoker`/`build_plist`/`invoke_netplist`), deleting per-bridge invoker/plist/subprocess copies. Plist output verified **byte-identical** to before; the `_netplist_worker` by-name dependency kept via a thin wrapper. (4 geometry bridges also gained a `status==ok` check — strictly more validation.)
- **tests −162** — consolidated `f16`, the one-hot-select trick, the ANE-availability gate, and the corpus-runner skeleton into `tests/_helpers.py` (reconciling drifted signatures); dropped 33 cargo-cult `# noqa`s that suppressed rules nothing enforces.

**DRY/maintainability (≈line-neutral, but kill duplicated logic):**
- **autograd** — factored the triplicated LayerNorm-family backward, a `_value_input` helper, dropped a dead `objective` param.
- **linalg** — shared `_mgs_qr_graph` (was duplicated) + `_run_multi`; hoisted `dot(v,v)` (kept `d2.rsqrt()` for bit-identical numerics).
- **graph** — one `_tiled_attention` for mha/cross_attention/sdpa (the riskiest triplicated kernel), `_pool`, conv guards.
- **compile/optimize** — conv/pool const-emit helpers, multi-root `_topo`, an `id(out)` `_topo` memo (the review's #1 perf finding), `_route_configs` dedup.

## Verification
- full on-device suite (`--forked`, Apple Silicon): **563 passed** — run to gate the bridge migration, the numeric-kernel refactors, and the f16 call-site rewrite.
- golden-MIL byte-identical (emit unchanged); pyright **0**; ruff clean; pylint 2-space clean.

Cross-cutting patterns the review flagged (graph re-traversal, netplist duplication, helper sprawl with drift) are addressed. The line-neutral core dedups were kept for their DRY value; the headline savings are the dead-code and dispatch-duplication removals.