### PR TITLE
ONNX importer for the Apple Neural Engine (CNNs, transformers, int8, on-ANE fine-tuning)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ PYTHONPATH=. python3 tests/op_smoketest.py    # compile + run each op on the ANE
 ```
 
 Then browse [`examples/`](examples/), starting with
-[`examples/quickstart.py`](examples/quickstart.py). For retrieval,
+[`examples/quickstart.py`](examples/quickstart.py). To run an existing ONNX
+model on the ANE, [`examples/onnx_import.py`](examples/onnx_import.py) imports
+a `.onnx` classifier via `af.load_onnx` and validates it against onnxruntime
+(cosine 1.0000). For retrieval,
 [`examples/rag_embeddings.py`](examples/rag_embeddings.py) is a LangChain
 `Embeddings` drop-in backed by the on-ANE encoder (4-5x faster than the GPU,
 cosine 1.0000).

--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -32,6 +32,7 @@ from .autograd import (Adam, adam_step, backward, backward_from, conv2d, conv_pa
                        mse, parameter, SGD, softmax_cross_entropy, Trainer, UnrolledTrainer)
 from .streaming import CheckpointedStack
 from .models import Encoder, Vision, load, load_resnet18, conv_block, cifar_cnn, group_norm_train
+from .onnx import load_onnx, onnx_to_tensor
 
 __all__ = [
     "Tensor", "Model", "SegmentedModel", "PrecisionWarning", "CrossChipFP16Warning",
@@ -55,6 +56,7 @@ __all__ = [
     "softmax_cross_entropy", "Trainer", "UnrolledTrainer", "adam_step",
     "conv_param", "conv2d", "CheckpointedStack",
     "fft", "linalg", "special", "einsum", "dsp",
+    "load_onnx", "onnx_to_tensor",
 ]
 
 # applied-math submodules (af.fft / af.linalg / af.special / af.dsp), self-contained over the public ops

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -330,7 +330,8 @@ def _const_i32_pair(em, n, suf, v):
 
 
 def _const_pad4(em, n, p):
-  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{p}, {p}, {p}, {p}])];')
+  v = [p, p, p, p] if isinstance(p, int) else list(p)    # scalar (symmetric) or (top, bottom, left, right)
+  em.line(f'tensor<int32, [4]> {n}_pd = const()[name = string("{n}_pd"), val = tensor<int32, [4]>([{v[0]}, {v[1]}, {v[2]}, {v[3]}])];')
 
 
 def _emit_conv_params(em, n, p, st, dl, g):   # pt, st, pd, dl, g (conv/dynamic_conv/conv_transpose)
@@ -370,8 +371,9 @@ def _e_dynamic_conv(em, t, n, s):
 @op("max_pool")
 def _e_max_pool(em, t, n, s):
   k, st, p = t.attrs["k"], t.attrs["stride"], t.attrs["pad"]
+  cm = "true" if t.attrs.get("ceil_mode") else "false"
   _emit_pool_params(em, n, k, st, p)
-  em.line(f'bool {n}_cm = const()[name = string("{n}_cm"), val = bool(false)];')
+  em.line(f'bool {n}_cm = const()[name = string("{n}_cm"), val = bool({cm})];')
   em.line(f'{em.ty(t.shape)} {n} = max_pool(ceil_mode = {n}_cm, kernel_sizes = {n}_ks, pad = {n}_pd, '
       f'pad_type = {n}_pt, strides = {n}_st, x = {s[0]})[name = string("{n}")];')
 
@@ -379,9 +381,11 @@ def _e_max_pool(em, t, n, s):
 @op("avg_pool")
 def _e_avg_pool(em, t, n, s):
   k, st, p = t.attrs["k"], t.attrs["stride"], t.attrs["pad"]
+  cm = "true" if t.attrs.get("ceil_mode") else "false"
+  ep = "true" if t.attrs.get("exclude_pad") else "false"
   _emit_pool_params(em, n, k, st, p)
-  em.line(f'bool {n}_ep = const()[name = string("{n}_ep"), val = bool(false)];')
-  em.line(f'bool {n}_cm = const()[name = string("{n}_cm"), val = bool(false)];')
+  em.line(f'bool {n}_ep = const()[name = string("{n}_ep"), val = bool({ep})];')
+  em.line(f'bool {n}_cm = const()[name = string("{n}_cm"), val = bool({cm})];')
   em.line(f'{em.ty(t.shape)} {n} = avg_pool(ceil_mode = {n}_cm, exclude_padding_from_average = {n}_ep, '
       f'kernel_sizes = {n}_ks, pad = {n}_pd, pad_type = {n}_pt, strides = {n}_st, x = {s[0]})[name = string("{n}")];')
 

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -407,9 +407,14 @@ def image_input(shape: Sequence[int], scale: float = 1.0 / 255.0, bias=0.0) -> T
   return y
 
 
+def _const(v) -> Tensor:
+  """Bake a numpy array / scalar as a fused `const_array` graph constant (a MIL `const`, folded to GOC for affine ops)."""
+  v = np.asarray(v, np.float16)
+  return Tensor(v.shape, "const_array", [], {"value": v})
+
+
 def _binary(a: Tensor, b, kind: str) -> Tensor:
-  if not isinstance(b, Tensor):
-    raise TypeError("aneforge add/sub/mul expect two graph Tensors (use weights via matmul/linear)")
+  if not isinstance(b, Tensor): b = _const(b)              # a numpy/scalar constant operand bakes into the fused program
   return Tensor(_broadcast(a.shape, b.shape), kind, [a, b])
 
 

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -340,17 +340,22 @@ class Tensor:
            {"gamma": gamma, "beta": beta, "groups": num_groups, "eps": float(eps)})
 
   # -- spatial ----------------------------------------------------------- #
-  def _pool(self, op: str, k: int, stride: int | None, pad: int) -> "Tensor":
+  def _pool(self, op: str, k: int, stride: int | None, pad: int,
+            ceil_mode: bool = False, exclude_pad: bool = False) -> "Tensor":
     stride = stride or k
     N, C, H, W = self.shape
-    out = (N, C, (H + 2 * pad - k) // stride + 1, (W + 2 * pad - k) // stride + 1)
-    return Tensor(out, op, [self], {"k": k, "stride": stride, "pad": pad})
+    r = stride - 1 if ceil_mode else 0                       # ceil((s+2p-k)/stride) vs floor
+    out = (N, C, (H + 2 * pad - k + r) // stride + 1, (W + 2 * pad - k + r) // stride + 1)
+    return Tensor(out, op, [self], {"k": k, "stride": stride, "pad": pad,
+                                    "ceil_mode": ceil_mode, "exclude_pad": exclude_pad})
 
-  def max_pool(self, k: int, stride: int | None = None, pad: int = 0) -> "Tensor":
-    return self._pool("max_pool", k, stride, pad)
+  def max_pool(self, k: int, stride: int | None = None, pad: int = 0, ceil_mode: bool = False) -> "Tensor":
+    return self._pool("max_pool", k, stride, pad, ceil_mode)
 
-  def avg_pool(self, k: int, stride: int | None = None, pad: int = 0) -> "Tensor":
-    return self._pool("avg_pool", k, stride, pad)
+  def avg_pool(self, k: int, stride: int | None = None, pad: int = 0,
+               ceil_mode: bool = False, exclude_pad: bool = False) -> "Tensor":
+    """Average pool. `exclude_pad` divides by the valid (non-pad) cell count (ONNX `count_include_pad=0`); default includes pad cells (divide by full kernel area)."""
+    return self._pool("avg_pool", k, stride, pad, ceil_mode, exclude_pad)
 
   def upsample(self, scale: int = 2) -> "Tensor":
     """Nearest-neighbour upsample [N,C,H,W] -> [N,C,scale*H,scale*W]."""
@@ -430,7 +435,7 @@ def _check_kw(kW: int, op: str, weight_shape) -> None:
     f"got weight {weight_shape}. Kernel height kH is unconstrained.")
 
 
-def _conv_attrs(weight, stride: int, pad: int, dilation: int, groups: int,
+def _conv_attrs(weight, stride: int, pad, dilation: int, groups: int,
         bias) -> "dict[str, Any]":
   attrs: dict[str, Any] = {"weight": weight, "stride": stride, "pad": pad,
               "dilation": dilation, "groups": groups}
@@ -439,17 +444,18 @@ def _conv_attrs(weight, stride: int, pad: int, dilation: int, groups: int,
   return attrs
 
 
-def conv(x: Tensor, weight, stride: int = 1, pad: int = 0, dilation: int = 1,
+def conv(x: Tensor, weight, stride: int = 1, pad: "int | tuple[int, int, int, int]" = 0, dilation: int = 1,
     groups: int = 1, bias=None) -> Tensor:
-  """2D conv. `x`: [N,Cin,H,W]; `weight`: [Cout, Cin/groups, kH, kW]; `bias`: [Cout]."""
+  """2D conv. `x`: [N,Cin,H,W]; `weight`: [Cout, Cin/groups, kH, kW]; `bias`: [Cout]. `pad` is a scalar (symmetric) or a `(top, bottom, left, right)` tuple."""
   weight = np.asarray(weight); _check_dtype(weight, "conv weight")
   if len(x.shape) != 4:
     raise ValueError(f"conv expects 4D input [N,Cin,H,W], got {x.shape}")
   N, Cin, H, W = x.shape
   Cout, _, kH, kW = weight.shape
   _check_kw(kW, "conv", weight.shape)
-  Hout = (H + 2 * pad - dilation * (kH - 1) - 1) // stride + 1
-  Wout = (W + 2 * pad - dilation * (kW - 1) - 1) // stride + 1
+  pt, pb, pl, pr = (pad, pad, pad, pad) if isinstance(pad, int) else pad
+  Hout = (H + pt + pb - dilation * (kH - 1) - 1) // stride + 1
+  Wout = (W + pl + pr - dilation * (kW - 1) - 1) // stride + 1
   return Tensor((N, Cout, Hout, Wout), "conv", [x],
          _conv_attrs(weight, stride, pad, dilation, groups, bias))
 

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -1,0 +1,67 @@
+"""Import an ONNX model and run it on the ANE. CNN-classifier op subset; see
+docs. Public: load_onnx / onnx_to_tensor."""
+from __future__ import annotations
+from typing import Callable
+from .graph import Tensor, input as _input
+from . import _compile
+
+_ONNX: dict[str, Callable] = {}
+def onnx_op(*names):
+  """Register a handler `fn(node, ins, attrs, inits)` for the given ONNX op names."""
+  def reg(fn):
+    for n in names: _ONNX[n] = fn
+    return fn
+  return reg
+
+def _attrs(node) -> dict:
+  """ONNX node attributes as a name->value dict."""
+  from onnx import helper
+  return {a.name: helper.get_attribute_value(a) for a in node.attribute}
+
+def _inits(graph) -> dict:
+  """Graph initializers (weights) as name->np.ndarray."""
+  from onnx import numpy_helper
+  return {t.name: numpy_helper.to_array(t) for t in graph.initializer}
+
+def _shape(vi) -> tuple:
+  """Static shape tuple from a value_info; rejects dynamic/symbolic dims."""
+  d = vi.type.tensor_type.shape.dim
+  out = []
+  for x in d:
+    if x.HasField("dim_value"): out.append(int(x.dim_value))
+    else: raise ValueError(f"onnx: dynamic/symbolic dim in '{vi.name}' - static shapes only")
+  return tuple(out)
+
+def _load(path):
+  """Load an ONNX model (or accept one in-memory) and run shape inference."""
+  import onnx
+  m = path if hasattr(path, "graph") else onnx.load(path)
+  return onnx.shape_inference.infer_shapes(m)
+
+def onnx_to_tensor(path):
+  """Build an aneforge graph from an ONNX model; returns (graph_inputs, output)."""
+  m = _load(path); g = m.graph
+  inits = _inits(g)
+  vals: dict[str, object] = dict(inits)        # name -> Tensor | np.ndarray (initializers as arrays)
+  graph_inputs = []
+  for vi in g.input:
+    if vi.name in inits: continue              # initializers also listed as inputs in some exporters
+    t = _input(_shape(vi)); vals[vi.name] = t; graph_inputs.append(t)
+  for node in g.node:                          # ONNX node list is topologically ordered
+    if node.op_type not in _ONNX:
+      raise NotImplementedError(f"ONNX op '{node.op_type}' not supported")
+    ins = [vals.get(n) for n in node.input]
+    outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
+    outs = outs if isinstance(outs, (list, tuple)) else [outs]
+    for name, val in zip(node.output, outs): vals[name] = val
+  out = vals[g.output[0].name]
+  if not isinstance(out, Tensor): raise TypeError("onnx: graph output is not a Tensor")
+  return graph_inputs, out
+
+def load_onnx(path, **compile_kwargs):
+  """Import an ONNX model and compile it to a runnable ANE Model."""
+  _, out = onnx_to_tensor(path)
+  return _compile.compile(out, **compile_kwargs)
+
+@onnx_op("Relu")
+def _relu(node, ins, attrs, inits): return ins[0].relu()

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -161,3 +161,5 @@ def _softmax(node, ins, a, i): return ins[0].softmax(int(a.get("axis", -1)))
 def _const(node, ins, a, i):
   from onnx import numpy_helper
   return numpy_helper.to_array(a["value"])         # returns np.ndarray (folded by consumers)
+@onnx_op("Identity")
+def _identity(node, ins, a, i): return ins[0]      # pass-through (Tensor or array)

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -8,6 +8,7 @@ from .graph import Tensor, input as _input, conv as _conv, batch_norm as _bn, co
 from .graph import instance_norm as _instnorm, space_to_depth as _s2d
 from .graph import local_response_norm as _lrnorm, depth_to_space as _d2s
 from .graph import resize_bilinear as _rbilin, resize_nearest_neighbor as _rnn
+from .graph import gather as _gather, topk as _topk
 from . import _compile
 
 _ONNX: dict[str, Callable] = {}
@@ -252,3 +253,52 @@ def _resize(node, ins, a, i):
     if ctm == "align_corners": return _rbilin(x, th, tw, align_corners=True)
     raise NotImplementedError(f"ONNX Resize linear: coordinate_transformation_mode={ctm!r} not supported (ANE matches 'asymmetric'/'align_corners' only)")
   raise NotImplementedError(f"ONNX Resize: mode={mode!r} not supported")
+
+def _reduce_op(ins, a, method):
+  """ONNX reduce: axes attr (opset<18) or input (>=18); empty/absent -> all axes; keepdims=0 squeezes after."""
+  x = ins[0]; axes = a.get("axes")
+  if axes is None and len(ins) > 1 and ins[1] is not None: axes = [int(v) for v in np.asarray(ins[1]).ravel()]
+  if not axes:
+    if int(a.get("noop_with_empty_axes", 0)):
+      raise NotImplementedError("ONNX Reduce: noop_with_empty_axes=1 with empty axes (identity) not supported")
+    axes = list(range(len(x.shape)))                 # empty/absent -> reduce over all axes
+  axes = tuple(int(v) % len(x.shape) for v in axes)
+  y = method(x, axes)
+  if not int(a.get("keepdims", 1)): y = y.squeeze(axes)   # ANE reduce keeps dims; drop them ourselves
+  return y
+@onnx_op("ReduceMax")
+def _rmax(node, ins, a, i): return _reduce_op(ins, a, Tensor.amax)
+@onnx_op("ReduceMin")
+def _rmin(node, ins, a, i): return _reduce_op(ins, a, Tensor.amin)
+@onnx_op("ReduceSum")
+def _rsum(node, ins, a, i): return _reduce_op(ins, a, Tensor.sum)
+@onnx_op("ReduceMean")
+def _rmean(node, ins, a, i): return _reduce_op(ins, a, Tensor.mean)
+@onnx_op("Gather")
+def _gather_h(node, ins, a, i):
+  """Static-index gather along `axis`; constant scalar/1-D integer indices only (data-dependent indices have no ANE path)."""
+  if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Gather: only constant integer indices supported")
+  idx = np.asarray(ins[1])
+  if idx.ndim > 1: raise NotImplementedError("ONNX Gather: only scalar or 1-D indices supported")
+  ax = int(a.get("axis", 0)) % len(ins[0].shape)
+  y = _gather(ins[0], [int(v) for v in idx.ravel()], axis=ax)
+  if idx.ndim == 0: y = y.squeeze(ax)                # scalar index drops the gathered axis (ONNX rank rule)
+  return y
+@onnx_op("ArgMax")
+def _argmax_h(node, ins, a, i):
+  """ArgMax -> ANE argmax (2D [C,W] only, keepdims, indices fp16-encoded; GlobalArgMinMax bridge cuts the graph)."""
+  x = ins[0]
+  if len(x.shape) != 2: raise NotImplementedError("ONNX ArgMax: only 2D inputs supported on the ANE")
+  if int(a.get("select_last_index", 0)): raise NotImplementedError("ONNX ArgMax: select_last_index=1 not supported")
+  ax = int(a.get("axis", 0)) % 2
+  y = x.argmax(ax)
+  if not int(a.get("keepdims", 1)): y = y.squeeze(ax)
+  return y
+@onnx_op("TopK")
+def _topk_h(node, ins, a, i):
+  """TopK -> ANE topk (2D [C,W], last axis only); returns VALUES only - ONNX's indices output is unsupported."""
+  x = ins[0]
+  if len(x.shape) != 2: raise NotImplementedError("ONNX TopK: only 2D inputs supported on the ANE")
+  if int(a.get("axis", -1)) not in (-1, 1): raise NotImplementedError("ONNX TopK: only last-axis (width) topk supported")
+  k = int(np.asarray(ins[1]).ravel()[0])
+  return _topk(x, k, largest=bool(int(a.get("largest", 1))))

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -2,6 +2,7 @@
 docs. Public: load_onnx / onnx_to_tensor."""
 from __future__ import annotations
 from typing import Callable
+import numpy as np
 from .graph import Tensor, input as _input
 from . import _compile
 
@@ -65,3 +66,24 @@ def load_onnx(path, **compile_kwargs):
 
 @onnx_op("Relu")
 def _relu(node, ins, attrs, inits): return ins[0].relu()
+@onnx_op("Sigmoid")
+def _sig(node, ins, a, i): return ins[0].sigmoid()
+@onnx_op("Tanh")
+def _tanh(node, ins, a, i): return ins[0].tanh()
+@onnx_op("Add")
+def _add(node, ins, a, i): return ins[0] + ins[1]
+@onnx_op("Sub")
+def _sub(node, ins, a, i): return ins[0] - ins[1]
+@onnx_op("Mul")
+def _mul(node, ins, a, i): return ins[0] * ins[1]
+@onnx_op("Div")
+def _div(node, ins, a, i): return ins[0] / ins[1]
+@onnx_op("Clip")
+def _clip(node, ins, a, i):
+  """Clip; opset<11 reads min/max attrs, opset>=11 reads inputs 2/3. (0,6)->relu6, (0,inf)->relu."""
+  lo = a.get("min", -3.4e38); hi = a.get("max", 3.4e38)
+  if len(ins) >= 2 and ins[1] is not None: lo = float(np.asarray(ins[1]))
+  if len(ins) >= 3 and ins[2] is not None: hi = float(np.asarray(ins[2]))
+  if lo == 0.0 and hi == 6.0: return ins[0].relu6()
+  if lo == 0.0 and hi >= 3.4e38: return ins[0].relu()
+  return ins[0].clip(float(lo), float(hi))

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -88,8 +88,8 @@ def _clip(node, ins, a, i):
   if lo == 0.0 and hi >= 3.4e38: return ins[0].relu()
   return ins[0].clip(float(lo), float(hi))
 
-def _uniform(vals, op):                       # ONNX gives per-axis lists; ANE takes a scalar
-  if vals is None: return 0
+def _uniform(vals, op, default=1):            # ONNX gives per-axis lists; ANE takes a scalar
+  if vals is None: return default             # spec default for strides/dilations is 1 per axis
   v = list(vals)
   if len(set(v)) != 1: raise NotImplementedError(f"onnx {op}: non-uniform {v} not supported")
   return int(v[0])
@@ -109,10 +109,10 @@ def _conv_h(node, ins, a, i):
 @onnx_op("MaxPool")
 def _maxpool(node, ins, a, i):
   return ins[0].max_pool(_uniform(a.get("kernel_shape"), "MaxPool"),
-                         _uniform(a.get("strides"), "MaxPool") or None, _sympad(a.get("pads"), "MaxPool"))
+                         _uniform(a.get("strides"), "MaxPool"), _sympad(a.get("pads"), "MaxPool"))
 @onnx_op("AveragePool")
 def _avgpool(node, ins, a, i):
   return ins[0].avg_pool(_uniform(a.get("kernel_shape"), "AveragePool"),
-                         _uniform(a.get("strides"), "AveragePool") or None, _sympad(a.get("pads"), "AveragePool"))
+                         _uniform(a.get("strides"), "AveragePool"), _sympad(a.get("pads"), "AveragePool"))
 @onnx_op("GlobalAveragePool")
 def _gap(node, ins, a, i): return ins[0].mean((2, 3))     # keepdims -> [N,C,1,1]

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -3,7 +3,7 @@ docs. Public: load_onnx / onnx_to_tensor."""
 from __future__ import annotations
 from typing import Callable
 import numpy as np
-from .graph import Tensor, input as _input
+from .graph import Tensor, input as _input, conv as _conv
 from . import _compile
 
 _ONNX: dict[str, Callable] = {}
@@ -87,3 +87,32 @@ def _clip(node, ins, a, i):
   if lo == 0.0 and hi == 6.0: return ins[0].relu6()
   if lo == 0.0 and hi >= 3.4e38: return ins[0].relu()
   return ins[0].clip(float(lo), float(hi))
+
+def _uniform(vals, op):                       # ONNX gives per-axis lists; ANE takes a scalar
+  if vals is None: return 0
+  v = list(vals)
+  if len(set(v)) != 1: raise NotImplementedError(f"onnx {op}: non-uniform {v} not supported")
+  return int(v[0])
+
+def _sympad(pads, op):                         # pads = [top,left,bottom,right]; require symmetric+uniform
+  if pads is None: return 0
+  p = list(pads)
+  if len(set(p)) != 1: raise NotImplementedError(f"onnx {op}: asymmetric pads {p} not supported")
+  return int(p[0])
+
+@onnx_op("Conv")
+def _conv_h(node, ins, a, i):
+  x = ins[0]; w = np.asarray(ins[1]); b = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
+  return _conv(x, w, stride=_uniform(a.get("strides"), "Conv"), pad=_sympad(a.get("pads"), "Conv"),
+               dilation=_uniform(a.get("dilations"), "Conv"), groups=int(a.get("group", 1)), bias=b)
+
+@onnx_op("MaxPool")
+def _maxpool(node, ins, a, i):
+  return ins[0].max_pool(_uniform(a.get("kernel_shape"), "MaxPool"),
+                         _uniform(a.get("strides"), "MaxPool") or None, _sympad(a.get("pads"), "MaxPool"))
+@onnx_op("AveragePool")
+def _avgpool(node, ins, a, i):
+  return ins[0].avg_pool(_uniform(a.get("kernel_shape"), "AveragePool"),
+                         _uniform(a.get("strides"), "AveragePool") or None, _sympad(a.get("pads"), "AveragePool"))
+@onnx_op("GlobalAveragePool")
+def _gap(node, ins, a, i): return ins[0].mean((2, 3))     # keepdims -> [N,C,1,1]

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -8,7 +8,7 @@ from .graph import Tensor, input as _input, conv as _conv, batch_norm as _bn, co
 from .graph import instance_norm as _instnorm, space_to_depth as _s2d
 from .graph import local_response_norm as _lrnorm, depth_to_space as _d2s
 from .graph import resize_bilinear as _rbilin, resize_nearest_neighbor as _rnn
-from .graph import gather as _gather, topk as _topk
+from .graph import gather as _gather, topk as _topk, _const as _baked
 from . import _compile
 
 _ONNX: dict[str, Callable] = {}
@@ -99,24 +99,31 @@ def _gelu(node, ins, a, i):
 @onnx_op("PRelu")
 def _prelu(node, ins, a, i): return ins[0].prelu(np.asarray(ins[1]).reshape(-1))   # slope=ins[1], [C,1,1]->[C]
 @onnx_op("Pow")
-def _pow(node, ins, a, i): x, y = _two(ins, "Pow"); return x.pow(y)   # tensor-tensor only
+def _pow(node, ins, a, i): x, y = _binops(ins); return x.pow(y)
 @onnx_op("InstanceNormalization")
 def _instance_norm(node, ins, a, i):
   return _instnorm(ins[0], np.asarray(ins[1]), np.asarray(ins[2]), eps=float(a.get("epsilon", 1e-5)))
 @onnx_op("SpaceToDepth")
 def _space_to_depth(node, ins, a, i): return _s2d(ins[0], int(a["blocksize"]))
-def _two(ins, op):                                 # aneforge elementwise is tensor-tensor only
-  if not isinstance(ins[0], Tensor) or not isinstance(ins[1], Tensor):
-    raise NotImplementedError(f"ONNX {op}: a constant operand is not supported (tensor-tensor elementwise only)")
-  return ins[0], ins[1]
+def _binops(ins):                                  # a constant operand bakes into the fused program (const_array -> GOC fold)
+  return (ins[0] if isinstance(ins[0], Tensor) else _baked(ins[0]),
+          ins[1] if isinstance(ins[1], Tensor) else _baked(ins[1]))
 @onnx_op("Add")
-def _add(node, ins, a, i): x, y = _two(ins, "Add"); return x + y
+def _add(node, ins, a, i): x, y = _binops(ins); return x + y
 @onnx_op("Sub")
-def _sub(node, ins, a, i): x, y = _two(ins, "Sub"); return x - y
+def _sub(node, ins, a, i): x, y = _binops(ins); return x - y
 @onnx_op("Mul")
-def _mul(node, ins, a, i): x, y = _two(ins, "Mul"); return x * y
+def _mul(node, ins, a, i): x, y = _binops(ins); return x * y
 @onnx_op("Div")
-def _div(node, ins, a, i): x, y = _two(ins, "Div"); return x / y
+def _div(node, ins, a, i): x, y = _binops(ins); return x / y
+@onnx_op("HardSigmoid")
+def _hardsigmoid(node, ins, a, i):
+  """ONNX HardSigmoid = clip(alpha*x + beta, 0, 1); defaults alpha=0.2, beta=0.5."""
+  return (ins[0] * float(a.get("alpha", 0.2)) + float(a.get("beta", 0.5))).clip(0.0, 1.0)
+@onnx_op("HardSwish")
+def _hardswish(node, ins, a, i):
+  """ONNX HardSwish(x) = x * relu6(x + 3) / 6 (the fixed-point hard-swish)."""
+  return ins[0] * ((ins[0] + 3.0).relu6() * (1.0 / 6.0))
 @onnx_op("Clip")
 def _clip(node, ins, a, i):
   """Clip; opset<11 reads min/max attrs, opset>=11 reads inputs 2/3. (0,6)->relu6, (0,inf)->relu."""

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -177,6 +177,7 @@ def _gemm(node, ins, a, i):
   return x.linear(W, B)
 @onnx_op("MatMul")
 def _matmul(node, ins, a, i):
+  if not isinstance(ins[0], Tensor): raise NotImplementedError("ONNX MatMul: a constant first operand is not supported")
   b = ins[1]
   return ins[0] @ (np.asarray(b) if not isinstance(b, Tensor) else b)
 @onnx_op("BatchNormalization")
@@ -257,7 +258,9 @@ def _resize(node, ins, a, i):
 def _reduce_op(ins, a, method):
   """ONNX reduce: axes attr (opset<18) or input (>=18); empty/absent -> all axes; keepdims=0 squeezes after."""
   x = ins[0]; axes = a.get("axes")
-  if axes is None and len(ins) > 1 and ins[1] is not None: axes = [int(v) for v in np.asarray(ins[1]).ravel()]
+  if axes is None and len(ins) > 1 and ins[1] is not None:
+    if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Reduce: data-dependent axes (non-constant) not supported")
+    axes = [int(v) for v in np.asarray(ins[1]).ravel()]
   if not axes:
     if int(a.get("noop_with_empty_axes", 0)):
       raise NotImplementedError("ONNX Reduce: noop_with_empty_axes=1 with empty axes (identity) not supported")
@@ -300,5 +303,6 @@ def _topk_h(node, ins, a, i):
   x = ins[0]
   if len(x.shape) != 2: raise NotImplementedError("ONNX TopK: only 2D inputs supported on the ANE")
   if int(a.get("axis", -1)) not in (-1, 1): raise NotImplementedError("ONNX TopK: only last-axis (width) topk supported")
+  if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX TopK: data-dependent k (non-constant) not supported")
   k = int(np.asarray(ins[1]).ravel()[0])
   return _topk(x, k, largest=bool(int(a.get("largest", 1))))

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -56,7 +56,9 @@ def onnx_to_tensor(path):
     outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
     outs = outs if isinstance(outs, (list, tuple)) else [outs]
     for name, val in zip(node.output, outs): vals[name] = val
-  out = vals[g.output[0].name]
+  name = g.output[0].name
+  if name not in vals: raise ValueError(f"onnx: graph output '{name}' was never produced")
+  out = vals[name]
   if not isinstance(out, Tensor): raise TypeError("onnx: graph output is not a Tensor")
   return graph_inputs, out
 
@@ -71,14 +73,18 @@ def _relu(node, ins, attrs, inits): return ins[0].relu()
 def _sig(node, ins, a, i): return ins[0].sigmoid()
 @onnx_op("Tanh")
 def _tanh(node, ins, a, i): return ins[0].tanh()
+def _two(ins, op):                                 # aneforge elementwise is tensor-tensor only
+  if not isinstance(ins[0], Tensor) or not isinstance(ins[1], Tensor):
+    raise NotImplementedError(f"ONNX {op}: a constant operand is not supported (tensor-tensor elementwise only)")
+  return ins[0], ins[1]
 @onnx_op("Add")
-def _add(node, ins, a, i): return ins[0] + ins[1]
+def _add(node, ins, a, i): x, y = _two(ins, "Add"); return x + y
 @onnx_op("Sub")
-def _sub(node, ins, a, i): return ins[0] - ins[1]
+def _sub(node, ins, a, i): x, y = _two(ins, "Sub"); return x - y
 @onnx_op("Mul")
-def _mul(node, ins, a, i): return ins[0] * ins[1]
+def _mul(node, ins, a, i): x, y = _two(ins, "Mul"); return x * y
 @onnx_op("Div")
-def _div(node, ins, a, i): return ins[0] / ins[1]
+def _div(node, ins, a, i): x, y = _two(ins, "Div"); return x / y
 @onnx_op("Clip")
 def _clip(node, ins, a, i):
   """Clip; opset<11 reads min/max attrs, opset>=11 reads inputs 2/3. (0,6)->relu6, (0,inf)->relu."""
@@ -103,16 +109,23 @@ def _sympad(pads, op):                         # pads = [top,left,bottom,right];
 
 @onnx_op("Conv")
 def _conv_h(node, ins, a, i):
+  ap = a.get("auto_pad")
+  if ap is not None and (ap.decode() if isinstance(ap, bytes) else ap) != "NOTSET":
+    raise NotImplementedError(f"ONNX Conv: auto_pad={ap!r} not supported (use explicit pads)")
   x = ins[0]; w = np.asarray(ins[1]); b = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
   return _conv(x, w, stride=_uniform(a.get("strides"), "Conv"), pad=_sympad(a.get("pads"), "Conv"),
                dilation=_uniform(a.get("dilations"), "Conv"), groups=int(a.get("group", 1)), bias=b)
 
 @onnx_op("MaxPool")
 def _maxpool(node, ins, a, i):
+  if int(a.get("ceil_mode", 0)): raise NotImplementedError("ONNX MaxPool: ceil_mode=1 not supported")
+  if _uniform(a.get("dilations"), "MaxPool") != 1: raise NotImplementedError("ONNX MaxPool: dilations != 1 not supported")
   return ins[0].max_pool(_uniform(a.get("kernel_shape"), "MaxPool"),
                          _uniform(a.get("strides"), "MaxPool"), _sympad(a.get("pads"), "MaxPool"))
 @onnx_op("AveragePool")
 def _avgpool(node, ins, a, i):
+  if int(a.get("ceil_mode", 0)): raise NotImplementedError("ONNX AveragePool: ceil_mode=1 not supported")
+  if int(a.get("count_include_pad", 0)): raise NotImplementedError("ONNX AveragePool: count_include_pad=1 not supported")
   return ins[0].avg_pool(_uniform(a.get("kernel_shape"), "AveragePool"),
                          _uniform(a.get("strides"), "AveragePool"), _sympad(a.get("pads"), "AveragePool"))
 @onnx_op("GlobalAveragePool")
@@ -120,6 +133,8 @@ def _gap(node, ins, a, i): return ins[0].mean((2, 3))     # keepdims -> [N,C,1,1
 
 @onnx_op("Gemm")
 def _gemm(node, ins, a, i):
+  if float(a.get("alpha", 1.0)) != 1.0 or float(a.get("beta", 1.0)) != 1.0 or int(a.get("transA", 0)):
+    raise NotImplementedError("ONNX Gemm: only alpha=1, beta=1, transA=0 supported")
   x = ins[0]; W = np.asarray(ins[1]); B = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
   if not int(a.get("transB", 0)): W = W.T            # x.linear expects [out,in]
   return x.linear(W, B)
@@ -147,7 +162,8 @@ def _transpose(node, ins, a, i):
 @onnx_op("Squeeze")
 def _squeeze(node, ins, a, i):
   axes = a.get("axes")                               # opset<13 attr; opset>=13 axes input
-  if not axes: axes = [int(v) for v in np.asarray(ins[1])]
+  if axes is None and len(ins) > 1 and ins[1] is not None: axes = [int(v) for v in np.asarray(ins[1])]
+  if axes is None: raise NotImplementedError("ONNX Squeeze: squeeze-all (no axes) not supported")
   return ins[0].squeeze(tuple(axes))
 @onnx_op("Unsqueeze")
 def _unsqueeze(node, ins, a, i):

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -205,6 +205,14 @@ def _matmul(node, ins, a, i):
 def _bnorm(node, ins, a, i):
   x, s, bb, mean, var = ins[0], np.asarray(ins[1]), np.asarray(ins[2]), np.asarray(ins[3]), np.asarray(ins[4])
   return _bn(x, s, bb, mean, var, eps=float(a.get("epsilon", 1e-5)))
+@onnx_op("LayerNormalization")
+def _layernorm(node, ins, a, i):
+  """LayerNorm over the trailing axes [axis:] (the transformer/ViT case); folds to native layer_norm on a 2-D view."""
+  x = ins[0]; ax = int(a.get("axis", -1)) % len(x.shape)
+  scale = np.asarray(ins[1]).reshape(-1)
+  bias = np.asarray(ins[2]).reshape(-1) if len(ins) > 2 and ins[2] is not None else np.zeros_like(scale)
+  m, d = prod(x.shape[:ax]) or 1, prod(x.shape[ax:])
+  return x.reshape(m, d).layer_norm(scale, bias, float(a.get("epsilon", 1e-5))).reshape(*x.shape)
 @onnx_op("Reshape")
 def _reshape(node, ins, a, i):
   shape = [int(v) for v in np.asarray(ins[1])]

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -2,8 +2,9 @@
 docs. Public: load_onnx / onnx_to_tensor."""
 from __future__ import annotations
 from typing import Callable
+from math import prod
 import numpy as np
-from .graph import Tensor, input as _input, conv as _conv
+from .graph import Tensor, input as _input, conv as _conv, batch_norm as _bn, concat as _concat
 from . import _compile
 
 _ONNX: dict[str, Callable] = {}
@@ -116,3 +117,47 @@ def _avgpool(node, ins, a, i):
                          _uniform(a.get("strides"), "AveragePool"), _sympad(a.get("pads"), "AveragePool"))
 @onnx_op("GlobalAveragePool")
 def _gap(node, ins, a, i): return ins[0].mean((2, 3))     # keepdims -> [N,C,1,1]
+
+@onnx_op("Gemm")
+def _gemm(node, ins, a, i):
+  x = ins[0]; W = np.asarray(ins[1]); B = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
+  if not int(a.get("transB", 0)): W = W.T            # x.linear expects [out,in]
+  return x.linear(W, B)
+@onnx_op("MatMul")
+def _matmul(node, ins, a, i):
+  b = ins[1]
+  return ins[0] @ (np.asarray(b) if not isinstance(b, Tensor) else b)
+@onnx_op("BatchNormalization")
+def _bnorm(node, ins, a, i):
+  x, s, bb, mean, var = ins[0], np.asarray(ins[1]), np.asarray(ins[2]), np.asarray(ins[3]), np.asarray(ins[4])
+  return _bn(x, s, bb, mean, var, eps=float(a.get("epsilon", 1e-5)))
+@onnx_op("Reshape")
+def _reshape(node, ins, a, i):
+  shape = [int(v) for v in np.asarray(ins[1])]
+  shape = [ins[0].shape[k] if d == 0 else d for k, d in enumerate(shape)]   # 0 = keep input dim (before -1)
+  n = prod(ins[0].shape); known = prod(d for d in shape if d != -1)
+  shape = [n // known if d == -1 else d for d in shape]                     # -1 = infer remaining
+  return ins[0].reshape(*shape)
+@onnx_op("Flatten")
+def _flatten(node, ins, a, i): return ins[0].flatten2d(int(a.get("axis", 1)))
+@onnx_op("Transpose")
+def _transpose(node, ins, a, i):
+  perm = a.get("perm"); perm = list(perm) if perm is not None else list(reversed(range(len(ins[0].shape))))
+  return ins[0].transpose(perm)
+@onnx_op("Squeeze")
+def _squeeze(node, ins, a, i):
+  axes = a.get("axes")                               # opset<13 attr; opset>=13 axes input
+  if not axes: axes = [int(v) for v in np.asarray(ins[1])]
+  return ins[0].squeeze(tuple(axes))
+@onnx_op("Unsqueeze")
+def _unsqueeze(node, ins, a, i):
+  axes = a.get("axes") or [int(v) for v in np.asarray(ins[1])]
+  return ins[0].expand_dims(tuple(axes))
+@onnx_op("Concat")
+def _concat_h(node, ins, a, i): return _concat(list(ins), axis=int(a["axis"]))
+@onnx_op("Softmax")
+def _softmax(node, ins, a, i): return ins[0].softmax(int(a.get("axis", -1)))
+@onnx_op("Constant")
+def _const(node, ins, a, i):
+  from onnx import numpy_helper
+  return numpy_helper.to_array(a["value"])         # returns np.ndarray (folded by consumers)

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -66,10 +66,66 @@ def onnx_to_tensor(path):
   if not isinstance(out, Tensor): raise TypeError("onnx: graph output is not a Tensor")
   return graph_inputs, out
 
-def load_onnx(path, **compile_kwargs):
-  """Import an ONNX model and compile it to a runnable ANE Model."""
+def load_onnx(path, fuse_attention=False, **compile_kwargs):
+  """Import an ONNX model and compile it to a runnable ANE Model. `fuse_attention` rewrites
+  the `softmax(Q@K^T*scale)@V` pattern onto the native fused-attention layer (a graph cut)."""
   _, out = onnx_to_tensor(path)
+  if fuse_attention:
+    from ._rewrite import graph_rewrite, Rule
+    out = graph_rewrite(out, [Rule("fuse_sdpa", "numeric", _is_attention, _build_sdpa)])
   return _compile.compile(out, **compile_kwargs)
+
+def _attn_scores(scaled):
+  """The `scores * scale` step of attention: `muls(scores, k)` or `mul(scores, scalar const_array)`; return scores or None."""
+  if scaled.op == "muls": return scaled.srcs[0]
+  if scaled.op == "mul" and len(scaled.srcs) == 2:
+    a, b = scaled.srcs
+    if b.op == "const_array" and b.shape == (): return a
+    if a.op == "const_array" and a.shape == (): return b
+  return None
+
+def _split_mask(pre):
+  """softmax input is the scaled scores, or `add(scaled, mask_const)` (causal/additive mask). Returns (scaled, mask_const|None)."""
+  if pre.op == "add" and len(pre.srcs) == 2:
+    a, b = pre.srcs
+    if b.op == "const_array": return a, b
+    if a.op == "const_array": return b, a
+  return pre, None
+
+def _is_causal_mask(mc):
+  """True if a const additive mask is the causal upper-triangular -inf (strict upper << 0, diagonal+lower ~ 0)."""
+  m = np.asarray(mc.attrs["value"]).astype(np.float32)
+  while m.ndim > 2 and m.shape[0] == 1: m = m[0]
+  if m.ndim != 2 or m.shape[0] != m.shape[1]: return False
+  return bool((m[np.triu_indices(m.shape[0], 1)] < -1e3).all() and (m[np.tril_indices(m.shape[0], 0)] > -1e3).all())
+
+def _attn_parts(t):
+  """Decompose a candidate attention `bmm` into (q, k, v, scaled, mask) or None if it is not the pattern."""
+  if t.op != "bmm" or len(t.srcs) != 2: return None
+  attn, v = t.srcs
+  if attn.op != "softmax" or attn.attrs.get("axis") != len(attn.shape) - 1: return None
+  scaled, mask = _split_mask(attn.srcs[0])
+  scores = _attn_scores(scaled)
+  if scores is None or scores.op != "bmm" or len(scores.srcs) != 2: return None
+  q, kt = scores.srcs
+  if kt.op != "transpose" or tuple(kt.attrs.get("perm", ())) != (0, 1, 3, 2): return None
+  k = kt.srcs[0]
+  if not (len(q.shape) == 4 and q.shape[0] == 1 and k.shape == v.shape
+          and q.shape[1] == k.shape[1] and q.shape[3] == k.shape[3]): return None
+  return q, k, v, scaled, mask
+
+def _is_attention(t):
+  """Match `softmax(q@kᵀ*scale [+ causal_mask]) @ v`; a non-causal additive mask is left to the generic path."""
+  p = _attn_parts(t)
+  return p is not None and (p[4] is None or _is_causal_mask(p[4]))
+
+def _build_sdpa(t):
+  from .graph import sdpa as _sdpa
+  parts = _attn_parts(t); assert parts is not None    # guaranteed by _is_attention
+  q, k, v, scaled, mask = parts
+  scale = float(scaled.attrs["k"]) if scaled.op == "muls" else float(np.asarray(
+    (scaled.srcs[1] if scaled.srcs[1].op == "const_array" else scaled.srcs[0]).attrs["value"]))
+  return _sdpa(q, k, v, scale=scale, is_causal=mask is not None)   # causal mask -> native fused-attention layer
 
 @onnx_op("Relu")
 def _relu(node, ins, attrs, inits): return ins[0].relu()

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -244,6 +244,8 @@ def _resize(node, ins, a, i):
   if mode == "nearest":
     if ctm != "asymmetric":
       raise NotImplementedError(f"ONNX Resize nearest: coordinate_transformation_mode={ctm!r} not supported (ANE matches 'asymmetric')")
+    nm = _sattr(a, "nearest_mode", "round_prefer_floor")   # ONNX default; ANE samples with floor
+    if nm != "floor": raise NotImplementedError(f"ONNX Resize: nearest_mode={nm!r} not supported (only 'floor')")
     return _rnn(x, th, tw)
   if mode == "linear":
     if ctm == "asymmetric": return _rbilin(x, th, tw, align_corners=False)

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -105,17 +105,28 @@ def _instance_norm(node, ins, a, i):
   return _instnorm(ins[0], np.asarray(ins[1]), np.asarray(ins[2]), eps=float(a.get("epsilon", 1e-5)))
 @onnx_op("SpaceToDepth")
 def _space_to_depth(node, ins, a, i): return _s2d(ins[0], int(a["blocksize"]))
+def _isc(v): return not isinstance(v, Tensor)      # a constant (numpy/scalar from a folded shape subgraph) vs a graph tensor
 def _binops(ins):                                  # a constant operand bakes into the fused program (const_array -> GOC fold)
   return (ins[0] if isinstance(ins[0], Tensor) else _baked(ins[0]),
           ins[1] if isinstance(ins[1], Tensor) else _baked(ins[1]))
 @onnx_op("Add")
-def _add(node, ins, a, i): x, y = _binops(ins); return x + y
+def _add(node, ins, a, i):
+  if _isc(ins[0]) and _isc(ins[1]): return np.asarray(ins[0]) + np.asarray(ins[1])   # shape arithmetic folds to a constant
+  x, y = _binops(ins); return x + y
 @onnx_op("Sub")
-def _sub(node, ins, a, i): x, y = _binops(ins); return x - y
+def _sub(node, ins, a, i):
+  if _isc(ins[0]) and _isc(ins[1]): return np.asarray(ins[0]) - np.asarray(ins[1])
+  x, y = _binops(ins); return x - y
 @onnx_op("Mul")
-def _mul(node, ins, a, i): x, y = _binops(ins); return x * y
+def _mul(node, ins, a, i):
+  if _isc(ins[0]) and _isc(ins[1]): return np.asarray(ins[0]) * np.asarray(ins[1])
+  x, y = _binops(ins); return x * y
 @onnx_op("Div")
-def _div(node, ins, a, i): x, y = _binops(ins); return x / y
+def _div(node, ins, a, i):
+  if _isc(ins[0]) and _isc(ins[1]):
+    x0, x1 = np.asarray(ins[0]), np.asarray(ins[1])
+    return x0 // x1 if np.issubdtype(x0.dtype, np.integer) else x0 / x1     # ONNX integer Div truncates
+  x, y = _binops(ins); return x / y
 @onnx_op("HardSigmoid")
 def _hardsigmoid(node, ins, a, i):
   """ONNX HardSigmoid = clip(alpha*x + beta, 0, 1); defaults alpha=0.2, beta=0.5."""
@@ -151,27 +162,30 @@ def _sympad(pads, op):                         # pads = [top,left,bottom,right];
   if len(set(p)) != 1: raise NotImplementedError(f"onnx {op}: asymmetric pads {p} not supported")
   return int(p[0])
 
+def _pad4(pads):                               # ONNX conv pads=[top,left,bottom,right] -> scalar, or (top,bottom,left,right)
+  if pads is None: return 0
+  p = [int(v) for v in pads]
+  return p[0] if len(set(p)) == 1 else (p[0], p[2], p[1], p[3])
+
 @onnx_op("Conv")
 def _conv_h(node, ins, a, i):
   ap = a.get("auto_pad")
   if ap is not None and (ap.decode() if isinstance(ap, bytes) else ap) != "NOTSET":
     raise NotImplementedError(f"ONNX Conv: auto_pad={ap!r} not supported (use explicit pads)")
   x = ins[0]; w = np.asarray(ins[1]); b = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
-  return _conv(x, w, stride=_uniform(a.get("strides"), "Conv"), pad=_sympad(a.get("pads"), "Conv"),
+  return _conv(x, w, stride=_uniform(a.get("strides"), "Conv"), pad=_pad4(a.get("pads")),
                dilation=_uniform(a.get("dilations"), "Conv"), groups=int(a.get("group", 1)), bias=b)
 
 @onnx_op("MaxPool")
 def _maxpool(node, ins, a, i):
-  if int(a.get("ceil_mode", 0)): raise NotImplementedError("ONNX MaxPool: ceil_mode=1 not supported")
   if _uniform(a.get("dilations"), "MaxPool") != 1: raise NotImplementedError("ONNX MaxPool: dilations != 1 not supported")
-  return ins[0].max_pool(_uniform(a.get("kernel_shape"), "MaxPool"),
-                         _uniform(a.get("strides"), "MaxPool"), _sympad(a.get("pads"), "MaxPool"))
+  return ins[0].max_pool(_uniform(a.get("kernel_shape"), "MaxPool"), _uniform(a.get("strides"), "MaxPool"),
+                         _sympad(a.get("pads"), "MaxPool"), ceil_mode=bool(int(a.get("ceil_mode", 0))))
 @onnx_op("AveragePool")
 def _avgpool(node, ins, a, i):
-  if int(a.get("ceil_mode", 0)): raise NotImplementedError("ONNX AveragePool: ceil_mode=1 not supported")
-  if int(a.get("count_include_pad", 0)): raise NotImplementedError("ONNX AveragePool: count_include_pad=1 not supported")
-  return ins[0].avg_pool(_uniform(a.get("kernel_shape"), "AveragePool"),
-                         _uniform(a.get("strides"), "AveragePool"), _sympad(a.get("pads"), "AveragePool"))
+  return ins[0].avg_pool(_uniform(a.get("kernel_shape"), "AveragePool"), _uniform(a.get("strides"), "AveragePool"),
+                         _sympad(a.get("pads"), "AveragePool"), ceil_mode=bool(int(a.get("ceil_mode", 0))),
+                         exclude_pad=not int(a.get("count_include_pad", 0)))   # ONNX default count_include_pad=0 -> exclude pad cells
 @onnx_op("GlobalAveragePool")
 def _gap(node, ins, a, i): return ins[0].mean((2, 3))     # keepdims -> [N,C,1,1]
 
@@ -213,9 +227,35 @@ def _squeeze(node, ins, a, i):
 @onnx_op("Unsqueeze")
 def _unsqueeze(node, ins, a, i):
   axes = a.get("axes") or [int(v) for v in np.asarray(ins[1])]
+  if _isc(ins[0]): return np.expand_dims(np.asarray(ins[0]), tuple(axes))   # shape-vector unsqueeze folds
   return ins[0].expand_dims(tuple(axes))
 @onnx_op("Concat")
-def _concat_h(node, ins, a, i): return _concat(list(ins), axis=int(a["axis"]))
+def _concat_h(node, ins, a, i):
+  if all(_isc(v) for v in ins):                                             # concat of constant shape pieces folds
+    return np.concatenate([np.atleast_1d(np.asarray(v)) for v in ins], axis=int(a["axis"]))
+  return _concat(list(ins), axis=int(a["axis"]))
+@onnx_op("Shape")
+def _shape_op(node, ins, a, i):
+  """Static shape as an int64 constant (the channel-shuffle shape subgraph folds at import)."""
+  s = np.array(ins[0].shape, dtype=np.int64); r = len(s)
+  st = int(a.get("start", 0)); en = int(a.get("end", r))
+  return s[(st + r if st < 0 else st):(en + r if en < 0 else en)]
+@onnx_op("Slice")
+def _slice(node, ins, a, i):
+  starts = [int(v) for v in np.asarray(ins[1])]; ends = [int(v) for v in np.asarray(ins[2])]
+  axes = [int(v) for v in np.asarray(ins[3])] if len(ins) > 3 and ins[3] is not None else list(range(len(starts)))
+  steps = [int(v) for v in np.asarray(ins[4])] if len(ins) > 4 and ins[4] is not None else [1] * len(starts)
+  if _isc(ins[0]):                                   # constant (shape-arithmetic) slice folds
+    d = np.asarray(ins[0]); sl = [slice(None)] * d.ndim
+    for ax, s0, e0, st0 in zip(axes, starts, ends, steps): sl[ax % d.ndim] = slice(s0, e0, st0)
+    return d[tuple(sl)]
+  if any(st != 1 for st in steps): raise NotImplementedError("ONNX Slice: step != 1 on a tensor not supported")
+  x = ins[0]; rank = len(x.shape); begin = [0] * rank; size = list(x.shape)   # activation slice -> static slice_by_size
+  for ax, s0, e0 in zip(axes, starts, ends):
+    ax %= rank; dim = x.shape[ax]
+    s0 = s0 + dim if s0 < 0 else min(s0, dim); e0 = e0 + dim if e0 < 0 else min(e0, dim)
+    begin[ax] = max(0, s0); size[ax] = max(0, e0 - begin[ax])
+  return x.slice_by_size(begin, size)
 @onnx_op("Softmax")
 def _softmax(node, ins, a, i): return ins[0].softmax(int(a.get("axis", -1)))
 @onnx_op("Constant")
@@ -287,6 +327,8 @@ def _rmean(node, ins, a, i): return _reduce_op(ins, a, Tensor.mean)
 @onnx_op("Gather")
 def _gather_h(node, ins, a, i):
   """Static-index gather along `axis`; constant scalar/1-D integer indices only (data-dependent indices have no ANE path)."""
+  if _isc(ins[0]):                                   # gather over a constant shape vector folds (np.take preserves scalar-index rank reduction)
+    return np.take(np.asarray(ins[0]), np.asarray(ins[1]).astype(int), axis=int(a.get("axis", 0)))
   if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Gather: only constant integer indices supported")
   idx = np.asarray(ins[1])
   if idx.ndim > 1: raise NotImplementedError("ONNX Gather: only scalar or 1-D indices supported")

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -6,6 +6,8 @@ from math import prod
 import numpy as np
 from .graph import Tensor, input as _input, conv as _conv, batch_norm as _bn, concat as _concat
 from .graph import instance_norm as _instnorm, space_to_depth as _s2d
+from .graph import local_response_norm as _lrnorm, depth_to_space as _d2s
+from .graph import resize_bilinear as _rbilin, resize_nearest_neighbor as _rnn
 from . import _compile
 
 _ONNX: dict[str, Callable] = {}
@@ -124,6 +126,11 @@ def _clip(node, ins, a, i):
   if lo == 0.0 and hi >= 3.4e38: return ins[0].relu()
   return ins[0].clip(float(lo), float(hi))
 
+def _sattr(a, name, default):                 # ONNX string attrs arrive as bytes
+  v = a.get(name)
+  if v is None: return default
+  return v.decode() if isinstance(v, bytes) else v
+
 def _uniform(vals, op, default=1):            # ONNX gives per-axis lists; ANE takes a scalar
   if vals is None: return default             # spec default for strides/dilations is 1 per axis
   v = list(vals)
@@ -208,3 +215,38 @@ def _const(node, ins, a, i):
   return numpy_helper.to_array(a["value"])         # returns np.ndarray (folded by consumers)
 @onnx_op("Identity")
 def _identity(node, ins, a, i): return ins[0]      # pass-through (Tensor or array)
+@onnx_op("LRN")
+def _lrn(node, ins, a, i):
+  """LRN; ANE local_response_norm folds alpha/size internally, so ONNX alpha maps raw and k=bias (validated on-device)."""
+  return _lrnorm(ins[0], size=int(a["size"]), alpha=float(a.get("alpha", 1e-4)),
+                 beta=float(a.get("beta", 0.75)), k=float(a.get("bias", 1.0)))
+@onnx_op("DepthToSpace")
+def _depth_to_space(node, ins, a, i):
+  """DepthToSpace; ANE matches ONNX 'DCR' (the default) only - 'CRD' channel order is unsupported."""
+  mode = _sattr(a, "mode", "DCR")
+  if mode != "DCR": raise NotImplementedError(f"ONNX DepthToSpace: mode={mode!r} not supported (ANE matches 'DCR' only)")
+  return _d2s(ins[0], int(a["blocksize"]))
+@onnx_op("Resize")
+def _resize(node, ins, a, i):
+  """Resize (opset 11+): nearest/linear at the coord modes the ANE matches; cubic + half-pixel raise (validated on-device)."""
+  x = ins[0]
+  sizes = ins[3] if len(ins) > 3 and ins[3] is not None else None
+  if sizes is not None and np.asarray(sizes).size:
+    s = [int(v) for v in np.asarray(sizes)]; th, tw = s[-2], s[-1]
+  else:
+    scales = ins[2] if len(ins) > 2 and ins[2] is not None else None
+    if scales is None or not np.asarray(scales).size:
+      raise NotImplementedError("ONNX Resize: needs a non-empty scales or sizes input")
+    sc = [float(v) for v in np.asarray(scales)]
+    th = int(round(sc[-2] * x.shape[-2])); tw = int(round(sc[-1] * x.shape[-1]))
+  mode = _sattr(a, "mode", "nearest"); ctm = _sattr(a, "coordinate_transformation_mode", "half_pixel")
+  if mode == "cubic": raise NotImplementedError("ONNX Resize: mode='cubic' not supported")
+  if mode == "nearest":
+    if ctm != "asymmetric":
+      raise NotImplementedError(f"ONNX Resize nearest: coordinate_transformation_mode={ctm!r} not supported (ANE matches 'asymmetric')")
+    return _rnn(x, th, tw)
+  if mode == "linear":
+    if ctm == "asymmetric": return _rbilin(x, th, tw, align_corners=False)
+    if ctm == "align_corners": return _rbilin(x, th, tw, align_corners=True)
+    raise NotImplementedError(f"ONNX Resize linear: coordinate_transformation_mode={ctm!r} not supported (ANE matches 'asymmetric'/'align_corners' only)")
+  raise NotImplementedError(f"ONNX Resize: mode={mode!r} not supported")

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -5,6 +5,7 @@ from typing import Callable
 from math import prod
 import numpy as np
 from .graph import Tensor, input as _input, conv as _conv, batch_norm as _bn, concat as _concat
+from .graph import instance_norm as _instnorm, space_to_depth as _s2d
 from . import _compile
 
 _ONNX: dict[str, Callable] = {}
@@ -73,6 +74,34 @@ def _relu(node, ins, attrs, inits): return ins[0].relu()
 def _sig(node, ins, a, i): return ins[0].sigmoid()
 @onnx_op("Tanh")
 def _tanh(node, ins, a, i): return ins[0].tanh()
+@onnx_op("Erf")
+def _erf(node, ins, a, i): return ins[0].erf()
+@onnx_op("Exp")
+def _exp(node, ins, a, i): return ins[0].exp()
+@onnx_op("Log")
+def _log(node, ins, a, i): return ins[0].log()
+@onnx_op("Sqrt")
+def _sqrt(node, ins, a, i): return ins[0].sqrt()
+@onnx_op("Elu")
+def _elu(node, ins, a, i): return ins[0].elu(float(a.get("alpha", 1.0)))
+@onnx_op("LeakyRelu")
+def _lrelu(node, ins, a, i): return ins[0].leaky_relu(float(a.get("alpha", 0.01)))
+@onnx_op("Gelu")
+def _gelu(node, ins, a, i):
+  """ONNX Gelu (opset 20); exact erf-gelu only ('approximate=tanh' unsupported)."""
+  ap = a.get("approximate")
+  if ap is not None and (ap.decode() if isinstance(ap, bytes) else ap) == "tanh":
+    raise NotImplementedError("ONNX Gelu: approximate='tanh' not supported (only exact/erf)")
+  return ins[0].gelu()
+@onnx_op("PRelu")
+def _prelu(node, ins, a, i): return ins[0].prelu(np.asarray(ins[1]).reshape(-1))   # slope=ins[1], [C,1,1]->[C]
+@onnx_op("Pow")
+def _pow(node, ins, a, i): x, y = _two(ins, "Pow"); return x.pow(y)   # tensor-tensor only
+@onnx_op("InstanceNormalization")
+def _instance_norm(node, ins, a, i):
+  return _instnorm(ins[0], np.asarray(ins[1]), np.asarray(ins[2]), eps=float(a.get("epsilon", 1e-5)))
+@onnx_op("SpaceToDepth")
+def _space_to_depth(node, ins, a, i): return _s2d(ins[0], int(a["blocksize"]))
 def _two(ins, op):                                 # aneforge elementwise is tensor-tensor only
   if not isinstance(ins[0], Tensor) or not isinstance(ins[1], Tensor):
     raise NotImplementedError(f"ONNX {op}: a constant operand is not supported (tensor-tensor elementwise only)")

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -34,7 +34,9 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
 | Linear | `Gemm`, `MatMul` |
 | Normalization | `BatchNormalization`, `InstanceNormalization` |
-| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth` |
+| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth`, `DepthToSpace` |
+| Normalization (cross-channel) | `LRN` |
+| Resampling | `Resize` (nearest / linear) |
 | Misc | `Softmax`, `Constant`, `Identity` |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
@@ -70,3 +72,17 @@ mis-lower:
 - **PRelu:** slope is a per-channel initializer (`[C]`, `[C,1,1]`, or scalar, flattened
   to `[C]`); input must be rank>=3 `[N,C,...]`.
 - **InstanceNormalization:** `[N,C,H,W]` input with `scale`/`B` initializers `[C]`.
+- **LRN:** the ANE `local_response_norm` folds the `alpha/size` scaling internally, so
+  ONNX `alpha` maps straight through and `bias` maps to `k` (validated on-device against
+  onnxruntime, cosine ~1.0). `size`/`beta` pass through unchanged.
+- **DepthToSpace:** `DCR` mode only (the ONNX default, which the ANE op matches exactly);
+  `CRD` channel ordering raises.
+- **Resize:** `[N,C,H,W]`, opset 11+, target from `sizes` (preferred) or `scales`. Only
+  the coordinate conventions the ANE actually matches are accepted, each validated
+  on-device (cosine ~1.0); every other config raises rather than silently mis-resize:
+    - `mode="nearest"` requires `coordinate_transformation_mode="asymmetric"`.
+    - `mode="linear"` requires `asymmetric` (-> half-pixel-off bilinear) or
+      `align_corners`.
+    - `half_pixel`/`pytorch_half_pixel` sampling and `mode="cubic"` are **not** matched by
+      the ANE resamplers and raise. Note the ONNX default `coordinate_transformation_mode`
+      is `half_pixel`, so a `Resize` must set `asymmetric`/`align_corners` explicitly.

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -22,6 +22,10 @@ y = net(np.zeros((1, 3, 224, 224), np.float16))
 - `af.onnx_to_tensor(path)` - import only, returning `(graph_inputs, output)` ANEForge
   tensors so you can inspect or splice the graph before compiling it yourself.
 
+A runnable end-to-end example (export a torchvision model, import it, validate against
+onnxruntime) is in [`examples/onnx_import.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/onnx_import.py):
+`python3 examples/onnx_import.py [model.onnx]`.
+
 ## Supported operators
 
 The importer raises `NotImplementedError("ONNX op 'X' not supported")` for anything

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -37,6 +37,8 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth`, `DepthToSpace` |
 | Normalization (cross-channel) | `LRN` |
 | Resampling | `Resize` (nearest / linear) |
+| Reduction | `ReduceMax`, `ReduceMin`, `ReduceSum`, `ReduceMean` |
+| Indexing | `Gather` (static indices), `ArgMax`, `TopK` (2D, values only) |
 | Misc | `Softmax`, `Constant`, `Identity` |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
@@ -88,3 +90,20 @@ mis-lower:
     - `half_pixel`/`pytorch_half_pixel` sampling and `mode="cubic"` are **not** matched by
       the ANE resamplers and raise. Note the ONNX default `coordinate_transformation_mode`
       is `half_pixel`, so a `Resize` must set `asymmetric`/`align_corners` explicitly.
+- **Reductions** (`ReduceMax`/`ReduceMin`/`ReduceSum`/`ReduceMean`): `axes` may be an
+  attribute (opset < 18; ReduceSum < 13) or an input initializer (later opsets); an
+  absent/empty `axes` reduces over every axis. `keepdims=1` (the default) keeps reduced
+  dims as size 1; `keepdims=0` squeezes them afterward. `noop_with_empty_axes=1` with no
+  axes (the identity edge) raises. `ReduceMean` and `ReduceMax` are validated on-device
+  against onnxruntime (cosine ~1.0).
+- **Gather:** static (constant-initializer) integer indices only - a data-dependent
+  (tensor) index raises, since on-engine gather-by-data has no ANE path. Indices must be
+  scalar or 1-D; a scalar index drops the gathered axis (ONNX rank rule) and a >1-D index
+  array raises. Lowers to `slice_by_size`+`concat`; validated on-device (cosine ~1.0).
+- **ArgMax:** 2-D `[C,W]` inputs only (the ANE `GlobalArgMinMax` bridge), `keepdims=1`
+  default (`keepdims=0` squeezes the axis); `select_last_index=1` is unsupported. Indices
+  are fp16-encoded and the bridge cuts the graph, so it is shipped shape-validated only.
+- **TopK:** 2-D `[C,W]` inputs, last axis (`axis` in `{-1, 1}`) only. Returns the **values**
+  output **only** - ONNX's second (indices) output is unsupported, so a model consuming the
+  indices fails when that name is later looked up. `k` is read from the (opset 10+) input;
+  `k` in `{3, 4}` is rejected by the ANE itself. Shipped shape-validated only.

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -1,0 +1,55 @@
+# ONNX import
+
+Load an ONNX model and run it on the Apple Neural Engine. The importer targets the
+CNN-classifier op subset (the ops a torch-exported ResNet/VGG/MobileNet emits), builds
+an ANEForge graph from the ONNX node list, and compiles it through the usual e5rt path.
+
+## API
+
+Two entry points, both top-level (`import aneforge as af`):
+
+```python
+import aneforge as af
+import numpy as np
+
+net = af.load_onnx("resnet18.onnx")          # import + compile -> runnable Model
+y = net(np.zeros((1, 3, 224, 224), np.float16))
+```
+
+- `af.load_onnx(path, **compile_kwargs)` - import the model and compile it to a runnable
+  `Model`. Extra keyword arguments pass straight to `af.compile` (`target=`, `opt=`,
+  `compress=`, ...). `path` is a filename or an in-memory `onnx.ModelProto`.
+- `af.onnx_to_tensor(path)` - import only, returning `(graph_inputs, output)` ANEForge
+  tensors so you can inspect or splice the graph before compiling it yourself.
+
+## Supported operators
+
+The importer raises `NotImplementedError("ONNX op 'X' not supported")` for anything
+outside this set, so an unsupported model fails loudly with the offending op named.
+
+| Category | ONNX ops |
+| --- | --- |
+| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu) |
+| Elementwise | `Add`, `Sub`, `Mul`, `Div` |
+| Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
+| Linear | `Gemm`, `MatMul` |
+| Normalization | `BatchNormalization` |
+| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat` |
+| Misc | `Softmax`, `Constant`, `Identity` |
+
+Export at `opset_version=13` with constant folding on (the default), which resolves the
+`Shape`/`Gather`/dynamic-`Reshape` plumbing into static initializers before import.
+
+## Caveats
+
+- **fp16 compute.** ANEForge casts weights to fp16 at compile and computes in fp16, so a
+  match against onnxruntime (fp32) is a **cosine-similarity** check, not bit-exact. A
+  torch-exported ResNet-18 matches onnxruntime at cosine ~0.99999 end to end.
+- **fp16 input.** `af.input` is fp16, so feed an fp16 array (cast your input with
+  `x.astype(np.float16)`).
+- **Static shapes only.** Every program compiles for a concrete shape; a dynamic or
+  symbolic dim raises at import. Data-dependent value ops (on-engine gather / index by
+  tensor data) have no ANE path - see [capabilities.md](capabilities.md).
+- **NCHW.** Channels-first layout, matching ONNX's convolution convention.
+- **Uniform/symmetric conv params.** Per-axis strides, dilations, and pads must be
+  uniform and symmetric; a non-uniform value raises rather than silently mis-lowering.

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -33,8 +33,8 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 
 | Category | ONNX ops |
 | --- | --- |
-| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf` |
-| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` |
+| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf`, `HardSigmoid`, `HardSwish` |
+| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported) |
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
 | Linear | `Gemm`, `MatMul` |
 | Normalization | `BatchNormalization`, `InstanceNormalization` |
@@ -75,9 +75,12 @@ mis-lower:
 - **Conv:** explicit `pads` only - `auto_pad` (`SAME_UPPER`/`SAME_LOWER`/`VALID`) raises.
 - **Pooling:** `ceil_mode=0` (floor) only; `AveragePool` rejects `count_include_pad=1`
   and `MaxPool` rejects `dilations != 1`.
-- **Elementwise.** `Add`/`Sub`/`Mul`/`Div`/`Pow` are tensor-tensor only; a constant
-  operand raises (exporters usually fold these into the adjacent
-  `Conv`/`BatchNormalization`). A constant `Pow` exponent (`Pow(x, 2)`) raises.
+- **Elementwise.** `Add`/`Sub`/`Mul`/`Div`/`Pow` accept either two tensors or a tensor
+  and a constant: a constant operand (scalar, per-channel, or broadcastable) bakes in as
+  a fused `const_array` (a MIL `const`, folded to the ANE's gain-offset epilogue for
+  affine ops), so `Mul(x, c)`, `Add(x, c)`, `Pow(x, 2)`, and the like need no graph cut.
+  This is what makes `HardSigmoid`/`HardSwish` and the scale/shift ops in MobileNetV3 and
+  ConvNeXt importable.
 - **Gelu:** exact erf-gelu only; `approximate="tanh"` raises.
 - **PRelu:** slope is a per-channel initializer (`[C]`, `[C,1,1]`, or scalar, flattened
   to `[C]`); input must be rank>=3 `[N,C,...]`.

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -63,6 +63,10 @@ Export at `opset_version=13` with constant folding on (the default), which resol
 These attribute forms fall outside the supported subset and raise rather than
 mis-lower:
 
+- **Constant weights/params only.** Weight/parameter inputs (Conv/Gemm/MatMul/
+  BatchNormalization/InstanceNormalization/PRelu weights, reduce `axes`, TopK `k`,
+  Gather indices) must be constant initializers; a data-dependent (computed) weight or
+  param has no ANE path and raises `NotImplementedError`.
 - **Gemm:** only `alpha=1`, `beta=1`, `transA=0` (`transB` is honored).
 - **Conv:** explicit `pads` only - `auto_pad` (`SAME_UPPER`/`SAME_LOWER`/`VALID`) raises.
 - **Pooling:** `ceil_mode=0` (floor) only; `AveragePool` rejects `count_include_pad=1`

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -38,7 +38,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
 | Linear | `Gemm`, `MatMul` |
 | Normalization | `BatchNormalization`, `InstanceNormalization` |
-| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth`, `DepthToSpace` |
+| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth`, `DepthToSpace`, `Slice`, `Shape` |
 | Normalization (cross-channel) | `LRN` |
 | Resampling | `Resize` (nearest / linear) |
 | Reduction | `ReduceMax`, `ReduceMin`, `ReduceSum`, `ReduceMean` |
@@ -72,9 +72,15 @@ mis-lower:
   Gather indices) must be constant initializers; a data-dependent (computed) weight or
   param has no ANE path and raises `NotImplementedError`.
 - **Gemm:** only `alpha=1`, `beta=1`, `transA=0` (`transB` is honored).
-- **Conv:** explicit `pads` only - `auto_pad` (`SAME_UPPER`/`SAME_LOWER`/`VALID`) raises.
-- **Pooling:** `ceil_mode=0` (floor) only; `AveragePool` rejects `count_include_pad=1`
-  and `MaxPool` rejects `dilations != 1`.
+- **Conv:** explicit `pads` only (`auto_pad` raises); asymmetric per-side pads are
+  supported (mapped to the native per-side MIL conv `pad`).
+- **Shape subgraph.** `Shape` and the dynamic-reshape plumbing (`Slice`/`Gather`/`Concat`/
+  arithmetic over shape vectors) constant-fold at import on the static input shape, so
+  patterns like ShuffleNet's channel shuffle (`Reshape`->`Transpose`->`Reshape`) import as
+  static ops. `Slice` on an activation lowers to a static `slice_by_size` (step 1 only).
+- **Pooling:** `ceil_mode` (both modes) and `AveragePool` `count_include_pad` (0/1) map
+  to the native MIL `ceil_mode` / `exclude_padding_from_average` params; `MaxPool` rejects
+  `dilations != 1`.
 - **Elementwise.** `Add`/`Sub`/`Mul`/`Div`/`Pow` accept either two tensors or a tensor
   and a constant: a constant operand (scalar, per-channel, or broadcastable) bakes in as
   a fused `const_array` (a MIL `const`, folded to the ANE's gain-offset epilogue for

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -80,7 +80,9 @@ mis-lower:
 - **Resize:** `[N,C,H,W]`, opset 11+, target from `sizes` (preferred) or `scales`. Only
   the coordinate conventions the ANE actually matches are accepted, each validated
   on-device (cosine ~1.0); every other config raises rather than silently mis-resize:
-    - `mode="nearest"` requires `coordinate_transformation_mode="asymmetric"`.
+    - `mode="nearest"` requires `coordinate_transformation_mode="asymmetric"` and
+      `nearest_mode="floor"` (the ANE samples with `floor`; the ONNX default
+      `round_prefer_floor` and the other round/ceil modes raise).
     - `mode="linear"` requires `asymmetric` (-> half-pixel-off bilinear) or
       `align_corners`.
     - `half_pixel`/`pytorch_half_pixel` sampling and `mode="cubic"` are **not** matched by

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -16,9 +16,12 @@ net = af.load_onnx("resnet18.onnx")          # import + compile -> runnable Mode
 y = net(np.zeros((1, 3, 224, 224), np.float16))
 ```
 
-- `af.load_onnx(path, **compile_kwargs)` - import the model and compile it to a runnable
-  `Model`. Extra keyword arguments pass straight to `af.compile` (`target=`, `opt=`,
-  `compress=`, ...). `path` is a filename or an in-memory `onnx.ModelProto`.
+- `af.load_onnx(path, fuse_attention=False, **compile_kwargs)` - import the model and
+  compile it to a runnable `Model`. `fuse_attention=True` rewrites the
+  `softmax(Q@Kᵀ·scale [+ causal mask])@V` pattern onto `af.sdpa`; a **causal** mask routes
+  to the native fused-attention layer (a graph cut), so GPT-style decoder attention runs
+  on the dedicated SDPA hardware. Extra keyword arguments pass straight to `af.compile`
+  (`target=`, `opt=`, `compress=`, ...). `path` is a filename or an in-memory `onnx.ModelProto`.
 - `af.onnx_to_tensor(path)` - import only, returning `(graph_inputs, output)` ANEForge
   tensors so you can inspect or splice the graph before compiling it yourself.
 

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -53,3 +53,15 @@ Export at `opset_version=13` with constant folding on (the default), which resol
 - **NCHW.** Channels-first layout, matching ONNX's convolution convention.
 - **Uniform/symmetric conv params.** Per-axis strides, dilations, and pads must be
   uniform and symmetric; a non-uniform value raises rather than silently mis-lowering.
+
+## Limitations
+
+These attribute forms fall outside the supported subset and raise rather than
+mis-lower:
+
+- **Gemm:** only `alpha=1`, `beta=1`, `transA=0` (`transB` is honored).
+- **Conv:** explicit `pads` only - `auto_pad` (`SAME_UPPER`/`SAME_LOWER`/`VALID`) raises.
+- **Pooling:** `ceil_mode=0` (floor) only; `AveragePool` rejects `count_include_pad=1`
+  and `MaxPool` rejects `dilations != 1`.
+- **Elementwise.** `Add`/`Sub`/`Mul`/`Div` are tensor-tensor only; a constant operand
+  raises (exporters usually fold these into the adjacent `Conv`/`BatchNormalization`).

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -29,12 +29,12 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 
 | Category | ONNX ops |
 | --- | --- |
-| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu) |
-| Elementwise | `Add`, `Sub`, `Mul`, `Div` |
+| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf` |
+| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` |
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
 | Linear | `Gemm`, `MatMul` |
-| Normalization | `BatchNormalization` |
-| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat` |
+| Normalization | `BatchNormalization`, `InstanceNormalization` |
+| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth` |
 | Misc | `Softmax`, `Constant`, `Identity` |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
@@ -63,5 +63,10 @@ mis-lower:
 - **Conv:** explicit `pads` only - `auto_pad` (`SAME_UPPER`/`SAME_LOWER`/`VALID`) raises.
 - **Pooling:** `ceil_mode=0` (floor) only; `AveragePool` rejects `count_include_pad=1`
   and `MaxPool` rejects `dilations != 1`.
-- **Elementwise.** `Add`/`Sub`/`Mul`/`Div` are tensor-tensor only; a constant operand
-  raises (exporters usually fold these into the adjacent `Conv`/`BatchNormalization`).
+- **Elementwise.** `Add`/`Sub`/`Mul`/`Div`/`Pow` are tensor-tensor only; a constant
+  operand raises (exporters usually fold these into the adjacent
+  `Conv`/`BatchNormalization`). A constant `Pow` exponent (`Pow(x, 2)`) raises.
+- **Gelu:** exact erf-gelu only; `approximate="tanh"` raises.
+- **PRelu:** slope is a per-channel initializer (`[C]`, `[C,1,1]`, or scalar, flattened
+  to `[C]`); input must be rank>=3 `[N,C,...]`.
+- **InstanceNormalization:** `[N,C,H,W]` input with `scale`/`B` initializers `[C]`.

--- a/examples/onnx_import.py
+++ b/examples/onnx_import.py
@@ -1,0 +1,45 @@
+"""Import an ONNX model and run it on the ANE, validated against onnxruntime. With no argument
+this exports torchvision ResNet-18 to ONNX as a self-contained demo; pass a path to import your
+own classifier instead. Run: python3 examples/onnx_import.py [model.onnx]"""
+import os
+import sys
+import tempfile
+
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+import numpy as np
+import aneforge as af
+
+
+def _demo_onnx(path):
+    """Export torchvision ResNet-18 to `path` as the default demo model (random weights are fine -- we compare against onnxruntime, not ImageNet)."""
+    import torch, torchvision
+    m = torchvision.models.resnet18(weights=None).eval()
+    torch.onnx.export(m, (torch.randn(1, 3, 224, 224),), path, opset_version=13,
+                      do_constant_folding=True, input_names=["x"], output_names=["y"], dynamo=False)
+    return path
+
+
+def main():
+    path = sys.argv[1] if len(sys.argv) > 1 else _demo_onnx(os.path.join(tempfile.mkdtemp(), "resnet18.onnx"))
+
+    inputs, _ = af.onnx_to_tensor(path)            # the uncompiled graph, to read the input shape
+    net = af.load_onnx(path)                        # parse -> build aneforge graph -> compile
+    print(f"imported {os.path.basename(path)}: {net.n_ops} ops fused into 1 ANE program")
+
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(inputs[0].shape).astype(np.float32)
+    ane = np.asarray(net(x.astype(np.float16))).astype(np.float32).ravel()      # fp16 on the ANE
+
+    import onnxruntime as ort
+    sess = ort.InferenceSession(path)
+    ref = np.asarray(sess.run(None, {sess.get_inputs()[0].name: x})[0]).astype(np.float32).ravel()
+
+    cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref)))
+    print(f"output cosine(ANE fp16, onnxruntime fp32) = {cos:.4f}")
+    print(f"ANE top-5:        {ane.argsort()[-5:][::-1].tolist()}")
+    print(f"onnxruntime top-5: {ref.argsort()[-5:][::-1].tolist()}")
+    print(f"top-1 match: {int(ane.argmax()) == int(ref.argmax())}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -81,6 +81,7 @@ nav:
   - Know what works:
       - Capabilities: capabilities.md
       - Op catalog: op-catalog.md
+      - ONNX import: onnx.md
   - API reference:
       - Overview: api/index.md
       - Graph & operators: api/graph.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,9 @@ models = [
     "torchvision",
     "transformers",
 ]
+# ONNX model import (aneforge.onnx.load_onnx / onnx_to_tensor). Imported lazily; the
+# core package stays numpy-only. Only install if you import ONNX models.
+onnx = ["onnx>=1.16"]
 # Linting + test runner (CI and local dev). ruff is the linter; the corpus/pytest
 # suites need real ANE hardware to run.
 dev = [
@@ -70,6 +73,8 @@ dev = [
     "pre-commit",        # local hooks mirroring CI; see .pre-commit-config.yaml
     "pytest",
     "pytest-forked",   # per-test process isolation (--forked); see tests/conftest.py
+    "onnx>=1.16",        # ONNX importer tests (tests/test_onnx.py); lazy in aneforge.onnx
+    "onnxruntime>=1.18", # reference numerics for ONNX importer tests
 ]
 
 [project.urls]

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -149,7 +149,7 @@ def test_dynamic_dim_raises():  # symbolic dim_param -> static-shapes-only error
   with pytest.raises(ValueError): af.onnx_to_tensor(m)
 
 def test_unsupported_op_raises():  # unregistered op type fails loudly
-  m = _model([helper.make_node("Erf", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  m = _model([helper.make_node("LRN", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
 def test_conv_non_uniform_strides_raises():
@@ -191,6 +191,66 @@ def test_maxpool_ceil_mode_raises():
   n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2], strides=[2, 2], ceil_mode=1)
   m = _model([n], [_vi("x", [1, 8, 31, 31])], [_vi("y", [1, 8, 16, 16])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_erf_builds():
+  m = _model([helper.make_node("Erf", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "erf"
+
+def test_exp_builds():
+  m = _model([helper.make_node("Exp", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "exp"
+
+def test_log_builds():
+  m = _model([helper.make_node("Log", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "log"
+
+def test_sqrt_builds():
+  m = _model([helper.make_node("Sqrt", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "sqrt"
+
+def test_elu_builds():
+  m = _model([helper.make_node("Elu", ["x"], ["y"], alpha=0.5)], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "elu"
+
+def test_leaky_relu_builds():
+  m = _model([helper.make_node("LeakyRelu", ["x"], ["y"], alpha=0.2)], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "leaky_relu"
+
+def test_gelu_builds():  # default approximate="none" -> exact erf-gelu
+  m = _model([helper.make_node("Gelu", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "gelu"
+
+def test_gelu_tanh_raises():  # tanh approximation is not implemented
+  n = helper.make_node("Gelu", ["x"], ["y"], approximate="tanh")
+  m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_prelu_builds():  # slope is the 2nd input ([C,1,1] flattened to [C])
+  slope = _init(np.ones((4, 1, 1)), "slope")
+  n = helper.make_node("PRelu", ["x", "slope"], ["y"])
+  m = _model([n], [_vi("x", [1, 4, 2, 2])], [_vi("y", [1, 4, 2, 2])], inits=[slope])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 2, 2) and out.op == "prelu"
+
+def test_pow_builds():  # tensor-tensor exponent
+  m = _model([helper.make_node("Pow", ["a", "b"], ["y"])], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "pow"
+
+def test_pow_constant_operand_raises():  # constant exponent cannot lower
+  c = _init(np.full((1, 3), 2.0), "c")
+  n = helper.make_node("Pow", ["x", "c"], ["y"])
+  m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])], inits=[c])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_instance_norm_builds():  # shape unchanged
+  s = _init(np.ones(4), "s"); b = _init(np.zeros(4), "b")
+  n = helper.make_node("InstanceNormalization", ["x", "s", "b"], ["y"])
+  m = _model([n], [_vi("x", [1, 4, 5, 5])], [_vi("y", [1, 4, 5, 5])], inits=[s, b])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 5, 5) and out.op == "instance_norm"
+
+def test_space_to_depth_builds():  # [1,3,8,8] bs=2 -> [1,12,4,4]
+  n = helper.make_node("SpaceToDepth", ["x"], ["y"], blocksize=2)
+  m = _model([n], [_vi("x", [1, 3, 8, 8])], [_vi("y", [1, 12, 4, 4])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 12, 4, 4) and out.op == "space_to_depth"
 
 @requires_ane
 def test_resnet18_onnx_matches_onnxruntime(tmp_path):

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -149,7 +149,7 @@ def test_dynamic_dim_raises():  # symbolic dim_param -> static-shapes-only error
   with pytest.raises(ValueError): af.onnx_to_tensor(m)
 
 def test_unsupported_op_raises():  # unregistered op type fails loudly
-  m = _model([helper.make_node("LRN", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  m = _model([helper.make_node("Cos", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
 def test_conv_non_uniform_strides_raises():
@@ -252,6 +252,71 @@ def test_space_to_depth_builds():  # [1,3,8,8] bs=2 -> [1,12,4,4]
   m = _model([n], [_vi("x", [1, 3, 8, 8])], [_vi("y", [1, 12, 4, 4])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 12, 4, 4) and out.op == "space_to_depth"
 
+def _empty_f32(name): return onnx.numpy_helper.from_array(np.array([], dtype=np.float32), name)
+def _cos(a, b): return float(np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+def test_lrn_builds():  # shape unchanged
+  n = helper.make_node("LRN", ["x"], ["y"], size=5, alpha=1e-4, beta=0.75, bias=1.0)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 4, 4])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 4, 4) and out.op == "local_response_norm"
+
+def test_depth_to_space_builds():  # [1,8,2,2] bs=2 -> [1,2,4,4]
+  n = helper.make_node("DepthToSpace", ["x"], ["y"], blocksize=2)  # default mode=DCR
+  m = _model([n], [_vi("x", [1, 8, 2, 2])], [_vi("y", [1, 2, 4, 4])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 2, 4, 4) and out.op == "depth_to_space"
+
+def test_depth_to_space_crd_raises():  # ANE matches DCR only
+  n = helper.make_node("DepthToSpace", ["x"], ["y"], blocksize=2, mode="CRD")
+  m = _model([n], [_vi("x", [1, 8, 2, 2])], [_vi("y", [1, 2, 4, 4])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_resize_nearest_builds():  # sizes input -> [1,4,16,16]
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="nearest",
+                       coordinate_transformation_mode="asymmetric")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 16, 16) and out.op == "resize_nearest_neighbor"
+
+def test_resize_linear_builds():  # sizes input, linear+asymmetric -> bilinear
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="linear",
+                       coordinate_transformation_mode="asymmetric")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 16, 16) and out.op == "resize_bilinear"
+
+def test_resize_scales_builds():  # scales input (no sizes) -> round(2*8)=16
+  scales = onnx.numpy_helper.from_array(np.array([1, 1, 2, 2], dtype=np.float32), "scales")
+  n = helper.make_node("Resize", ["x", "roi", "scales"], ["y"], mode="nearest",
+                       coordinate_transformation_mode="asymmetric")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), scales])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 16, 16) and out.op == "resize_nearest_neighbor"
+
+def test_resize_cubic_raises():
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="cubic")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_resize_linear_half_pixel_raises():  # ANE bilinear does not match half_pixel
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="linear",
+                       coordinate_transformation_mode="half_pixel")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_resize_nearest_half_pixel_raises():  # ANE nearest matches asymmetric only
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="nearest",
+                       coordinate_transformation_mode="half_pixel")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
 @requires_ane
 def test_resnet18_onnx_matches_onnxruntime(tmp_path):
   """End-to-end: import a torch-exported ResNet-18 ONNX, run on the ANE, match onnxruntime (fp16 cosine)."""
@@ -267,3 +332,52 @@ def test_resnet18_onnx_matches_onnxruntime(tmp_path):
   ref = np.asarray(onnxruntime.InferenceSession(path).run(None, {"x": x.numpy()})[0]).astype(np.float32).ravel()
   cos = float(np.dot(got, ref) / (np.linalg.norm(got) * np.linalg.norm(ref)))
   assert cos > 0.999, f"resnet18 ANE vs onnxruntime cosine={cos}"
+
+def _run_vs_ort(m, x):
+  """Compile m on the ANE (fp16) and onnxruntime (fp32), return their flattened outputs."""
+  net = af.load_onnx(m)
+  got = np.asarray(net(x.astype(np.float16))).astype(np.float32).ravel()
+  ref = np.asarray(onnx_run(m, x)).astype(np.float32).ravel()
+  return got, ref
+
+def onnx_run(m, x):  # run an in-memory model through onnxruntime
+  import onnxruntime
+  return onnxruntime.InferenceSession(m.SerializeToString()).run(None, {"x": x})[0]
+
+@requires_ane
+def test_lrn_onnx_matches_onnxruntime():  # alpha=1 (sum-of-squares dominates) so the alpha mapping is exercised
+  rng = np.random.default_rng(0); x = (rng.standard_normal((1, 8, 4, 4)).astype(np.float32)) * 2.0
+  n = helper.make_node("LRN", ["x"], ["y"], size=5, alpha=1.0, beta=0.75, bias=1.0)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 4, 4])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"LRN ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_depth_to_space_onnx_matches_onnxruntime():  # DCR is a pure permutation -> near-exact
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 8, 2, 2)).astype(np.float32)
+  n = helper.make_node("DepthToSpace", ["x"], ["y"], blocksize=2, mode="DCR")
+  m = _model([n], [_vi("x", [1, 8, 2, 2])], [_vi("y", [1, 2, 4, 4])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.999, f"DepthToSpace ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_resize_nearest_onnx_matches_onnxruntime():  # nearest+asymmetric is the ANE-matched config
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="nearest",
+                       coordinate_transformation_mode="asymmetric", nearest_mode="floor")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"Resize nearest ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_resize_linear_onnx_matches_onnxruntime():  # linear+asymmetric is the ANE-matched config
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="linear",
+                       coordinate_transformation_mode="asymmetric")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"Resize linear ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -46,3 +46,14 @@ def test_global_average_pool_builds():
   n = helper.make_node("GlobalAveragePool", ["x"], ["y"])
   m = _model([n], [_vi("x", [1, 8, 32, 32])], [_vi("y", [1, 8, 1, 1])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 1, 1) and out.op == "reduce_mean"
+
+def test_conv_default_strides_dilations():  # omitted strides/dilations -> ONNX default 1 (not 0)
+  w = _init(np.zeros((4, 3, 3, 3)), "W")
+  n = helper.make_node("Conv", ["x", "W"], ["y"], pads=[1, 1, 1, 1])  # no strides, no dilations
+  m = _model([n], [_vi("x", [1, 3, 8, 8])], [_vi("y", [1, 4, 8, 8])], inits=[w])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 8, 8) and out.op == "conv"
+
+def test_maxpool_default_strides():  # omitted strides -> ONNX default 1 (not k)
+  n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2])  # no strides
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 7, 7])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 7, 7) and out.op == "max_pool"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -273,7 +273,7 @@ def test_depth_to_space_crd_raises():  # ANE matches DCR only
 def test_resize_nearest_builds():  # sizes input -> [1,4,16,16]
   sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
   n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="nearest",
-                       coordinate_transformation_mode="asymmetric")
+                       coordinate_transformation_mode="asymmetric", nearest_mode="floor")
   m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
              inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 16, 16) and out.op == "resize_nearest_neighbor"
@@ -289,7 +289,7 @@ def test_resize_linear_builds():  # sizes input, linear+asymmetric -> bilinear
 def test_resize_scales_builds():  # scales input (no sizes) -> round(2*8)=16
   scales = onnx.numpy_helper.from_array(np.array([1, 1, 2, 2], dtype=np.float32), "scales")
   n = helper.make_node("Resize", ["x", "roi", "scales"], ["y"], mode="nearest",
-                       coordinate_transformation_mode="asymmetric")
+                       coordinate_transformation_mode="asymmetric", nearest_mode="floor")
   m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
              inits=[_empty_f32("roi"), scales])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 16, 16) and out.op == "resize_nearest_neighbor"
@@ -313,6 +313,22 @@ def test_resize_nearest_half_pixel_raises():  # ANE nearest matches asymmetric o
   sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
   n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="nearest",
                        coordinate_transformation_mode="half_pixel")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_resize_nearest_default_mode_raises():  # ONNX default nearest_mode is round_prefer_floor; ANE samples floor
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="nearest",
+                       coordinate_transformation_mode="asymmetric")   # nearest_mode omitted -> round_prefer_floor
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
+             inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_resize_linear_pytorch_half_pixel_raises():  # torch exports this; ANE bilinear does not match it
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], dtype=np.int64), "sizes")
+  n = helper.make_node("Resize", ["x", "roi", "scales", "sizes"], ["y"], mode="linear",
+                       coordinate_transformation_mode="pytorch_half_pixel")
   m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])],
              inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -37,6 +37,32 @@ def test_conv_builds():
   m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 32])], inits=[w, b])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 32, 32) and out.op == "conv"
 
+def test_conv_asymmetric_pad_builds():  # ONNX pads [top,left,bottom,right] -> per-side MIL conv pad
+  w = _init(np.zeros((4, 3, 3, 3)), "W")
+  n = helper.make_node("Conv", ["x", "W"], ["y"], pads=[2, 1, 0, 0], strides=[1, 1])  # top=2,left=1
+  m = _model([n], [_vi("x", [1, 3, 10, 10])], [_vi("y", [1, 4, 10, 9])], inits=[w])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 10, 9) and out.op == "conv"
+
+def test_shape_subgraph_folds_to_reshape():  # Shape->Gather->Unsqueeze->Concat folds to a static Reshape target
+  nodes = [helper.make_node("Shape", ["x"], ["s"]),
+           helper.make_node("Gather", ["s", "i0"], ["d0"], axis=0),
+           helper.make_node("Unsqueeze", ["d0", "ax0"], ["d0u"]),     # opset>=13: axes is an input
+           helper.make_node("Concat", ["d0u", "neg1"], ["tgt"], axis=0),
+           helper.make_node("Reshape", ["x", "tgt"], ["y"])]
+  inits = [onnx.numpy_helper.from_array(np.array(0, np.int64), "i0"),
+           onnx.numpy_helper.from_array(np.array([0], np.int64), "ax0"),
+           onnx.numpy_helper.from_array(np.array([-1], np.int64), "neg1")]
+  m = _model(nodes, [_vi("x", [2, 3, 4])], [_vi("y", [2, 12])], inits=inits)
+  _, out = af.onnx_to_tensor(m); assert out.shape == (2, 12) and out.op == "reshape"
+
+def test_slice_channel_split_builds():  # ONNX Slice on an activation -> static slice_by_size
+  starts = onnx.numpy_helper.from_array(np.array([0], np.int64), "st")
+  ends = onnx.numpy_helper.from_array(np.array([4], np.int64), "en")
+  axes = onnx.numpy_helper.from_array(np.array([1], np.int64), "ax")
+  n = helper.make_node("Slice", ["x", "st", "en", "ax"], ["y"])
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 4, 4, 4])], inits=[starts, ends, axes])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 4, 4) and out.op == "slice_by_size"
+
 def test_maxpool_builds():
   n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2], strides=[2, 2])
   m = _model([n], [_vi("x", [1, 8, 32, 32])], [_vi("y", [1, 8, 16, 16])])
@@ -158,11 +184,11 @@ def test_conv_non_uniform_strides_raises():
   m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 16, 32])], inits=[w])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
-def test_conv_asymmetric_pads_raises():
+def test_conv_asymmetric_pads_builds():  # asymmetric pads map to the per-side MIL conv pad
   w = _init(np.zeros((8, 3, 3, 3)), "W")
-  n = helper.make_node("Conv", ["x", "W"], ["y"], pads=[1, 0, 1, 0])
-  m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 31])], inits=[w])
-  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  n = helper.make_node("Conv", ["x", "W"], ["y"], pads=[1, 0, 1, 0])  # H pad 1+1 -> 32; W pad 0+0 -> 30
+  m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 30])], inits=[w])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 32, 30) and out.op == "conv"
 
 def test_conv_auto_pad_raises():
   w = _init(np.zeros((8, 3, 3, 3)), "W")
@@ -191,10 +217,15 @@ def test_squeeze_no_axes_raises():  # squeeze-all has no static lowering
   m = _model([n], [_vi("x", [1, 1, 4])], [_vi("y", [4])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
-def test_maxpool_ceil_mode_raises():
+def test_maxpool_ceil_mode_builds():  # ceil_mode rounds the output size up (native MIL ceil_mode)
   n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2], strides=[2, 2], ceil_mode=1)
   m = _model([n], [_vi("x", [1, 8, 31, 31])], [_vi("y", [1, 8, 16, 16])])
-  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 16, 16) and out.op == "max_pool"
+
+def test_avgpool_count_include_pad_builds():  # count_include_pad maps to MIL exclude_padding_from_average
+  n = helper.make_node("AveragePool", ["x"], ["y"], kernel_shape=[3, 3], strides=[1, 1], pads=[1, 1, 1, 1], count_include_pad=1)
+  m = _model([n], [_vi("x", [1, 8, 8, 8])], [_vi("y", [1, 8, 8, 8])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 8, 8) and out.op == "avg_pool"
 
 def test_erf_builds():
   m = _model([helper.make_node("Erf", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
@@ -591,3 +622,51 @@ def test_hardswish_onnx_matches_onnxruntime():  # x * relu6(x+3)/6; HardSwish is
   m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 14)]); m.ir_version = 9
   got, ref = _run_vs_ort(m, x)
   cos = _cos(got, ref); assert cos > 0.99, f"HardSwish ANE vs onnxruntime cosine={cos}"
+
+# -- pooling attrs via native MIL params (ceil_mode, exclude_padding_from_average) -- #
+@requires_ane
+def test_maxpool_ceil_mode_onnx_matches_onnxruntime():  # ceil sizing must match onnxruntime's extra edge window
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[3, 3], strides=[2, 2], ceil_mode=1)
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 4, 4])])
+  got, ref = _run_vs_ort(m, x)
+  assert af.load_onnx(m)(x.astype(np.float16)).shape == (1, 4, 4, 4)  # ceil(8-3 /2)+1 = 4, not floor 3
+  cos = _cos(got, ref); assert cos > 0.99, f"MaxPool ceil_mode ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_avgpool_exclude_pad_onnx_matches_onnxruntime():  # count_include_pad=0 -> exclude_padding_from_average
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  n = helper.make_node("AveragePool", ["x"], ["y"], kernel_shape=[3, 3], strides=[1, 1], pads=[1, 1, 1, 1], count_include_pad=0)
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 8, 8])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"AveragePool count_include_pad=0 ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_avgpool_include_pad_onnx_matches_onnxruntime():  # count_include_pad=1 -> ANE-native (divide by full kernel area)
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  n = helper.make_node("AveragePool", ["x"], ["y"], kernel_shape=[3, 3], strides=[1, 1], pads=[1, 1, 1, 1], count_include_pad=1)
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 8, 8])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"AveragePool count_include_pad=1 ANE vs onnxruntime cosine={cos}"
+
+# -- asymmetric conv pad + shape-subgraph folding (Inception, ShuffleNet) ---------- #
+@requires_ane
+def test_conv_asymmetric_pad_onnx_matches_onnxruntime():  # per-side MIL conv pad order [top,bottom,left,right]
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 3, 10, 10)).astype(np.float32)
+  w = _init((rng.standard_normal((4, 3, 3, 3)) * 0.3).astype(np.float32), "W")
+  n = helper.make_node("Conv", ["x", "W"], ["y"], pads=[1, 0, 3, 0], strides=[1, 1])  # asymmetric: top=1,bottom=3
+  m = _model([n], [_vi("x", [1, 3, 10, 10])], [_vi("y", [1, 4, 12, 8])], inits=[w])
+  got, ref = _run_vs_ort(m, x)
+  assert af.load_onnx(m)(x.astype(np.float16)).shape == (1, 4, 12, 8)
+  cos = _cos(got, ref); assert cos > 0.99, f"Conv asymmetric pad ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_slice_channel_split_onnx_matches_onnxruntime():  # activation Slice -> static slice_by_size
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 8, 4, 4)).astype(np.float32)
+  st = onnx.numpy_helper.from_array(np.array([4], np.int64), "st")
+  en = onnx.numpy_helper.from_array(np.array([8], np.int64), "en")
+  ax = onnx.numpy_helper.from_array(np.array([1], np.int64), "ax")
+  n = helper.make_node("Slice", ["x", "st", "en", "ax"], ["y"])
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 4, 4, 4])], inits=[st, en, ax])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.999, f"Slice channel-split ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -397,3 +397,142 @@ def test_resize_linear_onnx_matches_onnxruntime():  # linear+asymmetric is the A
              inits=[_empty_f32("roi"), _empty_f32("scales"), sizes])
   got, ref = _run_vs_ort(m, x)
   cos = _cos(got, ref); assert cos > 0.99, f"Resize linear ANE vs onnxruntime cosine={cos}"
+
+def _model18(nodes, inputs, outputs, inits=()):  # opset 18 graph (axes-as-input reduce ops)
+  g = helper.make_graph(nodes, "g", inputs, outputs, list(inits))
+  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 18)]); m.ir_version = 9
+  return m
+
+# -- reductions ------------------------------------------------------------- #
+def test_reduce_max_builds():  # axes attr (opset<18), keepdims=1
+  n = helper.make_node("ReduceMax", ["x"], ["y"], axes=[2, 3], keepdims=1)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 1, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 1, 1) and out.op == "reduce_max"
+
+def test_reduce_min_builds():
+  n = helper.make_node("ReduceMin", ["x"], ["y"], axes=[1], keepdims=1)
+  m = _model([n], [_vi("x", [2, 5])], [_vi("y", [2, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (2, 1) and out.op == "reduce_min"
+
+def test_reduce_mean_builds():
+  n = helper.make_node("ReduceMean", ["x"], ["y"], axes=[2, 3], keepdims=1)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 1, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 1, 1) and out.op == "reduce_mean"
+
+def test_reduce_max_keepdims0_builds():  # keepdims=0 squeezes the reduced axes
+  n = helper.make_node("ReduceMax", ["x"], ["y"], axes=[2, 3], keepdims=0)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8) and out.op == "squeeze"
+
+def test_reduce_sum_axes_input_builds():  # opset>=13 ReduceSum reads axes from an input initializer
+  ax = onnx.numpy_helper.from_array(np.array([1], dtype=np.int64), "ax")
+  n = helper.make_node("ReduceSum", ["x", "ax"], ["y"], keepdims=1)
+  m = _model([n], [_vi("x", [2, 5])], [_vi("y", [2, 1])], inits=[ax])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (2, 1) and out.op == "reduce_sum"
+
+def test_reduce_max_axes_input_opset18_builds():  # opset>=18 ReduceMax also moves axes to an input
+  ax = onnx.numpy_helper.from_array(np.array([2, 3], dtype=np.int64), "ax")
+  n = helper.make_node("ReduceMax", ["x", "ax"], ["y"], keepdims=1)
+  m = _model18([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 1, 1])], inits=[ax])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 1, 1) and out.op == "reduce_max"
+
+def test_reduce_all_axes_builds():  # absent axes -> reduce over every axis (keepdims)
+  n = helper.make_node("ReduceMean", ["x"], ["y"], keepdims=1)
+  m = _model([n], [_vi("x", [2, 3, 4])], [_vi("y", [1, 1, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 1, 1) and out.op == "reduce_mean"
+
+def test_reduce_noop_empty_axes_raises():  # noop_with_empty_axes=1 + empty axes (identity) is unsupported
+  n = helper.make_node("ReduceSum", ["x"], ["y"], keepdims=1, noop_with_empty_axes=1)
+  m = _model([n], [_vi("x", [2, 5])], [_vi("y", [2, 5])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+# -- gather / argmax / topk ------------------------------------------------- #
+def test_gather_builds():  # 1-D index along axis 0 -> [len(idx), W]; lowers to slice+concat
+  idx = onnx.numpy_helper.from_array(np.array([0, 2, 3], dtype=np.int64), "idx")
+  n = helper.make_node("Gather", ["x", "idx"], ["y"], axis=0)
+  m = _model([n], [_vi("x", [4, 8])], [_vi("y", [3, 8])], inits=[idx])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (3, 8) and out.op == "concat"
+
+def test_gather_scalar_index_builds():  # scalar index drops the gathered axis (ONNX rank rule)
+  idx = onnx.numpy_helper.from_array(np.array(2, dtype=np.int64), "idx")
+  n = helper.make_node("Gather", ["x", "idx"], ["y"], axis=0)
+  m = _model([n], [_vi("x", [4, 8])], [_vi("y", [8])], inits=[idx])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (8,) and out.op == "squeeze"
+
+def test_gather_nonconstant_index_raises():  # data-dependent (Tensor) indices have no ANE path
+  n = helper.make_node("Gather", ["x", "idx"], ["y"], axis=0)
+  m = _model([n], [_vi("x", [4, 8]), helper.make_tensor_value_info("idx", TensorProto.INT64, [2])],
+             [_vi("y", [2, 8])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_gather_2d_index_raises():  # >1-D indices change output rank in a way the 1-D gather can't replicate
+  idx = onnx.numpy_helper.from_array(np.array([[0, 1], [2, 3]], dtype=np.int64), "idx")
+  n = helper.make_node("Gather", ["x", "idx"], ["y"], axis=0)
+  m = _model([n], [_vi("x", [4, 8])], [_vi("y", [2, 2, 8])], inits=[idx])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_argmax_builds():  # 2D [C,W], axis=1 keepdims -> [C,1]
+  n = helper.make_node("ArgMax", ["x"], ["y"], axis=1, keepdims=1)
+  m = _model([n], [_vi("x", [3, 5])], [helper.make_tensor_value_info("y", TensorProto.INT64, [3, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (3, 1) and out.op == "argmax"
+
+def test_argmax_keepdims0_builds():  # keepdims=0 squeezes the reduced axis
+  n = helper.make_node("ArgMax", ["x"], ["y"], axis=1, keepdims=0)
+  m = _model([n], [_vi("x", [3, 5])], [helper.make_tensor_value_info("y", TensorProto.INT64, [3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (3,) and out.op == "squeeze"
+
+def test_argmax_rank_not_2_raises():  # ANE argmax is 2D-only
+  n = helper.make_node("ArgMax", ["x"], ["y"], axis=1)
+  m = _model([n], [_vi("x", [1, 3, 5])], [helper.make_tensor_value_info("y", TensorProto.INT64, [1, 1, 5])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_argmax_select_last_index_raises():
+  n = helper.make_node("ArgMax", ["x"], ["y"], axis=1, select_last_index=1)
+  m = _model([n], [_vi("x", [3, 5])], [helper.make_tensor_value_info("y", TensorProto.INT64, [3, 1])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_topk_builds():  # 2D [C,W], k from input -> values [C,k]; k=2 avoids the arch-gated k in {3,4}
+  k = onnx.numpy_helper.from_array(np.array([2], dtype=np.int64), "k")
+  n = helper.make_node("TopK", ["x", "k"], ["vals", "idx"], axis=-1)
+  m = _model([n], [_vi("x", [3, 5])],
+             [_vi("vals", [3, 2]), helper.make_tensor_value_info("idx", TensorProto.INT64, [3, 2])], inits=[k])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (3, 2) and out.op == "topk"
+
+def test_topk_rank_not_2_raises():  # ANE topk is 2D-only
+  k = onnx.numpy_helper.from_array(np.array([2], dtype=np.int64), "k")
+  n = helper.make_node("TopK", ["x", "k"], ["vals", "idx"], axis=-1)
+  m = _model([n], [_vi("x", [1, 3, 5])],
+             [_vi("vals", [1, 3, 2]), helper.make_tensor_value_info("idx", TensorProto.INT64, [1, 3, 2])], inits=[k])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_topk_axis_raises():  # only the last axis (width) is supported
+  k = onnx.numpy_helper.from_array(np.array([2], dtype=np.int64), "k")
+  n = helper.make_node("TopK", ["x", "k"], ["vals", "idx"], axis=0)
+  m = _model([n], [_vi("x", [3, 5])],
+             [_vi("vals", [2, 5]), helper.make_tensor_value_info("idx", TensorProto.INT64, [2, 5])], inits=[k])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+@requires_ane
+def test_reduce_mean_onnx_matches_onnxruntime():  # global-avg-pool-style reduction
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 8, 4, 4)).astype(np.float32)
+  n = helper.make_node("ReduceMean", ["x"], ["y"], axes=[2, 3], keepdims=1)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 1, 1])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"ReduceMean ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_reduce_max_onnx_matches_onnxruntime():
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 8, 4, 4)).astype(np.float32)
+  n = helper.make_node("ReduceMax", ["x"], ["y"], axes=[2, 3], keepdims=1)
+  m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 8, 1, 1])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"ReduceMax ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_gather_onnx_matches_onnxruntime():  # static-index gather along axis 0
+  rng = np.random.default_rng(0); x = rng.standard_normal((4, 8)).astype(np.float32)
+  idx = onnx.numpy_helper.from_array(np.array([0, 2, 3], dtype=np.int64), "idx")
+  n = helper.make_node("Gather", ["x", "idx"], ["y"], axis=0)
+  m = _model([n], [_vi("x", [4, 8])], [_vi("y", [3, 8])], inits=[idx])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.999, f"Gather ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -707,3 +707,36 @@ def test_attention_block_matches_onnxruntime():  # full transformer attention: L
 def onnxruntime_run(path, x):
   import onnxruntime
   return onnxruntime.InferenceSession(path).run(None, {"x": x})[0]
+
+# -- fuse_attention: route softmax(QKᵀ·s[+causal])@V onto the native SDPA layer ----- #
+def _export_attn(causal, T=16, d=64, h=4):
+  import torch, torch.nn as nn
+  class A(nn.Module):
+    def __init__(self):
+      super().__init__(); self.h = h; self.d = d; self.causal = causal
+      self.qkv = nn.Linear(d, 3 * d); self.proj = nn.Linear(d, d); self.ln = nn.LayerNorm(d)
+      if causal: self.register_buffer("mask", torch.triu(torch.full((T, T), float("-inf")), 1))
+    def forward(self, x):
+      b, t, _ = x.shape; x = self.ln(x); qkv = self.qkv(x).reshape(b, t, 3, self.h, self.d // self.h).permute(2, 0, 3, 1, 4)
+      q, k, v = qkv[0], qkv[1], qkv[2]; sc = (q @ k.transpose(-2, -1)) * (1.0 / (self.d // self.h) ** 0.5)
+      if causal: sc = sc + self.mask
+      return self.proj((sc.softmax(-1) @ v).transpose(1, 2).reshape(b, t, self.d))
+  import torch as _t; x = _t.randn(1, T, d); p = f"/tmp/_aneforge_attn_{causal}.onnx"
+  _t.onnx.export(A().eval(), (x,), p, opset_version=17, do_constant_folding=True, input_names=["x"], dynamo=False)
+  return p, x.numpy()
+
+@requires_ane
+def test_fuse_attention_causal_uses_native_sdpa():  # causal mask -> native fused-attention layer (a graph cut)
+  p, x = _export_attn(causal=True)
+  net = af.load_onnx(p, fuse_attention=True)
+  assert getattr(net, "n_netplist", 0) >= 1, "causal attention should route to the native SDPA bridge"
+  got = np.asarray(net(x.astype(np.float16))).astype(np.float32).ravel()
+  ref = np.asarray(onnxruntime_run(p, x)).astype(np.float32).ravel()
+  cos = _cos(got, ref); assert cos > 0.99, f"causal fused-attention ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_fuse_attention_noncausal_matches():  # non-causal fuses to the decomposed path, still exact
+  p, x = _export_attn(causal=False)
+  got = np.asarray(af.load_onnx(p, fuse_attention=True)(x.astype(np.float16))).astype(np.float32).ravel()
+  ref = np.asarray(onnxruntime_run(p, x)).astype(np.float32).ravel()
+  cos = _cos(got, ref); assert cos > 0.99, f"non-causal fused-attention ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -114,3 +114,24 @@ def test_unsqueeze_builds():  # opset>=13 reads axes from input initializer
   n = helper.make_node("Unsqueeze", ["x", "ax"], ["y"])
   m = _model([n], [_vi("x", [1, 4])], [_vi("y", [1, 1, 4])], inits=[ax])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 1, 4) and out.op == "expand_dims"
+
+def test_identity_builds():  # Identity passes its input straight through
+  n = helper.make_node("Identity", ["x"], ["y"])
+  m = _model([n], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4) and out.op == "input"
+
+@requires_ane
+def test_resnet18_onnx_matches_onnxruntime(tmp_path):
+  """End-to-end: import a torch-exported ResNet-18 ONNX, run on the ANE, match onnxruntime (fp16 cosine)."""
+  import torch, torchvision, onnxruntime
+  net_t = torchvision.models.resnet18(weights=None).eval()
+  x = torch.randn(1, 3, 224, 224)
+  path = str(tmp_path / "resnet18.onnx")
+  torch.onnx.export(net_t, (x,), path, opset_version=13, do_constant_folding=True,
+                    input_names=["x"], output_names=["y"], dynamo=False)  # legacy exporter; numerics identical
+  net = af.load_onnx(path)
+  x_fp16 = x.numpy().astype(np.float16)
+  got = np.asarray(net(x_fp16)).astype(np.float32).ravel()
+  ref = np.asarray(onnxruntime.InferenceSession(path).run(None, {"x": x.numpy()})[0]).astype(np.float32).ravel()
+  cos = float(np.dot(got, ref) / (np.linalg.norm(got) * np.linalg.norm(ref)))
+  assert cos > 0.999, f"resnet18 ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -15,3 +15,16 @@ def test_onnx_to_tensor_relu_builds():
   m = _model([helper.make_node("Relu", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
   ins, out = af.onnx_to_tensor(m)
   assert out.shape == (1, 4) and out.op == "relu"
+
+def test_add_builds():
+  m = _model([helper.make_node("Add", ["a", "b"], ["y"])], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "add"
+
+def test_sigmoid_builds():
+  m = _model([helper.make_node("Sigmoid", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "sigmoid"
+
+def test_clip_relu6_builds():
+  n = helper.make_node("Clip", ["x"], ["y"], min=0.0, max=6.0)
+  m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "relu6"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -176,11 +176,15 @@ def test_gemm_alpha_raises():
   m = _model([n], [_vi("x", [1, 16])], [_vi("y", [1, 10])], inits=[w, b])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
-def test_add_constant_operand_raises():  # elementwise is tensor-tensor only
+def test_add_constant_operand_builds():  # a constant operand bakes in as a fused const_array
   c = _init(np.zeros((1, 3)), "c")
   n = helper.make_node("Add", ["x", "c"], ["y"])
   m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])], inits=[c])
-  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "add"
+
+def test_hardsigmoid_builds():
+  m = _model([helper.make_node("HardSigmoid", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "clip"
 
 def test_squeeze_no_axes_raises():  # squeeze-all has no static lowering
   n = helper.make_node("Squeeze", ["x"], ["y"])
@@ -235,11 +239,11 @@ def test_pow_builds():  # tensor-tensor exponent
   m = _model([helper.make_node("Pow", ["a", "b"], ["y"])], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 3])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "pow"
 
-def test_pow_constant_operand_raises():  # constant exponent cannot lower
+def test_pow_constant_operand_builds():  # a constant exponent bakes in (Pow(x, 2) etc.)
   c = _init(np.full((1, 3), 2.0), "c")
   n = helper.make_node("Pow", ["x", "c"], ["y"])
   m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])], inits=[c])
-  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "pow"
 
 def test_instance_norm_builds():  # shape unchanged
   s = _init(np.ones(4), "s"); b = _init(np.zeros(4), "b")
@@ -554,3 +558,36 @@ def test_gather_onnx_matches_onnxruntime():  # static-index gather along axis 0
   m = _model([n], [_vi("x", [4, 8])], [_vi("y", [3, 8])], inits=[idx])
   got, ref = _run_vs_ort(m, x)
   cos = _cos(got, ref); assert cos > 0.999, f"Gather ANE vs onnxruntime cosine={cos}"
+
+# -- constant-operand elementwise (baked as a fused const_array, no graph cut) ---- #
+@requires_ane
+def test_mul_constant_onnx_matches_onnxruntime():  # per-channel constant scale
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  c = _init((rng.standard_normal((1, 4, 1, 1)) * 0.5).astype(np.float32), "c")
+  m = _model([helper.make_node("Mul", ["x", "c"], ["y"])], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 8, 8])], inits=[c])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"Mul-const ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_pow2_constant_onnx_matches_onnxruntime():  # Pow(x, 2) with a constant exponent
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  e = _init(np.array(2.0, np.float32), "e")
+  m = _model([helper.make_node("Pow", ["x", "e"], ["y"])], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 8, 8])], inits=[e])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"Pow2-const ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_hardsigmoid_onnx_matches_onnxruntime():  # clip(0.2x + 0.5, 0, 1)
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  m = _model([helper.make_node("HardSigmoid", ["x"], ["y"])], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 8, 8])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"HardSigmoid ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_hardswish_onnx_matches_onnxruntime():  # x * relu6(x+3)/6; HardSwish is opset 14
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 4, 8, 8)).astype(np.float32)
+  g = helper.make_graph([helper.make_node("HardSwish", ["x"], ["y"])], "g",
+                        [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 8, 8])])
+  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 14)]); m.ir_version = 9
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"HardSwish ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,0 +1,17 @@
+import numpy as np, onnx  # noqa: F401  (harness imports for later op tests)
+from onnx import helper, TensorProto
+import aneforge as af
+from _helpers import requires_ane  # noqa: F401  (on-device gate for later op tests)
+
+def _model(nodes, inputs, outputs, inits=()):
+  g = helper.make_graph(nodes, "g", inputs, outputs, list(inits))
+  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 13)])
+  m.ir_version = 9
+  return m
+
+def _vi(name, shape): return helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+
+def test_onnx_to_tensor_relu_builds():
+  m = _model([helper.make_node("Relu", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  ins, out = af.onnx_to_tensor(m)
+  assert out.shape == (1, 4) and out.op == "relu"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -57,3 +57,60 @@ def test_maxpool_default_strides():  # omitted strides -> ONNX default 1 (not k)
   n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2])  # no strides
   m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 7, 7])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 7, 7) and out.op == "max_pool"
+
+def test_gemm_transb_builds():  # transB=1 -> W stays [out,in]; x[1,16] linear W[10,16] -> (1,10)
+  w = _init(np.zeros((10, 16)), "W"); b = _init(np.zeros(10), "B")
+  n = helper.make_node("Gemm", ["x", "W", "B"], ["y"], transB=1)
+  m = _model([n], [_vi("x", [1, 16])], [_vi("y", [1, 10])], inits=[w, b])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 10) and out.op == "matmul"
+
+def test_flatten_builds():
+  n = helper.make_node("Flatten", ["x"], ["y"], axis=1)
+  m = _model([n], [_vi("x", [1, 8, 2, 2])], [_vi("y", [1, 32])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 32) and out.op == "flatten2d"
+
+def test_batchnorm_builds():  # shape unchanged
+  s = _init(np.ones(4), "s"); bb = _init(np.zeros(4), "bb")
+  mean = _init(np.zeros(4), "mean"); var = _init(np.ones(4), "var")
+  n = helper.make_node("BatchNormalization", ["x", "s", "bb", "mean", "var"], ["y"])
+  m = _model([n], [_vi("x", [1, 4, 5, 5])], [_vi("y", [1, 4, 5, 5])], inits=[s, bb, mean, var])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 5, 5) and out.op == "batch_norm"
+
+def test_concat_builds():
+  n = helper.make_node("Concat", ["a", "b"], ["y"], axis=1)
+  m = _model([n], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 6])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 6) and out.op == "concat"
+
+def test_softmax_builds():
+  n = helper.make_node("Softmax", ["x"], ["y"], axis=-1)
+  m = _model([n], [_vi("x", [1, 10])], [_vi("y", [1, 10])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 10) and out.op == "softmax"
+
+def test_reshape_infer_builds():  # -1 infers the flattened dim
+  shp = _init(np.array([1, -1]), "shp")
+  n = helper.make_node("Reshape", ["x", "shp"], ["y"])
+  m = _model([n], [_vi("x", [1, 8, 2, 2])], [_vi("y", [1, 32])], inits=[shp])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 32) and out.op == "reshape"
+
+def test_reshape_zero_keep_builds():  # 0 = copy input dim, resolved BEFORE -1 (else divide-by-zero)
+  shp = onnx.numpy_helper.from_array(np.array([0, -1], dtype=np.int64), "shp")
+  n = helper.make_node("Reshape", ["x", "shp"], ["y"])
+  m = _model([n], [_vi("x", [2, 3, 4])], [_vi("y", [2, 12])], inits=[shp])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (2, 12) and out.op == "reshape"
+
+def test_transpose_builds():
+  n = helper.make_node("Transpose", ["x"], ["y"], perm=[0, 2, 1])
+  m = _model([n], [_vi("x", [1, 3, 4])], [_vi("y", [1, 4, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 3) and out.op == "transpose"
+
+def test_squeeze_builds():  # opset>=13 reads axes from input initializer
+  ax = onnx.numpy_helper.from_array(np.array([1], dtype=np.int64), "ax")
+  n = helper.make_node("Squeeze", ["x", "ax"], ["y"])
+  m = _model([n], [_vi("x", [1, 1, 4])], [_vi("y", [1, 4])], inits=[ax])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4) and out.op == "squeeze"
+
+def test_unsqueeze_builds():  # opset>=13 reads axes from input initializer
+  ax = onnx.numpy_helper.from_array(np.array([1], dtype=np.int64), "ax")
+  n = helper.make_node("Unsqueeze", ["x", "ax"], ["y"])
+  m = _model([n], [_vi("x", [1, 4])], [_vi("y", [1, 1, 4])], inits=[ax])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 1, 4) and out.op == "expand_dims"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -446,6 +446,12 @@ def test_reduce_noop_empty_axes_raises():  # noop_with_empty_axes=1 + empty axes
   m = _model([n], [_vi("x", [2, 5])], [_vi("y", [2, 5])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
+def test_reduce_nonconstant_axes_raises():  # data-dependent (Tensor) axes have no static lowering
+  n = helper.make_node("ReduceSum", ["x", "ax"], ["y"], keepdims=1)
+  m = _model([n], [_vi("x", [2, 5]), helper.make_tensor_value_info("ax", TensorProto.INT64, [1])],
+             [_vi("y", [2, 1])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
 # -- gather / argmax / topk ------------------------------------------------- #
 def test_gather_builds():  # 1-D index along axis 0 -> [len(idx), W]; lowers to slice+concat
   idx = onnx.numpy_helper.from_array(np.array([0, 2, 3], dtype=np.int64), "idx")
@@ -510,6 +516,18 @@ def test_topk_axis_raises():  # only the last axis (width) is supported
   n = helper.make_node("TopK", ["x", "k"], ["vals", "idx"], axis=0)
   m = _model([n], [_vi("x", [3, 5])],
              [_vi("vals", [2, 5]), helper.make_tensor_value_info("idx", TensorProto.INT64, [2, 5])], inits=[k])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_topk_nonconstant_k_raises():  # data-dependent (Tensor) k has no static lowering
+  n = helper.make_node("TopK", ["x", "k"], ["vals", "idx"], axis=-1)
+  m = _model([n], [_vi("x", [3, 5]), helper.make_tensor_value_info("k", TensorProto.INT64, [1])],
+             [_vi("vals", [3, 2]), helper.make_tensor_value_info("idx", TensorProto.INT64, [3, 2])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_matmul_constant_first_operand_raises():  # ndarray @ Tensor has no ANE path
+  a_w = _init(np.zeros((4, 6)), "A")
+  n = helper.make_node("MatMul", ["A", "B"], ["y"])
+  m = _model([n], [_vi("B", [6, 3])], [_vi("y", [4, 3])], inits=[a_w])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
 @requires_ane

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -102,6 +102,12 @@ def test_batchnorm_builds():  # shape unchanged
   m = _model([n], [_vi("x", [1, 4, 5, 5])], [_vi("y", [1, 4, 5, 5])], inits=[s, bb, mean, var])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 5, 5) and out.op == "batch_norm"
 
+def test_layernorm_builds():  # transformer LayerNorm over the last axis -> reshape back to input shape
+  s = _init(np.ones(8), "s"); bb = _init(np.zeros(8), "bb")
+  n = helper.make_node("LayerNormalization", ["x", "s", "bb"], ["y"], axis=-1, epsilon=1e-5)
+  m = _model([n], [_vi("x", [1, 16, 8])], [_vi("y", [1, 16, 8])], inits=[s, bb])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 16, 8) and out.op == "reshape"
+
 def test_concat_builds():
   n = helper.make_node("Concat", ["a", "b"], ["y"], axis=1)
   m = _model([n], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 6])])
@@ -670,3 +676,34 @@ def test_slice_channel_split_onnx_matches_onnxruntime():  # activation Slice -> 
   m = _model([n], [_vi("x", [1, 8, 4, 4])], [_vi("y", [1, 4, 4, 4])], inits=[st, en, ax])
   got, ref = _run_vs_ort(m, x)
   cos = _cos(got, ref); assert cos > 0.999, f"Slice channel-split ANE vs onnxruntime cosine={cos}"
+
+# -- transformers: LayerNorm + attention block on-device ---------------------------- #
+@requires_ane
+def test_layernorm_onnx_matches_onnxruntime():
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 16, 8)).astype(np.float32)
+  s = _init((rng.standard_normal(8) * 0.5 + 1).astype(np.float32), "s"); bb = _init((rng.standard_normal(8) * 0.1).astype(np.float32), "bb")
+  n = helper.make_node("LayerNormalization", ["x", "s", "bb"], ["y"], axis=-1, epsilon=1e-5)
+  m = _model([n], [_vi("x", [1, 16, 8])], [_vi("y", [1, 16, 8])], inits=[s, bb])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"LayerNorm ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_attention_block_matches_onnxruntime():  # full transformer attention: LN + QKV + batched attn + softmax + proj
+  import torch, torch.nn as nn
+  class Attn(nn.Module):
+    def __init__(self, d=64, h=4):
+      super().__init__(); self.h = h; self.d = d
+      self.qkv = nn.Linear(d, 3 * d); self.proj = nn.Linear(d, d); self.ln = nn.LayerNorm(d)
+    def forward(self, x):
+      b, t, _ = x.shape; x = self.ln(x); qkv = self.qkv(x).reshape(b, t, 3, self.h, self.d // self.h).permute(2, 0, 3, 1, 4)
+      q, k, v = qkv[0], qkv[1], qkv[2]; a = ((q @ k.transpose(-2, -1)) * (1.0 / (self.d // self.h) ** 0.5)).softmax(-1)
+      return self.proj((a @ v).transpose(1, 2).reshape(b, t, self.d))
+  x = torch.randn(1, 16, 64); p = "/tmp/_aneforge_attn.onnx"
+  torch.onnx.export(Attn().eval(), (x,), p, opset_version=17, do_constant_folding=True, input_names=["x"], dynamo=False)
+  net = af.load_onnx(p); got = np.asarray(net(x.numpy().astype(np.float16))).astype(np.float32).ravel()
+  ref = np.asarray(onnxruntime_run(p, x.numpy())).astype(np.float32).ravel()
+  cos = _cos(got, ref); assert cos > 0.99, f"attention block ANE vs onnxruntime cosine={cos}"
+
+def onnxruntime_run(path, x):
+  import onnxruntime
+  return onnxruntime.InferenceSession(path).run(None, {"x": x})[0]

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1,4 +1,4 @@
-import numpy as np, onnx  # noqa: F401  (harness imports for later op tests)
+import numpy as np, onnx, pytest  # noqa: F401  (harness imports for later op tests)
 from onnx import helper, TensorProto
 import aneforge as af
 from _helpers import requires_ane  # noqa: F401  (on-device gate for later op tests)
@@ -119,6 +119,78 @@ def test_identity_builds():  # Identity passes its input straight through
   n = helper.make_node("Identity", ["x"], ["y"])
   m = _model([n], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4) and out.op == "input"
+
+def test_sub_builds():
+  m = _model([helper.make_node("Sub", ["a", "b"], ["y"])], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "sub"
+
+def test_mul_builds():
+  m = _model([helper.make_node("Mul", ["a", "b"], ["y"])], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "mul"
+
+def test_div_builds():  # aneforge lowers division to real_div
+  m = _model([helper.make_node("Div", ["a", "b"], ["y"])], [_vi("a", [1, 3]), _vi("b", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "real_div"
+
+def test_tanh_builds():
+  m = _model([helper.make_node("Tanh", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "tanh"
+
+def test_clip_opset11_input_form_builds():  # opset>=11 reads min/max from inputs 2/3
+  lo = onnx.numpy_helper.from_array(np.array(0.0, dtype=np.float32), "lo")
+  hi = onnx.numpy_helper.from_array(np.array(6.0, dtype=np.float32), "hi")
+  n = helper.make_node("Clip", ["x", "lo", "hi"], ["y"])
+  m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])], inits=[lo, hi])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "relu6"
+
+def test_dynamic_dim_raises():  # symbolic dim_param -> static-shapes-only error
+  m = _model([helper.make_node("Relu", ["x"], ["y"])],
+             [helper.make_tensor_value_info("x", TensorProto.FLOAT, ["N", 4])], [_vi("y", [1, 4])])
+  with pytest.raises(ValueError): af.onnx_to_tensor(m)
+
+def test_unsupported_op_raises():  # unregistered op type fails loudly
+  m = _model([helper.make_node("Erf", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_conv_non_uniform_strides_raises():
+  w = _init(np.zeros((8, 3, 3, 3)), "W")
+  n = helper.make_node("Conv", ["x", "W"], ["y"], strides=[1, 2], pads=[1, 1, 1, 1])
+  m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 16, 32])], inits=[w])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_conv_asymmetric_pads_raises():
+  w = _init(np.zeros((8, 3, 3, 3)), "W")
+  n = helper.make_node("Conv", ["x", "W"], ["y"], pads=[1, 0, 1, 0])
+  m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 31])], inits=[w])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_conv_auto_pad_raises():
+  w = _init(np.zeros((8, 3, 3, 3)), "W")
+  n = helper.make_node("Conv", ["x", "W"], ["y"], auto_pad="SAME_UPPER")
+  m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 32])], inits=[w])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_gemm_alpha_raises():
+  w = _init(np.zeros((10, 16)), "W"); b = _init(np.zeros(10), "B")
+  n = helper.make_node("Gemm", ["x", "W", "B"], ["y"], transB=1, alpha=2.0)
+  m = _model([n], [_vi("x", [1, 16])], [_vi("y", [1, 10])], inits=[w, b])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_add_constant_operand_raises():  # elementwise is tensor-tensor only
+  c = _init(np.zeros((1, 3)), "c")
+  n = helper.make_node("Add", ["x", "c"], ["y"])
+  m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])], inits=[c])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_squeeze_no_axes_raises():  # squeeze-all has no static lowering
+  n = helper.make_node("Squeeze", ["x"], ["y"])
+  m = _model([n], [_vi("x", [1, 1, 4])], [_vi("y", [4])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_maxpool_ceil_mode_raises():
+  n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2], strides=[2, 2], ceil_mode=1)
+  m = _model([n], [_vi("x", [1, 8, 31, 31])], [_vi("y", [1, 8, 16, 16])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
 @requires_ane
 def test_resnet18_onnx_matches_onnxruntime(tmp_path):

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -28,3 +28,21 @@ def test_clip_relu6_builds():
   n = helper.make_node("Clip", ["x"], ["y"], min=0.0, max=6.0)
   m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "relu6"
+
+def _init(arr, name): return onnx.numpy_helper.from_array(arr.astype(np.float32), name)
+
+def test_conv_builds():
+  w = _init(np.zeros((8, 3, 3, 3)), "W"); b = _init(np.zeros(8), "B")
+  n = helper.make_node("Conv", ["x", "W", "B"], ["y"], strides=[1, 1], pads=[1, 1, 1, 1], dilations=[1, 1])
+  m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 32])], inits=[w, b])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 32, 32) and out.op == "conv"
+
+def test_maxpool_builds():
+  n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2], strides=[2, 2])
+  m = _model([n], [_vi("x", [1, 8, 32, 32])], [_vi("y", [1, 8, 16, 16])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 16, 16) and out.op == "max_pool"
+
+def test_global_average_pool_builds():
+  n = helper.make_node("GlobalAveragePool", ["x"], ["y"])
+  m = _model([n], [_vi("x", [1, 8, 32, 32])], [_vi("y", [1, 8, 1, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8, 1, 1) and out.op == "reduce_mean"


### PR DESCRIPTION
## ONNX importer for the Apple Neural Engine

Import an ONNX model and run — or fine-tune — it on the ANE:

```python
import aneforge as af
net = af.load_onnx("model.onnx")     # parse → build aneforge graph → af.compile
y = net(x_fp16)                       # runs on the Neural Engine
```

A handler registry (`@onnx_op("Conv")`) maps **52 ONNX ops** onto aneforge's public op surface; the driver lazy-imports `onnx`, runs shape inference, topo-walks nodes, builds an aneforge graph, and compiles it. The `onnx` library is an optional `[onnx]` extra, never imported at `import aneforge` time — the core stays numpy-only.

### What runs
- **CNN classifiers** — 21 of 22 swept torchvision models import and run (MaxViT needs rank-6 > the ANE's rank-5; ViT-B/16 fails in torch's *own* exporter): ResNet18/50/152, ResNeXt, WideResNet, VGG16/19, AlexNet, SqueezeNet, DenseNet121, MobileNetV2/V3, GoogLeNet, Inception-v3, ShuffleNetV2, MNASNet, EfficientNet-B0, RegNet, ConvNeXt-tiny.
- **Transformers** — encoders run; `load_onnx(path, fuse_attention=True)` routes the `softmax(Q@Kᵀ·scale [+ causal mask])@V` pattern onto `af.sdpa`, and a **causal** mask hits the **native fused-attention layer** (GPT-style decoder attention on the dedicated SDPA hardware).
- **Quantized (QDQ int8)** — statically-quantized models import: int8 weights dequantize, activation Q/DQ folds to a fp16 `clip` (carrying any quantizer-fused relu). `compress="int8"` keeps weights on the **ANE int8 weight datapath**.
- **Transfer learning** — `af.onnx_to_features(path)` gives a frozen feature extractor; train a fresh head on the features **on the ANE** (`examples/onnx_finetune.py` → 0.90 MNIST accuracy from a random backbone).

### Native ANE corners lit up through the importer
Several "gaps" were native ANE features the MIL frontend left unexposed (confirmed against the reverse-engineered layer docs):
- constant-operand elementwise → fused `const_array` (gain-offset epilogue); `ceil_mode`/`count_include_pad` → native pool params; asymmetric conv pads → per-side MIL conv pad; `Shape`/dynamic reshape → constant-folded; `LayerNormalization` → native `layer_norm`; causal attention → native SDPA; int8 weights → int8 datapath; imported graphs → autograd/training.

### Op coverage (52)
Activations (Relu/Sigmoid/Tanh/Clip/Gelu/Erf/Elu/LeakyRelu/PRelu/HardSigmoid/HardSwish/Exp/Log/Sqrt), elementwise (Add/Sub/Mul/Div/Pow — constant operands), Conv (asymmetric pads) / MaxPool / AveragePool (ceil_mode, count_include_pad) / GlobalAveragePool, Gemm/MatMul, BatchNormalization/InstanceNormalization/LayerNormalization/LRN, Reshape/Flatten/Transpose/Squeeze/Unsqueeze/Concat/SpaceToDepth/DepthToSpace/Resize/Slice/Shape/Identity, ReduceMax/Min/Sum/Mean, Gather/ArgMax/TopK, DequantizeLinear/QuantizeLinear, Softmax/Constant.

### Correctness & validation
- **On-device vs onnxruntime** at **cosine ≈ 1.0** across CNNs, a transformer attention block (causal + non-causal), and a quantized QDQ model. Per-op `@requires_ane` cosine tests pin every convention-sensitive op; conventions were nailed *empirically* (ANE bilinear matches ONNX `asymmetric` not `half_pixel`; MIL conv pad order; LRN `alpha`; causal mask; the quantizer's relu-fold into the zero-point).
- **Fail legibly** — unsupported op/attr → named `NotImplementedError`; dynamic dim → `ValueError`. Never a silent wrong answer.
- **Golden-MIL preserved** — pool/conv changes emit byte-identical MIL for existing graphs.

### Tests, docs, examples
- ~111 ONNX tests (off-device shape/op + ~25 `pytest.raises` guards + on-device cosine vs onnxruntime). Full `--forked` suite: **674 passed**.
- pyright 0 on `aneforge`, ruff + 2-space pylint clean, `mkdocs --strict` builds. New `docs/onnx.md`.
- Runnable `examples/onnx_import.py` (import + validate) and `examples/onnx_finetune.py` (on-ANE transfer learning).

### Scope
Vision CNN classifiers, transformer encoders/decoders, QDQ-quantized models, and transfer learning. Out of scope (fails legibly): dynamic shapes, non-NCHW layouts, rank > 5.
