### PR TITLE
ONNX importer: int8 quant, on-ANE fine-tuning, +14 ops, segmentation

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,16 @@
+# Narrow lint config. This codebase is tinygrad-compact (semicolons, multi-statement
+# lines, short names, sparse docstrings) and deliberately violates most pylint defaults,
+# so pylint is used ONLY as a 2-space-indent + trailing-whitespace lock. CI and
+# pre-commit invoke it explicitly as:
+#   pylint --disable=all -e W0311 -e C0303 --indent-string='  ' --recursive=y aneforge tests
+# This file bakes those flags in so a bare `pylint aneforge tests` matches CI locally.
+# (ruff config lives in pyproject.toml's [tool.ruff]; there is intentionally no .ruff.toml.)
+[MAIN]
+recursive = yes
+
+[MESSAGES CONTROL]
+disable = all
+enable = W0311, C0303
+
+[FORMAT]
+indent-string = '  '

--- a/README.md
+++ b/README.md
@@ -78,7 +78,9 @@ Then browse [`examples/`](examples/), starting with
 [`examples/quickstart.py`](examples/quickstart.py). To run an existing ONNX
 model on the ANE, [`examples/onnx_import.py`](examples/onnx_import.py) imports
 a `.onnx` classifier via `af.load_onnx` and validates it against onnxruntime
-(cosine 1.0000). For retrieval,
+(cosine 1.0000); [`examples/onnx_finetune.py`](examples/onnx_finetune.py) imports
+one as a frozen feature extractor and trains a new head on it entirely on the
+ANE (transfer learning). For retrieval,
 [`examples/rag_embeddings.py`](examples/rag_embeddings.py) is a LangChain
 `Embeddings` drop-in backed by the on-ANE encoder (4-5x faster than the GPU,
 cosine 1.0000).

--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -32,7 +32,7 @@ from .autograd import (Adam, adam_step, backward, backward_from, conv2d, conv_pa
                        mse, parameter, SGD, softmax_cross_entropy, Trainer, UnrolledTrainer)
 from .streaming import CheckpointedStack
 from .models import Encoder, Vision, load, load_resnet18, conv_block, cifar_cnn, group_norm_train
-from .onnx import load_onnx, onnx_to_tensor
+from .onnx import load_onnx, onnx_to_tensor, onnx_to_features
 
 __all__ = [
     "Tensor", "Model", "SegmentedModel", "PrecisionWarning", "CrossChipFP16Warning",
@@ -56,7 +56,7 @@ __all__ = [
     "softmax_cross_entropy", "Trainer", "UnrolledTrainer", "adam_step",
     "conv_param", "conv2d", "CheckpointedStack",
     "fft", "linalg", "special", "einsum", "dsp",
-    "load_onnx", "onnx_to_tensor",
+    "load_onnx", "onnx_to_tensor", "onnx_to_features",
 ]
 
 # applied-math submodules (af.fft / af.linalg / af.special / af.dsp), self-contained over the public ops

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -223,6 +223,25 @@ def _pad4(pads):                               # ONNX conv pads=[top,left,bottom
   p = [int(v) for v in pads]
   return p[0] if len(set(p)) == 1 else (p[0], p[2], p[1], p[3])
 
+@onnx_op("DequantizeLinear")
+def _dequant(node, ins, a, i):
+  """int8/uint8 weight -> dequantized fp32 const (per-channel along `axis`); on an activation it is identity (the ANE computes in fp16)."""
+  if isinstance(ins[0], Tensor): return ins[0]                       # activation Q/DQ pair is a fp16 passthrough
+  x = np.asarray(ins[0]).astype(np.float32); scale = np.asarray(ins[1]).astype(np.float32)
+  zp = np.asarray(ins[2]).astype(np.float32) if len(ins) > 2 and ins[2] is not None else np.float32(0)
+  if scale.ndim and scale.size > 1:                                  # per-channel: broadcast scale/zp along `axis`
+    shp = [1] * x.ndim; shp[int(a.get("axis", 1)) % x.ndim] = scale.size
+    scale = scale.reshape(shp); zp = zp.reshape(shp) if zp.ndim else zp
+  return (x - zp) * scale
+@onnx_op("QuantizeLinear")
+def _quant(node, ins, a, i):
+  """On an activation: clip to the quant range (keeps fp16, skips int8 rounding) — this folds a relu/saturation the QDQ encoded (zp pinning qmin to 0). On a const: quantize."""
+  scale = np.asarray(ins[1]); zp = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else np.array(0, np.int8)
+  if isinstance(ins[0], Tensor):
+    qmin, qmax = (0, 255) if zp.dtype == np.uint8 else (-128, 127)
+    s, z = float(scale), float(np.asarray(zp))
+    return ins[0].clip((qmin - z) * s, (qmax - z) * s)
+  return np.clip(np.round(np.asarray(ins[0]) / scale) + zp, -128, 127).astype(zp.dtype)
 @onnx_op("Conv")
 def _conv_h(node, ins, a, i):
   ap = a.get("auto_pad")

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -66,6 +66,16 @@ def onnx_to_tensor(path):
   if not isinstance(out, Tensor): raise TypeError("onnx: graph output is not a Tensor")
   return graph_inputs, out
 
+def onnx_to_features(path):
+  """Import a classifier and return `(inputs, features)` where `features` is the input to the final
+  linear layer (a trailing softmax is peeled). Compile it for a frozen feature extractor — train a
+  fresh head on the features for on-ANE transfer learning."""
+  inputs, out = onnx_to_tensor(path)
+  if out.op == "softmax" and out.srcs: out = out.srcs[0]   # peel a trailing softmax to the logits
+  if out.op not in ("matmul", "bmm") or not out.srcs:
+    raise ValueError(f"onnx_to_features: expected the model to end in a linear classifier (matmul/bmm); got '{out.op}'")
+  return inputs, out.srcs[0]
+
 def load_onnx(path, fuse_attention=False, **compile_kwargs):
   """Import an ONNX model and compile it to a runnable ANE Model. `fuse_attention` rewrites
   the `softmax(Q@K^T*scale)@V` pattern onto the native fused-attention layer (a graph cut)."""

--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -3,6 +3,7 @@ docs. Public: load_onnx / onnx_to_tensor."""
 from __future__ import annotations
 from typing import Callable
 from math import prod
+from functools import reduce
 import numpy as np
 from .graph import Tensor, input as _input, conv as _conv, batch_norm as _bn, concat as _concat
 from .graph import instance_norm as _instnorm, space_to_depth as _s2d
@@ -44,27 +45,35 @@ def _load(path):
   m = path if hasattr(path, "graph") else onnx.load(path)
   return onnx.shape_inference.infer_shapes(m)
 
-def onnx_to_tensor(path):
-  """Build an aneforge graph from an ONNX model; returns (graph_inputs, output)."""
-  m = _load(path); g = m.graph
-  inits = _inits(g)
-  vals: dict[str, object] = dict(inits)        # name -> Tensor | np.ndarray (initializers as arrays)
-  graph_inputs = []
-  for vi in g.input:
-    if vi.name in inits: continue              # initializers also listed as inputs in some exporters
-    t = _input(_shape(vi)); vals[vi.name] = t; graph_inputs.append(t)
-  for node in g.node:                          # ONNX node list is topologically ordered
-    if node.op_type not in _ONNX:
-      raise NotImplementedError(f"ONNX op '{node.op_type}' not supported")
-    ins = [vals.get(n) for n in node.input]
-    outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
-    outs = outs if isinstance(outs, (list, tuple)) else [outs]
-    for name, val in zip(node.output, outs): vals[name] = val
-  name = g.output[0].name
-  if name not in vals: raise ValueError(f"onnx: graph output '{name}' was never produced")
-  out = vals[name]
-  if not isinstance(out, Tensor): raise TypeError("onnx: graph output is not a Tensor")
-  return graph_inputs, out
+_APPROX_RESIZE = False                          # opt-in: map a half-pixel Resize to the closest ANE bilinear
+
+def onnx_to_tensor(path, approx_resize=False):
+  """Build an aneforge graph from an ONNX model; returns (graph_inputs, output). `approx_resize` maps a
+  half-pixel Resize (no exact ANE match) to the closest bilinear (~0.99 on smooth maps) instead of raising."""
+  global _APPROX_RESIZE
+  prev = _APPROX_RESIZE; _APPROX_RESIZE = approx_resize
+  try:
+    m = _load(path); g = m.graph
+    inits = _inits(g)
+    vals: dict[str, object] = dict(inits)        # name -> Tensor | np.ndarray (initializers as arrays)
+    graph_inputs = []
+    for vi in g.input:
+      if vi.name in inits: continue              # initializers also listed as inputs in some exporters
+      t = _input(_shape(vi)); vals[vi.name] = t; graph_inputs.append(t)
+    for node in g.node:                          # ONNX node list is topologically ordered
+      if node.op_type not in _ONNX:
+        raise NotImplementedError(f"ONNX op '{node.op_type}' not supported")
+      ins = [vals.get(n) for n in node.input]
+      outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
+      outs = outs if isinstance(outs, (list, tuple)) else [outs]
+      for name, val in zip(node.output, outs): vals[name] = val
+    name = g.output[0].name
+    if name not in vals: raise ValueError(f"onnx: graph output '{name}' was never produced")
+    out = vals[name]
+    if not isinstance(out, Tensor): raise TypeError("onnx: graph output is not a Tensor")
+    return graph_inputs, out
+  finally:
+    _APPROX_RESIZE = prev
 
 def onnx_to_features(path):
   """Import a classifier and return `(inputs, features)` where `features` is the input to the final
@@ -76,10 +85,11 @@ def onnx_to_features(path):
     raise ValueError(f"onnx_to_features: expected the model to end in a linear classifier (matmul/bmm); got '{out.op}'")
   return inputs, out.srcs[0]
 
-def load_onnx(path, fuse_attention=False, **compile_kwargs):
+def load_onnx(path, fuse_attention=False, approx_resize=False, **compile_kwargs):
   """Import an ONNX model and compile it to a runnable ANE Model. `fuse_attention` rewrites
-  the `softmax(Q@K^T*scale)@V` pattern onto the native fused-attention layer (a graph cut)."""
-  _, out = onnx_to_tensor(path)
+  the `softmax(Q@K^T*scale)@V` pattern onto the native fused-attention layer (a graph cut).
+  `approx_resize` allows a half-pixel Resize (no exact ANE match) via the closest bilinear."""
+  _, out = onnx_to_tensor(path, approx_resize=approx_resize)
   if fuse_attention:
     from ._rewrite import graph_rewrite, Rule
     out = graph_rewrite(out, [Rule("fuse_sdpa", "numeric", _is_attention, _build_sdpa)])
@@ -151,6 +161,43 @@ def _exp(node, ins, a, i): return ins[0].exp()
 def _log(node, ins, a, i): return ins[0].log()
 @onnx_op("Sqrt")
 def _sqrt(node, ins, a, i): return ins[0].sqrt()
+@onnx_op("Abs")
+def _abs(node, ins, a, i): return ins[0].abs()
+@onnx_op("Sign")
+def _sign(node, ins, a, i): return ins[0].sign()
+@onnx_op("Sin")
+def _sin(node, ins, a, i): return ins[0].sin()
+@onnx_op("Cos")
+def _cos(node, ins, a, i): return ins[0].cos()
+@onnx_op("Softplus")
+def _softplus(node, ins, a, i): return ins[0].softplus()
+@onnx_op("Floor")
+def _floor(node, ins, a, i): return ins[0].floor()
+@onnx_op("Ceil")
+def _ceil(node, ins, a, i): return ins[0].ceil()
+@onnx_op("Round")
+def _round(node, ins, a, i): return ins[0].round()
+@onnx_op("Reciprocal")
+def _recip(node, ins, a, i): return ins[0].inverse()
+@onnx_op("Neg")
+def _neg(node, ins, a, i): return ins[0] * -1.0
+@onnx_op("Max")
+def _max(node, ins, a, i):
+  from .graph import maximum as _maximum
+  ts = [v if isinstance(v, Tensor) else _baked(v) for v in ins]
+  return reduce(_maximum, ts)
+@onnx_op("Min")
+def _min(node, ins, a, i):
+  from .graph import minimum as _minimum
+  ts = [v if isinstance(v, Tensor) else _baked(v) for v in ins]
+  return reduce(_minimum, ts)
+@onnx_op("Where")
+def _where(node, ins, a, i):
+  from .graph import select as _select
+  return _select(ins[0], ins[1] if isinstance(ins[1], Tensor) else _baked(ins[1]),
+                 ins[2] if isinstance(ins[2], Tensor) else _baked(ins[2]))
+@onnx_op("Tile")
+def _tile(node, ins, a, i): return ins[0].tile([int(v) for v in np.asarray(ins[1])])
 @onnx_op("Elu")
 def _elu(node, ins, a, i): return ins[0].elu(float(a.get("alpha", 1.0)))
 @onnx_op("LeakyRelu")
@@ -392,7 +439,10 @@ def _resize(node, ins, a, i):
   if mode == "linear":
     if ctm == "asymmetric": return _rbilin(x, th, tw, align_corners=False)
     if ctm == "align_corners": return _rbilin(x, th, tw, align_corners=True)
-    raise NotImplementedError(f"ONNX Resize linear: coordinate_transformation_mode={ctm!r} not supported (ANE matches 'asymmetric'/'align_corners' only)")
+    if _APPROX_RESIZE and ctm in ("half_pixel", "pytorch_half_pixel"):
+      return _rbilin(x, th, tw, align_corners=True)   # closest ANE convention (~0.99 on smooth maps; opt-in approx)
+    raise NotImplementedError(f"ONNX Resize linear: coordinate_transformation_mode={ctm!r} not supported "
+                              "(ANE matches 'asymmetric'/'align_corners'; pass approx_resize=True for half-pixel)")
   raise NotImplementedError(f"ONNX Resize: mode={mode!r} not supported")
 
 def _reduce_op(ins, a, method):

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -24,6 +24,10 @@ y = net(np.zeros((1, 3, 224, 224), np.float16))
   (`target=`, `opt=`, `compress=`, ...). `path` is a filename or an in-memory `onnx.ModelProto`.
 - `af.onnx_to_tensor(path)` - import only, returning `(graph_inputs, output)` ANEForge
   tensors so you can inspect or splice the graph before compiling it yourself.
+- `af.onnx_to_features(path)` - import a classifier and return `(inputs, features)` where
+  `features` is the input to the final linear layer. Compile it for a frozen feature
+  extractor and train a fresh head on the ANE for transfer learning (see
+  [`examples/onnx_finetune.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/onnx_finetune.py)).
 
 A runnable end-to-end example (export a torchvision model, import it, validate against
 onnxruntime) is in [`examples/onnx_import.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/onnx_import.py):

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -46,6 +46,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Resampling | `Resize` (nearest / linear) |
 | Reduction | `ReduceMax`, `ReduceMin`, `ReduceSum`, `ReduceMean` |
 | Indexing | `Gather` (static indices), `ArgMax`, `TopK` (2D, values only) |
+| Quantization | `DequantizeLinear`, `QuantizeLinear` (QDQ int8) |
 | Misc | `Softmax`, `Constant`, `Identity` |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
@@ -90,6 +91,12 @@ mis-lower:
   affine ops), so `Mul(x, c)`, `Add(x, c)`, `Pow(x, 2)`, and the like need no graph cut.
   This is what makes `HardSigmoid`/`HardSwish` and the scale/shift ops in MobileNetV3 and
   ConvNeXt importable.
+- **Quantized (QDQ int8).** A statically-quantized ONNX model imports: an int8 weight
+  `DequantizeLinear` folds to its dequantized constant, and an activation
+  `QuantizeLinear`/`DequantizeLinear` pair becomes a fp16 `clip` to the quant range (which
+  carries any relu/saturation the quantizer fused in). Weights run at fp16 by default;
+  pass `compress="int8"` to keep them on the ANE int8 weight datapath. Matches onnxruntime
+  on-device (cosine ~1.0).
 - **Gelu:** exact erf-gelu only; `approximate="tanh"` raises.
 - **PRelu:** slope is a per-channel initializer (`[C]`, `[C,1,1]`, or scalar, flattened
   to `[C]`); input must be rank>=3 `[N,C,...]`.

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -41,7 +41,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Category | ONNX ops |
 | --- | --- |
 | Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf`, `HardSigmoid`, `HardSwish` |
-| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported) |
+| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported), `Abs`, `Neg`, `Sign`, `Reciprocal`, `Sin`, `Cos`, `Softplus`, `Floor`, `Ceil`, `Round`, `Min`, `Max`, `Where`, `Tile` |
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
 | Linear | `Gemm`, `MatMul` |
 | Normalization | `BatchNormalization`, `InstanceNormalization` |
@@ -120,7 +120,10 @@ mis-lower:
       `align_corners`.
     - `half_pixel`/`pytorch_half_pixel` sampling and `mode="cubic"` are **not** matched by
       the ANE resamplers and raise. Note the ONNX default `coordinate_transformation_mode`
-      is `half_pixel`, so a `Resize` must set `asymmetric`/`align_corners` explicitly.
+      is `half_pixel`, so a `Resize` must set `asymmetric`/`align_corners` explicitly — or
+      pass `load_onnx(path, approx_resize=True)` to map a half-pixel `Resize` to the closest
+      ANE bilinear (an opt-in approximation, ~0.99 cosine on smooth maps). This is what lets
+      segmentation models (FCN, DeepLabV3) — whose final upsample is half-pixel — import.
 - **Reductions** (`ReduceMax`/`ReduceMin`/`ReduceSum`/`ReduceMean`): `axes` may be an
   attribute (opset < 18; ReduceSum < 13) or an input initializer (later opsets); an
   absent/empty `axes` reduces over every axis. `keepdims=1` (the default) keeps reduced

--- a/examples/onnx_finetune.py
+++ b/examples/onnx_finetune.py
@@ -1,0 +1,64 @@
+"""Transfer-learning from an imported ONNX model, entirely on the ANE: import a CNN as a frozen feature
+extractor (af.onnx_to_features), extract MNIST features on the Neural Engine, then train a fresh linear
+head on those features on the ANE (forward + backward + Adam). Run: python3 examples/onnx_finetune.py"""
+import os
+import sys
+import tempfile
+from pathlib import Path
+
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+import numpy as np
+import aneforge as af
+
+
+def _export_backbone(path):
+    """A small conv backbone -> ONNX. Random weights here; in practice you import a *pretrained* model."""
+    import torch, torch.nn as nn
+    import torch.nn.functional as fn
+
+    class Net(nn.Module):
+        def __init__(self):
+            super().__init__(); self.c1 = nn.Conv2d(1, 16, 3, padding=1); self.c2 = nn.Conv2d(16, 16, 3, padding=1)
+            self.fc = nn.Linear(16 * 14 * 14, 10)                  # the classifier we discard
+
+        def forward(self, x):
+            x = fn.max_pool2d(self.c1(x).relu(), 2); x = self.c2(x).relu().flatten(1); return self.fc(x)
+
+    torch.onnx.export(Net().eval(), (torch.randn(1, 1, 28, 28),), path, opset_version=13, input_names=["x"], dynamo=False)
+    return path
+
+
+def main():
+    d = np.load(Path(__file__).resolve().parent / "data" / "mnist_subset.npz")
+    Xtr = (d["Xtr"].astype(np.float32) / 255.0).reshape(-1, 1, 28, 28); ytr = d["ytr"].astype(np.int64)
+    Xte = (d["Xte"].astype(np.float32) / 255.0).reshape(-1, 1, 28, 28); yte = d["yte"].astype(np.int64)
+
+    onnx_path = _export_backbone(os.path.join(tempfile.mkdtemp(), "backbone.onnx"))
+    _, features = af.onnx_to_features(onnx_path)           # penultimate features (input to the discarded classifier)
+    extractor = af.compile(features)                       # frozen backbone -> features, on the ANE
+    D = features.shape[-1]
+
+    def feats(X):                                          # run the frozen extractor on the ANE
+        return np.stack([np.asarray(extractor(X[i:i + 1].astype(np.float16))).ravel() for i in range(len(X))]).astype(np.float32)
+    Ftr, Fte = feats(Xtr), feats(Xte)
+    print(f"imported ONNX backbone -> {D}-d features (extracted on the ANE: {Ftr.shape})")
+
+    rng = np.random.default_rng(0); onehot = np.eye(10, dtype=np.float32)[ytr]
+    B, K = 100, 10
+    P = [af.parameter((rng.standard_normal((D, 10)) * np.sqrt(1 / D)).astype(np.float32)), af.parameter(np.zeros((1, 10), np.float32))]
+    xs = [af.input((B, D)) for _ in range(K)]; ts = [af.input((B, 10)) for _ in range(K)]
+    tr = af.UnrolledTrainer(P, lambda W, x: x @ W[0] + W[1], "ce", xs, ts, (Ftr, onehot), lr=0.1, loss_scale=1024.0)
+
+    acc = lambda: float((tr.predict(Fte).argmax(1) == yte).mean())
+    print(f"\n{'steps':>6} | {'test acc':>9}")
+    print(f"{0:>6} | {acc():>9.4f}  (init)")
+    for e in range(1, 31):
+        tr.step()                                          # K on-engine training steps per dispatch
+        if e % 5 == 0:
+            print(f"{e*K:>6} | {acc():>9.4f}")
+    print(f"\ntrained a head on imported-ONNX features to {acc():.3f} test accuracy - entirely on the ANE")
+    tr.release()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -24,6 +24,27 @@ def test_sigmoid_builds():
   m = _model([helper.make_node("Sigmoid", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "sigmoid"
 
+def test_tier3_unary_ops_build():  # cheap unary ops over existing graph ops
+  for op, want in [("Abs", "abs"), ("Sign", "sign"), ("Sin", "sin"), ("Cos", "cos"), ("Softplus", "softplus"),
+                   ("Floor", "floor"), ("Ceil", "ceil"), ("Round", "round"), ("Reciprocal", "inverse"), ("Neg", "muls")]:
+    m = _model([helper.make_node(op, ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+    _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4) and out.op == want, f"{op} -> {out.op}"
+
+def test_tier3_max_min_tile_where_build():
+  for op, want in [("Max", "maximum"), ("Min", "minimum")]:
+    m = _model([helper.make_node(op, ["a", "b"], ["y"])], [_vi("a", [1, 4]), _vi("b", [1, 4])], [_vi("y", [1, 4])])
+    _, out = af.onnx_to_tensor(m); assert out.op == want
+  reps = onnx.numpy_helper.from_array(np.array([1, 2], np.int64), "r")
+  m = _model([helper.make_node("Tile", ["x", "r"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 8])], inits=[reps])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8) and out.op == "tile"
+
+def test_resize_half_pixel_needs_approx():  # default guards half_pixel; approx_resize=True maps it to bilinear
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], np.int64), "sz")
+  n = helper.make_node("Resize", ["x", "roi", "sc", "sz"], ["y"], mode="linear", coordinate_transformation_mode="half_pixel")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])], inits=[_empty_f32("roi"), _empty_f32("sc"), sizes])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  _, out = af.onnx_to_tensor(m, approx_resize=True); assert out.shape == (1, 4, 16, 16) and out.op == "resize_bilinear"
+
 def test_clip_relu6_builds():
   n = helper.make_node("Clip", ["x"], ["y"], min=0.0, max=6.0)
   m = _model([n], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
@@ -204,7 +225,7 @@ def test_dynamic_dim_raises():  # symbolic dim_param -> static-shapes-only error
   with pytest.raises(ValueError): af.onnx_to_tensor(m)
 
 def test_unsupported_op_raises():  # unregistered op type fails loudly
-  m = _model([helper.make_node("Cos", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  m = _model([helper.make_node("ScatterND", ["x", "i", "u"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
 def test_conv_non_uniform_strides_raises():
@@ -780,3 +801,22 @@ def test_quantized_qdq_matches_onnxruntime(tmp_path):
   got = np.asarray(af.load_onnx(qdq)(x.astype(np.float16))).astype(np.float32).ravel()
   ref = np.asarray(onnxruntime.InferenceSession(qdq).run(None, {"x": x})[0]).astype(np.float32).ravel()
   cos = _cos(got, ref); assert cos > 0.99, f"quantized QDQ ANE vs onnxruntime cosine={cos}"
+
+# -- Tier 3 cheap ops + Tier 5 half-pixel resize approximation -------------------- #
+@requires_ane
+def test_tier3_softplus_matches_onnxruntime():
+  rng = np.random.default_rng(0); x = (rng.standard_normal((1, 8)) * 2).astype(np.float32)
+  m = _model([helper.make_node("Softplus", ["x"], ["y"])], [_vi("x", [1, 8])], [_vi("y", [1, 8])])
+  got, ref = _run_vs_ort(m, x)
+  cos = _cos(got, ref); assert cos > 0.99, f"Softplus ANE vs onnxruntime cosine={cos}"
+
+@requires_ane
+def test_resize_half_pixel_approx_close():  # the opt-in approximation is ~0.99 on a smooth upsample
+  rng = np.random.default_rng(0)
+  x = np.repeat(np.repeat(rng.standard_normal((1, 4, 4, 4)).astype(np.float32), 2, 2), 2, 3)  # smooth 8x8
+  sizes = onnx.numpy_helper.from_array(np.array([1, 4, 16, 16], np.int64), "sz")
+  n = helper.make_node("Resize", ["x", "roi", "sc", "sz"], ["y"], mode="linear", coordinate_transformation_mode="half_pixel")
+  m = _model([n], [_vi("x", [1, 4, 8, 8])], [_vi("y", [1, 4, 16, 16])], inits=[_empty_f32("roi"), _empty_f32("sc"), sizes])
+  got = np.asarray(af.load_onnx(m, approx_resize=True)(x.astype(np.float16))).astype(np.float32).ravel()
+  ref = np.asarray(onnx_run(m, x)).astype(np.float32).ravel()
+  cos = _cos(got, ref); assert cos > 0.95, f"half-pixel approx Resize ANE vs onnxruntime cosine={cos}"

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -105,6 +105,14 @@ def test_gemm_transb_builds():  # transB=1 -> W stays [out,in]; x[1,16] linear W
   m = _model([n], [_vi("x", [1, 16])], [_vi("y", [1, 10])], inits=[w, b])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 10) and out.op == "matmul"
 
+def test_onnx_to_features_peels_classifier():  # features = the input to the final linear layer
+  w = _init(np.zeros((10, 16)), "W"); b = _init(np.zeros(10), "B")
+  nodes = [helper.make_node("Flatten", ["x"], ["f"], axis=1),
+           helper.make_node("Gemm", ["f", "W", "B"], ["y"], transB=1)]
+  m = _model(nodes, [_vi("x", [1, 16, 1, 1])], [_vi("y", [1, 10])], inits=[w, b])
+  ins, feats = af.onnx_to_features(m)
+  assert feats.shape == (1, 16) and feats.op == "flatten2d"    # the Gemm's input, not the logits
+
 def test_flatten_builds():
   n = helper.make_node("Flatten", ["x"], ["y"], axis=1)
   m = _model([n], [_vi("x", [1, 8, 2, 2])], [_vi("y", [1, 32])])

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -43,6 +43,21 @@ def test_conv_asymmetric_pad_builds():  # ONNX pads [top,left,bottom,right] -> p
   m = _model([n], [_vi("x", [1, 3, 10, 10])], [_vi("y", [1, 4, 10, 9])], inits=[w])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 10, 9) and out.op == "conv"
 
+def test_dequantize_weight_conv_builds():  # int8 weight DequantizeLinear -> fp32 const fed to conv
+  w8 = onnx.numpy_helper.from_array(np.ones((4, 3, 3, 3), np.int8), "w8")
+  sc = onnx.numpy_helper.from_array(np.full(4, 0.1, np.float32), "sc")
+  zp = onnx.numpy_helper.from_array(np.zeros(4, np.int8), "zp")
+  nodes = [helper.make_node("DequantizeLinear", ["w8", "sc", "zp"], ["w"], axis=0),
+           helper.make_node("Conv", ["x", "w"], ["y"], pads=[1, 1, 1, 1])]
+  m = _model(nodes, [_vi("x", [1, 3, 8, 8])], [_vi("y", [1, 4, 8, 8])], inits=[w8, sc, zp])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4, 8, 8) and out.op == "conv"
+
+def test_quantize_activation_folds_relu():  # QuantizeLinear with zp pinning qmin to 0 -> a clip (the folded relu)
+  sc = onnx.numpy_helper.from_array(np.array(0.05, np.float32), "sc"); zp = onnx.numpy_helper.from_array(np.array(-128, np.int8), "zp")
+  n = helper.make_node("QuantizeLinear", ["x", "sc", "zp"], ["y"])
+  m = _model([n], [_vi("x", [1, 8])], [_vi("y", [1, 8])], inits=[sc, zp])
+  _, out = af.onnx_to_tensor(m); assert out.op == "clip" and out.attrs["lo"] == 0.0
+
 def test_shape_subgraph_folds_to_reshape():  # Shape->Gather->Unsqueeze->Concat folds to a static Reshape target
   nodes = [helper.make_node("Shape", ["x"], ["s"]),
            helper.make_node("Gather", ["s", "i0"], ["d0"], axis=0),
@@ -740,3 +755,20 @@ def test_fuse_attention_noncausal_matches():  # non-causal fuses to the decompos
   got = np.asarray(af.load_onnx(p, fuse_attention=True)(x.astype(np.float16))).astype(np.float32).ravel()
   ref = np.asarray(onnxruntime_run(p, x)).astype(np.float32).ravel()
   cos = _cos(got, ref); assert cos > 0.99, f"non-causal fused-attention ANE vs onnxruntime cosine={cos}"
+
+# -- quantized (int8) ONNX: QDQ weights dequantize, activation Q/DQ clips (relu fold) -- #
+@requires_ane
+def test_quantized_qdq_matches_onnxruntime(tmp_path):
+  import torch, torch.nn as nn, onnxruntime
+  from onnxruntime.quantization import quantize_static, QuantType, QuantFormat, CalibrationDataReader
+  net = nn.Sequential(nn.Conv2d(3, 16, 3, padding=1), nn.ReLU(), nn.AdaptiveAvgPool2d(1), nn.Flatten(), nn.Linear(16, 10)).eval()
+  fp32 = str(tmp_path / "m.onnx"); qdq = str(tmp_path / "q.onnx")
+  torch.onnx.export(net, (torch.randn(1, 3, 32, 32),), fp32, opset_version=13, input_names=["x"], dynamo=False)
+  class DR(CalibrationDataReader):
+    def __init__(self): self.it = iter([{"x": np.random.randn(1, 3, 32, 32).astype(np.float32)} for _ in range(8)])
+    def get_next(self): return next(self.it, None)  # type: ignore[override]  # base stub omits the None sentinel
+  quantize_static(fp32, qdq, DR(), quant_format=QuantFormat.QDQ, weight_type=QuantType.QInt8, per_channel=True)
+  x = np.random.default_rng(0).standard_normal((1, 3, 32, 32)).astype(np.float32)
+  got = np.asarray(af.load_onnx(qdq)(x.astype(np.float16))).astype(np.float32).ravel()
+  ref = np.asarray(onnxruntime.InferenceSession(qdq).run(None, {"x": x})[0]).astype(np.float32).ravel()
+  cos = _cos(got, ref); assert cos > 0.99, f"quantized QDQ ANE vs onnxruntime cosine={cos}"


### PR DESCRIPTION
Follow-on to #42 (the ONNX importer, merged), adding capabilities on top of the merged importer.

## Quantized (QDQ int8) ONNX import
Handle `DequantizeLinear`/`QuantizeLinear`: int8 weights fold to dequantized constants; an activation Q/DQ pair becomes a fp16 `clip` to the quant range — carrying any **relu the quantizer fused into the zero-point** (QDQ commonly drops the `Relu` node, encoding it as `zero_point=-128`; this was the subtle bug behind an initial wrong result, isolated via conv-only ✓ / gemm-only ✓ / conv+relu ✗). `compress="int8"` keeps weights on the ANE int8 datapath. Matches onnxruntime on-device at cosine 1.0.

## On-ANE transfer learning
`af.onnx_to_features(path)` gives a frozen feature extractor (penultimate features); train a fresh head on the ANE. `examples/onnx_finetune.py` → 0.90 MNIST accuracy from a random backbone (forward+backward+Adam on-device).

## Tier-3 cheap ops (14)
`Abs/Sign/Sin/Cos/Softplus/Floor/Ceil/Round/Reciprocal/Neg/Min/Max/Where/Tile` over existing graph ops, all cosine 1.0 vs onnxruntime.

## Segmentation (dense prediction)
`load_onnx(path, approx_resize=True)` maps a half-pixel `Resize` (no exact ANE match) to the closest bilinear (~0.99 on smooth maps; opt-in, default still raises). **FCN and DeepLabV3 import and run on the ANE.**

## Tooling
`.pylintrc` baking the CI flags so bare `pylint aneforge tests` = 10.00/10 matches CI (no `.ruff.toml`: ruff config lives in pyproject.toml).

## Validation
66 ONNX ops total. ~120 ONNX tests (on-device cosine vs onnxruntime + off-device shape/guard). Full `--forked` suite: **679 passed**. pyright 0, ruff + 2-space pylint clean, mkdocs --strict.
