### PR TITLE
feat(llm): segmented decode — run large models (Qwen3-8B) past the ~2GB ANE program ceiling

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -112,6 +112,7 @@ class LlamaPrefill:
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
+    self._chunk_bytes = 1.6e9      # max fp16 weight bytes per decode program (under the ~2GB ANE ceiling)
 
   def compile(self, seq: int):
     cfg = self.cfg
@@ -139,29 +140,43 @@ class LlamaPrefill:
     """Prefill `token_ids` and return the next-token logits [1, vocab] (the transformer runs on the ANE)."""
     return self._logits(self._hidden(token_ids)[-1])[None]
 
+  def _layer_chunks(self):
+    """Group layers into contiguous chunks whose baked weights stay under the ANE single-program ceiling
+    (~2GB; measured ~1.5GB OK, ~3.4GB fails). int8/int4 weights are smaller, so more layers fit per chunk."""
+    per = sum(int(np.asarray(v).size) for v in self.w["layers"][0].values()) * 2   # fp16 bytes / layer
+    if self.compress in ("int8", "blockwise"): per //= 2
+    elif self.compress == "int4": per //= 4
+    n = max(1, min(self.cfg.n_layers, int(self._chunk_bytes // max(per, 1))))
+    return [range(i, min(i + n, self.cfg.n_layers)) for i in range(0, self.cfg.n_layers, n)]
+
   def _decoder(self, M):
-    """Build (once, cached) the resident-KV-cache decode-step program for a max sequence length `M`: all layers
-    run for one token attending to per-layer caches that stay on-device across `execute` via `share_buffer`."""
+    """Build (once, cached) the resident-KV-cache decode-step program(s) for a max sequence length `M`. Layers
+    are split into chunks under the ANE single-program weight ceiling (`_layer_chunks`); each chunk keeps its
+    layers' K/V caches on the ANE across `execute` via `share_buffer`, and the hidden state chains chunk->chunk."""
     if self._dec is not None and self._dec["M"] == M: return self._dec
-    if self._dec is not None: self._dec["net"].release()
+    if self._dec is not None:
+      for c in self._dec["chunks"]: c["net"].release()
     from ._compile import compile_multi
-    cfg = self.cfg; KV, dh, D, L = cfg.n_kv_heads, cfg.dh, cfg.dim, cfg.n_layers
-    x = _input((1, D)); oh = _input((1, M, 1)); inv = _input((1, M, 1)); mask = _input((1, 1, M))
-    cosp = _input((1, dh)); sinp = _input((1, dh))
-    Kin = [_input((KV, M, dh)) for _ in range(L)]; Vin = [_input((KV, M, dh)) for _ in range(L)]
-    h = x; Kout = []; Vout = []
-    for lw, ki, vi in zip(self.w["layers"], Kin, Vin):
-      h, ko, vo = _decode_block(h, lw, cfg, ki, vi, oh, inv, mask, cosp, sinp)
-      Kout.append(ko); Vout.append(vo)
-    h = h.rms_norm(self.w["final_norm"], cfg.norm_eps)
-    net = compile_multi([h] + Kout + Vout, compress=self.compress)
-    inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
-    for ki, vi, ko, vo in zip(Kin, Vin, Kout, Vout):           # alias each layer's cache output -> its input (resident)
-      net.prog.share_buffer(0, om[ko], 0, inm[id(ki)]); net.prog.share_buffer(0, om[vo], 0, inm[id(vi)])
+    cfg = self.cfg; KV, dh, D = cfg.n_kv_heads, cfg.dh, cfg.dim
+    groups = self._layer_chunks(); chunks = []
+    for gi, grp in enumerate(groups):
+      x = _input((1, D)); oh = _input((1, M, 1)); inv = _input((1, M, 1)); mask = _input((1, 1, M))
+      cosp = _input((1, dh)); sinp = _input((1, dh))
+      Kin = [_input((KV, M, dh)) for _ in grp]; Vin = [_input((KV, M, dh)) for _ in grp]
+      h = x; Kout = []; Vout = []
+      for li, ki, vi in zip(grp, Kin, Vin):
+        h, ko, vo = _decode_block(h, self.w["layers"][li], cfg, ki, vi, oh, inv, mask, cosp, sinp)
+        Kout.append(ko); Vout.append(vo)
+      if gi == len(groups) - 1: h = h.rms_norm(self.w["final_norm"], cfg.norm_eps)   # final norm on the last chunk
+      net = compile_multi([h] + Kout + Vout, compress=self.compress)
+      inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
+      for ki, vi, ko, vo in zip(Kin, Vin, Kout, Vout):          # alias each layer's cache output -> its input (resident)
+        net.prog.share_buffer(0, om[ko], 0, inm[id(ki)]); net.prog.share_buffer(0, om[vo], 0, inm[id(vi)])
+      chunks.append({"net": net, "p": {"x": inm[id(x)], "oh": inm[id(oh)], "inv": inm[id(inv)], "mask": inm[id(mask)],
+                     "cosp": inm[id(cosp)], "sinp": inm[id(sinp)], "h": om[h],
+                     "kv": [(inm[id(ki)], inm[id(vi)]) for ki, vi in zip(Kin, Vin)]}})
     cos_t, sin_t = rope_tables(M, dh, cfg.rope_base)
-    ports = {"x": inm[id(x)], "oh": inm[id(oh)], "inv": inm[id(inv)], "mask": inm[id(mask)],
-             "cosp": inm[id(cosp)], "sinp": inm[id(sinp)], "h": om[h], "kv": [(inm[id(ki)], inm[id(vi)]) for ki, vi in zip(Kin, Vin)]}
-    self._dec = {"M": M, "net": net, "p": ports, "cos": cos_t, "sin": sin_t}
+    self._dec = {"M": M, "chunks": chunks, "cos": cos_t, "sin": sin_t}
     return self._dec
 
   def warmup(self, max_len):
@@ -176,18 +191,22 @@ class LlamaPrefill:
     Returns the generated token ids."""
     cfg = self.cfg; KV, dh = cfg.n_kv_heads, cfg.dh; f16 = np.float16
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
-    d = self._decoder(M); net = d["net"]; p = d["p"]
-    for ki, vi in p["kv"]:                                      # reset the resident cache for this generation
-      net.prog.set_input(ki, np.zeros((KV, M, dh), f16)); net.prog.set_input(vi, np.zeros((KV, M, dh), f16))
+    d = self._decoder(M); chunks = d["chunks"]
+    for c in chunks:                                           # reset every chunk's resident cache for this generation
+      for ki, vi in c["p"]["kv"]:
+        c["net"].prog.set_input(ki, np.zeros((KV, M, dh), f16)); c["net"].prog.set_input(vi, np.zeros((KV, M, dh), f16))
     def step(tok, pos):
       ohv = np.zeros((1, M, 1), f16); ohv[0, pos, 0] = 1.0
       invv = np.ones((1, M, 1), f16); invv[0, pos, 0] = 0.0
       mv = np.full((1, 1, M), -1e4, f16); mv[..., :pos + 1] = 0.0
-      net.prog.set_input(p["x"], np.asarray(self.w["embed"][tok])[None].astype(f16))
-      net.prog.set_input(p["oh"], ohv); net.prog.set_input(p["inv"], invv); net.prog.set_input(p["mask"], mv)
-      net.prog.set_input(p["cosp"], d["cos"][pos][None]); net.prog.set_input(p["sinp"], d["sin"][pos][None])
-      net.prog.execute()
-      return np.asarray(net.prog.read_output(p["h"])).reshape(cfg.dim).astype(np.float32)
+      cosp = d["cos"][pos][None]; sinp = d["sin"][pos][None]
+      h = np.asarray(self.w["embed"][tok])[None].astype(f16)
+      for c in chunks:                                         # hidden flows chunk -> chunk (cheap [1,dim] round-trip)
+        p = c["p"]; pr = c["net"].prog
+        pr.set_input(p["x"], h); pr.set_input(p["oh"], ohv); pr.set_input(p["inv"], invv); pr.set_input(p["mask"], mv)
+        pr.set_input(p["cosp"], cosp); pr.set_input(p["sinp"], sinp)
+        pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
+      return h.reshape(cfg.dim).astype(np.float32)
     for pos, tok in enumerate(prompt[:-1]): step(tok, pos)      # prefill the cache (discard hidden)
     cur = prompt[-1]; pos = len(prompt) - 1; out = []
     for _ in range(max_new_tokens):                            # decode

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -44,14 +44,20 @@ On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode. On Qwen3-8B (36 la
 ## Quantized weights
 
 `compress="int8"` quantizes the ANE matmul weights to per-channel int8 (`"int4"` = 4-bit LUT),
-dequantized on the ANE. This cuts the weight bytes in half (int8) or to a quarter (int4):
+dequantized on the ANE — halving (int8) or quartering (int4) the weight bytes. Measured honestly,
+the tradeoffs are narrow:
 
-- Memory: fp16 is 2 bytes/param; int8 lets a model that doesn't fit in fp16 fit.
-- Decode speed: scales with model size. Decode rereads every weight per token. On a small model
-  decode is latency-bound, so int8 is roughly neutral (~1.1× on Qwen3-0.6B); as weights grow it
-  becomes bandwidth-bound and int8 approaches ~2×.
+- Speed: roughly neutral. Decode is latency-bound (the ANE's array is idle at one token/step), not
+  weight-bandwidth-bound, so fewer weight bytes barely move tok/s — Qwen3-8B was 7.9 (int8) vs 7.5
+  (fp16) tok/s, with *fewer* chunks.
+- Accuracy: faithful on small models (Qwen3-0.6B int8 is byte-identical to fp16) but per-channel
+  int8 degrades deep models — Qwen3-8B int8 collapses into repetition. Run large models in fp16.
+- Memory: the one real win (half the weight bytes). But fp16 + segmented decode already fits models
+  up to RAM, so int8 only matters for weights that exceed RAM in fp16 — and the accuracy has to be
+  solved first. The robust path is quantized *storage* dequantized to fp16 *compute* (not int8
+  compute), which this option does not yet do.
 
-On Qwen3-0.6B, int8 greedy `generate` is byte-identical to fp16. Pass `--int8` to the examples.
+Pass `--int8` to the examples to try it (best on small models).
 
 ## What's inside
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -28,12 +28,15 @@ logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 
 `generate()` prefills the prompt, then runs a greedy decode loop with a resident KV-cache: each
 layer's K/V stays on the ANE across steps via `share_buffer`, so a decode step feeds only the new
-token's embedding and a position one-hot, and runs one fused program over all layers. The decode
-program compiles once and is reused.
+token's embedding and a position one-hot. The decode program compiles once and is reused.
 
-On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode (after a one-time ~6 s decoder
-compile). *"The capital of France is"* → *"Paris. The capital of Italy is Rome. The capital of
-Spain is Madrid. ..."*
+A single ANE program holds ~2 GB of baked weights, so for larger models the layers are split into
+chunks under that ceiling; each chunk keeps its KV resident and the hidden state chains chunk →
+chunk (a `[1, dim]` round-trip). This is automatic — Qwen3-0.6B is one chunk; Qwen3-8B is nine.
+
+On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode. On Qwen3-8B (36 layers, 16 GB fp16,
+9 chunks): ~7.5 tok/s decode. Both produce correct text — e.g. *"The capital of France is"* →
+*"Paris. The capital of Italy is Rome. The capital of Spain is Madrid. ..."*
 
 `examples/llm_chat.py` is an interactive streaming chat; `examples/llm_prefill.py` is a benchmark
 (prompt-tok/s, and `--energy` for ANE joules/token via `powermetrics`).

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -66,6 +66,14 @@ def test_int8_decode_matches_fp16():  # int8-quantized ANE weights stay faithful
   assert len(out) == 5 and all(0 <= t < cfg.vocab for t in out)
 
 @requires_ane
+def test_segmented_decode_matches_single():  # splitting the decode across chunks must not change the output
+  cfg = LlamaConfig(dim=64, n_layers=6, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
+  out1 = _random_model(cfg).generate([1, 2, 3], max_new_tokens=6)    # fits in one chunk
+  m2 = _random_model(cfg); m2._chunk_bytes = 1                       # force one layer per chunk -> 6 chunks chained
+  assert len(m2._layer_chunks()) == cfg.n_layers
+  assert m2.generate([1, 2, 3], max_new_tokens=6) == out1, "segmented decode diverged from single-program"
+
+@requires_ane
 def test_prefill_matches_huggingface_llama():  # the definitive check: ANE prefill == HF LlamaForCausalLM
   import torch
   from transformers import LlamaConfig as HF, LlamaForCausalLM


### PR DESCRIPTION
Runs large LLMs (e.g. Qwen3-8B) on the ANE by splitting the decode past the single-program weight ceiling, and corrects the int8 claims to match measurement. Builds on #44.

## Segmented decode (the unlock)

A single compiled ANE program holds only **~2 GB of baked-constant weights** (measured: ~1.5 GB compiles, ~3.4 GB fails with `Espresso "Not implemented"`). The decode path baked *all* layers into one `compile_multi` program, so Qwen3-8B (16 GB) — and even int8 (8 GB) — **failed to compile at all**.

Fix: split the decode layers into chunks under the ceiling. Each chunk is its own `compile_multi` program keeping its layers' K/V resident via `share_buffer`; the hidden state chains chunk → chunk (a cheap `[1, dim]` round-trip). Chunk size is automatic from per-layer weight bytes (int8/int4 fit more layers/chunk). Qwen3-0.6B stays **one** chunk (no behavior change); Qwen3-8B becomes **nine**.

Result: **Qwen3-8B generates correct text on the ANE at ~7.5 tok/s** — *"The capital of France is Paris. … The capital of Germany is Berlin."* — a 16 GB model that previously couldn't compile.

## int8 claims corrected (honesty)

Measuring int8 on the 8B contradicted the speedup framing merged in #44:
- **Speed**: neutral (8B int8 7.9 vs fp16 7.5 tok/s). Decode is latency-bound (the ANE array idles at one token/step), not weight-bandwidth-bound — quantizing weights doesn't help tok/s.
- **Accuracy**: per-channel int8 is byte-identical on Qwen3-0.6B but **collapses the 8B into repetition**. Large models should run fp16.

Docs now state this plainly (memory-only win; fp16 for large models; quantized-*storage* → fp16-*compute* is the robust path, not yet implemented). The dropped "~2× as weights grow" claim was wrong.

## Validation

- Segmented decode is **byte-identical** to the single-program path on Qwen3-0.6B at 1 / 10 / 28 chunks (new `test_segmented_decode_matches_single`).
- Qwen3-8B runs end-to-end with correct output.
- Full `--forked` suite: **687 passed**. pyright 0/0/0, ruff, mkdocs --strict all clean.
