### PR TITLE
feat(moe): Mixture-of-Experts on the ANE (Qwen3-MoE + Qwen2-MoE)

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,19 @@ Pretrained models, each fused into one ANE program:
 Trained from scratch on the engine: an MLP, a CNN (CIFAR-10 to 71%), a transformer block, a LLaMA-style block, and a character language model.
 Operator coverage is tracked op by op across M1 to M5 in the [op catalog](docs/op-catalog.md), the exhaustive native-MIL-op x device table; [capabilities](docs/capabilities.md) has the dtype matrix and the known limits.
 
+## Language models
+
+Decoder LLMs run on the ANE from Hugging Face weights or GGUF — prefill plus resident-KV-cache decode, auto-segmented past the ~2 GB single-program ceiling:
+
+| Model                  | What runs                          | Measured                          |
+| ---------------------- | ---------------------------------- | --------------------------------- |
+| Qwen3-0.6B / 8B        | dense decode, matches HF logits    | ~75 / ~7.5 tok/s decode           |
+| Qwen3-8B + 0.6B draft  | speculative decoding, exact        | 2.28x (7.4 -> 16.8 tok/s)         |
+| Qwen1.5-MoE-A2.7B      | sparse MoE, full model on pure ANE | coherent text, ~2 tok/s (int8)    |
+| Qwen3.5 hybrid         | DeltaNet + gated attention         | fp16-safe (cosine 0.999999)       |
+
+Speculative verify is near-free on the ANE (`verify(K) ≈ verify(1)`, decode is latency-bound); MoE decode at 30B scale is weight-bandwidth-bound. Full writeup in the [LLMs guide](docs/llm.md).
+
 ## Verify
 
 The correctness corpus compiles and runs every op and kernel on the ANE, and serves as a reproducibility test:

--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -34,6 +34,7 @@ from .streaming import CheckpointedStack
 from .models import Encoder, Vision, load, load_resnet18, conv_block, cifar_cnn, group_norm_train
 from .onnx import load_onnx, onnx_to_tensor, onnx_to_features
 from .llm import LlamaConfig, LlamaPrefill, from_pretrained as load_llm, rope, rope_tables, prefill_block
+from . import moe as moe   # registers the "moe" MLP + Qwen3-MoE adapter into the llm registries
 
 __all__ = [
     "Tensor", "Model", "SegmentedModel", "PrecisionWarning", "CrossChipFP16Warning",

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -805,18 +805,16 @@ def _sig_ty(em, t: Tensor) -> str:
 
 
 def cache_root() -> Path:
-  """Persistent, content-addressed build/compile cache. Defaults under ~/Models so models, weights, and
-  compiled programs live together and are REUSED across runs/sessions (set ANEFORGE_CACHE_DIR to override).
-  Replaces per-compile $TMPDIR mkdtemp dirs, which leaked and forced a full re-emit on every compile."""
+  """Persistent content-addressed build/compile cache (default ~/Models/.aneforge-cache, override
+  ANEFORGE_CACHE_DIR) -- replaces per-compile $TMPDIR mkdtemp dirs, which leaked and re-emitted every call."""
   root = os.environ.get("ANEFORGE_CACHE_DIR") or os.path.join(os.path.expanduser("~"), "Models", ".aneforge-cache")
   p = Path(root); p.mkdir(parents=True, exist_ok=True)
   return p
 
 
 def _emit_program_dir(em, inputs, out_var, out_shape, build_dir):
-  """Write one e5rt program (MIL + weights) to a dir; return it. With no explicit `build_dir`, the dir is
-  content-addressed under `cache_root()`: an identical graph+weights is written (and later compiled) exactly
-  ONCE and reused on every subsequent compile -- no temp dirs piling up, no re-writing big weight blobs."""
+  """Write one e5rt program (MIL + weights) to a dir. Without an explicit `build_dir` it's content-addressed
+  under `cache_root()`: identical graph+weights is written and compiled ONCE, reused on every later compile."""
   sig = ", ".join(f"{_sig_ty(em, t)} {t._name}" for t in inputs)
   mil = (f"program(1.3)\n{_BUILD_INFO}\n{{\n    func main<ios18>({sig}) {{\n"
      + "\n".join(em.lines) + f"\n    }} -> ({out_var});\n}}\n")

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1,7 +1,8 @@
 """Lower a graph into ONE fused e5rt program (one MIL op per node, weights in one BLOBFILE)."""
 from __future__ import annotations
 
-import tempfile
+import hashlib
+import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable
 
@@ -803,15 +804,33 @@ def _sig_ty(em, t: Tensor) -> str:
   return em.ty(t.shape) if dt == "fp16" else em.ty_dt(t.shape, dt)
 
 
+def cache_root() -> Path:
+  """Persistent, content-addressed build/compile cache. Defaults under ~/Models so models, weights, and
+  compiled programs live together and are REUSED across runs/sessions (set ANEFORGE_CACHE_DIR to override).
+  Replaces per-compile $TMPDIR mkdtemp dirs, which leaked and forced a full re-emit on every compile."""
+  root = os.environ.get("ANEFORGE_CACHE_DIR") or os.path.join(os.path.expanduser("~"), "Models", ".aneforge-cache")
+  p = Path(root); p.mkdir(parents=True, exist_ok=True)
+  return p
+
+
 def _emit_program_dir(em, inputs, out_var, out_shape, build_dir):
-  """Write one e5rt program (MIL + weights) to a dir; return it."""
+  """Write one e5rt program (MIL + weights) to a dir; return it. With no explicit `build_dir`, the dir is
+  content-addressed under `cache_root()`: an identical graph+weights is written (and later compiled) exactly
+  ONCE and reused on every subsequent compile -- no temp dirs piling up, no re-writing big weight blobs."""
   sig = ", ".join(f"{_sig_ty(em, t)} {t._name}" for t in inputs)
   mil = (f"program(1.3)\n{_BUILD_INFO}\n{{\n    func main<ios18>({sig}) {{\n"
      + "\n".join(em.lines) + f"\n    }} -> ({out_var});\n}}\n")
-  d = Path(build_dir) if build_dir else Path(tempfile.mkdtemp(prefix="aneforge_"))
+  weights = em.blob.build()
+  if build_dir:
+    d = Path(build_dir)
+  else:
+    key = hashlib.sha256(mil.encode() + weights).hexdigest()[:24]
+    d = cache_root() / key
+    if (d / "model.mil").is_file() and (d / "weights.bin").is_file():
+      return d                                   # reuse: identical program already emitted (cache/ compiled too)
   d.mkdir(parents=True, exist_ok=True)
   (d / "model.mil").write_text(mil)
-  (d / "weights.bin").write_bytes(em.blob.build())
+  (d / "weights.bin").write_bytes(weights)
   return d
 
 

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -320,6 +320,14 @@ def _e_bmm(em, t, n, s):
       f'x = {s[0]}, y = {s[1]})[name = string("{n}")];')
 
 
+@op("bmm_w")
+def _e_bmm_w(em, t, n, s):
+  # batched matmul x @ W with a baked, quantizable weight W [B, K, N] (per-batch int8 scale via em.weight).
+  w = em.weight(f"{n}_w", t.attrs["wt"], allow_int8=True, int8=t.attrs.get("int8"), allow_int4=True)
+  em.line(f'{em.ty(t.shape)} {n} = matmul(transpose_x = bool(false), transpose_y = bool(false), '
+      f'x = {s[0]}, y = {w})[name = string("{n}")];')
+
+
 # shared const/param preambles for the conv & pool emitters.
 def _const_pt(em, n):
   em.line(f'string {n}_pt = const()[name = string("{n}_pt"), val = string("custom")];')

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -176,6 +176,15 @@ class Tensor:
     return Tensor(self.shape[:-1] + (W.shape[1],), "matmul", [self],
            {"wt": np.ascontiguousarray(W.T)})
 
+  def bmm_weight(self, W) -> "Tensor":
+    """Batched matmul `self @ W` where `W` [B, K, N] is a baked, QUANTIZABLE weight (unlike `@` with a
+    `_const`, whose operand stays fp16). `self` [B, M, K] -> [B, M, N]. Used for per-expert projections so
+    `compress=` shrinks them (per-batch int8 scale)."""
+    W = np.asarray(W); _check_dtype(W, "bmm_weight")
+    if W.ndim != 3 or self.shape[-1] != W.shape[-2]:
+      raise ValueError(f"bmm_weight: x{self.shape} @ W{W.shape} shape mismatch")
+    return Tensor(self.shape[:-1] + (W.shape[-1],), "bmm_w", [self], {"wt": np.ascontiguousarray(W)})
+
   def linear(self, W, bias=None) -> "Tensor":
     """`x @ W.T (+ bias)`. `W` is [out, in] (PyTorch convention)."""
     W = np.asarray(W); _check_dtype(W, "linear weight")

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -177,9 +177,8 @@ class Tensor:
            {"wt": np.ascontiguousarray(W.T)})
 
   def bmm_weight(self, W) -> "Tensor":
-    """Batched matmul `self @ W` where `W` [B, K, N] is a baked, QUANTIZABLE weight (unlike `@` with a
-    `_const`, whose operand stays fp16). `self` [B, M, K] -> [B, M, N]. Used for per-expert projections so
-    `compress=` shrinks them (per-batch int8 scale)."""
+    """Batched matmul `self [B,M,K] @ W [B,K,N]`, `W` a baked QUANTIZABLE weight (unlike `@` with a `_const`,
+    which stays fp16) -- for per-expert projections, so `compress=` shrinks them."""
     W = np.asarray(W); _check_dtype(W, "bmm_weight")
     if W.ndim != 3 or self.shape[-1] != W.shape[-2]:
       raise ValueError(f"bmm_weight: x{self.shape} @ W{W.shape} shape mismatch")

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -327,9 +327,8 @@ def _cfg_from_hf(c) -> LlamaConfig:
                      head_dim=int(getattr(c, "head_dim", 0) or 0))
 
 
-# Architecture adapters: (predicate(hf_config) -> bool, adapter(hf_config, state_dict) -> (cfg, weights)).
-# First match wins; the dense Llama/Qwen path is the fallback. New architectures (MoE, hybrid) append here
-# from their own module (e.g. aneforge.moe) so the loader stays arch-agnostic.
+# Architecture adapters: (predicate(hf_config) -> bool, adapter(hf_config, sd) -> (cfg, weights)); first match
+# wins, dense Llama/Qwen is the fallback. New archs append here (e.g. aneforge.moe) so the loader stays generic.
 ADAPTERS: list = []
 
 

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -228,6 +228,8 @@ class LlamaPrefill:
       for k, t in ctx.items():
         if id(t) in inm: p[k] = inm[id(t)]                      # only ports the chunk's mixers actually use
       chunks.append({"net": net, "p": p})
+      if hasattr(self.w["layers"], "free"):                    # streamed weights: free this chunk's fp16 now it's baked
+        for li in grp: self.w["layers"].free(li)
     cos_t, sin_t = rope_tables(M, dh, cfg.rope_base)
     self._dec = {"M": M, "chunks": chunks, "cos": cos_t, "sin": sin_t}
     return self._dec

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -313,11 +313,18 @@ def _cfg_from_hf(c) -> LlamaConfig:
                      head_dim=int(getattr(c, "head_dim", 0) or 0))
 
 
+# Architecture adapters: (predicate(hf_config) -> bool, adapter(hf_config, state_dict) -> (cfg, weights)).
+# First match wins; the dense Llama/Qwen path is the fallback. New architectures (MoE, hybrid) append here
+# from their own module (e.g. aneforge.moe) so the loader stays arch-agnostic.
+ADAPTERS: list = []
+
+
 def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
   """Load a Llama/Qwen-class model from Hugging Face for ANE inference. `compress` ("int8"/"int4"/"blockwise")
   quantizes the ANE weights."""
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)
   sd = {k: v.detach().float().numpy() for k, v in hf.state_dict().items()}
-  cfg, weights = _dense_adapter(hf.config, sd)
+  adapt = next((fn for pred, fn in ADAPTERS if pred(hf.config)), _dense_adapter)
+  cfg, weights = adapt(hf.config, sd)
   return LlamaPrefill(cfg, weights, compress=compress)

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -81,7 +81,8 @@ def _attn_prefill(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, cos, sin)
   causal attention -> o_proj, with the residual."""
   H, KV, dh, S = cfg.n_heads, cfg.n_kv_heads, cfg.dh, x.shape[0]
   xn = x.rms_norm(w["attn_norm"], cfg.norm_eps)
-  q = xn.linear(w["wq"]).reshape(S, H, dh); k = xn.linear(w["wk"]).reshape(S, KV, dh); v = xn.linear(w["wv"]).reshape(S, KV, dh)
+  q = xn.linear(w["wq"], w.get("q_bias")).reshape(S, H, dh)        # QKV biases (Qwen2): None when absent
+  k = xn.linear(w["wk"], w.get("k_bias")).reshape(S, KV, dh); v = xn.linear(w["wv"], w.get("v_bias")).reshape(S, KV, dh)
   if ls.qk_norm:                                   # Qwen3 QK-norm: per-head RMSNorm over head_dim before RoPE
     q = q.reshape(S * H, dh).rms_norm(w["q_norm"], cfg.norm_eps).reshape(S, H, dh)
     k = k.reshape(S * KV, dh).rms_norm(w["k_norm"], cfg.norm_eps).reshape(S, KV, dh)
@@ -121,7 +122,8 @@ def _attn_decode(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, ctx: dict,
   Kin = _input((KV, M, dh)); Vin = _input((KV, M, dh))
   oh, inv, mask, cosp, sinp = ctx["oh"], ctx["inv"], ctx["mask"], ctx["cosp"], ctx["sinp"]
   xn = x.rms_norm(w["attn_norm"], cfg.norm_eps)
-  q = xn.linear(w["wq"]).reshape(H, dh); k = xn.linear(w["wk"]).reshape(KV, dh); v = xn.linear(w["wv"]).reshape(KV, dh)
+  q = xn.linear(w["wq"], w.get("q_bias")).reshape(H, dh)           # QKV biases (Qwen2): None when absent
+  k = xn.linear(w["wk"], w.get("k_bias")).reshape(KV, dh); v = xn.linear(w["wv"], w.get("v_bias")).reshape(KV, dh)
   if ls.qk_norm:
     q = q.rms_norm(w["q_norm"], cfg.norm_eps); k = k.rms_norm(w["k_norm"], cfg.norm_eps)
   q = rope(q.reshape(H, 1, dh), cosp, sinp)        # [H, 1, dh]

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -1,16 +1,12 @@
-"""Qwen3-MoE (sparse Mixture-of-Experts) support. Registers a `moe` MLP into the `llm` registries.
+"""Sparse Mixture-of-Experts on the ANE: registers a `moe` MLP into the `llm` registries and loads Qwen-MoE
+GGUFs. Routing matches HF (softmax over experts -> top-k -> optional renorm); every expert is baked resident
+and computed densely (one batched matmul over the expert axis), then weighted by the top-k (others get 0).
+Dense is the right trade here -- decode is latency-bound, and the hidden state stays on-chip (no host
+round-trip for routing).
 
-Routing follows the HF Qwen3-MoE convention: softmax over all experts, take the top-k, then renormalize the
-selected weights. On the ANE every expert is baked resident and computed *densely* (one batched matmul over
-the expert axis), then weighted by the top-k router -- experts outside the top-k get weight 0. This trades
-FLOPs for simplicity, which is the right trade here: the ANE decode is latency-bound (computing all experts
-costs ~the same as a few), and the dense path keeps the hidden state on-chip with no per-layer host
-round-trip for the data-dependent routing.
-
-Canonical weights (from the adapter): mlp_norm [dim], router [n_experts, dim], wgate_exps/wup_exps
-[n_experts, ffn, dim], wdown_exps [n_experts, ffn, dim] (down stored transposed [E, ffn, dim] so the
-per-expert projection is a single batched `act @ wdown`). MoE dims live in cfg.extra: n_experts,
-n_experts_per_tok, norm_topk_prob."""
+Canonical per-layer weights: mlp_norm, router [E,dim], wgate_exps/wup_exps/wdown_exps [E,ffn,dim] (down stored
+transposed for the batched `act @ wdown`); Qwen2-MoE adds a shared expert (wgate_sh/wup_sh/wdown_sh/shared_gate)
+and QKV biases. cfg.extra: n_experts, n_experts_per_tok, norm_topk_prob."""
 from __future__ import annotations
 import numpy as np
 
@@ -18,27 +14,23 @@ from .graph import _const, concat as _concat, select
 from . import llm
 from .llm import LayerSpec, LlamaConfig
 
-_MAX_DIM = 65536          # ANE per-op dimension cap; the all-expert gate/up matmul must tile under it
+_MAX_DIM = 65536          # ANE per-op dimension cap; the all-expert gate/up matmul tiles under it
 
 
 def _topk_gate(probs, k, E, T):
-  """Top-k routing weights WITHOUT a graph cut. The native `topk`/`sort` ops are graph cuts that don't
-  compose -- two of them in one program (i.e. two MoE layers) fail to compile -- so build the top-k mask by
-  peeling the row-max k times with plain reductions (`amax`) and `select`. Returns probs masked to the top-k
-  (0 elsewhere); the caller renormalizes. Selection matches exact top-k for distinct logits."""
-  neg = _const(np.full((T, E), -3.0e4, np.float16))
-  one = _const(np.ones((T, E), np.float16)); chosen = _const(np.zeros((T, E), np.float16))
-  rem = probs
+  """probs [T,E] masked to the top-k per row (0 elsewhere), WITHOUT the native `topk`/`sort` ops -- those are
+  graph cuts that don't compose (two MoE layers in one program fail to compile). Peel the row-max k times with
+  `amax`+`select` instead; exact for distinct logits. Caller renormalizes."""
+  neg = _const(np.full((T, E), -3.0e4, np.float16)); one = _const(np.ones((T, E), np.float16))
+  chosen = _const(np.zeros((T, E), np.float16)); rem = probs
   for _ in range(k):
-    hit = rem.greater_equal(rem.amax([1]).reshape(T, 1))   # [T,E] bool: this round's row-max position
-    chosen = select(hit, one, chosen)                      # accumulate the selected experts
-    rem = select(hit, neg, rem)                            # drop it before the next round
-  return probs * chosen                                    # keep probs at the top-k, 0 elsewhere
+    hit = rem.greater_equal(rem.amax([1]).reshape(T, 1))         # this round's row-max position
+    chosen = select(hit, one, chosen); rem = select(hit, neg, rem)   # mark it, then drop it for the next round
+  return probs * chosen
 
 
 def _experts_gate(hn, wexps, E, ffn, dim, T):
-  """All experts' projection hn @ wexps[e].T -> [T, E, ffn], tiled over experts so each matmul's output
-  dimension (g*ffn) stays under the ANE's _MAX_DIM."""
+  """hn @ wexps[e].T over all experts -> [T, E, ffn], tiled so each matmul's output (g*ffn) stays under _MAX_DIM."""
   g = max(1, min(E, _MAX_DIM // ffn))
   parts = [hn.linear(wexps[s:s + g].reshape(min(g, E - s) * ffn, dim)).reshape(T, min(g, E - s), ffn)
            for s in range(0, E, g)]
@@ -46,27 +38,21 @@ def _experts_gate(hn, wexps, E, ffn, dim, T):
 
 
 def _moe(h, w, cfg, ls):
-  """Top-k sparse MoE SwiGLU MLP with its residual. Stateless -- one builder serves both prefill ([S, dim])
-  and decode ([1, dim]). All experts are computed densely (batched) and combined by the renormalized top-k
-  routing weights, so the output equals top-k routing exactly (non-selected experts contribute 0)."""
-  e = cfg.extra
-  E, k, dim = e["n_experts"], e["n_experts_per_tok"], cfg.dim
-  ffn = w["wgate_exps"].shape[1]
-  T = h.shape[0]
-  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)                       # [T, dim]
-  probs = hn.linear(w["router"]).softmax(-1)                         # [T, E] softmax over all experts
-  gate_w = _topk_gate(probs, k, E, T)                                # probs masked to top-k (cut-free)
+  """Top-k sparse MoE SwiGLU + residual. Stateless -- one builder for prefill [S,dim] and decode [1,dim]. All
+  experts computed densely and combined by the renormalized top-k weights (== exact top-k routing)."""
+  e = cfg.extra; E, k, dim = e["n_experts"], e["n_experts_per_tok"], cfg.dim
+  ffn, T = w["wgate_exps"].shape[1], h.shape[0]
+  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)
+  gate_w = _topk_gate(hn.linear(w["router"]).softmax(-1), k, E, T)
   if e.get("norm_topk_prob", True):
-    gate_w = gate_w / gate_w.sum([1]).reshape(T, 1)                  # renormalize over the selected k
-  gate = _experts_gate(hn, w["wgate_exps"], E, ffn, dim, T)          # [T, E, ffn] (tiled over experts)
-  up = _experts_gate(hn, w["wup_exps"], E, ffn, dim, T)
-  act = (gate.silu() * up).transpose([1, 0, 2])                      # [E, T, ffn]
-  out = act.bmm_weight(w["wdown_exps"])                             # [E,T,ffn] @ [E,ffn,dim] -> [E,T,dim] (quantizable)
-  combined = (out * gate_w.transpose([1, 0]).reshape(E, T, 1)).sum([0]).reshape(T, dim)   # weight + combine
-  if "wgate_sh" in w:                                                # Qwen2-MoE shared expert: always-on, sigmoid-gated
-    sh = (hn.linear(w["wgate_sh"]).silu() * hn.linear(w["wup_sh"])).linear(w["wdown_sh"])   # [T, dim]
-    combined = combined + sh * hn.linear(w["shared_gate"]).sigmoid()                        # gate [T,1] broadcasts
-  return h + combined                                                          # residual -> [T, dim]
+    gate_w = gate_w / gate_w.sum([1]).reshape(T, 1)
+  gate, up = _experts_gate(hn, w["wgate_exps"], E, ffn, dim, T), _experts_gate(hn, w["wup_exps"], E, ffn, dim, T)
+  out = (gate.silu() * up).transpose([1, 0, 2]).bmm_weight(w["wdown_exps"])   # [E,T,ffn] @ [E,ffn,dim] (quantizable)
+  combined = (out * gate_w.transpose([1, 0]).reshape(E, T, 1)).sum([0]).reshape(T, dim)
+  if "wgate_sh" in w:                                            # Qwen2-MoE always-on, sigmoid-gated shared expert
+    sh = (hn.linear(w["wgate_sh"]).silu() * hn.linear(w["wup_sh"])).linear(w["wdown_sh"])
+    combined = combined + sh * hn.linear(w["shared_gate"]).sigmoid()
+  return h + combined
 
 
 llm.PREFILL_MLPS["moe"] = _moe
@@ -74,11 +60,9 @@ llm.DECODE_MLPS["moe"] = _moe
 
 
 def _moe_adapter(c, sd) -> tuple[LlamaConfig, dict]:
-  """Adapter for Qwen3-MoE: attention layers as usual; sparse FFN layers carry stacked expert weights and a
-  router. Reads the fused HF expert layout -- experts.gate_up_proj [E, dim, 2*ffn] (gate||up) and
-  experts.down_proj [E, ffn, dim] -- and lays them out for `_moe` (wgate_exps/wup_exps [E, ffn, dim] for the
-  per-expert linears, wdown_exps [E, ffn, dim] for the batched matmul). `decoder_sparse_step`/`mlp_only_layers`
-  pick which layers are MoE vs plain SwiGLU."""
+  """Qwen3-MoE HF adapter: attention layers as usual, sparse FFN layers carry the fused expert weights
+  (experts.gate_up_proj [E,2*ffn,dim], experts.down_proj [E,dim,ffn]) + a router, laid out for `_moe`.
+  `decoder_sparse_step`/`mlp_only_layers` pick MoE vs plain-SwiGLU layers."""
   n, E, k = int(c.num_hidden_layers), int(c.num_experts), int(c.num_experts_per_tok)
   moe_ffn = int(c.moe_intermediate_size)
   qk = "model.layers.0.self_attn.q_norm.weight" in sd
@@ -103,11 +87,11 @@ def _moe_adapter(c, sd) -> tuple[LlamaConfig, dict]:
     if qk:
       lw["q_norm"] = sd[p + "self_attn.q_norm.weight"]; lw["k_norm"] = sd[p + "self_attn.k_norm.weight"]
     if is_moe[L]:
-      gu = sd[p + "mlp.experts.gate_up_proj"]                                    # [E, 2*ffn, dim] (out=gate||up)
-      lw["router"] = sd[p + "mlp.gate.weight"]                                   # [E, dim]
-      lw["wgate_exps"] = np.ascontiguousarray(gu[:, :moe_ffn, :])                # [E, ffn, dim] (Linear out,in)
-      lw["wup_exps"] = np.ascontiguousarray(gu[:, moe_ffn:, :])                  # [E, ffn, dim]
-      lw["wdown_exps"] = np.ascontiguousarray(sd[p + "mlp.experts.down_proj"].transpose(0, 2, 1))  # [E,dim,ffn]->[E,ffn,dim]
+      gu = sd[p + "mlp.experts.gate_up_proj"]                                  # [E, 2*ffn, dim] (out = gate||up)
+      lw["router"] = sd[p + "mlp.gate.weight"]
+      lw["wgate_exps"] = np.ascontiguousarray(gu[:, :moe_ffn, :])
+      lw["wup_exps"] = np.ascontiguousarray(gu[:, moe_ffn:, :])
+      lw["wdown_exps"] = np.ascontiguousarray(sd[p + "mlp.experts.down_proj"].transpose(0, 2, 1))  # ->[E,ffn,dim]
     else:
       lw["wgate"] = sd[p + "mlp.gate_proj.weight"]; lw["wup"] = sd[p + "mlp.up_proj.weight"]
       lw["wdown"] = sd[p + "mlp.down_proj.weight"]
@@ -120,8 +104,8 @@ llm.ADAPTERS.append((lambda c: bool(getattr(c, "num_experts", 0)), _moe_adapter)
 
 class _LazyLayers:
   """Per-layer weights materialized on demand and freed once a decode chunk has baked them, so the full model
-  never holds every layer's fp16 at once (48L fp16 ~60GB > RAM). `LlamaPrefill._decoder` calls `free(i)` after
-  each chunk compiles; re-materialization (e.g. recompiling for a new context length) just re-reads the GGUF."""
+  never holds every layer's fp16 at once (48L fp16 ~60GB > RAM). `_decoder` calls `free(i)` after each chunk
+  compiles; re-materializing (e.g. recompiling for a new context length) just re-reads the GGUF."""
   def __init__(self, materialize, n: int):
     self._mk = materialize; self._n = n; self._cache: dict = {}
 
@@ -135,15 +119,10 @@ class _LazyLayers:
 
 
 def load_gguf(path: str, n_layers: int | None = None, compress: str | None = None) -> "llm.LlamaPrefill":
-  """Load a Qwen-MoE GGUF (Qwen3-MoE e.g. 30B-A3B, or Qwen2-MoE e.g. Qwen1.5-MoE-A2.7B) for ANE inference,
-  dequantizing each tensor to fp16. Architecture features are detected from the tensors: QK-norm (Qwen3),
-  QKV biases + a shared expert (Qwen2), GQA, head_dim.
-
-  GGUF stores weights transposed-and-reversed; the `gguf` reader already returns them in PyTorch [out, in]
-  order, so the only re-layout is ffn_down_exps [E, dim, ffn] -> [E, ffn, dim] for the batched matmul.
-  `n_layers` truncates to the first N decoder layers -- the full 30B is ~60GB in fp16 (> RAM), but a few
-  layers fit, which is enough to measure whether MoE decode is latency-bound (dense viable) or
-  bandwidth-bound. Norms/router are F32 in the file; everything is cast to fp16 to halve resident memory."""
+  """Load a Qwen-MoE GGUF (Qwen3-MoE e.g. 30B-A3B, or Qwen2-MoE e.g. Qwen1.5-MoE-A2.7B), dequantizing each
+  tensor to fp16. Arch features are detected from the tensors (QK-norm, QKV biases + shared expert, GQA,
+  head_dim). The reader returns PyTorch [out,in] order, so the only re-layout is ffn_down_exps -> [E,ffn,dim].
+  `n_layers` truncates the model (the full 30B is ~60GB fp16 > RAM); layers load lazily and free after baking."""
   import gguf
   from gguf.quants import dequantize
   r = gguf.GGUFReader(path)
@@ -155,54 +134,53 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
   tn = {t.name: t for t in r.tensors}
   has = lambda name: name in tn
 
-  def get(name, dtype: np.typing.DTypeLike = np.float16):   # dequantize -> fp16 (halves resident memory)
+  def get(name, dtype: np.typing.DTypeLike = np.float16):    # dequantize -> fp16 (halves resident memory)
     t = tn[name]; d = np.asarray(t.data)
     if t.tensor_type != gguf.GGMLQuantizationType.F32:
       d = dequantize(d, t.tensor_type)
     return d.astype(dtype)
-  opt = lambda name: get(name) if has(name) else None       # optional tensor -> array or None
+  opt = lambda name: get(name) if has(name) else None
 
   n_total = int(sc("block_count", 0)); n = n_total if n_layers is None else min(n_layers, n_total)
   E, k = int(sc("expert_count", 0)), int(sc("expert_used_count", 0))
   dim, vocab = int(sc("embedding_length", 0)), int(tn["token_embd.weight"].data.shape[0])
   heads = int(sc("attention.head_count", 0))
   moe_ffn = int(tn["blk.0.ffn_gate_exps.weight"].shape[1])   # GGUF [dim, ffn, E] -> ffn (no metadata key on Qwen1.5)
-  qk = has("blk.0.attn_q_norm.weight")                       # Qwen3 has QK-norm; Qwen2 (Qwen1.5-MoE) does not
+  qk = has("blk.0.attn_q_norm.weight")                       # Qwen3 has QK-norm; Qwen2 doesn't
   shared = has("blk.0.ffn_gate_shexp.weight")                # Qwen2-MoE shared expert
   cfg = llm.LlamaConfig(
     dim=dim, n_layers=n, n_heads=heads, n_kv_heads=int(sc("attention.head_count_kv", heads)),
     ffn_dim=moe_ffn, vocab=vocab, rope_base=float(sc("rope.freq_base", 10000.0)),
     norm_eps=float(sc("attention.layer_norm_rms_epsilon", 1e-6)), head_dim=int(sc("attention.key_length") or dim // heads),
     layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=qk) for _ in range(n)],
-    extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": arch != "qwen2moe"})  # Qwen1.5-MoE doesn't renorm
+    extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": arch != "qwen2moe"})  # Qwen1.5 doesn't renorm
+
   import mmap as _mmap
-  def _drop_mmap():                                        # release the GGUF's resident pages (keeps warmup peak low)
+  def _drop_mmap():                                          # release the GGUF's resident pages (low warmup peak)
     mm = getattr(r.data, "_mmap", None)
     if mm is not None:
       try: mm.madvise(_mmap.MADV_DONTNEED)
       except (AttributeError, OSError): pass
 
-  def layer(L):                                            # materialize one layer's fp16 weights on demand
+  def layer(L):                                             # materialize one layer's fp16 weights on demand
     b = f"blk.{L}."
-    d = {
-      "wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
-      "wo": get(b + "attn_output.weight"), "attn_norm": get(b + "attn_norm.weight"),
-      "mlp_norm": get(b + "ffn_norm.weight"), "router": get(b + "ffn_gate_inp.weight"),
-      "wgate_exps": get(b + "ffn_gate_exps.weight"), "wup_exps": get(b + "ffn_up_exps.weight"),
-      "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))}  # [E,dim,ffn]->[E,ffn,dim]
+    d = {"wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
+         "wo": get(b + "attn_output.weight"), "attn_norm": get(b + "attn_norm.weight"),
+         "mlp_norm": get(b + "ffn_norm.weight"), "router": get(b + "ffn_gate_inp.weight"),
+         "wgate_exps": get(b + "ffn_gate_exps.weight"), "wup_exps": get(b + "ffn_up_exps.weight"),
+         "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))}  # ->[E,ffn,dim]
     for key, nm in (("q_norm", "attn_q_norm.weight"), ("k_norm", "attn_k_norm.weight"),
                     ("q_bias", "attn_q.bias"), ("k_bias", "attn_k.bias"), ("v_bias", "attn_v.bias")):
-      v = opt(b + nm)                                       # Qwen3 QK-norm / Qwen2 QKV biases -- only if present
+      v = opt(b + nm)                                        # QK-norm (Qwen3) / QKV biases (Qwen2) -- only if present
       if v is not None: d[key] = v
-    if shared:                                              # Qwen2-MoE shared expert (SwiGLU FFN + sigmoid gate)
+    if shared:                                               # Qwen2-MoE shared expert (SwiGLU FFN + sigmoid gate)
       d["wgate_sh"] = get(b + "ffn_gate_shexp.weight"); d["wup_sh"] = get(b + "ffn_up_shexp.weight")
       d["wdown_sh"] = get(b + "ffn_down_shexp.weight"); d["shared_gate"] = get(b + "ffn_gate_inp_shexp.weight").reshape(1, dim)
-    _drop_mmap()                                           # this layer's GGUF pages are now copied into fp16; release them
+    _drop_mmap()
     return d
 
-  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no BLAS for fp16, so an fp16 lm_head
-  # at vocab 151936 makes per-token logits pathologically slow. Layers are LAZY (_LazyLayers): the decoder
-  # frees each layer's fp16 after its chunk bakes, so the full 48L (~60GB fp16) never resides all at once.
+  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no fp16 BLAS, so an fp16 lm_head at
+  # vocab 151936 makes per-token logits pathologically slow.
   w = {"embed": get("token_embd.weight", np.float32), "final_norm": get("output_norm.weight"),
        "lm_head": get("output.weight", np.float32), "layers": _LazyLayers(layer, n)}
   return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from .graph import _const, select, topk
 from . import llm
+from .llm import LayerSpec, LlamaConfig
 
 
 def _moe(h, w, cfg, ls):
@@ -42,3 +43,48 @@ def _moe(h, w, cfg, ls):
 
 llm.PREFILL_MLPS["moe"] = _moe
 llm.DECODE_MLPS["moe"] = _moe
+
+
+def _moe_adapter(c, sd) -> tuple[LlamaConfig, dict]:
+  """Adapter for Qwen3-MoE: attention layers as usual; sparse FFN layers carry stacked expert weights and a
+  router. Reads the fused HF expert layout -- experts.gate_up_proj [E, dim, 2*ffn] (gate||up) and
+  experts.down_proj [E, ffn, dim] -- and lays them out for `_moe` (wgate_exps/wup_exps [E, ffn, dim] for the
+  per-expert linears, wdown_exps [E, ffn, dim] for the batched matmul). `decoder_sparse_step`/`mlp_only_layers`
+  pick which layers are MoE vs plain SwiGLU."""
+  n, E, k = int(c.num_hidden_layers), int(c.num_experts), int(c.num_experts_per_tok)
+  moe_ffn = int(c.moe_intermediate_size)
+  qk = "model.layers.0.self_attn.q_norm.weight" in sd
+  step = int(getattr(c, "decoder_sparse_step", 1) or 1)
+  mlp_only = set(getattr(c, "mlp_only_layers", []) or [])
+  is_moe = [(L not in mlp_only) and ((L + 1) % step == 0) for L in range(n)]
+  specs = [LayerSpec(mixer="attention", mlp=("moe" if is_moe[L] else "swiglu"), qk_norm=qk) for L in range(n)]
+  cfg = LlamaConfig(dim=c.hidden_size, n_layers=n, n_heads=c.num_attention_heads,
+                    n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
+                    ffn_dim=c.intermediate_size, vocab=c.vocab_size,
+                    rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps),
+                    head_dim=int(getattr(c, "head_dim", 0) or 0), layers=specs,
+                    extra={"n_experts": E, "n_experts_per_tok": k,
+                           "norm_topk_prob": bool(getattr(c, "norm_topk_prob", True))})
+  w = {"embed": sd["model.embed_tokens.weight"], "final_norm": sd["model.norm.weight"],
+       "lm_head": sd.get("lm_head.weight", sd["model.embed_tokens.weight"]), "layers": []}
+  for L in range(n):
+    p = f"model.layers.{L}."
+    lw = {"wq": sd[p + "self_attn.q_proj.weight"], "wk": sd[p + "self_attn.k_proj.weight"],
+          "wv": sd[p + "self_attn.v_proj.weight"], "wo": sd[p + "self_attn.o_proj.weight"],
+          "attn_norm": sd[p + "input_layernorm.weight"], "mlp_norm": sd[p + "post_attention_layernorm.weight"]}
+    if qk:
+      lw["q_norm"] = sd[p + "self_attn.q_norm.weight"]; lw["k_norm"] = sd[p + "self_attn.k_norm.weight"]
+    if is_moe[L]:
+      gu = sd[p + "mlp.experts.gate_up_proj"]                                    # [E, 2*ffn, dim] (out=gate||up)
+      lw["router"] = sd[p + "mlp.gate.weight"]                                   # [E, dim]
+      lw["wgate_exps"] = np.ascontiguousarray(gu[:, :moe_ffn, :])                # [E, ffn, dim] (Linear out,in)
+      lw["wup_exps"] = np.ascontiguousarray(gu[:, moe_ffn:, :])                  # [E, ffn, dim]
+      lw["wdown_exps"] = np.ascontiguousarray(sd[p + "mlp.experts.down_proj"].transpose(0, 2, 1))  # [E,dim,ffn]->[E,ffn,dim]
+    else:
+      lw["wgate"] = sd[p + "mlp.gate_proj.weight"]; lw["wup"] = sd[p + "mlp.up_proj.weight"]
+      lw["wdown"] = sd[p + "mlp.down_proj.weight"]
+    w["layers"].append(lw)
+  return cfg, w
+
+
+llm.ADAPTERS.append((lambda c: bool(getattr(c, "num_experts", 0)), _moe_adapter))

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -63,6 +63,9 @@ def _moe(h, w, cfg, ls):
   act = (gate.silu() * up).transpose([1, 0, 2])                      # [E, T, ffn]
   out = act.bmm_weight(w["wdown_exps"])                             # [E,T,ffn] @ [E,ffn,dim] -> [E,T,dim] (quantizable)
   combined = (out * gate_w.transpose([1, 0]).reshape(E, T, 1)).sum([0]).reshape(T, dim)   # weight + combine
+  if "wgate_sh" in w:                                                # Qwen2-MoE shared expert: always-on, sigmoid-gated
+    sh = (hn.linear(w["wgate_sh"]).silu() * hn.linear(w["wup_sh"])).linear(w["wdown_sh"])   # [T, dim]
+    combined = combined + sh * hn.linear(w["shared_gate"]).sigmoid()                        # gate [T,1] broadcasts
   return h + combined                                                          # residual -> [T, dim]
 
 
@@ -132,7 +135,9 @@ class _LazyLayers:
 
 
 def load_gguf(path: str, n_layers: int | None = None, compress: str | None = None) -> "llm.LlamaPrefill":
-  """Load a Qwen3-MoE GGUF (e.g. Qwen3-30B-A3B Q4_K_M) for ANE inference, dequantizing each tensor to fp16.
+  """Load a Qwen-MoE GGUF (Qwen3-MoE e.g. 30B-A3B, or Qwen2-MoE e.g. Qwen1.5-MoE-A2.7B) for ANE inference,
+  dequantizing each tensor to fp16. Architecture features are detected from the tensors: QK-norm (Qwen3),
+  QKV biases + a shared expert (Qwen2), GQA, head_dim.
 
   GGUF stores weights transposed-and-reversed; the `gguf` reader already returns them in PyTorch [out, in]
   order, so the only re-layout is ffn_down_exps [E, dim, ffn] -> [E, ffn, dim] for the batched matmul.
@@ -144,24 +149,32 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
   r = gguf.GGUFReader(path)
   meta = {f.name: f for f in r.fields.values()}
   arch = next(k.split(".")[0] for k in meta if k.endswith(".block_count"))
-  sc = lambda key: meta[arch + "." + key].parts[meta[arch + "." + key].data[-1]][0]
+  def sc(key, default=None):
+    f = meta.get(arch + "." + key)
+    return f.parts[f.data[-1]][0] if f is not None else default
   tn = {t.name: t for t in r.tensors}
+  has = lambda name: name in tn
 
   def get(name, dtype: np.typing.DTypeLike = np.float16):   # dequantize -> fp16 (halves resident memory)
     t = tn[name]; d = np.asarray(t.data)
     if t.tensor_type != gguf.GGMLQuantizationType.F32:
       d = dequantize(d, t.tensor_type)
     return d.astype(dtype)
+  opt = lambda name: get(name) if has(name) else None       # optional tensor -> array or None
 
-  n_total = int(sc("block_count")); n = n_total if n_layers is None else min(n_layers, n_total)
-  E, k = int(sc("expert_count")), int(sc("expert_used_count"))
-  dim, vocab = int(sc("embedding_length")), tn["token_embd.weight"].data.shape[0]
+  n_total = int(sc("block_count", 0)); n = n_total if n_layers is None else min(n_layers, n_total)
+  E, k = int(sc("expert_count", 0)), int(sc("expert_used_count", 0))
+  dim, vocab = int(sc("embedding_length", 0)), int(tn["token_embd.weight"].data.shape[0])
+  heads = int(sc("attention.head_count", 0))
+  moe_ffn = int(tn["blk.0.ffn_gate_exps.weight"].shape[1])   # GGUF [dim, ffn, E] -> ffn (no metadata key on Qwen1.5)
+  qk = has("blk.0.attn_q_norm.weight")                       # Qwen3 has QK-norm; Qwen2 (Qwen1.5-MoE) does not
+  shared = has("blk.0.ffn_gate_shexp.weight")                # Qwen2-MoE shared expert
   cfg = llm.LlamaConfig(
-    dim=dim, n_layers=n, n_heads=int(sc("attention.head_count")), n_kv_heads=int(sc("attention.head_count_kv")),
-    ffn_dim=int(sc("expert_feed_forward_length")), vocab=int(vocab), rope_base=float(sc("rope.freq_base")),
-    norm_eps=float(sc("attention.layer_norm_rms_epsilon")), head_dim=int(sc("attention.key_length")),
-    layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=True) for _ in range(n)],
-    extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": True})
+    dim=dim, n_layers=n, n_heads=heads, n_kv_heads=int(sc("attention.head_count_kv", heads)),
+    ffn_dim=moe_ffn, vocab=vocab, rope_base=float(sc("rope.freq_base", 10000.0)),
+    norm_eps=float(sc("attention.layer_norm_rms_epsilon", 1e-6)), head_dim=int(sc("attention.key_length") or dim // heads),
+    layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=qk) for _ in range(n)],
+    extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": arch != "qwen2moe"})  # Qwen1.5-MoE doesn't renorm
   import mmap as _mmap
   def _drop_mmap():                                        # release the GGUF's resident pages (keeps warmup peak low)
     mm = getattr(r.data, "_mmap", None)
@@ -173,11 +186,17 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     b = f"blk.{L}."
     d = {
       "wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
-      "wo": get(b + "attn_output.weight"), "q_norm": get(b + "attn_q_norm.weight"),
-      "k_norm": get(b + "attn_k_norm.weight"), "attn_norm": get(b + "attn_norm.weight"),
+      "wo": get(b + "attn_output.weight"), "attn_norm": get(b + "attn_norm.weight"),
       "mlp_norm": get(b + "ffn_norm.weight"), "router": get(b + "ffn_gate_inp.weight"),
       "wgate_exps": get(b + "ffn_gate_exps.weight"), "wup_exps": get(b + "ffn_up_exps.weight"),
       "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))}  # [E,dim,ffn]->[E,ffn,dim]
+    for key, nm in (("q_norm", "attn_q_norm.weight"), ("k_norm", "attn_k_norm.weight"),
+                    ("q_bias", "attn_q.bias"), ("k_bias", "attn_k.bias"), ("v_bias", "attn_v.bias")):
+      v = opt(b + nm)                                       # Qwen3 QK-norm / Qwen2 QKV biases -- only if present
+      if v is not None: d[key] = v
+    if shared:                                              # Qwen2-MoE shared expert (SwiGLU FFN + sigmoid gate)
+      d["wgate_sh"] = get(b + "ffn_gate_shexp.weight"); d["wup_sh"] = get(b + "ffn_up_shexp.weight")
+      d["wdown_sh"] = get(b + "ffn_down_shexp.weight"); d["shared_gate"] = get(b + "ffn_gate_inp_shexp.weight").reshape(1, dim)
     _drop_mmap()                                           # this layer's GGUF pages are now copied into fp16; release them
     return d
 

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -115,6 +115,22 @@ def _moe_adapter(c, sd) -> tuple[LlamaConfig, dict]:
 llm.ADAPTERS.append((lambda c: bool(getattr(c, "num_experts", 0)), _moe_adapter))
 
 
+class _LazyLayers:
+  """Per-layer weights materialized on demand and freed once a decode chunk has baked them, so the full model
+  never holds every layer's fp16 at once (48L fp16 ~60GB > RAM). `LlamaPrefill._decoder` calls `free(i)` after
+  each chunk compiles; re-materialization (e.g. recompiling for a new context length) just re-reads the GGUF."""
+  def __init__(self, materialize, n: int):
+    self._mk = materialize; self._n = n; self._cache: dict = {}
+
+  def __len__(self) -> int: return self._n
+
+  def __getitem__(self, i: int) -> dict:
+    if i not in self._cache: self._cache[i] = self._mk(i)
+    return self._cache[i]
+
+  def free(self, i: int) -> None: self._cache.pop(i, None)
+
+
 def load_gguf(path: str, n_layers: int | None = None, compress: str | None = None) -> "llm.LlamaPrefill":
   """Load a Qwen3-MoE GGUF (e.g. Qwen3-30B-A3B Q4_K_M) for ANE inference, dequantizing each tensor to fp16.
 
@@ -146,17 +162,19 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     norm_eps=float(sc("attention.layer_norm_rms_epsilon")), head_dim=int(sc("attention.key_length")),
     layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=True) for _ in range(n)],
     extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": True})
-  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no BLAS for fp16, so an fp16 lm_head
-  # at vocab 151936 makes per-token logits pathologically slow.
-  w = {"embed": get("token_embd.weight", np.float32), "final_norm": get("output_norm.weight"),
-       "lm_head": get("output.weight", np.float32), "layers": []}
-  for L in range(n):
+  def layer(L):                                            # materialize one layer's fp16 weights on demand
     b = f"blk.{L}."
-    w["layers"].append({
+    return {
       "wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
       "wo": get(b + "attn_output.weight"), "q_norm": get(b + "attn_q_norm.weight"),
       "k_norm": get(b + "attn_k_norm.weight"), "attn_norm": get(b + "attn_norm.weight"),
       "mlp_norm": get(b + "ffn_norm.weight"), "router": get(b + "ffn_gate_inp.weight"),
       "wgate_exps": get(b + "ffn_gate_exps.weight"), "wup_exps": get(b + "ffn_up_exps.weight"),
-      "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))})  # [E,dim,ffn]->[E,ffn,dim]
+      "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))}  # [E,dim,ffn]->[E,ffn,dim]
+
+  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no BLAS for fp16, so an fp16 lm_head
+  # at vocab 151936 makes per-token logits pathologically slow. Layers are LAZY (_LazyLayers): the decoder
+  # frees each layer's fp16 after its chunk bakes, so the full 48L (~60GB fp16) never resides all at once.
+  w = {"embed": get("token_embd.weight", np.float32), "final_norm": get("output_norm.weight"),
+       "lm_head": get("output.weight", np.float32), "layers": _LazyLayers(layer, n)}
   return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -61,7 +61,7 @@ def _moe(h, w, cfg, ls):
   gate = _experts_gate(hn, w["wgate_exps"], E, ffn, dim, T)          # [T, E, ffn] (tiled over experts)
   up = _experts_gate(hn, w["wup_exps"], E, ffn, dim, T)
   act = (gate.silu() * up).transpose([1, 0, 2])                      # [E, T, ffn]
-  out = act @ _const(np.ascontiguousarray(w["wdown_exps"]))          # [E,T,ffn] @ [E,ffn,dim] -> [E, T, dim]
+  out = act.bmm_weight(w["wdown_exps"])                             # [E,T,ffn] @ [E,ffn,dim] -> [E,T,dim] (quantizable)
   combined = (out * gate_w.transpose([1, 0]).reshape(E, T, 1)).sum([0]).reshape(T, dim)   # weight + combine
   return h + combined                                                          # residual -> [T, dim]
 
@@ -162,15 +162,24 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     norm_eps=float(sc("attention.layer_norm_rms_epsilon")), head_dim=int(sc("attention.key_length")),
     layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=True) for _ in range(n)],
     extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": True})
+  import mmap as _mmap
+  def _drop_mmap():                                        # release the GGUF's resident pages (keeps warmup peak low)
+    mm = getattr(r.data, "_mmap", None)
+    if mm is not None:
+      try: mm.madvise(_mmap.MADV_DONTNEED)
+      except (AttributeError, OSError): pass
+
   def layer(L):                                            # materialize one layer's fp16 weights on demand
     b = f"blk.{L}."
-    return {
+    d = {
       "wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
       "wo": get(b + "attn_output.weight"), "q_norm": get(b + "attn_q_norm.weight"),
       "k_norm": get(b + "attn_k_norm.weight"), "attn_norm": get(b + "attn_norm.weight"),
       "mlp_norm": get(b + "ffn_norm.weight"), "router": get(b + "ffn_gate_inp.weight"),
       "wgate_exps": get(b + "ffn_gate_exps.weight"), "wup_exps": get(b + "ffn_up_exps.weight"),
       "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))}  # [E,dim,ffn]->[E,ffn,dim]
+    _drop_mmap()                                           # this layer's GGUF pages are now copied into fp16; release them
+    return d
 
   # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no BLAS for fp16, so an fp16 lm_head
   # at vocab 151936 makes per-token logits pathologically slow. Layers are LAZY (_LazyLayers): the decoder

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -14,9 +14,35 @@ n_experts_per_tok, norm_topk_prob."""
 from __future__ import annotations
 import numpy as np
 
-from .graph import _const, select, topk
+from .graph import _const, concat as _concat, select
 from . import llm
 from .llm import LayerSpec, LlamaConfig
+
+_MAX_DIM = 65536          # ANE per-op dimension cap; the all-expert gate/up matmul must tile under it
+
+
+def _topk_gate(probs, k, E, T):
+  """Top-k routing weights WITHOUT a graph cut. The native `topk`/`sort` ops are graph cuts that don't
+  compose -- two of them in one program (i.e. two MoE layers) fail to compile -- so build the top-k mask by
+  peeling the row-max k times with plain reductions (`amax`) and `select`. Returns probs masked to the top-k
+  (0 elsewhere); the caller renormalizes. Selection matches exact top-k for distinct logits."""
+  neg = _const(np.full((T, E), -3.0e4, np.float16))
+  one = _const(np.ones((T, E), np.float16)); chosen = _const(np.zeros((T, E), np.float16))
+  rem = probs
+  for _ in range(k):
+    hit = rem.greater_equal(rem.amax([1]).reshape(T, 1))   # [T,E] bool: this round's row-max position
+    chosen = select(hit, one, chosen)                      # accumulate the selected experts
+    rem = select(hit, neg, rem)                            # drop it before the next round
+  return probs * chosen                                    # keep probs at the top-k, 0 elsewhere
+
+
+def _experts_gate(hn, wexps, E, ffn, dim, T):
+  """All experts' projection hn @ wexps[e].T -> [T, E, ffn], tiled over experts so each matmul's output
+  dimension (g*ffn) stays under the ANE's _MAX_DIM."""
+  g = max(1, min(E, _MAX_DIM // ffn))
+  parts = [hn.linear(wexps[s:s + g].reshape(min(g, E - s) * ffn, dim)).reshape(T, min(g, E - s), ffn)
+           for s in range(0, E, g)]
+  return parts[0] if len(parts) == 1 else _concat(parts, axis=1)
 
 
 def _moe(h, w, cfg, ls):
@@ -29,12 +55,11 @@ def _moe(h, w, cfg, ls):
   T = h.shape[0]
   hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)                       # [T, dim]
   probs = hn.linear(w["router"]).softmax(-1)                         # [T, E] softmax over all experts
-  thr = topk(probs, k).slice_by_size([0, k - 1], [T, 1])            # [T, 1]: the k-th largest prob (cutoff)
-  gate_w = select(probs.greater_equal(thr), probs, _const(np.zeros((T, E), np.float16)))   # zero out non-top-k
+  gate_w = _topk_gate(probs, k, E, T)                                # probs masked to top-k (cut-free)
   if e.get("norm_topk_prob", True):
     gate_w = gate_w / gate_w.sum([1]).reshape(T, 1)                  # renormalize over the selected k
-  gate = hn.linear(w["wgate_exps"].reshape(E * ffn, dim)).reshape(T, E, ffn)   # all experts, one matmul
-  up = hn.linear(w["wup_exps"].reshape(E * ffn, dim)).reshape(T, E, ffn)
+  gate = _experts_gate(hn, w["wgate_exps"], E, ffn, dim, T)          # [T, E, ffn] (tiled over experts)
+  up = _experts_gate(hn, w["wup_exps"], E, ffn, dim, T)
   act = (gate.silu() * up).transpose([1, 0, 2])                      # [E, T, ffn]
   out = act @ _const(np.ascontiguousarray(w["wdown_exps"]))          # [E,T,ffn] @ [E,ffn,dim] -> [E, T, dim]
   combined = (out * gate_w.transpose([1, 0]).reshape(E, T, 1)).sum([0]).reshape(T, dim)   # weight + combine
@@ -88,3 +113,50 @@ def _moe_adapter(c, sd) -> tuple[LlamaConfig, dict]:
 
 
 llm.ADAPTERS.append((lambda c: bool(getattr(c, "num_experts", 0)), _moe_adapter))
+
+
+def load_gguf(path: str, n_layers: int | None = None, compress: str | None = None) -> "llm.LlamaPrefill":
+  """Load a Qwen3-MoE GGUF (e.g. Qwen3-30B-A3B Q4_K_M) for ANE inference, dequantizing each tensor to fp16.
+
+  GGUF stores weights transposed-and-reversed; the `gguf` reader already returns them in PyTorch [out, in]
+  order, so the only re-layout is ffn_down_exps [E, dim, ffn] -> [E, ffn, dim] for the batched matmul.
+  `n_layers` truncates to the first N decoder layers -- the full 30B is ~60GB in fp16 (> RAM), but a few
+  layers fit, which is enough to measure whether MoE decode is latency-bound (dense viable) or
+  bandwidth-bound. Norms/router are F32 in the file; everything is cast to fp16 to halve resident memory."""
+  import gguf
+  from gguf.quants import dequantize
+  r = gguf.GGUFReader(path)
+  meta = {f.name: f for f in r.fields.values()}
+  arch = next(k.split(".")[0] for k in meta if k.endswith(".block_count"))
+  sc = lambda key: meta[arch + "." + key].parts[meta[arch + "." + key].data[-1]][0]
+  tn = {t.name: t for t in r.tensors}
+
+  def get(name, dtype: np.typing.DTypeLike = np.float16):   # dequantize -> fp16 (halves resident memory)
+    t = tn[name]; d = np.asarray(t.data)
+    if t.tensor_type != gguf.GGMLQuantizationType.F32:
+      d = dequantize(d, t.tensor_type)
+    return d.astype(dtype)
+
+  n_total = int(sc("block_count")); n = n_total if n_layers is None else min(n_layers, n_total)
+  E, k = int(sc("expert_count")), int(sc("expert_used_count"))
+  dim, vocab = int(sc("embedding_length")), tn["token_embd.weight"].data.shape[0]
+  cfg = llm.LlamaConfig(
+    dim=dim, n_layers=n, n_heads=int(sc("attention.head_count")), n_kv_heads=int(sc("attention.head_count_kv")),
+    ffn_dim=int(sc("expert_feed_forward_length")), vocab=int(vocab), rope_base=float(sc("rope.freq_base")),
+    norm_eps=float(sc("attention.layer_norm_rms_epsilon")), head_dim=int(sc("attention.key_length")),
+    layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=True) for _ in range(n)],
+    extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": True})
+  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no BLAS for fp16, so an fp16 lm_head
+  # at vocab 151936 makes per-token logits pathologically slow.
+  w = {"embed": get("token_embd.weight", np.float32), "final_norm": get("output_norm.weight"),
+       "lm_head": get("output.weight", np.float32), "layers": []}
+  for L in range(n):
+    b = f"blk.{L}."
+    w["layers"].append({
+      "wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
+      "wo": get(b + "attn_output.weight"), "q_norm": get(b + "attn_q_norm.weight"),
+      "k_norm": get(b + "attn_k_norm.weight"), "attn_norm": get(b + "attn_norm.weight"),
+      "mlp_norm": get(b + "ffn_norm.weight"), "router": get(b + "ffn_gate_inp.weight"),
+      "wgate_exps": get(b + "ffn_gate_exps.weight"), "wup_exps": get(b + "ffn_up_exps.weight"),
+      "wdown_exps": np.ascontiguousarray(get(b + "ffn_down_exps.weight").transpose(0, 2, 1))})  # [E,dim,ffn]->[E,ffn,dim]
+  return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -1,0 +1,44 @@
+"""Qwen3-MoE (sparse Mixture-of-Experts) support. Registers a `moe` MLP into the `llm` registries.
+
+Routing follows the HF Qwen3-MoE convention: softmax over all experts, take the top-k, then renormalize the
+selected weights. On the ANE every expert is baked resident and computed *densely* (one batched matmul over
+the expert axis), then weighted by the top-k router -- experts outside the top-k get weight 0. This trades
+FLOPs for simplicity, which is the right trade here: the ANE decode is latency-bound (computing all experts
+costs ~the same as a few), and the dense path keeps the hidden state on-chip with no per-layer host
+round-trip for the data-dependent routing.
+
+Canonical weights (from the adapter): mlp_norm [dim], router [n_experts, dim], wgate_exps/wup_exps
+[n_experts, ffn, dim], wdown_exps [n_experts, ffn, dim] (down stored transposed [E, ffn, dim] so the
+per-expert projection is a single batched `act @ wdown`). MoE dims live in cfg.extra: n_experts,
+n_experts_per_tok, norm_topk_prob."""
+from __future__ import annotations
+import numpy as np
+
+from .graph import _const, select, topk
+from . import llm
+
+
+def _moe(h, w, cfg, ls):
+  """Top-k sparse MoE SwiGLU MLP with its residual. Stateless -- one builder serves both prefill ([S, dim])
+  and decode ([1, dim]). All experts are computed densely (batched) and combined by the renormalized top-k
+  routing weights, so the output equals top-k routing exactly (non-selected experts contribute 0)."""
+  e = cfg.extra
+  E, k, dim = e["n_experts"], e["n_experts_per_tok"], cfg.dim
+  ffn = w["wgate_exps"].shape[1]
+  T = h.shape[0]
+  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)                       # [T, dim]
+  probs = hn.linear(w["router"]).softmax(-1)                         # [T, E] softmax over all experts
+  thr = topk(probs, k).slice_by_size([0, k - 1], [T, 1])            # [T, 1]: the k-th largest prob (cutoff)
+  gate_w = select(probs.greater_equal(thr), probs, _const(np.zeros((T, E), np.float16)))   # zero out non-top-k
+  if e.get("norm_topk_prob", True):
+    gate_w = gate_w / gate_w.sum([1]).reshape(T, 1)                  # renormalize over the selected k
+  gate = hn.linear(w["wgate_exps"].reshape(E * ffn, dim)).reshape(T, E, ffn)   # all experts, one matmul
+  up = hn.linear(w["wup_exps"].reshape(E * ffn, dim)).reshape(T, E, ffn)
+  act = (gate.silu() * up).transpose([1, 0, 2])                      # [E, T, ffn]
+  out = act @ _const(np.ascontiguousarray(w["wdown_exps"]))          # [E,T,ffn] @ [E,ffn,dim] -> [E, T, dim]
+  combined = (out * gate_w.transpose([1, 0]).reshape(E, T, 1)).sum([0]).reshape(T, dim)   # weight + combine
+  return h + combined                                                          # residual -> [T, dim]
+
+
+llm.PREFILL_MLPS["moe"] = _moe
+llm.DECODE_MLPS["moe"] = _moe

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,7 +1,8 @@
 # LLMs on the ANE
 
-ANEForge runs a Llama/Qwen-class decoder on the Apple Neural Engine — prefill and KV-cache
-decode, from Hugging Face weights, as fused ANE programs.
+ANEForge runs decoder LLMs on the Apple Neural Engine — prefill and KV-cache decode, from Hugging
+Face weights or GGUF, as fused ANE programs. Beyond dense Llama/Qwen, it runs sparse Mixture-of-Experts
+and hybrid DeltaNet+attention models, with quantization and exact speculative decoding (sections below).
 
 Prefill (processing the prompt) is compute-bound: a stack of matmuls over all prompt tokens at
 once, which is the ANE's efficient regime. Decode (one token at a time) is memory-bound; it
@@ -41,6 +42,22 @@ On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode. On Qwen3-8B (36 la
 `examples/llm_chat.py` is an interactive streaming chat; `examples/llm_prefill.py` is a benchmark
 (prompt-tok/s, and `--energy` for ANE joules/token via `powermetrics`).
 
+## Speculative decoding
+
+A small *draft* model proposes K tokens; the large *target* verifies all K in a single forward. This
+is a natural fit for the ANE: decode is latency-bound, so `verify(K) ≈ verify(1)` — measured 1.05× for
+K=5 on Qwen3-8B — and the draft's proposals are checked almost for free. The output is **exact**: the
+same tokens plain greedy decode would produce.
+
+```python
+from aneforge.speculative import spec_generate
+out = spec_generate(target, draft, prompt_ids, max_new_tokens=40)   # target, draft = af.load_llm(...)
+```
+
+Measured 2.28× on Qwen3-8B with a Qwen3-0.6B draft (7.4 → 16.8 tok/s), using a tiled on-ANE lm_head.
+Profiling one round: ~64% is the target verify (a single 8B forward — the irreducible floor), ~36% the
+draft, and ~0 orchestration overhead. `examples/spec_chat.py` is an interactive speculative chat.
+
 ## Quantized weights
 
 `compress="int8"` quantizes the ANE matmul weights to per-channel int8 (`"int4"` = 4-bit LUT),
@@ -58,6 +75,40 @@ the tradeoffs are narrow:
   compute), which this option does not yet do.
 
 Pass `--int8` to the examples to try it (best on small models).
+
+## Mixture-of-Experts
+
+Sparse MoE decoders run from a GGUF — Qwen3-MoE (e.g. 30B-A3B) and Qwen2-MoE (e.g. Qwen1.5-MoE-A2.7B):
+
+```python
+from aneforge.moe import load_gguf
+model = load_gguf("Qwen1.5-MoE-A2.7B-Chat.Q4_K_M.gguf", compress="int8")
+```
+
+The router and *every* expert run on the ANE: a softmax over the experts, a top-k mask, then one
+batched matmul over all experts weighted by the top-k (non-selected experts contribute 0). The top-k
+mask is built from `amax` + `select` rather than the native `topk` op, which is a graph cut that won't
+compose across layers. Qwen2-MoE's shared expert and QKV biases are detected from the weights. The
+math matches HF `Qwen3MoeForCausalLM` (cosine >0.99), and the full 24-layer Qwen1.5-MoE-A2.7B decodes
+coherently end-to-end on the ANE at int8 (~2 tok/s). `examples/moe_chat.py` is an interactive MoE chat.
+
+Unlike the dense 8B, MoE decode at 30B scale is **weight-bandwidth-bound**: ~13.5 ms per MoE layer
+(~89 GB/s), because each token reads all of the experts' weights. So here int8 *does* help (~1.3×), and
+the experts' sparsity (4–8 of 60–128 active) is the real lever — but exploiting it needs a host-side
+FFN split (measured ~4.6× in a prototype), not the dense on-ANE path. The 30B-A3B is currently gated
+only by compile-time RAM on a 52 GB machine (it fits and runs on more).
+
+## Hybrid models (Qwen3.5)
+
+Qwen3.5 / Qwen3-Next interleave gated **DeltaNet** (linear-attention) layers with gated full-attention
+layers. Both mixers run on the ANE: DeltaNet carries a resident causal-conv state and a recurrent
+`[heads, dk, dv]` state across decode steps (a decay-first recurrence), validated fp16-safe on-device
+(cosine 0.999999 over 512 tokens). A per-layer plan (`LayerSpec`) names the mixer for each layer, so
+the runner stays architecture-agnostic — it dispatches on the plan, not the weight shapes.
+
+Caveat: llama.cpp **permutes** the DeltaNet weights in its GGUF export, so reconstructing the model
+from a Qwen3.5 GGUF is wrong. The forward is validated against the original safetensors (cosine 1.0 vs
+transformers), not the GGUF.
 
 ## What's inside
 
@@ -82,4 +133,7 @@ before RoPE), and a large vocab — the layers run on the ANE; the lm_head proje
 
 ## Scope
 
-Llama/Qwen-class decoders (RMSNorm + RoPE + GQA + SwiGLU). Static prompt length per compiled graph.
+Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), sparse **Mixture-of-Experts**
+(Qwen3-MoE, Qwen2-MoE), and **hybrid** DeltaNet+attention (Qwen3.5). Runtime features: prefill + resident
+KV-cache decode, automatic segmentation past the ~2 GB program ceiling, int8/int4 weights, and exact
+speculative decoding. Static prompt length per compiled graph; the lm_head projection runs on host.

--- a/examples/moe_chat.py
+++ b/examples/moe_chat.py
@@ -1,12 +1,11 @@
-"""Interactive chat with a Qwen Mixture-of-Experts model decoding ENTIRELY on the Apple Neural Engine -- no
-host/CPU FFN. Loads a GGUF (Qwen3-MoE e.g. 30B-A3B, or Qwen2-MoE e.g. Qwen1.5-MoE-A2.7B), dequantizes each
-tensor to int8, and runs the full model as a segmented ANE decode (one MoE layer per program). The first run
-compiles the chunks (cached under ~/Models/.aneforge-cache), so later runs start fast.
+"""Interactive chat with a Qwen Mixture-of-Experts model decoding ENTIRELY on the ANE (no host FFN). Loads a
+GGUF (Qwen3-MoE e.g. 30B-A3B, or Qwen2-MoE e.g. Qwen1.5-MoE-A2.7B) at int8 and runs the full model as a
+segmented decode (one MoE layer per program); the first run compiles the chunks (cached under ~/Models).
 
 Run: python3 examples/moe_chat.py [gguf-path] [tokenizer-path]
   e.g. python3 examples/moe_chat.py ~/Models/Qwen1.5-MoE-A2.7B-GGUF/Qwen1.5-MoE-A2.7B-Chat.Q4_K_M.gguf
-With no gguf-path it picks the smallest *MoE* GGUF under ~/Models. The tokenizer is read from the GGUF itself
-(so the chat template + special tokens match the model); pass a 2nd arg to override with an HF tokenizer dir."""
+No gguf-path picks the smallest MoE GGUF under ~/Models; the tokenizer is read from the GGUF (matching chat
+template), overridable with a 2nd arg."""
 import glob
 import os
 import sys

--- a/examples/moe_chat.py
+++ b/examples/moe_chat.py
@@ -1,0 +1,80 @@
+"""Interactive chat with a Qwen Mixture-of-Experts model decoding ENTIRELY on the Apple Neural Engine -- no
+host/CPU FFN. Loads a GGUF (Qwen3-MoE e.g. 30B-A3B, or Qwen2-MoE e.g. Qwen1.5-MoE-A2.7B), dequantizes each
+tensor to int8, and runs the full model as a segmented ANE decode (one MoE layer per program). The first run
+compiles the chunks (cached under ~/Models/.aneforge-cache), so later runs start fast.
+
+Run: python3 examples/moe_chat.py [gguf-path] [tokenizer-path]
+  e.g. python3 examples/moe_chat.py ~/Models/Qwen1.5-MoE-A2.7B-GGUF/Qwen1.5-MoE-A2.7B-Chat.Q4_K_M.gguf
+With no gguf-path it picks the smallest *MoE* GGUF under ~/Models. The tokenizer is read from the GGUF itself
+(so the chat template + special tokens match the model); pass a 2nd arg to override with an HF tokenizer dir."""
+import glob
+import os
+import sys
+import time
+
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+from aneforge.moe import load_gguf
+
+MAX_LEN = 512
+
+
+def _default_gguf():
+  hits = glob.glob(os.path.expanduser("~/Models/*MoE*-GGUF/*.gguf")) + glob.glob(os.path.expanduser("~/Models/*-A*B-GGUF/*.gguf"))
+  hits = [h for h in hits if "incomplete" not in h]
+  return min(hits, key=os.path.getsize) if hits else None      # smallest = most likely to fit + compile fast
+
+
+def _encode(tok, prompt):
+  """Apply the chat template (no 'thinking' block); returns a list of token ids."""
+  msgs = [{"role": "user", "content": prompt}]
+  try:
+    r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
+  except TypeError:
+    r = tok.apply_chat_template(msgs, add_generation_prompt=True)
+  if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]
+  if r and isinstance(r[0], (list, tuple)): r = r[0]
+  return [int(t) for t in r]
+
+
+def main():
+  gguf = sys.argv[1] if len(sys.argv) > 1 else _default_gguf()
+  if not gguf:
+    print("usage: python3 examples/moe_chat.py <gguf-path> [tokenizer-path]  (no MoE GGUF found under ~/Models)"); return 1
+  print(f"loading {os.path.basename(gguf)} (int8, ANE) ...")
+  m = load_gguf(gguf, compress="int8")
+  m._chunk_bytes = 1.0e9                          # one MoE layer per program (two MoE blocks/program won't compile)
+  from transformers import AutoTokenizer
+  if len(sys.argv) > 2:                            # override tokenizer (HF dir)
+    tok = AutoTokenizer.from_pretrained(sys.argv[2])
+  else:                                           # read the model's own tokenizer from the GGUF (matching chat template)
+    tok = AutoTokenizer.from_pretrained(os.path.dirname(gguf), gguf_file=os.path.basename(gguf))
+  e = m.cfg.extra
+  print(f"{m.cfg.n_layers}L dim {m.cfg.dim}, {e['n_experts']} experts / top-{e['n_experts_per_tok']}. "
+        f"compiling {len(m._layer_chunks())} chunks (one-time; cached under ~/Models) ...", end="", flush=True)
+  m.warmup(MAX_LEN)
+  imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
+  eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
+  print(" done.")
+  print("type a message (Ctrl-D or 'exit' to quit). full MoE model, decoding on the ANE.\n")
+
+  while True:
+    try:
+      prompt = input("you> ").strip()
+    except EOFError:
+      print(); break
+    if not prompt: continue
+    if prompt in ("exit", "quit"): break
+    ids = _encode(tok, prompt)
+    if len(ids) >= MAX_LEN - 32:
+      print("ane> (prompt too long for the demo context)\n"); continue
+    print("ane> ", end="", flush=True)
+    n = [0]; t0 = time.perf_counter()
+    m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos,
+               on_token=lambda t: (n.__setitem__(0, n[0] + 1), print(tok.decode([t]), end="", flush=True)))
+    dt = time.perf_counter() - t0
+    print(f"\n   [{n[0]} tokens, {n[0] / dt:.1f} tok/s on the ANE]\n")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -82,7 +82,7 @@ nav:
       - Capabilities: capabilities.md
       - Op catalog: op-catalog.md
       - ONNX import: onnx.md
-      - LLM prefill: llm.md
+      - LLMs (decode, MoE, speculative): llm.md
   - API reference:
       - Overview: api/index.md
       - Graph & operators: api/graph.md

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,12 +54,14 @@ bench = [
     "mlx>=0.31",
     "torch",
 ]
-# Pretrained model loaders (aneforge.models.load / load_resnet18) and the
-# diffusion examples. Imported lazily; only install if you use them.
+# Pretrained model loaders (aneforge.models.load / load_resnet18), the LLM/MoE GGUF
+# loader (aneforge.moe.load_gguf needs gguf), and the diffusion examples. Imported
+# lazily; only install if you use them.
 models = [
     "torch",
     "torchvision",
     "transformers",
+    "gguf",
 ]
 # ONNX model import (aneforge.onnx.load_onnx / onnx_to_tensor). Imported lazily; the
 # core package stays numpy-only. Only install if you import ONNX models.

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -1,0 +1,54 @@
+import numpy as np
+import aneforge as af
+import aneforge.moe  # noqa: F401 - registers the "moe" MLP into the llm registries
+from aneforge.llm import LlamaConfig, LayerSpec
+from aneforge.moe import _moe
+from _helpers import requires_ane
+
+
+def _cfg(dim=32, E=8, k=2):
+  return LlamaConfig(dim=dim, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=16, vocab=16,
+                     extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": True})
+
+
+def _weights(cfg, ffn, seed=0):
+  rng = np.random.default_rng(seed); dim, E = cfg.dim, cfg.extra["n_experts"]
+  R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
+  return {"mlp_norm": np.ones(dim, np.float32), "router": R(E, dim),
+          "wgate_exps": R(E, ffn, dim), "wup_exps": R(E, ffn, dim), "wdown_exps": R(E, ffn, dim)}
+
+
+def _ref(h, w, cfg, ffn):
+  """Numpy reference: HF Qwen3-MoE routing (softmax-all -> top-k -> renorm) over SwiGLU experts, + residual."""
+  E, k, eps = cfg.extra["n_experts"], cfg.extra["n_experts_per_tok"], cfg.norm_eps
+  hn = h / np.sqrt((h ** 2).mean(-1, keepdims=True) + eps) * w["mlp_norm"]
+  logits = hn @ w["router"].T
+  probs = np.exp(logits - logits.max(-1, keepdims=True)); probs /= probs.sum(-1, keepdims=True)
+  idx = np.argsort(-probs, axis=1)[:, :k]
+  gw = np.zeros_like(probs)
+  for t in range(h.shape[0]): gw[t, idx[t]] = probs[t, idx[t]]
+  gw /= gw.sum(1, keepdims=True)
+  silu = lambda x: x / (1.0 + np.exp(-x))
+  out = np.zeros((h.shape[0], cfg.dim))
+  for ex in range(E):
+    g = silu(hn @ w["wgate_exps"][ex].T) * (hn @ w["wup_exps"][ex].T)   # [T, ffn]
+    out += gw[:, ex:ex + 1] * (g @ w["wdown_exps"][ex])                  # wdown stored [ffn, dim]
+  return h + out
+
+
+def test_moe_builds():  # the moe MLP builds with the right output shape and is registered for prefill+decode
+  cfg = _cfg(); ffn = 16
+  out = _moe(af.input((5, cfg.dim)), _weights(cfg, ffn), cfg, LayerSpec(mlp="moe"))
+  assert out.shape == (5, cfg.dim)
+  assert "moe" in af.llm.PREFILL_MLPS and "moe" in af.llm.DECODE_MLPS
+
+
+@requires_ane
+def test_moe_matches_numpy_reference():  # dense ANE MoE == exact top-k routing reference (prefill + decode shapes)
+  cfg = _cfg(dim=32, E=8, k=2); ffn = 16; w = _weights(cfg, ffn)
+  for T in (1, 5):
+    h = (np.random.default_rng(T).standard_normal((T, cfg.dim)) * 0.5).astype(np.float32)
+    got = np.asarray(af.compile(_moe(af.input((T, cfg.dim)), w, cfg, LayerSpec(mlp="moe")))(h.astype(np.float16))).astype(np.float32)
+    ref = _ref(h, w, cfg, ffn)
+    cos = float((got.ravel() @ ref.ravel()) / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
+    assert cos > 0.99, f"T={T}: dense MoE diverged from top-k reference (cos {cos:.4f})"

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -27,7 +27,7 @@ def _ref(h, w, cfg, ffn):
   idx = np.argsort(-probs, axis=1)[:, :k]
   gw = np.zeros_like(probs)
   for t in range(h.shape[0]): gw[t, idx[t]] = probs[t, idx[t]]
-  gw /= gw.sum(1, keepdims=True)
+  if cfg.extra.get("norm_topk_prob", True): gw /= gw.sum(1, keepdims=True)
   silu = lambda x: x / (1.0 + np.exp(-x))
   out = np.zeros((h.shape[0], cfg.dim))
   for ex in range(E):
@@ -52,6 +52,22 @@ def test_moe_matches_numpy_reference():  # dense ANE MoE == exact top-k routing 
     ref = _ref(h, w, cfg, ffn)
     cos = float((got.ravel() @ ref.ravel()) / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
     assert cos > 0.99, f"T={T}: dense MoE diverged from top-k reference (cos {cos:.4f})"
+
+
+@requires_ane
+def test_moe_shared_expert_matches_numpy():  # Qwen2-MoE: routed top-k + always-on sigmoid-gated shared expert
+  cfg = _cfg(dim=32, E=8, k=2); cfg.extra["norm_topk_prob"] = False; ffn, sh = 16, 24
+  w = _weights(cfg, ffn); rng = np.random.default_rng(1); R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
+  w |= {"wgate_sh": R(sh, cfg.dim), "wup_sh": R(sh, cfg.dim), "wdown_sh": R(cfg.dim, sh), "shared_gate": R(1, cfg.dim)}
+  silu = lambda x: x / (1.0 + np.exp(-x)); sig = lambda x: 1.0 / (1.0 + np.exp(-x))
+  for T in (1, 5):
+    h = (np.random.default_rng(T).standard_normal((T, cfg.dim)) * 0.5).astype(np.float32)
+    got = np.asarray(af.compile(_moe(af.input((T, cfg.dim)), w, cfg, LayerSpec(mlp="moe")))(h.astype(np.float16))).astype(np.float32)
+    hn = h / np.sqrt((h ** 2).mean(-1, keepdims=True) + cfg.norm_eps) * w["mlp_norm"]
+    ref = _ref(h, w, cfg, ffn)                                  # routed part (norm_topk_prob=False)
+    ref = ref + (silu(hn @ w["wgate_sh"].T) * (hn @ w["wup_sh"].T)) @ w["wdown_sh"].T * sig(hn @ w["shared_gate"].T)
+    cos = float((got.ravel() @ ref.ravel()) / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
+    assert cos > 0.99, f"T={T}: shared-expert MoE diverged from reference (cos {cos:.4f})"
 
 
 @requires_ane

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -1,8 +1,8 @@
 import numpy as np
 import aneforge as af
-import aneforge.moe  # noqa: F401 - registers the "moe" MLP into the llm registries
-from aneforge.llm import LlamaConfig, LayerSpec
-from aneforge.moe import _moe
+import aneforge.moe  # noqa: F401 - registers the "moe" MLP + adapter into the llm registries
+from aneforge.llm import LlamaConfig, LayerSpec, LlamaPrefill
+from aneforge.moe import _moe, _moe_adapter
 from _helpers import requires_ane
 
 
@@ -52,3 +52,22 @@ def test_moe_matches_numpy_reference():  # dense ANE MoE == exact top-k routing 
     ref = _ref(h, w, cfg, ffn)
     cos = float((got.ravel() @ ref.ravel()) / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
     assert cos > 0.99, f"T={T}: dense MoE diverged from top-k reference (cos {cos:.4f})"
+
+
+@requires_ane
+def test_moe_prefill_matches_huggingface():  # definitive: ANE MoE model (adapter + _moe) == HF Qwen3MoeForCausalLM
+  import torch
+  from transformers import Qwen3MoeConfig, Qwen3MoeForCausalLM
+  hf_cfg = Qwen3MoeConfig(hidden_size=64, num_hidden_layers=2, num_attention_heads=4, num_key_value_heads=2,
+                          intermediate_size=128, moe_intermediate_size=32, num_experts=8, num_experts_per_tok=2,
+                          vocab_size=64, rms_norm_eps=1e-5, rope_theta=10000.0, max_position_embeddings=64,
+                          decoder_sparse_step=1, norm_topk_prob=True, head_dim=16)
+  torch.manual_seed(0); m = Qwen3MoeForCausalLM(hf_cfg).eval()
+  toks = np.random.default_rng(0).integers(0, 64, 10)
+  with torch.no_grad(): ref = m(torch.tensor(toks)[None]).logits[0, -1].numpy()
+  sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
+  cfg, weights = _moe_adapter(m.config, sd)
+  assert [ls.mlp for ls in cfg.layers] == ["moe", "moe"]      # both layers routed (decoder_sparse_step=1)
+  ane = np.asarray(LlamaPrefill(cfg, weights).prefill(toks)).ravel().astype(np.float32)
+  cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
+  assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE MoE vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"


### PR DESCRIPTION
Adds sparse Mixture-of-Experts support to the ANE LLM runtime. A full MoE model (Qwen1.5-MoE-A2.7B, 24 layers) now **decodes coherently end-to-end entirely on the Neural Engine** — no host/CPU FFN.

## What's here
- **Dense `_moe` MLP** registered into the prefill/decode registries: router → top-k mask → softmax-weighted dense expert sum, all on-chip. Matches an exact top-k numpy reference (cosine 0.999995) and HF `Qwen3MoeForCausalLM` (cosine >0.99, argmax).
- **Arch-agnostic adapter registry** (`ADAPTERS`) so `load_llm` dispatches by architecture; Qwen3-MoE HF adapter (fused expert layout).
- **GGUF loader** (`load_gguf`) — dequantizes Qwen-MoE GGUFs to fp16; `n_layers` truncation; lazy **streaming** per-layer load that frees each layer's fp16 after its chunk bakes (full model never holds all fp16 at once).
- **Cut-free top-k** — `topk`/`sort` are graph cuts that don't compose across layers; routing uses an iterative `amax`+`select` mask instead. Expert gate/up matmuls tiled under the 65536 per-op cap.
- **Quantizable down-proj** (`bmm_w` graph op) so `compress=int8` shrinks the per-expert down projection too (it was an `@ _const` bmm left fp16) — ~50GB→~32GB on the 30B; logit cosine 0.9993.
- **Qwen2-MoE support** — QKV biases (attention mixers, backward-compatible), an always-on shared expert (`sigmoid(shared_gate(h))`), QK-norm/GQA/head_dim/`norm_topk_prob` auto-detected from the tensors.
- **Content-addressed compile cache** in `~/Models/.aneforge-cache` (`ANEFORGE_CACHE_DIR` to override): `af.compile()` used to `mkdtemp` a fresh temp dir per call and never clean up; now identical graph+weights compiles once and is reused across runs/sessions.
- **`examples/moe_chat.py`** — interactive MoE chat on the ANE.

## Findings (measured on the real 30B-A3B)
- MoE decode is **weight-bandwidth-bound at 30B** (~13.5 ms/MoE-layer, ~89 GB/s), *not* latency-bound like the 8B — so dense reads all experts every token. int8 ~1.3×; a host-FFN hybrid (reads top-8 of 128) measured ~4.6× and would be the path for the 30B.
- The full 30B-A3B is blocked only by **compile-time RAM on a 52GB machine** (the ANE compiler needs headroom above the ~32GB of resident chunks) — not the ANE, accuracy, or the loader. Demonstrated on the smaller Qwen1.5-MoE instead.

Gates: ruff, pyright 0/0/0, 12 tests (incl. shared-expert + HF-reference) green.