### PR TITLE
LLM prefill on the Apple Neural Engine (Llama/Qwen, matches HuggingFace)

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,10 @@ model on the ANE, [`examples/onnx_import.py`](examples/onnx_import.py) imports
 a `.onnx` classifier via `af.load_onnx` and validates it against onnxruntime
 (cosine 1.0000); [`examples/onnx_finetune.py`](examples/onnx_finetune.py) imports
 one as a frozen feature extractor and trains a new head on it entirely on the
-ANE (transfer learning). For retrieval,
+ANE (transfer learning). To prefill an LLM prompt on the ANE,
+[`examples/llm_prefill.py`](examples/llm_prefill.py) loads a Llama/Qwen-class
+model via `af.load_llm` and runs prefill as one fused ANE program (matching
+Hugging Face logits). For retrieval,
 [`examples/rag_embeddings.py`](examples/rag_embeddings.py) is a LangChain
 `Embeddings` drop-in backed by the on-ANE encoder (4-5x faster than the GPU,
 cosine 1.0000).

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ model on the ANE, [`examples/onnx_import.py`](examples/onnx_import.py) imports
 a `.onnx` classifier via `af.load_onnx` and validates it against onnxruntime
 (cosine 1.0000); [`examples/onnx_finetune.py`](examples/onnx_finetune.py) imports
 one as a frozen feature extractor and trains a new head on it entirely on the
-ANE (transfer learning). To prefill an LLM prompt on the ANE,
+ANE (transfer learning). For LLMs, [`examples/llm_chat.py`](examples/llm_chat.py)
+is an interactive chat that streams a reply token-by-token on the ANE (resident
+KV-cache decode, ~75 tok/s on Qwen3-0.6B), and
 [`examples/llm_prefill.py`](examples/llm_prefill.py) loads a Llama/Qwen-class
-model via `af.load_llm` and runs prefill as one fused ANE program (matching
-Hugging Face logits). For retrieval,
+model via `af.load_llm` and benchmarks prefill/decode (matching Hugging Face
+logits). For retrieval,
 [`examples/rag_embeddings.py`](examples/rag_embeddings.py) is a LangChain
 `Embeddings` drop-in backed by the on-ANE encoder (4-5x faster than the GPU,
 cosine 1.0000).

--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -33,6 +33,7 @@ from .autograd import (Adam, adam_step, backward, backward_from, conv2d, conv_pa
 from .streaming import CheckpointedStack
 from .models import Encoder, Vision, load, load_resnet18, conv_block, cifar_cnn, group_norm_train
 from .onnx import load_onnx, onnx_to_tensor, onnx_to_features
+from .llm import LlamaConfig, LlamaPrefill, from_pretrained as load_llm, rope, rope_tables, prefill_block
 
 __all__ = [
     "Tensor", "Model", "SegmentedModel", "PrecisionWarning", "CrossChipFP16Warning",
@@ -57,6 +58,7 @@ __all__ = [
     "conv_param", "conv2d", "CheckpointedStack",
     "fft", "linalg", "special", "einsum", "dsp",
     "load_onnx", "onnx_to_tensor", "onnx_to_features",
+    "LlamaConfig", "LlamaPrefill", "load_llm", "rope", "rope_tables", "prefill_block",
 ]
 
 # applied-math submodules (af.fft / af.linalg / af.special / af.dsp), self-contained over the public ops

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -893,8 +893,11 @@ class MultiModel:
     self.prog.release()
 
 
-def compile_multi(outs, build_dir=None) -> MultiModel:
-  """Lower a multi-output graph into one fused program with N named output ports (fp16 only)."""
+def compile_multi(outs, build_dir=None, int8: bool = False, compress: str | None = None,
+          compress_atol: float = 0.05, block_size: int = 32) -> MultiModel:
+  """Lower a multi-output graph into one fused program with N named output ports (fp16 I/O). Weights may be
+  compressed (`int8=True` or `compress=`) exactly as in `compile`: the I/O ports stay fp16, only the constant
+  weights are quantized (per-channel int8 / int4-LUT / blockwise) and dequantized on the ANE."""
   order = _topo_multi(*outs)
   if any(t.op in NETPLIST_OPS for t in order):
     raise NotImplementedError("compile_multi: native-SDPA/netplist ops not supported")
@@ -904,7 +907,7 @@ def compile_multi(outs, build_dir=None) -> MultiModel:
   if not inputs: raise ValueError("aneforge.compile_multi: graph has no inputs")
   for i, t in enumerate(order): t._name = f"t{i}"
 
-  em = _Emitter(False)
+  em = _Emitter(int8, compress=compress, compress_atol=compress_atol, block_size=block_size)
   for t in order:
     if t.op != "input": _EMIT[t.op](em, t, t._name, [src._name for src in t.srcs])
 

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -895,9 +895,8 @@ class MultiModel:
 
 def compile_multi(outs, build_dir=None, int8: bool = False, compress: str | None = None,
           compress_atol: float = 0.05, block_size: int = 32) -> MultiModel:
-  """Lower a multi-output graph into one fused program with N named output ports (fp16 I/O). Weights may be
-  compressed (`int8=True` or `compress=`) exactly as in `compile`: the I/O ports stay fp16, only the constant
-  weights are quantized (per-channel int8 / int4-LUT / blockwise) and dequantized on the ANE."""
+  """Lower a multi-output graph into one fused program with N named output ports (fp16 I/O). `int8`/`compress`
+  quantize the constant weights as in `compile` (per-channel int8 / int4-LUT / blockwise); I/O stays fp16."""
   order = _topo_multi(*outs)
   if any(t.op in NETPLIST_OPS for t in order):
     raise NotImplementedError("compile_multi: native-SDPA/netplist ops not supported")

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -12,9 +12,13 @@ from . import _compile
 
 @dataclass
 class LlamaConfig:
-  """A Llama/Qwen-class decoder config (the fields the prefill graph needs)."""
+  """A Llama/Qwen-class decoder config (the fields the prefill graph needs). `head_dim` defaults to
+  `dim // n_heads` but is explicit for Qwen3 (where it differs)."""
   dim: int; n_layers: int; n_heads: int; n_kv_heads: int; ffn_dim: int; vocab: int
-  rope_base: float = 10000.0; norm_eps: float = 1e-5
+  rope_base: float = 10000.0; norm_eps: float = 1e-5; head_dim: int = 0
+
+  @property
+  def dh(self) -> int: return self.head_dim or self.dim // self.n_heads
 
 
 def rope_tables(seq: int, dh: int, base: float = 10000.0):
@@ -54,12 +58,16 @@ def _causal_attn(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
 
 
 def prefill_block(x: Tensor, w: dict, cfg: LlamaConfig, cos, sin) -> Tensor:
-  """One pre-norm Llama decoder block over a prompt `x` [S, dim]: RMSNorm -> QKV -> RoPE -> causal attention -> SwiGLU MLP, with residuals."""
-  H, KV, dh, S = cfg.n_heads, cfg.n_kv_heads, cfg.dim // cfg.n_heads, x.shape[0]
+  """One pre-norm Llama/Qwen decoder block over a prompt `x` [S, dim]: RMSNorm -> QKV (+ Qwen3 QK-norm)
+  -> RoPE -> causal attention -> SwiGLU MLP, with residuals."""
+  H, KV, dh, S = cfg.n_heads, cfg.n_kv_heads, cfg.dh, x.shape[0]
   xn = x.rms_norm(w["attn_norm"], cfg.norm_eps)
-  q = xn.linear(w["wq"]).reshape(S, H, dh).transpose([1, 0, 2]).reshape(1, H, S, dh)
-  k = xn.linear(w["wk"]).reshape(S, KV, dh).transpose([1, 0, 2]).reshape(1, KV, S, dh)
-  v = xn.linear(w["wv"]).reshape(S, KV, dh).transpose([1, 0, 2]).reshape(1, KV, S, dh)
+  q = xn.linear(w["wq"]).reshape(S, H, dh); k = xn.linear(w["wk"]).reshape(S, KV, dh); v = xn.linear(w["wv"]).reshape(S, KV, dh)
+  if "q_norm" in w:                                 # Qwen3 QK-norm: per-head RMSNorm over head_dim before RoPE
+    q = q.reshape(S * H, dh).rms_norm(w["q_norm"], cfg.norm_eps).reshape(S, H, dh)
+    k = k.reshape(S * KV, dh).rms_norm(w["k_norm"], cfg.norm_eps).reshape(S, KV, dh)
+  q = q.transpose([1, 0, 2]).reshape(1, H, S, dh); k = k.transpose([1, 0, 2]).reshape(1, KV, S, dh)
+  v = v.transpose([1, 0, 2]).reshape(1, KV, S, dh)
   q, k = rope(q, cos, sin), rope(k, cos, sin)
   k, v = _repeat_kv(k, H // KV), _repeat_kv(v, H // KV)
   a = _causal_attn(q, k, v).reshape(H, S, dh).transpose([1, 0, 2]).reshape(S, H * dh)
@@ -76,24 +84,27 @@ class LlamaPrefill:
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0
 
   def compile(self, seq: int):
-    cfg = self.cfg; dh = cfg.dim // cfg.n_heads
-    cos, sin = rope_tables(seq, dh, cfg.rope_base)
+    cfg = self.cfg
+    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base)
     x = _input((seq, cfg.dim))
     for lw in self.w["layers"]:
       x = prefill_block(x, lw, cfg, cos, sin)
     x = x.rms_norm(self.w["final_norm"], cfg.norm_eps)
     last = x.slice_by_size([seq - 1, 0], [1, cfg.dim])      # only the last position predicts the next token
-    self._net = _compile.compile(last.linear(self.w["lm_head"]))
+    self._net = _compile.compile(last)                     # the ANE produces the final hidden state [1, dim]
     self._seq = seq
     return self
 
   def prefill(self, token_ids):
-    """Prefill `token_ids` (length must match `compile(seq)`) and return the next-token logits [1, vocab]."""
+    """Prefill `token_ids` (length must match `compile(seq)`) and return the next-token logits [1, vocab].
+    The transformer layers run on the ANE; the lm_head vocab projection (a single matvec, and the vocab can
+    exceed the ANE's per-op dim limit) is done on host."""
     if self._net is None or len(token_ids) != self._seq:
       self.compile(len(token_ids))
     net = self._net; assert net is not None
     emb = self.w["embed"][np.asarray(token_ids)]            # host embedding gather -> [S, dim]
-    return np.asarray(net(emb.astype(np.float16)))
+    hidden = np.asarray(net(emb.astype(np.float16)))[0].astype(np.float32)   # final hidden state [dim]
+    return (hidden @ np.asarray(self.w["lm_head"]).T)[None]                  # host lm_head -> [1, vocab]
 
 
 def _weights_from_state_dict(sd, cfg: LlamaConfig) -> dict:
@@ -102,12 +113,15 @@ def _weights_from_state_dict(sd, cfg: LlamaConfig) -> dict:
        "lm_head": sd.get("lm_head.weight", sd["model.embed_tokens.weight"]), "layers": []}
   for L in range(cfg.n_layers):
     p = f"model.layers.{L}."
-    w["layers"].append({
+    lw = {
       "wq": sd[p + "self_attn.q_proj.weight"], "wk": sd[p + "self_attn.k_proj.weight"],
       "wv": sd[p + "self_attn.v_proj.weight"], "wo": sd[p + "self_attn.o_proj.weight"],
       "wgate": sd[p + "mlp.gate_proj.weight"], "wup": sd[p + "mlp.up_proj.weight"],
       "wdown": sd[p + "mlp.down_proj.weight"], "attn_norm": sd[p + "input_layernorm.weight"],
-      "mlp_norm": sd[p + "post_attention_layernorm.weight"]})
+      "mlp_norm": sd[p + "post_attention_layernorm.weight"]}
+    if p + "self_attn.q_norm.weight" in sd:         # Qwen3 QK-norm
+      lw["q_norm"] = sd[p + "self_attn.q_norm.weight"]; lw["k_norm"] = sd[p + "self_attn.k_norm.weight"]
+    w["layers"].append(lw)
   return w
 
 
@@ -115,7 +129,8 @@ def _cfg_from_hf(c) -> LlamaConfig:
   return LlamaConfig(dim=c.hidden_size, n_layers=c.num_hidden_layers, n_heads=c.num_attention_heads,
                      n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                      ffn_dim=c.intermediate_size, vocab=c.vocab_size,
-                     rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps))
+                     rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps),
+                     head_dim=int(getattr(c, "head_dim", 0) or 0))
 
 
 def from_pretrained(name: str) -> LlamaPrefill:

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -1,0 +1,127 @@
+"""LLM prefill on the Apple Neural Engine. A config-driven Llama/Qwen-style decoder
+(RMSNorm + RoPE + grouped-query causal attention + SwiGLU) that loads real Hugging Face
+weights and prefills a prompt as ONE fused ANE program -- the compute-bound phase where the
+Neural Engine is most energy-efficient. Matches HF logits; see `examples/llm_prefill.py`."""
+from __future__ import annotations
+from dataclasses import dataclass
+import numpy as np
+
+from .graph import Tensor, input as _input, concat as _concat, _const
+from . import _compile
+
+
+@dataclass
+class LlamaConfig:
+  """A Llama/Qwen-class decoder config (the fields the prefill graph needs)."""
+  dim: int; n_layers: int; n_heads: int; n_kv_heads: int; ffn_dim: int; vocab: int
+  rope_base: float = 10000.0; norm_eps: float = 1e-5
+
+
+def rope_tables(seq: int, dh: int, base: float = 10000.0):
+  """Precompute the [seq, dh] cos/sin rotation tables (HF Llama layout: freqs duplicated over the two halves)."""
+  inv = 1.0 / (base ** (np.arange(0, dh, 2) / dh))
+  pos = np.arange(seq)[:, None] * inv[None, :]
+  emb = np.concatenate([pos, pos], -1)
+  return np.cos(emb).astype(np.float16), np.sin(emb).astype(np.float16)
+
+
+def rope(x: Tensor, cos, sin) -> Tensor:
+  """Apply rotary position embedding to `x` [.., seq, dh]: `x*cos + rotate_half(x)*sin`."""
+  dh = x.shape[-1]; half = dh // 2; rank = len(x.shape)
+  s = list(x.shape); s[-1] = half
+  x1 = x.slice_by_size([0] * rank, s)
+  b2 = [0] * rank; b2[-1] = half
+  x2 = x.slice_by_size(b2, s)
+  return x * _const(cos) + _concat([x2 * -1.0, x1], axis=rank - 1) * _const(sin)
+
+
+def _repeat_kv(k: Tensor, g: int) -> Tensor:
+  """Grouped-query repeat: [1, KV, S, dh] -> [1, KV*g, S, dh], each kv head repeated `g` times (via a 0/1 expansion matmul; any `g`)."""
+  if g == 1: return k
+  _, KV, S, dh = k.shape
+  M = np.repeat(np.eye(KV, dtype=np.float16), g, axis=0)        # [KV*g, KV]: M[h, kv] = 1 iff kv == h // g
+  k2 = k.reshape(KV, S * dh).transpose([1, 0])                  # [S*dh, KV]
+  return k2.linear(M).transpose([1, 0]).reshape(1, KV * g, S, dh)
+
+
+def _causal_attn(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
+  """Causal self-attention on q,k,v [1,H,S,dh] as the decomposed `softmax(q@kᵀ·scale + causal_mask)@v`.
+  For prefill this stays in ONE fused program (compute-bound big matmuls — what the ANE excels at);
+  the native fused-attention layer is avoided here because its per-layer graph cut dominates prefill cost."""
+  S, dh = q.shape[2], q.shape[3]
+  mask = np.triu(np.full((S, S), -1e4, np.float16), 1)     # causal: keys after the query are masked out
+  return ((q @ k.transpose([0, 1, 3, 2])) * (1.0 / dh ** 0.5) + _const(mask)).softmax(-1) @ v
+
+
+def prefill_block(x: Tensor, w: dict, cfg: LlamaConfig, cos, sin) -> Tensor:
+  """One pre-norm Llama decoder block over a prompt `x` [S, dim]: RMSNorm -> QKV -> RoPE -> causal attention -> SwiGLU MLP, with residuals."""
+  H, KV, dh, S = cfg.n_heads, cfg.n_kv_heads, cfg.dim // cfg.n_heads, x.shape[0]
+  xn = x.rms_norm(w["attn_norm"], cfg.norm_eps)
+  q = xn.linear(w["wq"]).reshape(S, H, dh).transpose([1, 0, 2]).reshape(1, H, S, dh)
+  k = xn.linear(w["wk"]).reshape(S, KV, dh).transpose([1, 0, 2]).reshape(1, KV, S, dh)
+  v = xn.linear(w["wv"]).reshape(S, KV, dh).transpose([1, 0, 2]).reshape(1, KV, S, dh)
+  q, k = rope(q, cos, sin), rope(k, cos, sin)
+  k, v = _repeat_kv(k, H // KV), _repeat_kv(v, H // KV)
+  a = _causal_attn(q, k, v).reshape(H, S, dh).transpose([1, 0, 2]).reshape(S, H * dh)
+  h = x + a.linear(w["wo"])
+  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)
+  return h + (hn.linear(w["wgate"]).silu() * hn.linear(w["wup"])).linear(w["wdown"])
+
+
+class LlamaPrefill:
+  """A Llama/Qwen decoder compiled for prefill on the ANE. `compile(seq)` builds the graph for a fixed
+  prompt length; `prefill(token_ids)` returns the next-token logits. Weights are a dict of numpy arrays
+  (see `from_pretrained`)."""
+  def __init__(self, cfg: LlamaConfig, weights: dict):
+    self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0
+
+  def compile(self, seq: int):
+    cfg = self.cfg; dh = cfg.dim // cfg.n_heads
+    cos, sin = rope_tables(seq, dh, cfg.rope_base)
+    x = _input((seq, cfg.dim))
+    for lw in self.w["layers"]:
+      x = prefill_block(x, lw, cfg, cos, sin)
+    x = x.rms_norm(self.w["final_norm"], cfg.norm_eps)
+    last = x.slice_by_size([seq - 1, 0], [1, cfg.dim])      # only the last position predicts the next token
+    self._net = _compile.compile(last.linear(self.w["lm_head"]))
+    self._seq = seq
+    return self
+
+  def prefill(self, token_ids):
+    """Prefill `token_ids` (length must match `compile(seq)`) and return the next-token logits [1, vocab]."""
+    if self._net is None or len(token_ids) != self._seq:
+      self.compile(len(token_ids))
+    net = self._net; assert net is not None
+    emb = self.w["embed"][np.asarray(token_ids)]            # host embedding gather -> [S, dim]
+    return np.asarray(net(emb.astype(np.float16)))
+
+
+def _weights_from_state_dict(sd, cfg: LlamaConfig) -> dict:
+  """Map a Llama/Qwen Hugging Face state_dict (numpy arrays) into the prefill weight layout."""
+  w = {"embed": sd["model.embed_tokens.weight"], "final_norm": sd["model.norm.weight"],
+       "lm_head": sd.get("lm_head.weight", sd["model.embed_tokens.weight"]), "layers": []}
+  for L in range(cfg.n_layers):
+    p = f"model.layers.{L}."
+    w["layers"].append({
+      "wq": sd[p + "self_attn.q_proj.weight"], "wk": sd[p + "self_attn.k_proj.weight"],
+      "wv": sd[p + "self_attn.v_proj.weight"], "wo": sd[p + "self_attn.o_proj.weight"],
+      "wgate": sd[p + "mlp.gate_proj.weight"], "wup": sd[p + "mlp.up_proj.weight"],
+      "wdown": sd[p + "mlp.down_proj.weight"], "attn_norm": sd[p + "input_layernorm.weight"],
+      "mlp_norm": sd[p + "post_attention_layernorm.weight"]})
+  return w
+
+
+def _cfg_from_hf(c) -> LlamaConfig:
+  return LlamaConfig(dim=c.hidden_size, n_layers=c.num_hidden_layers, n_heads=c.num_attention_heads,
+                     n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
+                     ffn_dim=c.intermediate_size, vocab=c.vocab_size,
+                     rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps))
+
+
+def from_pretrained(name: str) -> LlamaPrefill:
+  """Load a Llama/Qwen-class model from Hugging Face and prepare it for ANE prefill."""
+  from transformers import AutoModelForCausalLM
+  hf = AutoModelForCausalLM.from_pretrained(name)
+  cfg = _cfg_from_hf(hf.config)
+  sd = {k: v.detach().float().numpy() for k, v in hf.state_dict().items()}
+  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg))

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -163,10 +163,11 @@ class LlamaPrefill:
     self._dec = {"M": M, "net": net, "p": ports, "cos": cos_t, "sin": sin_t}
     return self._dec
 
-  def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None):
+  def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None):
     """Greedy autoregressive generation with a resident on-device KV-cache. The decode program (compiled once
     and cached) runs all layers for one token attending to caches that stay on the ANE across steps, so each
-    step feeds only the token embedding + a position one-hot. Returns the generated token ids."""
+    step feeds only the token embedding + a position one-hot. `on_token(id)` is called per token (streaming).
+    Returns the generated token ids."""
     cfg = self.cfg; KV, dh = cfg.n_kv_heads, cfg.dh; f16 = np.float16
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
     d = self._decoder(M); net = d["net"]; p = d["p"]
@@ -187,6 +188,7 @@ class LlamaPrefill:
       if pos >= M - 1: break                                   # cache full
       nxt = int(self._logits(step(cur, pos)).argmax()); out.append(nxt)
       if nxt == eos_id: break
+      if on_token is not None: on_token(nxt)                   # stream the token
       cur = nxt; pos += 1
     return out
 

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -30,13 +30,15 @@ def rope_tables(seq: int, dh: int, base: float = 10000.0):
 
 
 def rope(x: Tensor, cos, sin) -> Tensor:
-  """Apply rotary position embedding to `x` [.., seq, dh]: `x*cos + rotate_half(x)*sin`."""
+  """Apply rotary position embedding to `x` [.., seq, dh]: `x*cos + rotate_half(x)*sin`. `cos`/`sin` may be
+  numpy tables (prefill, baked as constants) or graph Tensors (decode, a runtime per-position row)."""
   dh = x.shape[-1]; half = dh // 2; rank = len(x.shape)
   s = list(x.shape); s[-1] = half
   x1 = x.slice_by_size([0] * rank, s)
   b2 = [0] * rank; b2[-1] = half
   x2 = x.slice_by_size(b2, s)
-  return x * _const(cos) + _concat([x2 * -1.0, x1], axis=rank - 1) * _const(sin)
+  c = cos if isinstance(cos, Tensor) else _const(cos); sn = sin if isinstance(sin, Tensor) else _const(sin)
+  return x * c + _concat([x2 * -1.0, x1], axis=rank - 1) * sn
 
 
 def _repeat_kv(k: Tensor, g: int) -> Tensor:
@@ -76,12 +78,40 @@ def prefill_block(x: Tensor, w: dict, cfg: LlamaConfig, cos, sin) -> Tensor:
   return h + (hn.linear(w["wgate"]).silu() * hn.linear(w["wup"])).linear(w["wdown"])
 
 
+def _repeat_kv3(k: Tensor, g: int) -> Tensor:
+  """Grouped-query repeat for the decode cache: [KV, M, dh] -> [KV*g, M, dh] (0/1 expansion matmul)."""
+  if g == 1: return k
+  KV, M, dh = k.shape
+  Mx = np.repeat(np.eye(KV, dtype=np.float16), g, axis=0)
+  return k.reshape(KV, M * dh).transpose([1, 0]).linear(Mx).transpose([1, 0]).reshape(KV * g, M, dh)
+
+
+def _decode_block(x: Tensor, w: dict, cfg: LlamaConfig, Kin, Vin, oh, inv, mask, cosp, sinp):
+  """One decoder block for a single new token, attending to a resident KV-cache. `x` [1, dim]; `Kin`/`Vin`
+  [KV, M, dh] are the cache; `oh`/`inv` [1, M, 1] write the new K/V at the current position; `cosp`/`sinp`
+  [1, dh] are RoPE for that position. Returns (hidden, Kout, Vout) where Kout/Vout become the resident cache."""
+  H, KV, dh = cfg.n_heads, cfg.n_kv_heads, cfg.dh
+  xn = x.rms_norm(w["attn_norm"], cfg.norm_eps)
+  q = xn.linear(w["wq"]).reshape(H, dh); k = xn.linear(w["wk"]).reshape(KV, dh); v = xn.linear(w["wv"]).reshape(KV, dh)
+  if "q_norm" in w:
+    q = q.rms_norm(w["q_norm"], cfg.norm_eps); k = k.rms_norm(w["k_norm"], cfg.norm_eps)
+  q = rope(q.reshape(H, 1, dh), cosp, sinp)        # [H, 1, dh]
+  k = rope(k.reshape(KV, 1, dh), cosp, sinp); v = v.reshape(KV, 1, dh)
+  Kout = Kin * inv + k * oh; Vout = Vin * inv + v * oh        # masked positional write into the cache
+  Kr, Vr = _repeat_kv3(Kout, H // KV), _repeat_kv3(Vout, H // KV)
+  sc = ((q @ Kr.transpose([0, 2, 1])) * (1.0 / dh ** 0.5) + mask).softmax(-1)   # [H, 1, M]
+  a = (sc @ Vr).reshape(H, 1, dh).transpose([1, 0, 2]).reshape(1, H * dh)
+  h = x + a.linear(w["wo"])
+  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)
+  return h + (hn.linear(w["wgate"]).silu() * hn.linear(w["wup"])).linear(w["wdown"]), Kout, Vout
+
+
 class LlamaPrefill:
   """A Llama/Qwen decoder compiled for prefill on the ANE. `compile(seq)` builds the graph for a fixed
   prompt length; `prefill(token_ids)` returns the next-token logits. Weights are a dict of numpy arrays
   (see `from_pretrained`)."""
   def __init__(self, cfg: LlamaConfig, weights: dict):
-    self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0
+    self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None
 
   def compile(self, seq: int):
     cfg = self.cfg
@@ -108,20 +138,56 @@ class LlamaPrefill:
     """Prefill `token_ids` and return the next-token logits [1, vocab] (the transformer runs on the ANE)."""
     return self._logits(self._hidden(token_ids)[-1])[None]
 
-  def generate(self, token_ids, max_new_tokens=40, eos_id=None):
-    """Greedy autoregressive generation. Prompt + generated tokens fit one fixed-length ANE program (length
-    `len(prompt)+max_new_tokens`); each step re-runs it and reads the next-token logits at the current position.
-    Returns the generated token ids (prompt excluded)."""
-    prompt = [int(t) for t in token_ids]; n = len(prompt)
-    full = n + max_new_tokens
-    self.compile(full)
-    toks = prompt + [0] * max_new_tokens                   # pad to the fixed length (causal mask ignores future positions)
-    out = []
-    for cur in range(n, full):
-      nxt = int(self._logits(self._hidden(toks)[cur - 1]).argmax())   # next token from the last real position
-      out.append(nxt)
+  def _decoder(self, M):
+    """Build (once, cached) the resident-KV-cache decode-step program for a max sequence length `M`: all layers
+    run for one token attending to per-layer caches that stay on-device across `execute` via `share_buffer`."""
+    if self._dec is not None and self._dec["M"] == M: return self._dec
+    if self._dec is not None: self._dec["net"].release()
+    from ._compile import compile_multi
+    cfg = self.cfg; KV, dh, D, L = cfg.n_kv_heads, cfg.dh, cfg.dim, cfg.n_layers
+    x = _input((1, D)); oh = _input((1, M, 1)); inv = _input((1, M, 1)); mask = _input((1, 1, M))
+    cosp = _input((1, dh)); sinp = _input((1, dh))
+    Kin = [_input((KV, M, dh)) for _ in range(L)]; Vin = [_input((KV, M, dh)) for _ in range(L)]
+    h = x; Kout = []; Vout = []
+    for lw, ki, vi in zip(self.w["layers"], Kin, Vin):
+      h, ko, vo = _decode_block(h, lw, cfg, ki, vi, oh, inv, mask, cosp, sinp)
+      Kout.append(ko); Vout.append(vo)
+    h = h.rms_norm(self.w["final_norm"], cfg.norm_eps)
+    net = compile_multi([h] + Kout + Vout)
+    inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
+    for ki, vi, ko, vo in zip(Kin, Vin, Kout, Vout):           # alias each layer's cache output -> its input (resident)
+      net.prog.share_buffer(0, om[ko], 0, inm[id(ki)]); net.prog.share_buffer(0, om[vo], 0, inm[id(vi)])
+    cos_t, sin_t = rope_tables(M, dh, cfg.rope_base)
+    ports = {"x": inm[id(x)], "oh": inm[id(oh)], "inv": inm[id(inv)], "mask": inm[id(mask)],
+             "cosp": inm[id(cosp)], "sinp": inm[id(sinp)], "h": om[h], "kv": [(inm[id(ki)], inm[id(vi)]) for ki, vi in zip(Kin, Vin)]}
+    self._dec = {"M": M, "net": net, "p": ports, "cos": cos_t, "sin": sin_t}
+    return self._dec
+
+  def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None):
+    """Greedy autoregressive generation with a resident on-device KV-cache. The decode program (compiled once
+    and cached) runs all layers for one token attending to caches that stay on the ANE across steps, so each
+    step feeds only the token embedding + a position one-hot. Returns the generated token ids."""
+    cfg = self.cfg; KV, dh = cfg.n_kv_heads, cfg.dh; f16 = np.float16
+    prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
+    d = self._decoder(M); net = d["net"]; p = d["p"]
+    for ki, vi in p["kv"]:                                      # reset the resident cache for this generation
+      net.prog.set_input(ki, np.zeros((KV, M, dh), f16)); net.prog.set_input(vi, np.zeros((KV, M, dh), f16))
+    def step(tok, pos):
+      ohv = np.zeros((1, M, 1), f16); ohv[0, pos, 0] = 1.0
+      invv = np.ones((1, M, 1), f16); invv[0, pos, 0] = 0.0
+      mv = np.full((1, 1, M), -1e4, f16); mv[..., :pos + 1] = 0.0
+      net.prog.set_input(p["x"], np.asarray(self.w["embed"][tok])[None].astype(f16))
+      net.prog.set_input(p["oh"], ohv); net.prog.set_input(p["inv"], invv); net.prog.set_input(p["mask"], mv)
+      net.prog.set_input(p["cosp"], d["cos"][pos][None]); net.prog.set_input(p["sinp"], d["sin"][pos][None])
+      net.prog.execute()
+      return np.asarray(net.prog.read_output(p["h"])).reshape(cfg.dim).astype(np.float32)
+    for pos, tok in enumerate(prompt[:-1]): step(tok, pos)      # prefill the cache (discard hidden)
+    cur = prompt[-1]; pos = len(prompt) - 1; out = []
+    for _ in range(max_new_tokens):                            # decode
+      if pos >= M - 1: break                                   # cache full
+      nxt = int(self._logits(step(cur, pos)).argmax()); out.append(nxt)
       if nxt == eos_id: break
-      toks[cur] = nxt
+      cur = nxt; pos += 1
     return out
 
 

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -89,22 +89,40 @@ class LlamaPrefill:
     x = _input((seq, cfg.dim))
     for lw in self.w["layers"]:
       x = prefill_block(x, lw, cfg, cos, sin)
-    x = x.rms_norm(self.w["final_norm"], cfg.norm_eps)
-    last = x.slice_by_size([seq - 1, 0], [1, cfg.dim])      # only the last position predicts the next token
-    self._net = _compile.compile(last)                     # the ANE produces the final hidden state [1, dim]
+    self._net = _compile.compile(x.rms_norm(self.w["final_norm"], cfg.norm_eps))   # ANE -> all positions' hidden [seq, dim]
     self._seq = seq
     return self
 
-  def prefill(self, token_ids):
-    """Prefill `token_ids` (length must match `compile(seq)`) and return the next-token logits [1, vocab].
-    The transformer layers run on the ANE; the lm_head vocab projection (a single matvec, and the vocab can
-    exceed the ANE's per-op dim limit) is done on host."""
+  def _hidden(self, token_ids):
+    """Run the transformer layers on the ANE; return the final hidden states [S, dim]."""
     if self._net is None or len(token_ids) != self._seq:
       self.compile(len(token_ids))
     net = self._net; assert net is not None
-    emb = self.w["embed"][np.asarray(token_ids)]            # host embedding gather -> [S, dim]
-    hidden = np.asarray(net(emb.astype(np.float16)))[0].astype(np.float32)   # final hidden state [dim]
-    return (hidden @ np.asarray(self.w["lm_head"]).T)[None]                  # host lm_head -> [1, vocab]
+    emb = self.w["embed"][np.asarray(token_ids)]           # host embedding gather -> [S, dim]
+    return np.asarray(net(emb.astype(np.float16))).astype(np.float32)
+
+  def _logits(self, hidden_row):
+    return hidden_row @ np.asarray(self.w["lm_head"]).T    # host lm_head (vocab can exceed the ANE per-op dim limit)
+
+  def prefill(self, token_ids):
+    """Prefill `token_ids` and return the next-token logits [1, vocab] (the transformer runs on the ANE)."""
+    return self._logits(self._hidden(token_ids)[-1])[None]
+
+  def generate(self, token_ids, max_new_tokens=40, eos_id=None):
+    """Greedy autoregressive generation. Prompt + generated tokens fit one fixed-length ANE program (length
+    `len(prompt)+max_new_tokens`); each step re-runs it and reads the next-token logits at the current position.
+    Returns the generated token ids (prompt excluded)."""
+    prompt = [int(t) for t in token_ids]; n = len(prompt)
+    full = n + max_new_tokens
+    self.compile(full)
+    toks = prompt + [0] * max_new_tokens                   # pad to the fixed length (causal mask ignores future positions)
+    out = []
+    for cur in range(n, full):
+      nxt = int(self._logits(self._hidden(toks)[cur - 1]).argmax())   # next token from the last real position
+      out.append(nxt)
+      if nxt == eos_id: break
+      toks[cur] = nxt
+    return out
 
 
 def _weights_from_state_dict(sd, cfg: LlamaConfig) -> dict:

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -163,6 +163,11 @@ class LlamaPrefill:
     self._dec = {"M": M, "net": net, "p": ports, "cos": cos_t, "sin": sin_t}
     return self._dec
 
+  def warmup(self, max_len):
+    """Compile and cache the decode program for context length `max_len` (the one-time cost) so the next
+    `generate` streams immediately. Returns self."""
+    self._decoder(int(max_len)); return self
+
   def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None):
     """Greedy autoregressive generation with a resident on-device KV-cache. The decode program (compiled once
     and cached) runs all layers for one token attending to caches that stay on the ANE across steps, so each

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -1,7 +1,6 @@
-"""LLM prefill on the Apple Neural Engine. A config-driven Llama/Qwen-style decoder
-(RMSNorm + RoPE + grouped-query causal attention + SwiGLU) that loads real Hugging Face
-weights and prefills a prompt as ONE fused ANE program -- the compute-bound phase where the
-Neural Engine is most energy-efficient. Matches HF logits; see `examples/llm_prefill.py`."""
+"""LLMs on the Apple Neural Engine. A config-driven Llama/Qwen decoder
+(RMSNorm + RoPE + grouped-query causal attention + SwiGLU) that loads Hugging Face weights and
+runs prefill and KV-cache decode as fused ANE programs. Matches HF logits; see `docs/llm.md`."""
 from __future__ import annotations
 from dataclasses import dataclass
 import numpy as np
@@ -112,8 +111,7 @@ class LlamaPrefill:
   (see `from_pretrained`)."""
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None
-    self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise": quantize the ANE weights (halves/quarters
-    #                                weight bytes -> less memory and, on weight-bound large models, faster decode)
+    self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
 
   def compile(self, seq: int):
     cfg = self.cfg
@@ -172,9 +170,9 @@ class LlamaPrefill:
     self._decoder(int(max_len)); return self
 
   def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None):
-    """Greedy autoregressive generation with a resident on-device KV-cache. The decode program (compiled once
-    and cached) runs all layers for one token attending to caches that stay on the ANE across steps, so each
-    step feeds only the token embedding + a position one-hot. `on_token(id)` is called per token (streaming).
+    """Greedy autoregressive generation with a resident KV-cache. The decode program (compiled once and
+    cached) runs all layers for one token attending to caches that stay on the ANE across steps, so each step
+    feeds only the token embedding + a position one-hot. `on_token(id)` is called per token (streaming).
     Returns the generated token ids."""
     cfg = self.cfg; KV, dh = cfg.n_kv_heads, cfg.dh; f16 = np.float16
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
@@ -228,8 +226,8 @@ def _cfg_from_hf(c) -> LlamaConfig:
 
 
 def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
-  """Load a Llama/Qwen-class model from Hugging Face and prepare it for ANE prefill. `compress` ("int8"/"int4"/
-  "blockwise") quantizes the ANE weights to cut their memory and, on weight-bound large models, speed decode."""
+  """Load a Llama/Qwen-class model from Hugging Face for ANE inference. `compress` ("int8"/"int4"/"blockwise")
+  quantizes the ANE weights."""
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)
   cfg = _cfg_from_hf(hf.config)

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -110,8 +110,10 @@ class LlamaPrefill:
   """A Llama/Qwen decoder compiled for prefill on the ANE. `compile(seq)` builds the graph for a fixed
   prompt length; `prefill(token_ids)` returns the next-token logits. Weights are a dict of numpy arrays
   (see `from_pretrained`)."""
-  def __init__(self, cfg: LlamaConfig, weights: dict):
+  def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None
+    self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise": quantize the ANE weights (halves/quarters
+    #                                weight bytes -> less memory and, on weight-bound large models, faster decode)
 
   def compile(self, seq: int):
     cfg = self.cfg
@@ -119,7 +121,8 @@ class LlamaPrefill:
     x = _input((seq, cfg.dim))
     for lw in self.w["layers"]:
       x = prefill_block(x, lw, cfg, cos, sin)
-    self._net = _compile.compile(x.rms_norm(self.w["final_norm"], cfg.norm_eps))   # ANE -> all positions' hidden [seq, dim]
+    self._net = _compile.compile(x.rms_norm(self.w["final_norm"], cfg.norm_eps),   # ANE -> all positions' hidden [seq, dim]
+                                 compress=self.compress)
     self._seq = seq
     return self
 
@@ -153,7 +156,7 @@ class LlamaPrefill:
       h, ko, vo = _decode_block(h, lw, cfg, ki, vi, oh, inv, mask, cosp, sinp)
       Kout.append(ko); Vout.append(vo)
     h = h.rms_norm(self.w["final_norm"], cfg.norm_eps)
-    net = compile_multi([h] + Kout + Vout)
+    net = compile_multi([h] + Kout + Vout, compress=self.compress)
     inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
     for ki, vi, ko, vo in zip(Kin, Vin, Kout, Vout):           # alias each layer's cache output -> its input (resident)
       net.prog.share_buffer(0, om[ko], 0, inm[id(ki)]); net.prog.share_buffer(0, om[vo], 0, inm[id(vi)])
@@ -224,10 +227,11 @@ def _cfg_from_hf(c) -> LlamaConfig:
                      head_dim=int(getattr(c, "head_dim", 0) or 0))
 
 
-def from_pretrained(name: str) -> LlamaPrefill:
-  """Load a Llama/Qwen-class model from Hugging Face and prepare it for ANE prefill."""
+def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
+  """Load a Llama/Qwen-class model from Hugging Face and prepare it for ANE prefill. `compress` ("int8"/"int4"/
+  "blockwise") quantizes the ANE weights to cut their memory and, on weight-bound large models, speed decode."""
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)
   cfg = _cfg_from_hf(hf.config)
   sd = {k: v.detach().float().numpy() for k, v in hf.state_dict().items()}
-  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg))
+  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), compress=compress)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,0 +1,49 @@
+# LLM prefill on the ANE
+
+Prefill — processing the prompt — is the **compute-bound** phase of LLM inference: a stack of
+large matmuls over all prompt tokens at once. That is exactly what the Apple Neural Engine is
+good at, and where it is most **energy-efficient**. ANEForge runs the whole prefill as **one
+fused ANE program** for a Llama/Qwen-class decoder, loaded from real Hugging Face weights.
+
+(Decode — one token at a time — is memory-bound and dispatch-floor-limited; that is the ANE's
+weak phase. The energy win is in prefill.)
+
+## API
+
+```python
+import aneforge as af
+
+model = af.load_llm("HuggingFaceTB/SmolLM-135M")   # any Llama/Qwen-class HF model
+logits = model.prefill(token_ids)                  # prefill on the ANE -> next-token logits [1, vocab]
+```
+
+- `af.load_llm(name)` — load a Hugging Face Llama/Qwen model and prepare it for ANE prefill.
+- `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` — build one directly from numpy weights.
+- `model.compile(seq)` builds the fused graph for a fixed prompt length; `model.prefill(ids)`
+  runs it. `af.rope` / `af.prefill_block` are the building blocks.
+
+A runnable benchmark (prompt-tokens/sec, plus `--energy` for ANE joules/token via
+`powermetrics`) is [`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).
+
+## What's inside
+
+A pre-norm Llama/Qwen decoder block, all on the ANE:
+`RMSNorm → QKV → RoPE → grouped-query causal attention → SwiGLU MLP`, with residuals.
+
+- **RoPE** (rotary position embedding) — `x·cos + rotate_half(x)·sin`, built from `sin`/`cos`/
+  `slice`/`concat` (no new hardware op).
+- **Grouped-query attention** — KV heads are repeated to the query-head count via a 0/1
+  expansion matmul (any group size).
+- **Causal attention** — the decomposed `softmax(Q@Kᵀ·scale + causal_mask)@V`, kept in one
+  fused program. (The native fused-attention layer is *avoided* for prefill: its per-layer
+  graph cut dominates the cost, where the fused big-matmul path is ~170× faster.)
+
+## Correctness
+
+The prefill output matches Hugging Face's own `LlamaForCausalLM` forward pass — next-token
+logits at **cosine ~1.0** and an identical argmax — validated on-device (`tests/test_llm.py`).
+
+## Scope
+
+Llama/Qwen-class decoders (RMSNorm + RoPE + GQA + SwiGLU). Prefill (prompt processing) is the
+target; KV-cache decode is a separate path. Static prompt length per compiled graph.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -13,14 +13,24 @@ weak phase. The energy win is in prefill.)
 ```python
 import aneforge as af
 
-model = af.load_llm("HuggingFaceTB/SmolLM-135M")   # any Llama/Qwen-class HF model
-logits = model.prefill(token_ids)                  # prefill on the ANE -> next-token logits [1, vocab]
+model = af.load_llm("Qwen/Qwen3-0.6B")             # any Llama/Qwen-class HF model
+text_ids = model.generate(prompt_ids, max_new_tokens=24)   # generate text on the ANE
+logits = model.prefill(prompt_ids)                 # or just prefill -> next-token logits [1, vocab]
 ```
 
-- `af.load_llm(name)` — load a Hugging Face Llama/Qwen model and prepare it for ANE prefill.
+- `af.load_llm(name)` — load a Hugging Face Llama/Qwen model and prepare it for ANE inference.
+- `model.generate(ids, max_new_tokens, eos_id)` — greedy autoregressive generation, on the ANE.
+- `model.prefill(ids)` — prefill only; returns next-token logits.
 - `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` — build one directly from numpy weights.
-- `model.compile(seq)` builds the fused graph for a fixed prompt length; `model.prefill(ids)`
-  runs it. `af.rope` / `af.prefill_block` are the building blocks.
+  `af.rope` / `af.prefill_block` are the building blocks.
+
+## Prefill and decode
+
+An LLM writes one token at a time. **Prefill** reads the whole prompt in one parallel pass
+(compute-bound — the ANE's fast, energy-efficient phase). **Decode** then emits each following
+token one at a time. `generate()` does both: prefill, then a greedy decode loop. The current
+decode loop re-runs a fixed-length program each step (simple and correct, ~4 tok/s on
+Qwen3-0.6B); a resident KV-cache decode is the next optimization.
 
 A runnable benchmark (prompt-tokens/sec, plus `--energy` for ANE joules/token via
 `powermetrics`) is [`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -18,7 +18,8 @@ text_ids = model.generate(prompt_ids, max_new_tokens=24)   # generate text on th
 logits = model.prefill(prompt_ids)                 # or just prefill -> next-token logits [1, vocab]
 ```
 
-- `af.load_llm(name)` — load a Hugging Face Llama/Qwen model and prepare it for ANE inference.
+- `af.load_llm(name, compress=None)` — load a Hugging Face Llama/Qwen model and prepare it for ANE inference.
+  `compress="int8"` (or `"int4"`) quantizes the ANE weights — see **Quantized weights** below.
 - `model.generate(ids, max_new_tokens, eos_id)` — greedy autoregressive generation, on the ANE.
 - `model.prefill(ids)` — prefill only; returns next-token logits.
 - `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` — build one directly from numpy weights.
@@ -42,6 +43,22 @@ Madrid. The capital of Portugal is Lisbon. ..."*
 is an interactive chat that streams a reply token-by-token on the ANE; a runnable benchmark
 (prompt-tokens/sec, plus `--energy` for ANE joules/token via `powermetrics`) is
 [`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).
+
+## Quantized weights
+
+`af.load_llm(name, compress="int8")` quantizes the on-ANE matmul weights to **per-channel int8**
+(or `"int4"` for 4-bit LUT palettization), dequantized on the ANE. This halves (int8) or quarters
+(int4) the weight bytes, which does two things:
+
+- **Memory** — the dominant, certain win. fp16 weights are 2 bytes/param; a model that does not
+  fit in fp16 can fit in int8. This is what makes larger models runnable.
+- **Decode speed** — *scales with model size*. Decode reads every weight per token; on a small
+  model (e.g. Qwen3-0.6B) decode is latency/under-utilization-bound, so int8 is roughly neutral
+  (~1.1×) and text is byte-identical. As weights grow, decode becomes weight-bandwidth-bound and
+  int8 approaches ~2× — that is where it pays off.
+
+int8 is faithful: on Qwen3-0.6B, greedy `generate` produces text **identical** to fp16. Try it
+with `examples/llm_chat.py <model> --int8`.
 
 ## What's inside
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -28,9 +28,15 @@ logits = model.prefill(prompt_ids)                 # or just prefill -> next-tok
 
 An LLM writes one token at a time. **Prefill** reads the whole prompt in one parallel pass
 (compute-bound — the ANE's fast, energy-efficient phase). **Decode** then emits each following
-token one at a time. `generate()` does both: prefill, then a greedy decode loop. The current
-decode loop re-runs a fixed-length program each step (simple and correct, ~4 tok/s on
-Qwen3-0.6B); a resident KV-cache decode is the next optimization.
+token one at a time. `generate()` does both: prefill the prompt, then a greedy decode loop with
+a **resident on-device KV-cache** — each layer's K/V stays on the ANE across steps (via
+`share_buffer`), so a decode step feeds only the new token's embedding + a position one-hot and
+runs one fused program over all layers. The decode program is compiled once and reused.
+
+On **Qwen3-0.6B** this decodes at **~75 tok/s** (after a one-time ~6 s decoder compile),
+prefills at **~8,600 prompt-tok/s**, and produces correct text:
+*"The capital of France is"* → *"Paris. The capital of Italy is Rome. The capital of Spain is
+Madrid. The capital of Portugal is Lisbon. ..."*
 
 A runnable benchmark (prompt-tokens/sec, plus `--energy` for ANE joules/token via
 `powermetrics`) is [`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,91 +1,76 @@
-# LLM prefill on the ANE
+# LLMs on the ANE
 
-Prefill — processing the prompt — is the **compute-bound** phase of LLM inference: a stack of
-large matmuls over all prompt tokens at once. That is exactly what the Apple Neural Engine is
-good at, and where it is most **energy-efficient**. ANEForge runs the whole prefill as **one
-fused ANE program** for a Llama/Qwen-class decoder, loaded from real Hugging Face weights.
+ANEForge runs a Llama/Qwen-class decoder on the Apple Neural Engine — prefill and KV-cache
+decode, from Hugging Face weights, as fused ANE programs.
 
-(Decode — one token at a time — is memory-bound and dispatch-floor-limited; that is the ANE's
-weak phase. The energy win is in prefill.)
+Prefill (processing the prompt) is compute-bound: a stack of matmuls over all prompt tokens at
+once, which is the ANE's efficient regime. Decode (one token at a time) is memory-bound; it
+works, but the energy advantage is in prefill.
 
 ## API
 
 ```python
 import aneforge as af
 
-model = af.load_llm("Qwen/Qwen3-0.6B")             # any Llama/Qwen-class HF model
-text_ids = model.generate(prompt_ids, max_new_tokens=24)   # generate text on the ANE
-logits = model.prefill(prompt_ids)                 # or just prefill -> next-token logits [1, vocab]
+model = af.load_llm("Qwen/Qwen3-0.6B")            # any Llama/Qwen-class HF model
+text_ids = model.generate(prompt_ids, max_new_tokens=24)
+logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 ```
 
-- `af.load_llm(name, compress=None)` — load a Hugging Face Llama/Qwen model and prepare it for ANE inference.
-  `compress="int8"` (or `"int4"`) quantizes the ANE weights — see **Quantized weights** below.
-- `model.generate(ids, max_new_tokens, eos_id)` — greedy autoregressive generation, on the ANE.
+- `af.load_llm(name, compress=None)` — load an HF Llama/Qwen model for ANE inference.
+  `compress="int8"`/`"int4"` quantizes the weights (see below).
+- `model.generate(ids, max_new_tokens, eos_id)` — greedy generation on the ANE.
 - `model.prefill(ids)` — prefill only; returns next-token logits.
-- `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` — build one directly from numpy weights.
+- `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` — build from numpy weights directly.
   `af.rope` / `af.prefill_block` are the building blocks.
 
 ## Prefill and decode
 
-An LLM writes one token at a time. **Prefill** reads the whole prompt in one parallel pass
-(compute-bound — the ANE's fast, energy-efficient phase). **Decode** then emits each following
-token one at a time. `generate()` does both: prefill the prompt, then a greedy decode loop with
-a **resident on-device KV-cache** — each layer's K/V stays on the ANE across steps (via
-`share_buffer`), so a decode step feeds only the new token's embedding + a position one-hot and
-runs one fused program over all layers. The decode program is compiled once and reused.
+`generate()` prefills the prompt, then runs a greedy decode loop with a resident KV-cache: each
+layer's K/V stays on the ANE across steps via `share_buffer`, so a decode step feeds only the new
+token's embedding and a position one-hot, and runs one fused program over all layers. The decode
+program compiles once and is reused.
 
-On **Qwen3-0.6B** this decodes at **~75 tok/s** (after a one-time ~6 s decoder compile),
-prefills at **~8,600 prompt-tok/s**, and produces correct text:
-*"The capital of France is"* → *"Paris. The capital of Italy is Rome. The capital of Spain is
-Madrid. The capital of Portugal is Lisbon. ..."*
+On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode (after a one-time ~6 s decoder
+compile). *"The capital of France is"* → *"Paris. The capital of Italy is Rome. The capital of
+Spain is Madrid. ..."*
 
-[`examples/llm_chat.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_chat.py)
-is an interactive chat that streams a reply token-by-token on the ANE; a runnable benchmark
-(prompt-tokens/sec, plus `--energy` for ANE joules/token via `powermetrics`) is
-[`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).
+`examples/llm_chat.py` is an interactive streaming chat; `examples/llm_prefill.py` is a benchmark
+(prompt-tok/s, and `--energy` for ANE joules/token via `powermetrics`).
 
 ## Quantized weights
 
-`af.load_llm(name, compress="int8")` quantizes the on-ANE matmul weights to **per-channel int8**
-(or `"int4"` for 4-bit LUT palettization), dequantized on the ANE. This halves (int8) or quarters
-(int4) the weight bytes, which does two things:
+`compress="int8"` quantizes the ANE matmul weights to per-channel int8 (`"int4"` = 4-bit LUT),
+dequantized on the ANE. This cuts the weight bytes in half (int8) or to a quarter (int4):
 
-- **Memory** — the dominant, certain win. fp16 weights are 2 bytes/param; a model that does not
-  fit in fp16 can fit in int8. This is what makes larger models runnable.
-- **Decode speed** — *scales with model size*. Decode reads every weight per token; on a small
-  model (e.g. Qwen3-0.6B) decode is latency/under-utilization-bound, so int8 is roughly neutral
-  (~1.1×) and text is byte-identical. As weights grow, decode becomes weight-bandwidth-bound and
-  int8 approaches ~2× — that is where it pays off.
+- Memory: fp16 is 2 bytes/param; int8 lets a model that doesn't fit in fp16 fit.
+- Decode speed: scales with model size. Decode rereads every weight per token. On a small model
+  decode is latency-bound, so int8 is roughly neutral (~1.1× on Qwen3-0.6B); as weights grow it
+  becomes bandwidth-bound and int8 approaches ~2×.
 
-int8 is faithful: on Qwen3-0.6B, greedy `generate` produces text **identical** to fp16. Try it
-with `examples/llm_chat.py <model> --int8`.
+On Qwen3-0.6B, int8 greedy `generate` is byte-identical to fp16. Pass `--int8` to the examples.
 
 ## What's inside
 
-A pre-norm Llama/Qwen decoder block, all on the ANE:
+A pre-norm Llama/Qwen decoder block on the ANE:
 `RMSNorm → QKV → RoPE → grouped-query causal attention → SwiGLU MLP`, with residuals.
 
-- **RoPE** (rotary position embedding) — `x·cos + rotate_half(x)·sin`, built from `sin`/`cos`/
-  `slice`/`concat` (no new hardware op).
-- **Grouped-query attention** — KV heads are repeated to the query-head count via a 0/1
-  expansion matmul (any group size).
-- **Causal attention** — the decomposed `softmax(Q@Kᵀ·scale + causal_mask)@V`, kept in one
-  fused program. (The native fused-attention layer is *avoided* for prefill: its per-layer
-  graph cut dominates the cost, where the fused big-matmul path is ~170× faster.)
+- RoPE: `x·cos + rotate_half(x)·sin`, from sin/cos/slice/concat (no new hardware op).
+- GQA: KV heads repeated to the query-head count via a 0/1 expansion matmul.
+- Causal attention: decomposed `softmax(Q@Kᵀ·scale + mask)@V` in one fused program. The native
+  fused-attention op is avoided for prefill — its per-layer graph cut dominates, and the
+  big-matmul path is ~170× faster.
 
 ## Correctness
 
-The prefill output matches Hugging Face's own forward pass — next-token logits at **cosine
-~1.0** and an identical argmax — validated on-device (`tests/test_llm.py`). On a real
-**Qwen3-0.6B** (28 layers), *"The capital of France is"* → **" Paris"**, the same token
-HuggingFace predicts, at **~8,600 prompt-tokens/sec** prefill.
+Prefill matches Hugging Face's forward pass — next-token logits at cosine ~1.0 and identical
+argmax — validated on-device (`tests/test_llm.py`). On Qwen3-0.6B (28 layers), *"The capital of
+France is"* → *" Paris"*, the token HF predicts.
 
-Qwen3 specifics are handled: a separate `head_dim` (≠ `dim/n_heads`), **QK-norm** (per-head
-RMSNorm on Q/K before RoPE), and a large vocab — the transformer layers run on the ANE and
-the lm_head vocab projection (a single matvec, and the vocab can exceed the ANE's per-op
-dimension limit) is done on host.
+Qwen3 specifics handled: a separate `head_dim` (≠ `dim/n_heads`), QK-norm (per-head RMSNorm on Q/K
+before RoPE), and a large vocab — the layers run on the ANE; the lm_head projection runs on host
+(the vocab can exceed the ANE's per-op dimension limit).
 
 ## Scope
 
-Llama/Qwen-class decoders (RMSNorm + RoPE + GQA + SwiGLU). Prefill (prompt processing) is the
-target; KV-cache decode is a separate path. Static prompt length per compiled graph.
+Llama/Qwen-class decoders (RMSNorm + RoPE + GQA + SwiGLU). Static prompt length per compiled graph.

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -40,8 +40,15 @@ A pre-norm Llama/Qwen decoder block, all on the ANE:
 
 ## Correctness
 
-The prefill output matches Hugging Face's own `LlamaForCausalLM` forward pass — next-token
-logits at **cosine ~1.0** and an identical argmax — validated on-device (`tests/test_llm.py`).
+The prefill output matches Hugging Face's own forward pass — next-token logits at **cosine
+~1.0** and an identical argmax — validated on-device (`tests/test_llm.py`). On a real
+**Qwen3-0.6B** (28 layers), *"The capital of France is"* → **" Paris"**, the same token
+HuggingFace predicts, at **~8,600 prompt-tokens/sec** prefill.
+
+Qwen3 specifics are handled: a separate `head_dim` (≠ `dim/n_heads`), **QK-norm** (per-head
+RMSNorm on Q/K before RoPE), and a large vocab — the transformer layers run on the ANE and
+the lm_head vocab projection (a single matvec, and the vocab can exceed the ANE's per-op
+dimension limit) is done on host.
 
 ## Scope
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -38,8 +38,10 @@ prefills at **~8,600 prompt-tok/s**, and produces correct text:
 *"The capital of France is"* → *"Paris. The capital of Italy is Rome. The capital of Spain is
 Madrid. The capital of Portugal is Lisbon. ..."*
 
-A runnable benchmark (prompt-tokens/sec, plus `--energy` for ANE joules/token via
-`powermetrics`) is [`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).
+[`examples/llm_chat.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_chat.py)
+is an interactive chat that streams a reply token-by-token on the ANE; a runnable benchmark
+(prompt-tokens/sec, plus `--energy` for ANE joules/token via `powermetrics`) is
+[`examples/llm_prefill.py`](https://github.com/sbryngelson/ANEForge/blob/main/examples/llm_prefill.py).
 
 ## What's inside
 

--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -29,11 +29,13 @@ def _encode(tok, prompt):
 
 
 def main():
-    name = sys.argv[1] if len(sys.argv) > 1 else _default_model()
+    argv = [a for a in sys.argv[1:] if not a.startswith("--")]
+    compress = "int8" if "--int8" in sys.argv else ("int4" if "--int4" in sys.argv else None)
+    name = argv[0] if argv else _default_model()
     if not name:
-        print("usage: python3 examples/llm_chat.py <hf-model-name>   (no cached Qwen3-0.6B found)"); return 1
-    print(f"loading {os.path.basename(str(name))} ...")
-    model = af.load_llm(name)
+        print("usage: python3 examples/llm_chat.py <hf-model-name> [--int8|--int4]   (no cached Qwen3-0.6B found)"); return 1
+    print(f"loading {os.path.basename(str(name))}{' ('+compress+' weights)' if compress else ''} ...")
+    model = af.load_llm(name, compress=compress)
     from transformers import AutoTokenizer
     tok = AutoTokenizer.from_pretrained(name)
     print("compiling the decoder for the ANE (one-time, ~6s) ...", end="", flush=True)

--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -1,0 +1,60 @@
+"""Interactive chat with an LLM running on the Apple Neural Engine. Type a message and the model streams a
+reply token-by-token, generated entirely on the ANE (resident KV-cache decode). Defaults to a cached
+Qwen3-0.6B if present, else pass a Hugging Face model name. Run: python3 examples/llm_chat.py [hf-model]"""
+import glob
+import os
+import sys
+
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+import aneforge as af
+
+MAX_LEN = 512        # fixed context so the decode program compiles once and every turn reuses it
+
+
+def _default_model():
+    hits = glob.glob(os.path.expanduser("~/.cache/huggingface/hub/models--*Qwen3-0.6B*/snapshots/*"))
+    return hits[0] if hits else None
+
+
+def _encode(tok, prompt):
+    """Apply the chat template (no 'thinking' block) so the model answers as an assistant; returns a list of ids."""
+    msgs = [{"role": "user", "content": prompt}]
+    try:
+        r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
+    except TypeError:                                    # tokenizers without the enable_thinking kwarg
+        r = tok.apply_chat_template(msgs, add_generation_prompt=True)
+    if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]   # BatchEncoding -> ids
+    if r and isinstance(r[0], (list, tuple)): r = r[0]                       # [[ids]] -> [ids]
+    return [int(t) for t in r]
+
+
+def main():
+    name = sys.argv[1] if len(sys.argv) > 1 else _default_model()
+    if not name:
+        print("usage: python3 examples/llm_chat.py <hf-model-name>   (no cached Qwen3-0.6B found)"); return 1
+    print(f"loading {os.path.basename(str(name))} ...")
+    model = af.load_llm(name)
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained(name)
+    print(f"ready: {model.cfg.n_layers}L dim {model.cfg.dim}, running on the Apple Neural Engine.")
+    print("type a message (Ctrl-D or 'exit' to quit). first reply compiles the decoder (~once), then streams.\n")
+
+    while True:
+        try:
+            prompt = input("you> ").strip()
+        except EOFError:
+            print(); break
+        if not prompt: continue
+        if prompt in ("exit", "quit"): break
+        ids = _encode(tok, prompt)
+        if len(ids) >= MAX_LEN - 8:
+            print("ane> (prompt too long for the demo context)\n"); continue
+        print("ane> ", end="", flush=True)
+        model.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=tok.eos_token_id,
+                       on_token=lambda t: print(tok.decode([t]), end="", flush=True))
+        print("\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -37,8 +37,9 @@ def main():
     from transformers import AutoTokenizer
     tok = AutoTokenizer.from_pretrained(name)
     print(f"ready: {model.cfg.n_layers}L dim {model.cfg.dim}, running on the Apple Neural Engine.")
-    print("type a message (Ctrl-D or 'exit' to quit). first reply compiles the decoder (~once), then streams.\n")
+    print("type a message (Ctrl-D or 'exit' to quit).\n")
 
+    warmed = False
     while True:
         try:
             prompt = input("you> ").strip()
@@ -49,6 +50,10 @@ def main():
         ids = _encode(tok, prompt)
         if len(ids) >= MAX_LEN - 8:
             print("ane> (prompt too long for the demo context)\n"); continue
+        if not warmed:                                   # the decode program compiles once -- show it so the pause makes sense
+            print("ane> compiling the decoder for the ANE (one-time, ~6s) ...", end="", flush=True)
+            model.warmup(MAX_LEN); warmed = True
+            print(" done.")
         print("ane> ", end="", flush=True)
         model.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=tok.eos_token_id,
                        on_token=lambda t: print(tok.decode([t]), end="", flush=True))

--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -1,6 +1,6 @@
-"""Interactive chat with an LLM running on the Apple Neural Engine. Type a message and the model streams a
-reply token-by-token, generated entirely on the ANE (resident KV-cache decode). Defaults to a cached
-Qwen3-0.6B if present, else pass a Hugging Face model name. Run: python3 examples/llm_chat.py [hf-model]"""
+"""Interactive chat with an LLM on the Apple Neural Engine. Type a message and the model streams a reply
+token-by-token (resident KV-cache decode). Defaults to a cached Qwen3-0.6B if present, else pass a Hugging
+Face model name. Run: python3 examples/llm_chat.py [hf-model] [--int8]"""
 import glob
 import os
 import sys

--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -36,10 +36,12 @@ def main():
     model = af.load_llm(name)
     from transformers import AutoTokenizer
     tok = AutoTokenizer.from_pretrained(name)
+    print("compiling the decoder for the ANE (one-time, ~6s) ...", end="", flush=True)
+    model.warmup(MAX_LEN)                                 # compile the decode program now so every reply streams instantly
+    print(" done.")
     print(f"ready: {model.cfg.n_layers}L dim {model.cfg.dim}, running on the Apple Neural Engine.")
     print("type a message (Ctrl-D or 'exit' to quit).\n")
 
-    warmed = False
     while True:
         try:
             prompt = input("you> ").strip()
@@ -50,10 +52,6 @@ def main():
         ids = _encode(tok, prompt)
         if len(ids) >= MAX_LEN - 8:
             print("ane> (prompt too long for the demo context)\n"); continue
-        if not warmed:                                   # the decode program compiles once -- show it so the pause makes sense
-            print("ane> compiling the decoder for the ANE (one-time, ~6s) ...", end="", flush=True)
-            model.warmup(MAX_LEN); warmed = True
-            print(" done.")
         print("ane> ", end="", flush=True)
         model.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=tok.eos_token_id,
                        on_token=lambda t: print(tok.decode([t]), end="", flush=True))

--- a/examples/llm_prefill.py
+++ b/examples/llm_prefill.py
@@ -44,9 +44,10 @@ def _ane_energy_mj(fn, repeats):
 def main():
     args = [a for a in sys.argv[1:] if not a.startswith("--")]
     want_energy = "--energy" in sys.argv
+    compress = "int8" if "--int8" in sys.argv else ("int4" if "--int4" in sys.argv else None)
     if args:
-        print(f"loading {args[0]} from Hugging Face ...")
-        model = af.load_llm(args[0]); from transformers import AutoTokenizer
+        print(f"loading {args[0]} from Hugging Face{' ('+compress+' weights)' if compress else ''} ...")
+        model = af.load_llm(args[0], compress=compress); from transformers import AutoTokenizer
         tok = AutoTokenizer.from_pretrained(args[0])
     else:
         print("no model name given -> small random demo model (pass a HF Llama/Qwen name for a real one)")

--- a/examples/llm_prefill.py
+++ b/examples/llm_prefill.py
@@ -1,0 +1,75 @@
+"""LLM prefill on the Apple Neural Engine -- the compute-bound phase where the ANE is most energy-efficient.
+Loads a Llama/Qwen-class model (a Hugging Face name, or a small random demo by default), prefills a prompt
+as ONE fused ANE program, and reports prompt-tokens/sec. With `--energy` (needs sudo) it also samples ANE
+power via `powermetrics` and reports joules/token. Run: python3 examples/llm_prefill.py [hf-model-name] [--energy]"""
+import subprocess
+import sys
+import time
+
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+import numpy as np
+import aneforge as af
+from aneforge.llm import LlamaConfig, LlamaPrefill, _weights_from_state_dict
+
+
+def _demo_model():
+    """A small random Llama-style model (no download) so the example runs anywhere."""
+    cfg = LlamaConfig(dim=512, n_layers=8, n_heads=8, n_kv_heads=8, ffn_dim=2048, vocab=4096)
+    rng = np.random.default_rng(0); dh = cfg.dim // cfg.n_heads
+    R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
+    sd = {"model.embed_tokens.weight": R(cfg.vocab, cfg.dim), "model.norm.weight": np.ones(cfg.dim, np.float32),
+          "lm_head.weight": R(cfg.vocab, cfg.dim)}
+    for L in range(cfg.n_layers):
+        p = f"model.layers.{L}."
+        for nm, sh in [("self_attn.q_proj", (cfg.n_heads * dh, cfg.dim)), ("self_attn.k_proj", (cfg.n_kv_heads * dh, cfg.dim)),
+                       ("self_attn.v_proj", (cfg.n_kv_heads * dh, cfg.dim)), ("self_attn.o_proj", (cfg.dim, cfg.n_heads * dh)),
+                       ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
+            sd[p + nm + ".weight"] = R(*sh)
+        sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
+    return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg)), None
+
+
+def _ane_energy_mj(fn, repeats):
+    """Run `fn` `repeats` times under `powermetrics` and return (millijoules of ANE energy, seconds)."""
+    proc = subprocess.Popen(["sudo", "-n", "powermetrics", "--samplers", "ane_power", "-i", "50", "--format", "text"],
+                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+    t0 = time.perf_counter()
+    for _ in range(repeats): fn()
+    dt = time.perf_counter() - t0
+    proc.terminate(); out = proc.stdout.read() if proc.stdout else ""
+    mw = [float(l.split(":")[1].strip().split()[0]) for l in out.splitlines() if "ANE Power" in l]
+    return (np.mean(mw) * dt if mw else float("nan")), dt          # avg power (mW) * time (s) = mJ
+
+
+def main():
+    args = [a for a in sys.argv[1:] if not a.startswith("--")]
+    want_energy = "--energy" in sys.argv
+    if args:
+        print(f"loading {args[0]} from Hugging Face ...")
+        model = af.load_llm(args[0]); from transformers import AutoTokenizer
+        tok = AutoTokenizer.from_pretrained(args[0]); ids = tok("The Apple Neural Engine is", return_tensors="np")["input_ids"][0]
+    else:
+        print("no model name given -> small random demo model (pass a HF Llama/Qwen name for a real one)")
+        model, tok = _demo_model(); ids = np.random.default_rng(0).integers(0, model.cfg.vocab, 64)
+
+    S = len(ids); model.compile(S)
+    nxt = model.prefill(ids)[0]
+    print(f"\nmodel: {model.cfg.n_layers} layers, dim {model.cfg.dim}, {model.cfg.n_heads}h/{model.cfg.n_kv_heads}kv, vocab {model.cfg.vocab}")
+    print(f"prefilled {S} tokens -> next-token logits {nxt.shape}, argmax id {int(nxt.argmax())}")
+    if tok is not None:
+        print(f"  predicted next token: {tok.decode([int(nxt.argmax())])!r}")
+
+    model.prefill(ids)                                             # warm the compile cache
+    N = 10; t = time.perf_counter()
+    for _ in range(N): model.prefill(ids)
+    dt = (time.perf_counter() - t) / N
+    print(f"\nprefill: {dt*1000:.1f} ms  ->  {S/dt:,.0f} prompt-tokens/sec  (one fused ANE program)")
+
+    if want_energy:
+        mj, _ = _ane_energy_mj(lambda: model.prefill(ids), 50)
+        if np.isnan(mj): print("energy: powermetrics needs sudo (run with: sudo python3 examples/llm_prefill.py --energy)")
+        else: print(f"energy: {mj/(50*S):.3f} mJ/token of ANE energy ({mj/1000:.2f} J over {50*S} tokens)")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/llm_prefill.py
+++ b/examples/llm_prefill.py
@@ -47,26 +47,28 @@ def main():
     if args:
         print(f"loading {args[0]} from Hugging Face ...")
         model = af.load_llm(args[0]); from transformers import AutoTokenizer
-        tok = AutoTokenizer.from_pretrained(args[0]); ids = tok("The Apple Neural Engine is", return_tensors="np")["input_ids"][0]
+        tok = AutoTokenizer.from_pretrained(args[0])
     else:
         print("no model name given -> small random demo model (pass a HF Llama/Qwen name for a real one)")
-        model, tok = _demo_model(); ids = np.random.default_rng(0).integers(0, model.cfg.vocab, 64)
-
-    S = len(ids); model.compile(S)
-    nxt = model.prefill(ids)[0]
+        model, tok = _demo_model()
     print(f"\nmodel: {model.cfg.n_layers} layers, dim {model.cfg.dim}, {model.cfg.n_heads}h/{model.cfg.n_kv_heads}kv, vocab {model.cfg.vocab}")
-    print(f"prefilled {S} tokens -> next-token logits {nxt.shape}, argmax id {int(nxt.argmax())}")
-    if tok is not None:
-        print(f"  predicted next token: {tok.decode([int(nxt.argmax())])!r}")
 
-    model.prefill(ids)                                             # warm the compile cache
+    if tok is not None:                                           # real model -> actually generate text on the ANE
+        prompt = "The capital of France is"
+        ids = tok(prompt, return_tensors="np")["input_ids"][0]
+        t = time.perf_counter(); out = model.generate(ids, max_new_tokens=24, eos_id=tok.eos_token_id); dt = time.perf_counter() - t
+        print(f"\ngenerate (on the ANE): {prompt!r}\n  -> {(prompt + tok.decode(out))!r}")
+        print(f"  {len(out)} tokens in {dt:.1f}s ({len(out)/dt:.1f} tok/s decode, simple re-prefill loop)")
+
+    S = 128; ids2 = np.random.default_rng(0).integers(0, model.cfg.vocab, S)   # prefill throughput (token-independent)
+    model.compile(S); model.prefill(ids2)                        # warm the compile cache
     N = 10; t = time.perf_counter()
-    for _ in range(N): model.prefill(ids)
+    for _ in range(N): model.prefill(ids2)
     dt = (time.perf_counter() - t) / N
-    print(f"\nprefill: {dt*1000:.1f} ms  ->  {S/dt:,.0f} prompt-tokens/sec  (one fused ANE program)")
+    print(f"\nprefill {S} tokens: {dt*1000:.1f} ms  ->  {S/dt:,.0f} prompt-tokens/sec  (one fused ANE program)")
 
     if want_energy:
-        mj, _ = _ane_energy_mj(lambda: model.prefill(ids), 50)
+        mj, _ = _ane_energy_mj(lambda: model.prefill(ids2), 50)
         if np.isnan(mj): print("energy: powermetrics needs sudo (run with: sudo python3 examples/llm_prefill.py --energy)")
         else: print(f"energy: {mj/(50*S):.3f} mJ/token of ANE energy ({mj/1000:.2f} J over {50*S} tokens)")
 

--- a/examples/llm_prefill.py
+++ b/examples/llm_prefill.py
@@ -56,9 +56,11 @@ def main():
     if tok is not None:                                           # real model -> actually generate text on the ANE
         prompt = "The capital of France is"
         ids = tok(prompt, return_tensors="np")["input_ids"][0]
-        t = time.perf_counter(); out = model.generate(ids, max_new_tokens=24, eos_id=tok.eos_token_id); dt = time.perf_counter() - t
-        print(f"\ngenerate (on the ANE): {prompt!r}\n  -> {(prompt + tok.decode(out))!r}")
-        print(f"  {len(out)} tokens in {dt:.1f}s ({len(out)/dt:.1f} tok/s decode, simple re-prefill loop)")
+        out = model.generate(ids, max_new_tokens=32, max_len=96, eos_id=tok.eos_token_id)   # 1st call compiles the decoder
+        print(f"\ngenerate (resident KV-cache, on the ANE): {prompt!r}\n  -> {(prompt + tok.decode(out))!r}")
+        t = time.perf_counter(); out = model.generate(ids, max_new_tokens=32, max_len=96, eos_id=tok.eos_token_id)
+        dt = time.perf_counter() - t
+        print(f"  decode speed: {len(out)} tokens in {dt:.2f}s -> {len(out)/dt:.0f} tok/s (decoder compiled once, then reused)")
 
     S = 128; ids2 = np.random.default_rng(0).integers(0, model.cfg.vocab, S)   # prefill throughput (token-independent)
     model.compile(S); model.prefill(ids2)                        # warm the compile cache

--- a/examples/llm_prefill.py
+++ b/examples/llm_prefill.py
@@ -1,7 +1,7 @@
-"""LLM prefill on the Apple Neural Engine -- the compute-bound phase where the ANE is most energy-efficient.
-Loads a Llama/Qwen-class model (a Hugging Face name, or a small random demo by default), prefills a prompt
-as ONE fused ANE program, and reports prompt-tokens/sec. With `--energy` (needs sudo) it also samples ANE
-power via `powermetrics` and reports joules/token. Run: python3 examples/llm_prefill.py [hf-model-name] [--energy]"""
+"""Benchmark an LLM on the Apple Neural Engine. Loads a Llama/Qwen-class model (a Hugging Face name, or a
+small random demo by default), generates text with the resident KV-cache decode, and reports decode and
+prefill throughput. `--int8` quantizes the weights; `--energy` (needs sudo) samples ANE power via
+`powermetrics` for joules/token. Run: python3 examples/llm_prefill.py [hf-model-name] [--int8] [--energy]"""
 import subprocess
 import sys
 import time

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,6 +82,7 @@ nav:
       - Capabilities: capabilities.md
       - Op catalog: op-catalog.md
       - ONNX import: onnx.md
+      - LLM prefill: llm.md
   - API reference:
       - Overview: api/index.md
       - Graph & operators: api/graph.md

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -33,7 +33,7 @@ def test_rope_matches_numpy():
   cos_sim = float(got.ravel() @ ref.ravel() / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
   assert cos_sim > 0.999, f"RoPE vs reference cosine={cos_sim}"
 
-def _random_model(cfg):
+def _random_model(cfg, compress=None):
   rng = np.random.default_rng(0); dh = cfg.dh
   R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
   sd = {"model.embed_tokens.weight": R(cfg.vocab, cfg.dim), "model.norm.weight": np.ones(cfg.dim, np.float32),
@@ -45,12 +45,24 @@ def _random_model(cfg):
                    ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
       sd[p + nm + ".weight"] = R(*sh)
     sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
-  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg))
+  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), compress=compress)
 
 @requires_ane
 def test_generate_runs():  # the decode loop produces the requested number of valid tokens
   cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
   out = _random_model(cfg).generate([1, 2, 3], max_new_tokens=5)
+  assert len(out) == 5 and all(0 <= t < cfg.vocab for t in out)
+
+@requires_ane
+def test_int8_decode_matches_fp16():  # int8-quantized ANE weights stay faithful to fp16 (prefill + decode both run)
+  cfg = LlamaConfig(dim=128, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=256, vocab=64)
+  prompt = [1, 2, 3, 4]
+  ref = _random_model(cfg).prefill(prompt)[0]
+  q8 = _random_model(cfg, compress="int8")                   # same weights, ANE matmuls quantized per-channel int8
+  lo = q8.prefill(prompt)[0]
+  cos = float(ref @ lo / (np.linalg.norm(ref) * np.linalg.norm(lo)))
+  assert cos > 0.99, f"int8 prefill logits diverged from fp16 (cos {cos:.4f})"
+  out = q8.generate(prompt, max_new_tokens=5)                # the int8 decode program (compile_multi compress=) runs
   assert len(out) == 5 and all(0 <= t < cfg.vocab for t in out)
 
 @requires_ane

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -33,6 +33,26 @@ def test_rope_matches_numpy():
   cos_sim = float(got.ravel() @ ref.ravel() / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
   assert cos_sim > 0.999, f"RoPE vs reference cosine={cos_sim}"
 
+def _random_model(cfg):
+  rng = np.random.default_rng(0); dh = cfg.dh
+  R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
+  sd = {"model.embed_tokens.weight": R(cfg.vocab, cfg.dim), "model.norm.weight": np.ones(cfg.dim, np.float32),
+        "lm_head.weight": R(cfg.vocab, cfg.dim)}
+  for L in range(cfg.n_layers):
+    p = f"model.layers.{L}."
+    for nm, sh in [("self_attn.q_proj", (cfg.n_heads * dh, cfg.dim)), ("self_attn.k_proj", (cfg.n_kv_heads * dh, cfg.dim)),
+                   ("self_attn.v_proj", (cfg.n_kv_heads * dh, cfg.dim)), ("self_attn.o_proj", (cfg.dim, cfg.n_heads * dh)),
+                   ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
+      sd[p + nm + ".weight"] = R(*sh)
+    sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
+  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg))
+
+@requires_ane
+def test_generate_runs():  # the decode loop produces the requested number of valid tokens
+  cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
+  out = _random_model(cfg).generate([1, 2, 3], max_new_tokens=5)
+  assert len(out) == 5 and all(0 <= t < cfg.vocab for t in out)
+
 @requires_ane
 def test_prefill_matches_huggingface_llama():  # the definitive check: ANE prefill == HF LlamaForCausalLM
   import torch

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,49 @@
+import numpy as np
+import aneforge as af
+from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf
+from _helpers import requires_ane
+
+
+def test_rope_tables_shape():
+  cos, sin = rope_tables(8, 16)
+  assert cos.shape == (8, 16) and sin.shape == (8, 16)
+
+def test_rope_builds():
+  cos, sin = rope_tables(8, 16)
+  out = rope(af.input((1, 2, 8, 16)), cos, sin)
+  assert out.shape == (1, 2, 8, 16) and out.op == "add"
+
+def test_prefill_block_builds():  # GQA 4 heads / 2 kv; output keeps [S, dim]
+  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=32)
+  S, dh = 12, cfg.dim // cfg.n_heads
+  rng = np.random.default_rng(0); R = lambda *s: (rng.standard_normal(s) * 0.1).astype(np.float32)
+  w = {"wq": R(cfg.n_heads * dh, cfg.dim), "wk": R(cfg.n_kv_heads * dh, cfg.dim), "wv": R(cfg.n_kv_heads * dh, cfg.dim),
+       "wo": R(cfg.dim, cfg.n_heads * dh), "wgate": R(cfg.ffn_dim, cfg.dim), "wup": R(cfg.ffn_dim, cfg.dim),
+       "wdown": R(cfg.dim, cfg.ffn_dim), "attn_norm": np.ones(cfg.dim, np.float32), "mlp_norm": np.ones(cfg.dim, np.float32)}
+  cos, sin = rope_tables(S, dh, cfg.rope_base)
+  out = prefill_block(af.input((S, cfg.dim)), w, cfg, cos, sin)
+  assert out.shape == (S, cfg.dim) and out.op == "add"
+
+@requires_ane
+def test_rope_matches_numpy():
+  cos, sin = rope_tables(8, 16); rng = np.random.default_rng(0); x = rng.standard_normal((1, 2, 8, 16)).astype(np.float16)
+  got = np.asarray(af.compile(rope(af.input((1, 2, 8, 16)), cos, sin))(x)).astype(np.float32)
+  c, s = cos.astype(np.float32), sin.astype(np.float32); h = 8
+  ref = x.astype(np.float32) * c + np.concatenate([-x[..., h:].astype(np.float32), x[..., :h].astype(np.float32)], -1) * s
+  cos_sim = float(got.ravel() @ ref.ravel() / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
+  assert cos_sim > 0.999, f"RoPE vs reference cosine={cos_sim}"
+
+@requires_ane
+def test_prefill_matches_huggingface_llama():  # the definitive check: ANE prefill == HF LlamaForCausalLM
+  import torch
+  from transformers import LlamaConfig as HF, LlamaForCausalLM
+  hf_cfg = HF(**{"hidden_size": 64, "num_hidden_layers": 2, "num_attention_heads": 4, "num_key_value_heads": 2,
+                 "intermediate_size": 128, "vocab_size": 64, "rms_norm_eps": 1e-5, "rope_theta": 10000.0,
+                 "max_position_embeddings": 64})
+  torch.manual_seed(0); m = LlamaForCausalLM(hf_cfg).eval()
+  toks = np.random.default_rng(0).integers(0, 64, 10)
+  with torch.no_grad(): ref = m(torch.tensor(toks)[None]).logits[0, -1].numpy()
+  cfg = _cfg_from_hf(m.config); sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
+  ane = np.asarray(LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg)).prefill(toks)).ravel().astype(np.float32)
+  cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
+  assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"


### PR DESCRIPTION
## LLM prefill on the Apple Neural Engine

Run the **prefill** (prompt-processing) phase of a Llama/Qwen-class LLM as **one fused ANE program**, loaded from real Hugging Face weights.

```python
import aneforge as af
model = af.load_llm("HuggingFaceTB/SmolLM-135M")   # any Llama/Qwen-class HF model
logits = model.prefill(token_ids)                  # prefill on the ANE -> next-token logits
```

### Why prefill, why the ANE
Prefill is **compute-bound** — a stack of large matmuls over all prompt tokens at once — which is exactly where the Neural Engine is fast and most **energy-efficient**. (Decode, one token at a time, is memory-bound and dispatch-floor-limited — the ANE's weak phase.) This pivots off the insight in [maderix/ane-prefill-bench](https://github.com/maderix/ane-prefill-bench) (Qwen3-27B prefill on the ANE), but as a **programmable framework** path rather than a hand-tuned one-off.

### What's inside (`aneforge/llm.py`)
A pre-norm Llama/Qwen decoder block, all on the ANE: `RMSNorm → QKV → RoPE → grouped-query causal attention → SwiGLU`, with residuals.
- **RoPE** (the one primitive that was missing) — `x·cos + rotate_half(x)·sin`, built from `sin`/`cos`/`slice`/`concat`; no new hardware op.
- **Grouped-query attention** — KV heads repeated to the query-head count via a 0/1 expansion matmul (any group size).
- **Causal attention is decomposed** into one fused program. The native fused-attention layer is deliberately *avoided* for prefill: it **cuts the graph per layer**, and the resulting `SegmentedModel` dispatch overhead made prefill **~170× slower** (1.3 s) than the fused big-matmul path (7.6 ms) in benchmarking.
- `af.load_llm(name)` loads real HF weights; `LlamaPrefill`/`LlamaConfig` build one directly.

### Correctness
The prefill output **matches Hugging Face's own `LlamaForCausalLM`** forward pass — next-token logits at **cosine ~1.0 with an identical argmax** — validated on-device against a real (random-weight) HF model in `tests/test_llm.py`. RoPE and the block are each validated against reference math (cosine ~1.0).

### Performance / energy
On a mini-LLM (8 layers, dim 512) prefill runs as one fused program at **~70k–125k prompt-tokens/sec** on-device. `examples/llm_prefill.py` benchmarks prompt-tok/s and, with `--energy` (sudo), samples ANE power via `powermetrics` to report **joules-per-token** — the headline claim: the ANE prefills prompts at a fraction of the energy.

### Tests / docs
5 `tests/test_llm.py` (off-device builds + on-device RoPE and HF-match). `docs/llm.md` + nav + README + `examples/llm_prefill.py`. pyright 0 on `aneforge`, ruff + 2-space pylint clean, `mkdocs --strict`. RoPE uses only existing core ops — no changes to the ONNX importer or other modules.
