### PR TITLE
feat(qwen35): gated_attention mixer + qwen3_5 adapter (completes hybrid support)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -29,6 +29,7 @@ class LlamaConfig:
   all-attention with QK-norm detected from the weights (back-compat)."""
   dim: int; n_layers: int; n_heads: int; n_kv_heads: int; ffn_dim: int; vocab: int
   rope_base: float = 10000.0; norm_eps: float = 1e-5; head_dim: int = 0
+  rotary_dim: int = 0; rope_interleaved: bool = False   # 0 = full RoPE (dh); interleaved = GPT-J pair layout
   layers: list[LayerSpec] = field(default_factory=list)
   extra: dict = field(default_factory=dict)   # arch-specific params for non-default mixers (e.g. DeltaNet head dims)
 
@@ -36,12 +37,21 @@ class LlamaConfig:
   def dh(self) -> int: return self.head_dim or self.dim // self.n_heads
 
 
-def rope_tables(seq: int, dh: int, base: float = 10000.0):
-  """Precompute the [seq, dh] cos/sin rotation tables (HF Llama layout: freqs duplicated over the two halves)."""
-  inv = 1.0 / (base ** (np.arange(0, dh, 2) / dh))
-  pos = np.arange(seq)[:, None] * inv[None, :]
-  emb = np.concatenate([pos, pos], -1)
-  return np.cos(emb).astype(np.float16), np.sin(emb).astype(np.float16)
+def rope_tables(seq: int, dh: int, base: float = 10000.0, rotary_dim: int = 0, interleaved: bool = False):
+  """Precompute the [seq, dh] cos/sin rotation tables. Default: HF Llama "neox" layout (full `dh`, freqs
+  duplicated over the two halves). `rotary_dim < dh` rotates only the first `rotary_dim` dims and pads the rest
+  with cos=1/sin=0 (partial RoPE). `interleaved=True` uses the GPT-J pair layout (dim 2p,2p+1 share freq p) for
+  use with the matmul-rope `x*cos + (x@P)*sin`."""
+  rd = rotary_dim or dh
+  inv = 1.0 / (base ** (np.arange(0, rd, 2) / rd))
+  pos = np.arange(seq)[:, None] * inv[None, :]               # [seq, rd/2]
+  if interleaved:
+    c = np.repeat(np.cos(pos), 2, axis=1); s = np.repeat(np.sin(pos), 2, axis=1)   # pair layout [seq, rd]
+  else:
+    emb = np.concatenate([pos, pos], -1); c = np.cos(emb); s = np.sin(emb)         # half-split [seq, rd]
+  if rd < dh:                                                # pad pass-through dims (cos=1, sin=0)
+    c = np.concatenate([c, np.ones((seq, dh - rd))], 1); s = np.concatenate([s, np.zeros((seq, dh - rd))], 1)
+  return c.astype(np.float16), s.astype(np.float16)
 
 
 def rope(x: Tensor, cos, sin) -> Tensor:
@@ -163,7 +173,7 @@ class LlamaPrefill:
 
   def compile(self, seq: int):
     cfg = self.cfg
-    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base)
+    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)
     x = _input((seq, cfg.dim))
     for i, lw in enumerate(self.w["layers"]):
       ls = self._spec(i)
@@ -228,7 +238,7 @@ class LlamaPrefill:
       for k, t in ctx.items():
         if id(t) in inm: p[k] = inm[id(t)]                      # only ports the chunk's mixers actually use
       chunks.append({"net": net, "p": p})
-    cos_t, sin_t = rope_tables(M, dh, cfg.rope_base)
+    cos_t, sin_t = rope_tables(M, dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)
     self._dec = {"M": M, "chunks": chunks, "cos": cos_t, "sin": sin_t}
     return self._dec
 

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -81,3 +81,39 @@ def _deltanet_decode(x, w, cfg, ls, ctx, M):
 
 llm.DECODE_MIXERS["gated_deltanet"] = _deltanet_decode
 llm.DECODE_MIXERS["gated_attention"] = _gated_attn_decode
+
+
+def adapt(c, sd, prefix: str = ""):
+  """Adapter for a Qwen3.5 / Qwen3-Next hybrid TEXT model: emit (LlamaConfig with the interleaved per-layer
+  plan, canonical weights) from the HF text config `c` and a numpy state_dict `sd`. `prefix` is the layers
+  prefix in `sd` ('' for Qwen3_5TextModel, 'model.language_model.' for the VL checkpoint). Canonicalizes the
+  Qwen3.5 `(1+w)` RMSNorms (bake +1) and bakes `-exp(A_log)` so the runtime stays uniform."""
+  n = int(c.num_hidden_layers); interval = int(getattr(c, "full_attention_interval", 4))
+  hd = int(getattr(c, "head_dim", 0) or 0)
+  is_attn = lambda L: (L + 1) % interval == 0
+  cfg = llm.LlamaConfig(
+    dim=c.hidden_size, n_layers=n, n_heads=c.num_attention_heads, n_kv_heads=c.num_key_value_heads,
+    ffn_dim=c.intermediate_size, vocab=c.vocab_size, rope_base=float(getattr(c, "rope_theta", 1e4)),
+    norm_eps=float(c.rms_norm_eps), head_dim=hd, rotary_dim=int(hd * getattr(c, "partial_rotary_factor", 1.0)),
+    layers=[llm.LayerSpec(mixer="gated_attention" if is_attn(L) else "gated_deltanet") for L in range(n)],
+    extra={"nk": c.linear_num_key_heads, "nv": c.linear_num_value_heads, "dk": c.linear_key_head_dim,
+           "dv": c.linear_value_head_dim, "conv_k": c.linear_conv_kernel_dim})
+  g = lambda k: sd[prefix + k]; p1 = lambda k: 1.0 + sd[prefix + k]      # p1: canonicalize (1+w) norm
+  w = {"embed": g("embed_tokens.weight"), "final_norm": p1("norm.weight"),
+       "lm_head": sd.get("lm_head.weight", sd.get(prefix + "embed_tokens.weight")), "layers": []}
+  for L in range(n):
+    q = f"layers.{L}."
+    lw = {"in_norm": p1(q + "input_layernorm.weight"), "mlp_norm": p1(q + "post_attention_layernorm.weight"),
+          "wgate": g(q + "mlp.gate_proj.weight"), "wup": g(q + "mlp.up_proj.weight"), "wdown": g(q + "mlp.down_proj.weight")}
+    if is_attn(L):
+      a = q + "self_attn."
+      lw |= {"wq": g(a + "q_proj.weight"), "wk": g(a + "k_proj.weight"), "wv": g(a + "v_proj.weight"),
+             "wo": g(a + "o_proj.weight"), "q_norm": p1(a + "q_norm.weight"), "k_norm": p1(a + "k_norm.weight")}
+    else:
+      d = q + "linear_attn."
+      lw |= {"in_proj_qkv": g(d + "in_proj_qkv.weight"), "in_proj_z": g(d + "in_proj_z.weight"),
+             "in_proj_a": g(d + "in_proj_a.weight"), "in_proj_b": g(d + "in_proj_b.weight"),
+             "conv1d": np.squeeze(g(d + "conv1d.weight")), "neg_exp_A": -np.exp(g(d + "A_log")),
+             "dt_bias": g(d + "dt_bias"), "ssm_norm": g(d + "norm.weight"), "out_proj": g(d + "out_proj.weight")}
+    w["layers"].append(lw)
+  return cfg, w

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -10,6 +10,42 @@ import numpy as np
 
 from .graph import input as _input, _const, concat as _concat
 from . import llm
+from .llm import _repeat_kv3
+
+
+def _rotate_matrix(dh: int, rotary_dim: int, interleaved: bool) -> np.ndarray:
+  """The [dh, dh] matrix P for matmul-rope `x*cos + (x@P)*sin` over the first `rotary_dim` dims (pass-through
+  elsewhere, where cos=1/sin=0). `interleaved` (GPT-J) rotates pairs (2p, 2p+1); otherwise (NeoX/HF) rotates
+  the two halves (i, i+rotary_dim/2)."""
+  rd = rotary_dim or dh; half = rd // 2; P = np.zeros((dh, dh), np.float32)
+  if interleaved:
+    for p in range(half): P[2 * p + 1, 2 * p] = -1.0; P[2 * p, 2 * p + 1] = 1.0
+  else:
+    for i in range(half): P[i + half, i] = -1.0; P[i, i + half] = 1.0
+  return P
+
+
+def _gated_attn_decode(x, w, cfg, ls, ctx, M):
+  """Single-token gated attention against a resident KV-cache (Qwen3.5): RMSNorm -> q_proj (q + output gate)
+  /k/v -> QK-norm -> partial interleaved RoPE (matmul form) -> GQA causal SDPA -> out * sigmoid(gate) -> o_proj.
+  Returns (hidden+residual, [(Kout,Kin),(Vout,Vin)])."""
+  H, KV, dh = cfg.n_heads, cfg.n_kv_heads, cfg.dh
+  Kin = _input((KV, M, dh)); Vin = _input((KV, M, dh))
+  oh, inv, mask, cosp, sinp = ctx["oh"], ctx["inv"], ctx["mask"], ctx["cosp"], ctx["sinp"]
+  P = _const(_rotate_matrix(dh, cfg.rotary_dim, cfg.rope_interleaved))
+  xn = x.rms_norm(w["in_norm"], cfg.norm_eps)
+  qg = xn.linear(w["wq"]).reshape((H, dh * 2))                  # q_proj outputs query + output gate
+  q = qg.slice_by_size([0, 0], [H, dh]).rms_norm(w["q_norm"], cfg.norm_eps)
+  gate = qg.slice_by_size([0, dh], [H, dh]).reshape((1, H * dh))
+  k = xn.linear(w["wk"]).reshape((KV, dh)).rms_norm(w["k_norm"], cfg.norm_eps)
+  v = xn.linear(w["wv"]).reshape((KV, dh))
+  q = (q * cosp + (q @ P) * sinp).reshape((H, 1, dh))           # matmul-rope (interleaved partial)
+  k = (k * cosp + (k @ P) * sinp).reshape((KV, 1, dh))
+  Kout = Kin * inv + k * oh; Vout = Vin * inv + v.reshape((KV, 1, dh)) * oh
+  Kr, Vr = _repeat_kv3(Kout, H // KV), _repeat_kv3(Vout, H // KV)
+  sc = ((q @ Kr.transpose([0, 2, 1])) * (1.0 / dh ** 0.5) + mask).softmax(-1)
+  a = (sc @ Vr).reshape((1, H * dh)) * gate.sigmoid()
+  return x + a.linear(w["wo"]), [(Kout, Kin), (Vout, Vin)]
 
 
 def _deltanet_decode(x, w, cfg, ls, ctx, M):
@@ -44,3 +80,4 @@ def _deltanet_decode(x, w, cfg, ls, ctx, M):
 
 
 llm.DECODE_MIXERS["gated_deltanet"] = _deltanet_decode
+llm.DECODE_MIXERS["gated_attention"] = _gated_attn_decode

--- a/tests/test_qwen35.py
+++ b/tests/test_qwen35.py
@@ -86,3 +86,40 @@ def test_gated_attention_decode_matches_transformers():
   delta = outs - xs
   cos_ = float(delta.ravel() @ ref.ravel() / (np.linalg.norm(delta) * np.linalg.norm(ref)))
   assert cos_ > 0.95, f"gated_attention decode vs transformers: cosine {cos_}"
+
+
+@requires_ane
+def test_qwen35_hybrid_model_matches_transformers():
+  import torch
+  from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+  from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5TextModel
+  import aneforge.qwen35 as q35
+  from aneforge.llm import LlamaPrefill
+  torch.manual_seed(0)
+  ct = Qwen3_5TextConfig(hidden_size=64, num_hidden_layers=4, full_attention_interval=4, num_attention_heads=4,
+    num_key_value_heads=2, head_dim=16, partial_rotary_factor=0.5, linear_num_key_heads=2, linear_num_value_heads=6,
+    linear_key_head_dim=16, linear_value_head_dim=16, linear_conv_kernel_dim=4, hidden_act="silu", rms_norm_eps=1e-6,
+    vocab_size=32, rope_theta=1e4, intermediate_size=128, mlp_only_layers=[0, 1, 2, 3], max_position_embeddings=32)
+  m = Qwen3_5TextModel(ct).eval()
+  T = 8; ids = torch.randint(0, 32, (1, T))
+  with torch.no_grad(): ref = m(ids).last_hidden_state[0].numpy()
+  sd = {k: v.detach().float().numpy() for k, v in m.named_parameters()}
+  cfg, w = q35.adapt(ct, sd)
+  assert [ls.mixer for ls in cfg.layers] == ["gated_deltanet", "gated_deltanet", "gated_deltanet", "gated_attention"]
+  model = LlamaPrefill(cfg, w); M = T; d = model._decoder(M); chunks = d["chunks"]; f16 = np.float16
+  for c in chunks:
+    for name, shape in c["p"]["states"].items(): c["net"].prog.set_input(name, np.zeros(shape, f16))
+  outs = np.zeros((T, cfg.dim), np.float32); idl = ids[0].numpy()
+  for pos in range(T):
+    oh = np.zeros((1, M, 1), f16); oh[0, pos, 0] = 1; iv = np.ones((1, M, 1), f16); iv[0, pos, 0] = 0
+    mv = np.full((1, 1, M), -1e4, f16); mv[..., :pos + 1] = 0
+    vals = {"oh": oh, "inv": iv, "mask": mv, "cosp": d["cos"][pos][None], "sinp": d["sin"][pos][None]}
+    h = np.asarray(w["embed"][idl[pos]])[None].astype(f16)
+    for c in chunks:
+      p = c["p"]; pr = c["net"].prog; pr.set_input(p["x"], h)
+      for k in ("oh", "inv", "mask", "cosp", "sinp"):
+        if k in p: pr.set_input(p[k], vals[k].astype(f16))
+      pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
+    outs[pos] = h.reshape(cfg.dim).astype(np.float32)
+  cos = float((outs.ravel() @ ref.ravel()) / (np.linalg.norm(outs) * np.linalg.norm(ref)))
+  assert cos > 0.95, f"qwen3.5 hybrid model vs transformers: cosine {cos}"

--- a/tests/test_qwen35.py
+++ b/tests/test_qwen35.py
@@ -6,7 +6,7 @@ from _helpers import requires_ane
 @requires_ane
 def test_gated_deltanet_decode_matches_transformers():
   import torch
-  from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5Config
+  from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
   from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5GatedDeltaNet
   import aneforge.qwen35  # noqa: F401 - registers the gated_deltanet mixer
   from aneforge.llm import LlamaConfig, LayerSpec, DECODE_MIXERS
@@ -14,7 +14,7 @@ def test_gated_deltanet_decode_matches_transformers():
   from aneforge import _compile
   torch.manual_seed(0)
   nk, nv, dk, dv, K, D = 2, 6, 16, 16, 4, 64
-  ct = Qwen3_5Config(hidden_size=D, linear_num_key_heads=nk, linear_num_value_heads=nv, linear_key_head_dim=dk,
+  ct = Qwen3_5TextConfig(hidden_size=D, linear_num_key_heads=nk, linear_num_value_heads=nv, linear_key_head_dim=dk,
                      linear_value_head_dim=dv, linear_conv_kernel_dim=K, hidden_act="silu", rms_norm_eps=1e-6)
   m = Qwen3_5GatedDeltaNet(ct, layer_idx=0).eval()
   T = 6; x = torch.randn(1, T, D); x = x / x.pow(2).mean(-1, keepdim=True).sqrt()   # unit-RMS rows
@@ -39,3 +39,50 @@ def test_gated_deltanet_decode_matches_transformers():
   delta = outs - xs                                                 # strip the residual -> out_proj(deltanet)
   cos = float(delta.ravel() @ ref.ravel() / (np.linalg.norm(delta) * np.linalg.norm(ref)))
   assert cos > 0.95, f"gated_deltanet decode vs transformers: cosine {cos}"
+
+
+@requires_ane
+def test_gated_attention_decode_matches_transformers():
+  import torch
+  from transformers.models.qwen3_5.configuration_qwen3_5 import Qwen3_5TextConfig
+  from transformers.models.qwen3_5.modeling_qwen3_5 import Qwen3_5Attention, Qwen3_5TextRotaryEmbedding
+  import aneforge.qwen35  # noqa: F401 - registers gated_attention
+  from aneforge.llm import LlamaConfig, LayerSpec, DECODE_MIXERS
+  from aneforge.graph import input as _input
+  from aneforge import _compile
+  torch.manual_seed(0)
+  H, KV, dh, D = 4, 2, 32, 128
+  ct = Qwen3_5TextConfig(hidden_size=D, num_attention_heads=H, num_key_value_heads=KV, head_dim=dh,
+                     partial_rotary_factor=0.5, attn_output_gate=True, rms_norm_eps=1e-6, rope_theta=1e4,
+                     max_position_embeddings=64)
+  att = Qwen3_5Attention(ct, layer_idx=0).eval(); rot = Qwen3_5TextRotaryEmbedding(ct)
+  T = 6; x = torch.randn(1, T, D); x = x / x.pow(2).mean(-1, keepdim=True).sqrt()
+  pos = torch.arange(T)[None]; cos, sin = rot(x, pos)
+  rd = cos.shape[-1]
+  mask = torch.full((T, T), float("-inf")).triu(1)[None, None]
+  with torch.no_grad(): ref = att(x, (cos, sin), mask)[0][0].numpy()        # out_proj(gate*attn), no residual
+  W = {n: p.detach().numpy().astype(np.float32) for n, p in att.named_parameters()}
+  w = {"in_norm": np.ones(D, np.float32), "wq": W["q_proj.weight"], "wk": W["k_proj.weight"],
+       "wv": W["v_proj.weight"], "wo": W["o_proj.weight"], "q_norm": 1.0 + W["q_norm.weight"], "k_norm": 1.0 + W["k_norm.weight"]}
+  cfg = LlamaConfig(dim=D, n_layers=1, n_heads=H, n_kv_heads=KV, ffn_dim=1, vocab=1, head_dim=dh,
+                    rotary_dim=rd, rope_interleaved=False, norm_eps=1e-6)
+  xin = _input((1, D)); ctx = {k: _input(s) for k, s in
+                               [("oh", (1, T, 1)), ("inv", (1, T, 1)), ("mask", (1, 1, T)), ("cosp", (1, dh)), ("sinp", (1, dh))]}
+  h, pairs = DECODE_MIXERS["gated_attention"](xin, w, cfg, LayerSpec(mixer="gated_attention"), ctx, T)
+  net = _compile.compile_multi([h] + [o for o, _ in pairs])
+  inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
+  for o, i in pairs: net.prog.share_buffer(0, om[o], 0, inm[id(i)])
+  for o, i in pairs: net.prog.set_input(inm[id(i)], np.zeros(i.shape, np.float16))
+  f16 = np.float16
+  pad = lambda a, fl: np.concatenate([a, np.full((a.shape[0], dh - a.shape[1]), fl, a.dtype)], 1)
+  cosF = pad(cos[0].numpy(), 1.0); sinF = pad(sin[0].numpy(), 0.0); xs = x[0].numpy(); outs = np.zeros((T, D), np.float32)
+  for t in range(T):
+    oh = np.zeros((1, T, 1), f16); oh[0, t, 0] = 1; iv = np.ones((1, T, 1), f16); iv[0, t, 0] = 0
+    mv = np.full((1, 1, T), -1e4, f16); mv[..., :t + 1] = 0
+    for nm, val in [("oh", oh), ("inv", iv), ("mask", mv), ("cosp", cosF[t][None]), ("sinp", sinF[t][None])]:
+      net.prog.set_input(inm[id(ctx[nm])], val.astype(f16))
+    net.prog.set_input(inm[id(xin)], xs[t].reshape(1, D).astype(f16)); net.prog.execute()
+    outs[t] = np.asarray(net.prog.read_output(om[h])).reshape(D)
+  delta = outs - xs
+  cos_ = float(delta.ravel() @ ref.ravel() / (np.linalg.norm(delta) * np.linalg.norm(ref)))
+  assert cos_ > 0.95, f"gated_attention decode vs transformers: cosine {cos_}"


### PR DESCRIPTION
Completes Qwen3.5 / Qwen3-Next hybrid support: the `gated_attention` mixer and the `qwen3_5` adapter, on top of the `gated_deltanet` mixer from #47.

## What

- **`gated_attention` mixer** (the 16 full-attention layers): q_proj emits query + output gate, QK-norm, partial RoPE (matmul form `x*cos + (x@P)*sin`), GQA causal SDPA, `out * sigmoid(gate)`, o_proj. Owns its KV state; registers into `DECODE_MIXERS`.
- **RoPE generalization**: `rope_tables` now supports partial RoPE (`rotary_dim`) and the GPT-J pair layout (`rope_interleaved`); `LlamaConfig` gains the two fields. Default (`rotary_dim=0`, NeoX) is byte-identical, so the dense path is unchanged.
- **`qwen35.adapt()`**: maps a Qwen3.5/Qwen3-Next text config + state_dict to `(LlamaConfig with the interleaved per-layer plan, canonical weights)`. Canonicalizes the `(1+w)` RMSNorms (bakes +1) and bakes `-exp(A_log)`, so the runtime stays uniform.

## Validation

`tests/test_qwen35.py`:
- `gated_attention` decode vs `transformers.Qwen3_5Attention` on the ANE.
- **End-to-end**: a 4-layer hybrid `Qwen3_5TextModel` (3 DeltaNet + 1 attention) runs through the full framework (adapter → `LlamaPrefill` → segmented decode → registered mixers) and matches transformers (cosine >0.95).

11 tests pass, pyright 0/0/0, ruff clean. Dense path unchanged.

## Context

The DeltaNet forward was proven correct against transformers on the real Qwen3.5-27B's safetensors weights (cosine 1.0); running the real 27B is gated only by memory (54 GB fp16 > host RAM) and the clean-layout weights, not by the architecture — which this PR makes a first-class, tested capability on the runtime.
