### PR TITLE
feat(qwen35): gated_deltanet mixer for hybrid models (on #46)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -30,6 +30,7 @@ class LlamaConfig:
   dim: int; n_layers: int; n_heads: int; n_kv_heads: int; ffn_dim: int; vocab: int
   rope_base: float = 10000.0; norm_eps: float = 1e-5; head_dim: int = 0
   layers: list[LayerSpec] = field(default_factory=list)
+  extra: dict = field(default_factory=dict)   # arch-specific params for non-default mixers (e.g. DeltaNet head dims)
 
   @property
   def dh(self) -> int: return self.head_dim or self.dim // self.n_heads

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -1,0 +1,46 @@
+"""Qwen3.5 / Qwen3-Next hybrid support. Registers a `gated_deltanet` token-mixer (linear attention with a
+resident conv + recurrent state) into the `llm` registries, so a hybrid model is a per-layer plan mixing
+`gated_deltanet` and `attention` layers.
+
+Canonical weight keys (from the adapter): in_norm, in_proj_qkv, in_proj_z, in_proj_a, in_proj_b, conv1d
+[conv_dim, K], neg_exp_A [nv] (= -exp(A_log)), dt_bias, ssm_norm, out_proj, + SwiGLU MLP. DeltaNet dims are
+in `cfg.extra`: nk/nv (key/value heads), dk/dv (head dims), conv_k."""
+from __future__ import annotations
+import numpy as np
+
+from .graph import input as _input, _const, concat as _concat
+from . import llm
+
+
+def _deltanet_decode(x, w, cfg, ls, ctx, M):
+  """Single-token Gated-DeltaNet decode. Owns a resident conv state [conv_dim, K-1] and recurrent state
+  [nv, dk, dv]; ignores the per-position `ctx` (it carries its own state). Returns (hidden+residual,
+  [(conv_out,conv_in), (rec_out,rec_in)]) for the runner to alias resident via `share_buffer`."""
+  e = cfg.extra
+  nk, nv, dk, dv, K = e["nk"], e["nv"], e["dk"], e["dv"], e["conv_k"]
+  kd, vd, CD, g3 = nk * dk, nv * dv, nk * dk * 2 + nv * dv, nv // nk
+  cs = _input((CD, K - 1)); S = _input((nv, dk, dv))
+  xn = x.rms_norm(w["in_norm"], cfg.norm_eps)
+  qkv = xn.linear(w["in_proj_qkv"]).reshape((CD, 1))
+  z = xn.linear(w["in_proj_z"]).reshape((nv, dv))
+  b = xn.linear(w["in_proj_b"]).reshape((1, nv)); a = xn.linear(w["in_proj_a"]).reshape((1, nv))
+  win = _concat([cs, qkv], axis=1)                               # [CD, K]: oldest..newest
+  conv = (win * _const(w["conv1d"])).sum([1]).reshape((1, CD)).silu()
+  cs_out = win.slice_by_size([0, 1], [CD, K - 1])                # drop the oldest -> new conv state
+  q = conv.slice_by_size([0, 0], [1, kd]).reshape((nk, dk))
+  k = conv.slice_by_size([0, kd], [1, kd]).reshape((nk, dk))
+  v = conv.slice_by_size([0, 2 * kd], [1, vd]).reshape((nv, dv))
+  beta = b.sigmoid().reshape((nv, 1, 1))
+  gt = ((a + _const(w["dt_bias"])).softplus() * _const(w["neg_exp_A"])).exp().reshape((nv, 1, 1))  # exp(-exp(A_log)*softplus(a+dt))
+  rep = _const(np.repeat(np.eye(nk, dtype=np.float32), g3, 0))   # GQA: nk -> nv heads
+  q = (rep @ q).l2_norm(-1, 1e-6) * (dk ** -0.5); k = (rep @ k).l2_norm(-1, 1e-6)
+  q = q.reshape((nv, 1, dk)); k = k.reshape((nv, 1, dk)); v = v.reshape((nv, 1, dv))
+  S1 = S * gt                                                    # decay first (transformers/qwen3.5)
+  kv = k @ S1; delta = (v - kv) * beta
+  Sout = S1 + (k.transpose([0, 2, 1]) @ delta)
+  o = (q @ Sout).reshape((nv, dv))
+  o = o.rms_norm(w["ssm_norm"], cfg.norm_eps) * z.silu()         # RMSNormGated, then SwiGLU gate
+  return x + o.reshape((1, vd)).linear(w["out_proj"]), [(cs_out, cs), (Sout, S)]
+
+
+llm.DECODE_MIXERS["gated_deltanet"] = _deltanet_decode

--- a/tests/test_qwen35.py
+++ b/tests/test_qwen35.py
@@ -1,0 +1,41 @@
+"""Qwen3.5 hybrid mixer validation against the transformers reference."""
+import numpy as np
+from _helpers import requires_ane
+
+
+@requires_ane
+def test_gated_deltanet_decode_matches_transformers():
+  import torch
+  from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5Config
+  from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
+  import aneforge.qwen35  # noqa: F401 - registers the gated_deltanet mixer
+  from aneforge.llm import LlamaConfig, LayerSpec, DECODE_MIXERS
+  from aneforge.graph import input as _input
+  from aneforge import _compile
+  torch.manual_seed(0)
+  nk, nv, dk, dv, K, D = 2, 6, 16, 16, 4, 64
+  ct = Qwen3_5Config(hidden_size=D, linear_num_key_heads=nk, linear_num_value_heads=nv, linear_key_head_dim=dk,
+                     linear_value_head_dim=dv, linear_conv_kernel_dim=K, hidden_act="silu", rms_norm_eps=1e-6)
+  m = Qwen3_5GatedDeltaNet(ct, layer_idx=0).eval()
+  T = 6; x = torch.randn(1, T, D); x = x / x.pow(2).mean(-1, keepdim=True).sqrt()   # unit-RMS rows
+  with torch.no_grad():
+    o = m(x); ref = (o[0] if isinstance(o, tuple) else o)[0].numpy()   # [T, D] = out_proj(deltanet)
+  W = {n: p.detach().numpy().astype(np.float32) for n, p in m.named_parameters()}
+  w = {"in_norm": np.ones(D, np.float32), "in_proj_qkv": W["in_proj_qkv.weight"], "in_proj_z": W["in_proj_z.weight"],
+       "in_proj_a": W["in_proj_a.weight"], "in_proj_b": W["in_proj_b.weight"], "conv1d": np.squeeze(W["conv1d.weight"]),
+       "neg_exp_A": -np.exp(W["A_log"]), "dt_bias": W["dt_bias"], "ssm_norm": W["norm.weight"], "out_proj": W["out_proj.weight"]}
+  cfg = LlamaConfig(dim=D, n_layers=1, n_heads=1, n_kv_heads=1, ffn_dim=1, vocab=1, norm_eps=1e-6,
+                    extra={"nk": nk, "nv": nv, "dk": dk, "dv": dv, "conv_k": K})
+  xin = _input((1, D))
+  h, pairs = DECODE_MIXERS["gated_deltanet"](xin, w, cfg, LayerSpec(mixer="gated_deltanet"), {}, T)
+  net = _compile.compile_multi([h] + [o for o, _ in pairs])
+  inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
+  for o, i in pairs: net.prog.share_buffer(0, om[o], 0, inm[id(i)])
+  for o, i in pairs: net.prog.set_input(inm[id(i)], np.zeros(i.shape, np.float16))
+  xs = x[0].numpy(); outs = np.zeros((T, D), np.float32)
+  for t in range(T):
+    net.prog.set_input(inm[id(xin)], xs[t].reshape(1, D).astype(np.float16)); net.prog.execute()
+    outs[t] = np.asarray(net.prog.read_output(om[h])).reshape(D)
+  delta = outs - xs                                                 # strip the residual -> out_proj(deltanet)
+  cos = float(delta.ravel() @ ref.ravel() / (np.linalg.norm(delta) * np.linalg.norm(ref)))
+  assert cos > 0.95, f"gated_deltanet decode vs transformers: cosine {cos}"


### PR DESCRIPTION
Adds a `gated_deltanet` token-mixer for Qwen3.5 / Qwen3-Next hybrid models, on the model-adapter framework from #46.

**Stacked on #46** — this branch includes that refactor commit (`refactor(llm): model-adapter + mixer/MLP registry`). Merge #46 first, or merge this to take both.

## What

A hybrid model is 48 linear-attention (DeltaNet) layers + 16 full-attention layers. This adds the DeltaNet mixer:

- `gated_deltanet` decode mixer (in `aneforge/qwen35.py`): linear attention with a resident conv state `[conv_dim, K-1]` + recurrent state `[nv, dk, dv]`, decay-first recurrence, RMSNormGated + SwiGLU gate, `out_proj`.
- Registers into `DECODE_MIXERS` with no hot-path changes: the mixer owns its state and returns `(out, in)` pairs the runner aliases via `share_buffer`; it reads no per-position ctx (it carries its own state). `LlamaConfig.extra` carries the DeltaNet head dims.

## Validation

`tests/test_qwen35.py` runs the mixer step-by-step on the ANE and checks it against `transformers.Qwen3_5GatedDeltaNet` (the forward math is cosine 1.0 vs transformers on the real model's safetensors weights; this test confirms the fp16 ANE port). Dense path unchanged — pyright 0/0/0, ruff clean.

## Scope

First piece of hybrid support. Still to come: a `gated_attention` mixer (output gate + partial/interleaved RoPE — needs a small framework rope-spec extension) and a `qwen3_5` adapter (safetensors loader emitting the interleaved per-layer plan).
