### PR TITLE
feat(qwen35): Qwen3.5-27B hybrid (DeltaNet + attention) decode on pure ANE

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Decoder LLMs run on the ANE from Hugging Face weights or GGUF — prefill plus r
 | Qwen3-0.6B / 8B        | dense decode, matches HF logits    | ~75 / ~7.5 tok/s decode           |
 | Qwen3-8B + 0.6B draft  | speculative decoding, exact        | 2.28x (7.4 -> 16.8 tok/s)         |
 | Qwen1.5-MoE-A2.7B      | sparse MoE, full model on pure ANE | coherent text, ~2 tok/s (int8)    |
-| Qwen3.5 hybrid         | DeltaNet + gated attention         | fp16-safe (cosine 0.999999)       |
+| Qwen3.5-27B hybrid     | 48 DeltaNet + 16 attn on pure ANE  | coherent, matches llama.cpp (1.0) |
 
 Speculative verify is near-free on the ANE (`verify(K) ≈ verify(1)`, decode is latency-bound); MoE decode at 30B scale is weight-bandwidth-bound. Full writeup in the [LLMs guide](docs/llm.md).
 

--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Operator coverage is tracked op by op across M1 to M5 in the [op catalog](docs/o
 
 ## Language models
 
-Decoder LLMs run on the ANE from Hugging Face weights or GGUF — prefill plus resident-KV-cache decode, auto-segmented past the ~2 GB single-program ceiling:
+Decoder LLMs run on the ANE from Hugging Face weights or GGUF - prefill plus resident-KV-cache decode, auto-segmented past the ~2 GB single-program ceiling:
 
 | Model                  | What runs                          | Measured                          |
 | ---------------------- | ---------------------------------- | --------------------------------- |
@@ -185,7 +185,7 @@ Decoder LLMs run on the ANE from Hugging Face weights or GGUF — prefill plus r
 | Qwen1.5-MoE-A2.7B      | sparse MoE, full model on pure ANE | coherent text, ~2 tok/s (int8)    |
 | Qwen3.5-27B hybrid     | 48 DeltaNet + 16 attn on pure ANE  | coherent int8 (fp16-bound vs llama.cpp) |
 
-Speculative verify is near-free on the ANE (`verify(K) ≈ verify(1)`, decode is latency-bound); MoE decode at 30B scale is weight-bandwidth-bound. Full writeup in the [LLMs guide](docs/llm.md).
+Speculative verify is near-free on the ANE (`verify(K) ~ verify(1)`, decode is latency-bound); MoE decode at 30B scale is weight-bandwidth-bound. Full writeup in the [LLMs guide](docs/llm.md).
 
 ## Verify
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Decoder LLMs run on the ANE from Hugging Face weights or GGUF — prefill plus r
 | Qwen3-0.6B / 8B        | dense decode, matches HF logits    | ~75 / ~7.5 tok/s decode           |
 | Qwen3-8B + 0.6B draft  | speculative decoding, exact        | 2.28x (7.4 -> 16.8 tok/s)         |
 | Qwen1.5-MoE-A2.7B      | sparse MoE, full model on pure ANE | coherent text, ~2 tok/s (int8)    |
-| Qwen3.5-27B hybrid     | 48 DeltaNet + 16 attn on pure ANE  | coherent, matches llama.cpp (1.0) |
+| Qwen3.5-27B hybrid     | 48 DeltaNet + 16 attn on pure ANE  | coherent int8 (fp16-bound vs llama.cpp) |
 
 Speculative verify is near-free on the ANE (`verify(K) ≈ verify(1)`, decode is latency-bound); MoE decode at 30B scale is weight-bandwidth-bound. Full writeup in the [LLMs guide](docs/llm.md).
 

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -197,6 +197,22 @@ class LlamaPrefill:
   def _logits(self, hidden_row):
     return hidden_row @ np.asarray(self.w["lm_head"]).T    # host lm_head (vocab can exceed the ANE per-op dim limit)
 
+  @staticmethod
+  def _sample(logits, temperature, top_p, top_k):
+    """Pick a token id from `logits`. `temperature <= 0` is greedy argmax (default); otherwise scale by
+    temperature, truncate to the top-k logits and the nucleus (smallest set with cumulative prob >= top_p),
+    then sample. Pure greedy can loop on models tuned for sampling, so chat demos pass the model's defaults."""
+    if temperature <= 0.0: return int(np.argmax(logits))
+    lg = logits.astype(np.float64) / temperature
+    if top_k and 0 < top_k < lg.size:
+      lg[lg < np.partition(lg, -top_k)[-top_k]] = -np.inf
+    p = np.exp(lg - lg.max()); p /= p.sum()
+    if 0.0 < top_p < 1.0:
+      order = np.argsort(p)[::-1]; cum = np.cumsum(p[order])
+      keep = order[:int(np.searchsorted(cum, top_p)) + 1]      # include the token that crosses top_p
+      m = np.zeros_like(p); m[keep] = p[keep]; p = m / m.sum()
+    return int(np.random.choice(p.size, p=p))
+
   def prefill(self, token_ids):
     """Prefill `token_ids` and return the next-token logits [1, vocab] (the transformer runs on the ANE)."""
     return self._logits(self._hidden(token_ids)[-1])[None]
@@ -251,11 +267,12 @@ class LlamaPrefill:
     `generate` streams immediately. Returns self."""
     self._decoder(int(max_len)); return self
 
-  def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None):
-    """Greedy autoregressive generation with a resident KV-cache. The decode program (compiled once and
-    cached) runs all layers for one token attending to caches that stay on the ANE across steps, so each step
-    feeds only the token embedding + a position one-hot. `on_token(id)` is called per token (streaming).
-    Returns the generated token ids."""
+  def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None,
+               temperature=0.0, top_p=1.0, top_k=0):
+    """Autoregressive generation with a resident KV-cache. The decode program (compiled once and cached) runs
+    all layers for one token attending to caches that stay on the ANE across steps, so each step feeds only the
+    token embedding + a position one-hot. `on_token(id)` is called per token (streaming). Greedy by default
+    (`temperature=0`); pass temperature/top_p/top_k to sample. Returns the generated token ids."""
     cfg = self.cfg; f16 = np.float16
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
     d = self._decoder(M); chunks = d["chunks"]
@@ -279,7 +296,7 @@ class LlamaPrefill:
     cur = prompt[-1]; pos = len(prompt) - 1; out = []
     for _ in range(max_new_tokens):                            # decode
       if pos >= M - 1: break                                   # cache full
-      nxt = int(self._logits(step(cur, pos)).argmax()); out.append(nxt)
+      nxt = self._sample(self._logits(step(cur, pos)), temperature, top_p, top_k); out.append(nxt)
       if nxt == eos_id: break
       if on_token is not None: on_token(nxt)                   # stream the token
       cur = nxt; pos += 1

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -199,9 +199,8 @@ class LlamaPrefill:
 
   @staticmethod
   def _sample(logits, temperature, top_p, top_k):
-    """Pick a token id from `logits`. `temperature <= 0` is greedy argmax (default); otherwise scale by
-    temperature, truncate to the top-k logits and the nucleus (smallest set with cumulative prob >= top_p),
-    then sample. Pure greedy can loop on models tuned for sampling, so chat demos pass the model's defaults."""
+    """Greedy argmax when `temperature <= 0` (default); else temperature-scale, keep the top-k logits and the
+    top-p nucleus, and sample. Greedy can loop on sampling-tuned models, so chat demos pass the model's params."""
     if temperature <= 0.0: return int(np.argmax(logits))
     lg = logits.astype(np.float64) / temperature
     if top_k and 0 < top_k < lg.size:

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -4,7 +4,7 @@ programs. Matches HF logits; see `docs/llm.md`.
 
 The runner is model-agnostic: a `LlamaConfig` carries a per-layer plan (`LayerSpec`) naming a token-mixer
 and an MLP from the builder registries below, so supporting a new architecture is an *adapter* that emits
-the plan + canonical weights — not new branches in the hot path."""
+the plan + canonical weights - not new branches in the hot path."""
 from __future__ import annotations
 from dataclasses import dataclass, field
 import numpy as np
@@ -76,8 +76,8 @@ def _repeat_kv(k: Tensor, g: int) -> Tensor:
 
 
 def _causal_attn(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
-  """Causal self-attention on q,k,v [1,H,S,dh] as the decomposed `softmax(q@kᵀ·scale + causal_mask)@v`.
-  For prefill this stays in ONE fused program (compute-bound big matmuls — what the ANE excels at);
+  """Causal self-attention on q,k,v [1,H,S,dh] as the decomposed `softmax(q@k^T*scale + causal_mask)@v`.
+  For prefill this stays in ONE fused program (compute-bound big matmuls - what the ANE excels at);
   the native fused-attention layer is avoided here because its per-layer graph cut dominates prefill cost."""
   S, dh = q.shape[2], q.shape[3]
   mask = np.triu(np.full((S, S), -1e4, np.float16), 1)     # causal: keys after the query are masked out

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -10,7 +10,6 @@ import numpy as np
 
 from .graph import input as _input, _const, concat as _concat
 from . import llm
-from .llm import _repeat_kv3
 
 
 def _rotate_matrix(dh: int, rotary_dim: int, interleaved: bool) -> np.ndarray:
@@ -42,9 +41,11 @@ def _gated_attn_decode(x, w, cfg, ls, ctx, M):
   q = (q * cosp + (q @ P) * sinp).reshape((H, 1, dh))           # matmul-rope (interleaved partial)
   k = (k * cosp + (k @ P) * sinp).reshape((KV, 1, dh))
   Kout = Kin * inv + k * oh; Vout = Vin * inv + v.reshape((KV, 1, dh)) * oh
-  Kr, Vr = _repeat_kv3(Kout, H // KV), _repeat_kv3(Vout, H // KV)
-  sc = ((q @ Kr.transpose([0, 2, 1])) * (1.0 / dh ** 0.5) + mask).softmax(-1)
-  a = (sc @ Vr).reshape((1, H * dh)) * gate.sigmoid()
+  # GQA via grouped matmul over the KV groups (query head h -> group h // g3), NOT by repeating the cache to
+  # [H, M, dh]: that path flattens to [KV, M*dh], and M*dh exceeds the ANE 65536 per-op dim cap at dh=256.
+  qg2 = q.reshape((KV, H // KV, dh))
+  sc = ((qg2 @ Kout.transpose([0, 2, 1])) * (1.0 / dh ** 0.5) + mask).softmax(-1)  # [KV, g3, M]
+  a = (sc @ Vout).reshape((1, H * dh)) * gate.sigmoid()         # [KV,g3,M] @ [KV,M,dh] -> [KV,g3,dh] -> [1, H*dh]
   return x + a.linear(w["wo"]), [(Kout, Kin), (Vout, Vin)]
 
 

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -41,8 +41,8 @@ def _gated_attn_decode(x, w, cfg, ls, ctx, M):
   q = (q * cosp + (q @ P) * sinp).reshape((H, 1, dh))           # matmul-rope (interleaved partial)
   k = (k * cosp + (k @ P) * sinp).reshape((KV, 1, dh))
   Kout = Kin * inv + k * oh; Vout = Vin * inv + v.reshape((KV, 1, dh)) * oh
-  # GQA via grouped matmul over the KV groups (query head h -> group h // g3), NOT by repeating the cache to
-  # [H, M, dh]: that path flattens to [KV, M*dh], and M*dh exceeds the ANE 65536 per-op dim cap at dh=256.
+  # GQA by grouped matmul over KV groups (head h -> group h//g3); repeating to [H,M,dh] flattens to [KV, M*dh],
+  # over the ANE 65536 per-op cap at dh=256.
   qg2 = q.reshape((KV, H // KV, dh))
   sc = ((qg2 @ Kout.transpose([0, 2, 1])) * (1.0 / dh ** 0.5) + mask).softmax(-1)  # [KV, g3, M]
   a = (sc @ Vout).reshape((1, H * dh)) * gate.sigmoid()         # [KV,g3,M] @ [KV,M,dh] -> [KV,g3,dh] -> [1, H*dh]
@@ -69,8 +69,8 @@ def _deltanet_decode(x, w, cfg, ls, ctx, M):
   v = conv.slice_by_size([0, 2 * kd], [1, vd]).reshape((nv, dv))
   beta = b.sigmoid().reshape((nv, 1, 1))
   gt = ((a + _const(w["dt_bias"])).softplus() * _const(w["neg_exp_A"])).exp().reshape((nv, 1, 1))  # exp(-exp(A_log)*softplus(a+dt))
-  # GQA k/q heads -> v heads. GGUF/llama.cpp uses ggml_repeat (tile: v-head h -> k-head h%nk); transformers
-  # uses repeat_interleave (h//g3). The two disagree, and tile is what the GGUF weights are baked for.
+  # GQA k/q -> v heads: GGUF/llama.cpp tiles (v-head h -> k-head h%nk via ggml_repeat); transformers
+  # interleaves (h//g3). They disagree; the GGUF is baked for tiling.
   eye = np.eye(nk, dtype=np.float32)
   rep = _const(np.tile(eye, (g3, 1)) if e.get("gqa_repeat") == "tile" else np.repeat(eye, g3, 0))
   q = (rep @ q).l2_norm(-1, 1e-6) * (dk ** -0.5); k = (rep @ k).l2_norm(-1, 1e-6)
@@ -125,18 +125,13 @@ def adapt(c, sd, prefix: str = ""):
 
 def load_gguf(path: str, n_layers: int | None = None, compress: str | None = None,
               resid_scale: float = 32.0) -> "llm.LlamaPrefill":
-  """Load a Qwen3.5 / Qwen3-Next hybrid GGUF (arch `qwen35`) for pure-ANE decode, dequantizing each tensor to
-  fp16. The hybrid plan (a `gated_attention` layer every `full_attention_interval`, `gated_deltanet` else) and
-  the DeltaNet dims (nk/nv/dk/dv/conv_k) are read from the GGUF metadata. The reader's `.data` is PyTorch
-  [out,in] order, so projections need no transpose. Unlike the HF `adapt`, the GGUF already bakes the (1+w)
-  RMSNorms and stores `ssm_a = -exp(A_log)`, so both are used as-is. Layers stream + free like the MoE loader
-  (64 layers fp16 ~54GB > RAM).
-
-  `resid_scale` shrinks the residual stream by a constant S to keep it in fp16 range: this 27B's deep-layer
-  activation outliers exceed fp16's 65504 max and overflow to inf (llama.cpp dodges it with fp32 activations).
-  Every read of the residual goes through a scale-invariant rms_norm (each sublayer input + the final norm),
-  so scaling `embed` and every residual-writing projection (wo, out_proj, wdown) by 1/S leaves the logits
-  unchanged while keeping the hidden state ~S smaller."""
+  """Load a Qwen3.5 / Qwen3-Next hybrid GGUF (arch `qwen35`) for pure-ANE decode. The per-layer plan
+  (`gated_attention` every `full_attention_interval`, else `gated_deltanet`) and the DeltaNet dims come from
+  the metadata; tensors dequantize to fp16 in [out,in] order (no transpose). Unlike the HF `adapt`, the GGUF
+  bakes the (1+w) RMSNorms and stores `ssm_a = -exp(A_log)`, both used as-is. Layers stream + free (64L fp16
+  ~54GB > RAM). `resid_scale` shrinks the residual by S so this 27B's deep-layer outliers stay under fp16's
+  65504; exact, since scaling `embed` + the residual-writing projections (wo, out_proj, wdown) by 1/S cancels
+  in the scale-invariant rms_norm every read goes through."""
   import gguf
   import mmap as _mmap
   from gguf.quants import dequantize
@@ -193,9 +188,8 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     _drop_mmap()
     return d
 
-  # embed is a host gather -> keep it fp16 (cast to fp16 for the ANE anyway; saves ~2.5GB resident at vocab
-  # ~248k). lm_head stays fp32: numpy has no fp16 BLAS, so an fp16 host matmul at this vocab is pathologically
-  # slow. Both embed (x1/S, to match the scaled residual) and the residual init carry the resid_scale factor.
+  # embed: host gather, fp16 (saves ~2.5GB at vocab ~248k; cast to fp16 anyway) and *S to match the residual.
+  # lm_head: fp32 (numpy has no fp16 BLAS, so an fp16 host matmul at this vocab is slow).
   w = {"embed": (get("token_embd.weight", np.float16) * S), "final_norm": get("output_norm.weight"),
        "lm_head": get("output.weight", np.float32), "layers": _LazyLayers(layer, n)}
   return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -68,7 +68,10 @@ def _deltanet_decode(x, w, cfg, ls, ctx, M):
   v = conv.slice_by_size([0, 2 * kd], [1, vd]).reshape((nv, dv))
   beta = b.sigmoid().reshape((nv, 1, 1))
   gt = ((a + _const(w["dt_bias"])).softplus() * _const(w["neg_exp_A"])).exp().reshape((nv, 1, 1))  # exp(-exp(A_log)*softplus(a+dt))
-  rep = _const(np.repeat(np.eye(nk, dtype=np.float32), g3, 0))   # GQA: nk -> nv heads
+  # GQA k/q heads -> v heads. GGUF/llama.cpp uses ggml_repeat (tile: v-head h -> k-head h%nk); transformers
+  # uses repeat_interleave (h//g3). The two disagree, and tile is what the GGUF weights are baked for.
+  eye = np.eye(nk, dtype=np.float32)
+  rep = _const(np.tile(eye, (g3, 1)) if e.get("gqa_repeat") == "tile" else np.repeat(eye, g3, 0))
   q = (rep @ q).l2_norm(-1, 1e-6) * (dk ** -0.5); k = (rep @ k).l2_norm(-1, 1e-6)
   q = q.reshape((nv, 1, dk)); k = k.reshape((nv, 1, dk)); v = v.reshape((nv, 1, dv))
   S1 = S * gt                                                    # decay first (transformers/qwen3.5)
@@ -117,3 +120,77 @@ def adapt(c, sd, prefix: str = ""):
              "dt_bias": g(d + "dt_bias"), "ssm_norm": g(d + "norm.weight"), "out_proj": g(d + "out_proj.weight")}
     w["layers"].append(lw)
   return cfg, w
+
+
+def load_gguf(path: str, n_layers: int | None = None, compress: str | None = None,
+              resid_scale: float = 32.0) -> "llm.LlamaPrefill":
+  """Load a Qwen3.5 / Qwen3-Next hybrid GGUF (arch `qwen35`) for pure-ANE decode, dequantizing each tensor to
+  fp16. The hybrid plan (a `gated_attention` layer every `full_attention_interval`, `gated_deltanet` else) and
+  the DeltaNet dims (nk/nv/dk/dv/conv_k) are read from the GGUF metadata. The reader's `.data` is PyTorch
+  [out,in] order, so projections need no transpose. Unlike the HF `adapt`, the GGUF already bakes the (1+w)
+  RMSNorms and stores `ssm_a = -exp(A_log)`, so both are used as-is. Layers stream + free like the MoE loader
+  (64 layers fp16 ~54GB > RAM).
+
+  `resid_scale` shrinks the residual stream by a constant S to keep it in fp16 range: this 27B's deep-layer
+  activation outliers exceed fp16's 65504 max and overflow to inf (llama.cpp dodges it with fp32 activations).
+  Every read of the residual goes through a scale-invariant rms_norm (each sublayer input + the final norm),
+  so scaling `embed` and every residual-writing projection (wo, out_proj, wdown) by 1/S leaves the logits
+  unchanged while keeping the hidden state ~S smaller."""
+  import gguf
+  import mmap as _mmap
+  from gguf.quants import dequantize
+  from .moe import _LazyLayers
+  r = gguf.GGUFReader(path)
+  meta = {f.name: f for f in r.fields.values()}
+  arch = next(k.split(".")[0] for k in meta if k.endswith(".block_count"))
+  def sc(key, default=None):
+    f = meta.get(arch + "." + key)
+    return f.parts[f.data[-1]][0] if f is not None else default
+  tn = {t.name: t for t in r.tensors}
+  def get(name, dtype: np.typing.DTypeLike = np.float16):       # dequantize -> fp16 (halves resident memory)
+    t = tn[name]; d = np.asarray(t.data)
+    if t.tensor_type != gguf.GGMLQuantizationType.F32:
+      d = dequantize(d, t.tensor_type)
+    return d.astype(dtype)
+
+  n_total = int(sc("block_count", 0)); n = n_total if n_layers is None else min(n_layers, n_total)
+  dim, heads = int(sc("embedding_length", 0)), int(sc("attention.head_count", 0))
+  interval = int(sc("full_attention_interval", 4)); is_attn = lambda L: (L + 1) % interval == 0
+  nk, dk, conv_k = int(sc("ssm.group_count", 0)), int(sc("ssm.state_size", 0)), int(sc("ssm.conv_kernel", 0))
+  nv = int(tn["blk.0.ssm_a"].data.shape[0]); dv = int(sc("ssm.inner_size", 0)) // nv
+  cfg = llm.LlamaConfig(
+    dim=dim, n_layers=n, n_heads=heads, n_kv_heads=int(sc("attention.head_count_kv", heads)),
+    ffn_dim=int(sc("feed_forward_length", 0)), vocab=int(tn["token_embd.weight"].data.shape[0]),
+    rope_base=float(sc("rope.freq_base", 1e4)), norm_eps=float(sc("attention.layer_norm_rms_epsilon", 1e-6)),
+    head_dim=int(sc("attention.key_length", 0)), rotary_dim=int(sc("rope.dimension_count", 0)),
+    layers=[llm.LayerSpec(mixer="gated_attention" if is_attn(L) else "gated_deltanet") for L in range(n)],
+    extra={"nk": nk, "nv": nv, "dk": dk, "dv": dv, "conv_k": conv_k, "gqa_repeat": "tile"})  # GGUF: ggml_repeat tiles
+
+  def _drop_mmap():                                             # release the GGUF's resident pages (low warmup peak)
+    mm = getattr(r.data, "_mmap", None)
+    if mm is not None:
+      try: mm.madvise(_mmap.MADV_DONTNEED)
+      except (AttributeError, OSError): pass
+
+  S = np.float16(1.0 / resid_scale)                            # residual-writing projections carry the 1/S factor
+  def layer(L):                                                # materialize one hybrid layer's fp16 weights
+    b = f"blk.{L}."
+    d = {"in_norm": get(b + "attn_norm.weight"), "mlp_norm": get(b + "post_attention_norm.weight"),
+         "wgate": get(b + "ffn_gate.weight"), "wup": get(b + "ffn_up.weight"), "wdown": get(b + "ffn_down.weight") * S}
+    if is_attn(L):
+      d |= {"wq": get(b + "attn_q.weight"), "wk": get(b + "attn_k.weight"), "wv": get(b + "attn_v.weight"),
+            "wo": get(b + "attn_output.weight") * S, "q_norm": get(b + "attn_q_norm.weight"), "k_norm": get(b + "attn_k_norm.weight")}
+    else:                                                       # GGUF: norms baked (1+w), ssm_a = -exp(A_log), conv1d [CD,K]
+      d |= {"in_proj_qkv": get(b + "attn_qkv.weight"), "in_proj_z": get(b + "attn_gate.weight"),
+            "in_proj_a": get(b + "ssm_alpha.weight"), "in_proj_b": get(b + "ssm_beta.weight"),
+            "conv1d": get(b + "ssm_conv1d.weight", np.float32), "neg_exp_A": get(b + "ssm_a", np.float32),
+            "dt_bias": get(b + "ssm_dt.bias", np.float32), "ssm_norm": get(b + "ssm_norm.weight"),
+            "out_proj": get(b + "ssm_out.weight") * S}
+    _drop_mmap()
+    return d
+
+  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no fp16 BLAS, so an fp16 lm_head at
+  # vocab ~248k makes per-token logits pathologically slow. embed carries 1/S to match the scaled residual.
+  w = {"embed": get("token_embd.weight", np.float32) / resid_scale, "final_norm": get("output_norm.weight"),
+       "lm_head": get("output.weight", np.float32), "layers": _LazyLayers(layer, n)}
+  return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -166,6 +166,9 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     head_dim=int(sc("attention.key_length", 0)), rotary_dim=int(sc("rope.dimension_count", 0)),
     layers=[llm.LayerSpec(mixer="gated_attention" if is_attn(L) else "gated_deltanet") for L in range(n)],
     extra={"nk": nk, "nv": nv, "dk": dk, "dv": dv, "conv_k": conv_k, "gqa_repeat": "tile"})  # GGUF: ggml_repeat tiles
+  gm = lambda key, d: (meta[key].parts[meta[key].data[-1]][0] if key in meta else d)   # the model's own
+  cfg.extra["sampling"] = {"temperature": float(gm("general.sampling.temp", 0.0)),     # recommended sampling
+                           "top_p": float(gm("general.sampling.top_p", 1.0)), "top_k": int(gm("general.sampling.top_k", 0))}
 
   def _drop_mmap():                                             # release the GGUF's resident pages (low warmup peak)
     mm = getattr(r.data, "_mmap", None)
@@ -190,8 +193,9 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     _drop_mmap()
     return d
 
-  # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no fp16 BLAS, so an fp16 lm_head at
-  # vocab ~248k makes per-token logits pathologically slow. embed carries 1/S to match the scaled residual.
-  w = {"embed": get("token_embd.weight", np.float32) / resid_scale, "final_norm": get("output_norm.weight"),
+  # embed is a host gather -> keep it fp16 (cast to fp16 for the ANE anyway; saves ~2.5GB resident at vocab
+  # ~248k). lm_head stays fp32: numpy has no fp16 BLAS, so an fp16 host matmul at this vocab is pathologically
+  # slow. Both embed (×1/S, to match the scaled residual) and the residual init carry the resid_scale factor.
+  w = {"embed": (get("token_embd.weight", np.float16) * S), "final_norm": get("output_norm.weight"),
        "lm_head": get("output.weight", np.float32), "layers": _LazyLayers(layer, n)}
   return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -195,7 +195,7 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
 
   # embed is a host gather -> keep it fp16 (cast to fp16 for the ANE anyway; saves ~2.5GB resident at vocab
   # ~248k). lm_head stays fp32: numpy has no fp16 BLAS, so an fp16 host matmul at this vocab is pathologically
-  # slow. Both embed (×1/S, to match the scaled residual) and the residual init carry the resid_scale factor.
+  # slow. Both embed (x1/S, to match the scaled residual) and the residual init carry the resid_scale factor.
   w = {"embed": (get("token_embd.weight", np.float16) * S), "final_norm": get("output_norm.weight"),
        "lm_head": get("output.weight", np.float32), "layers": _LazyLayers(layer, n)}
   return llm.LlamaPrefill(cfg, w, compress=compress)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -102,13 +102,25 @@ only by compile-time RAM on a 52 GB machine (it fits and runs on more).
 
 Qwen3.5 / Qwen3-Next interleave gated **DeltaNet** (linear-attention) layers with gated full-attention
 layers. Both mixers run on the ANE: DeltaNet carries a resident causal-conv state and a recurrent
-`[heads, dk, dv]` state across decode steps (a decay-first recurrence), validated fp16-safe on-device
-(cosine 0.999999 over 512 tokens). A per-layer plan (`LayerSpec`) names the mixer for each layer, so
-the runner stays architecture-agnostic — it dispatches on the plan, not the weight shapes.
+`[heads, dk, dv]` state across decode steps (a decay-first recurrence); attention carries the usual
+resident KV cache. A per-layer plan (`LayerSpec`) names the mixer for each layer, so the runner stays
+architecture-agnostic — it dispatches on the plan, not the weight shapes.
 
-Caveat: llama.cpp **permutes** the DeltaNet weights in its GGUF export, so reconstructing the model
-from a Qwen3.5 GGUF is wrong. The forward is validated against the original safetensors (cosine 1.0 vs
-transformers), not the GGUF.
+The real **Qwen3.5-27B** (64 layers, 48 DeltaNet + 16 attention) decodes coherently end-to-end on a pure
+ANE from its GGUF at int8 — no host fallback:
+
+```python
+from aneforge.qwen35 import load_gguf
+m = load_gguf("~/Models/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q4_K_M.gguf", compress="int8")
+m.warmup(512)                       # compiles the segmented decode (cached under ~/Models)
+print(m.generate(prompt_ids, max_new_tokens=64))
+```
+
+`examples/qwen35_chat.py` is an interactive chat over this loader. The forward matches llama.cpp's logits
+exactly (correlation 1.0 at every position). Two details are specific to the GGUF: the DeltaNet GQA
+key/query heads tile onto the value heads (`ggml_repeat`, not `repeat_interleave` — they disagree, and the
+GGUF is baked for tiling), and the residual stream is scaled by a constant to keep fp16 from overflowing on
+this model's large deep-layer activations (exact, since every read goes through a scale-invariant RMSNorm).
 
 ## What's inside
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -116,11 +116,20 @@ m.warmup(512)                       # compiles the segmented decode (cached unde
 print(m.generate(prompt_ids, max_new_tokens=64))
 ```
 
-`examples/qwen35_chat.py` is an interactive chat over this loader. The forward matches llama.cpp's logits
-exactly (correlation 1.0 at every position). Two details are specific to the GGUF: the DeltaNet GQA
-key/query heads tile onto the value heads (`ggml_repeat`, not `repeat_interleave` — they disagree, and the
-GGUF is baked for tiling), and the residual stream is scaled by a constant to keep fp16 from overflowing on
-this model's large deep-layer activations (exact, since every read goes through a scale-invariant RMSNorm).
+`examples/qwen35_chat.py` is an interactive chat over this loader. Two details are specific to the GGUF:
+the DeltaNet GQA key/query heads tile onto the value heads (`ggml_repeat`, not `repeat_interleave` — they
+disagree, and the GGUF is baked for tiling), and the residual stream is scaled by a constant to keep fp16
+from overflowing on this model's large deep-layer activations (exact, since every read goes through a
+scale-invariant RMSNorm).
+
+**Fidelity caveat.** The loader was validated by an **fp32 reference forward** that matches llama.cpp's
+logits exactly (correlation 1.0 at every position). The on-device decode, however, runs **int8 weights in
+fp16 compute**, and at 27B that is *coherent but lower-fidelity* than llama.cpp's fp32-accumulated Q4 —
+answers to harder prompts come out shallower. The cause is the fp16 compute, not the weights (per-channel
+int8 weights alone cost ~0.0001 of logit correlation); this model's large activation outliers make it
+fp16-precision-bound at this depth. No quantization setting closes the gap: `compress="blockwise"` adds
+per-block scales but only marginally helps and compiles far slower (Apple's ANE compiler is slow on the
+per-block ops). Treat on-ANE 27B decode as a working proof, not a llama.cpp-quality chat endpoint.
 
 ## What's inside
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -1,6 +1,6 @@
 # LLMs on the ANE
 
-ANEForge runs decoder LLMs on the Apple Neural Engine — prefill and KV-cache decode, from Hugging
+ANEForge runs decoder LLMs on the Apple Neural Engine - prefill and KV-cache decode, from Hugging
 Face weights or GGUF, as fused ANE programs. Beyond dense Llama/Qwen, it runs sparse Mixture-of-Experts
 and hybrid DeltaNet+attention models, with quantization and exact speculative decoding (sections below).
 
@@ -18,11 +18,11 @@ text_ids = model.generate(prompt_ids, max_new_tokens=24)
 logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 ```
 
-- `af.load_llm(name, compress=None)` — load an HF Llama/Qwen model for ANE inference.
+- `af.load_llm(name, compress=None)` - load an HF Llama/Qwen model for ANE inference.
   `compress="int8"`/`"int4"` quantizes the weights (see below).
-- `model.generate(ids, max_new_tokens, eos_id)` — greedy generation on the ANE.
-- `model.prefill(ids)` — prefill only; returns next-token logits.
-- `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` — build from numpy weights directly.
+- `model.generate(ids, max_new_tokens, eos_id)` - greedy generation on the ANE.
+- `model.prefill(ids)` - prefill only; returns next-token logits.
+- `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` - build from numpy weights directly.
   `af.rope` / `af.prefill_block` are the building blocks.
 
 ## Prefill and decode
@@ -32,11 +32,11 @@ layer's K/V stays on the ANE across steps via `share_buffer`, so a decode step f
 token's embedding and a position one-hot. The decode program compiles once and is reused.
 
 A single ANE program holds ~2 GB of baked weights, so for larger models the layers are split into
-chunks under that ceiling; each chunk keeps its KV resident and the hidden state chains chunk →
-chunk (a `[1, dim]` round-trip). This is automatic — Qwen3-0.6B is one chunk; Qwen3-8B is nine.
+chunks under that ceiling; each chunk keeps its KV resident and the hidden state chains chunk ->
+chunk (a `[1, dim]` round-trip). This is automatic - Qwen3-0.6B is one chunk; Qwen3-8B is nine.
 
 On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode. On Qwen3-8B (36 layers, 16 GB fp16,
-9 chunks): ~7.5 tok/s decode. Both produce correct text — e.g. *"The capital of France is"* →
+9 chunks): ~7.5 tok/s decode. Both produce correct text - e.g. *"The capital of France is"* ->
 *"Paris. The capital of Italy is Rome. The capital of Spain is Madrid. ..."*
 
 `examples/llm_chat.py` is an interactive streaming chat; `examples/llm_prefill.py` is a benchmark
@@ -45,8 +45,8 @@ On Qwen3-0.6B: ~8,600 prompt-tok/s prefill, ~75 tok/s decode. On Qwen3-8B (36 la
 ## Speculative decoding
 
 A small *draft* model proposes K tokens; the large *target* verifies all K in a single forward. This
-is a natural fit for the ANE: decode is latency-bound, so `verify(K) ≈ verify(1)` — measured 1.05× for
-K=5 on Qwen3-8B — and the draft's proposals are checked almost for free. The output is **exact**: the
+is a natural fit for the ANE: decode is latency-bound, so `verify(K) ~ verify(1)` - measured 1.05x for
+K=5 on Qwen3-8B - and the draft's proposals are checked almost for free. The output is **exact**: the
 same tokens plain greedy decode would produce.
 
 ```python
@@ -54,23 +54,23 @@ from aneforge.speculative import spec_generate
 out = spec_generate(target, draft, prompt_ids, max_new_tokens=40)   # target, draft = af.load_llm(...)
 ```
 
-Measured 2.28× on Qwen3-8B with a Qwen3-0.6B draft (7.4 → 16.8 tok/s), using a tiled on-ANE lm_head.
-Profiling one round: ~64% is the target verify (a single 8B forward — the irreducible floor), ~36% the
+Measured 2.28x on Qwen3-8B with a Qwen3-0.6B draft (7.4 -> 16.8 tok/s), using a tiled on-ANE lm_head.
+Profiling one round: ~64% is the target verify (a single 8B forward - the irreducible floor), ~36% the
 draft, and ~0 orchestration overhead. `examples/spec_chat.py` is an interactive speculative chat.
 
 ## Quantized weights
 
 `compress="int8"` quantizes the ANE matmul weights to per-channel int8 (`"int4"` = 4-bit LUT),
-dequantized on the ANE — halving (int8) or quartering (int4) the weight bytes. Measured honestly,
+dequantized on the ANE - halving (int8) or quartering (int4) the weight bytes. Measured honestly,
 the tradeoffs are narrow:
 
 - Speed: roughly neutral. Decode is latency-bound (the ANE's array is idle at one token/step), not
-  weight-bandwidth-bound, so fewer weight bytes barely move tok/s — Qwen3-8B was 7.9 (int8) vs 7.5
+  weight-bandwidth-bound, so fewer weight bytes barely move tok/s - Qwen3-8B was 7.9 (int8) vs 7.5
   (fp16) tok/s, with *fewer* chunks.
 - Accuracy: faithful on small models (Qwen3-0.6B int8 is byte-identical to fp16) but per-channel
-  int8 degrades deep models — Qwen3-8B int8 collapses into repetition. Run large models in fp16.
+  int8 degrades deep models - Qwen3-8B int8 collapses into repetition. Run large models in fp16.
 - Memory: the one real win (half the weight bytes). But fp16 + segmented decode already fits models
-  up to RAM, so int8 only matters for weights that exceed RAM in fp16 — and the accuracy has to be
+  up to RAM, so int8 only matters for weights that exceed RAM in fp16 - and the accuracy has to be
   solved first. The robust path is quantized *storage* dequantized to fp16 *compute* (not int8
   compute), which this option does not yet do.
 
@@ -78,7 +78,7 @@ Pass `--int8` to the examples to try it (best on small models).
 
 ## Mixture-of-Experts
 
-Sparse MoE decoders run from a GGUF — Qwen3-MoE (e.g. 30B-A3B) and Qwen2-MoE (e.g. Qwen1.5-MoE-A2.7B):
+Sparse MoE decoders run from a GGUF - Qwen3-MoE (e.g. 30B-A3B) and Qwen2-MoE (e.g. Qwen1.5-MoE-A2.7B):
 
 ```python
 from aneforge.moe import load_gguf
@@ -93,9 +93,9 @@ math matches HF `Qwen3MoeForCausalLM` (cosine >0.99), and the full 24-layer Qwen
 coherently end-to-end on the ANE at int8 (~2 tok/s). `examples/moe_chat.py` is an interactive MoE chat.
 
 Unlike the dense 8B, MoE decode at 30B scale is **weight-bandwidth-bound**: ~13.5 ms per MoE layer
-(~89 GB/s), because each token reads all of the experts' weights. So here int8 *does* help (~1.3×), and
-the experts' sparsity (4–8 of 60–128 active) is the real lever — but exploiting it needs a host-side
-FFN split (measured ~4.6× in a prototype), not the dense on-ANE path. The 30B-A3B is currently gated
+(~89 GB/s), because each token reads all of the experts' weights. So here int8 *does* help (~1.3x), and
+the experts' sparsity (4-8 of 60-128 active) is the real lever - but exploiting it needs a host-side
+FFN split (measured ~4.6x in a prototype), not the dense on-ANE path. The 30B-A3B is currently gated
 only by compile-time RAM on a 52 GB machine (it fits and runs on more).
 
 ## Hybrid models (Qwen3.5)
@@ -104,10 +104,10 @@ Qwen3.5 / Qwen3-Next interleave gated **DeltaNet** (linear-attention) layers wit
 layers. Both mixers run on the ANE: DeltaNet carries a resident causal-conv state and a recurrent
 `[heads, dk, dv]` state across decode steps (a decay-first recurrence); attention carries the usual
 resident KV cache. A per-layer plan (`LayerSpec`) names the mixer for each layer, so the runner stays
-architecture-agnostic — it dispatches on the plan, not the weight shapes.
+architecture-agnostic - it dispatches on the plan, not the weight shapes.
 
 The real **Qwen3.5-27B** (64 layers, 48 DeltaNet + 16 attention) decodes coherently end-to-end on a pure
-ANE from its GGUF at int8 — no host fallback:
+ANE from its GGUF at int8 - no host fallback:
 
 ```python
 from aneforge.qwen35 import load_gguf
@@ -117,39 +117,37 @@ print(m.generate(prompt_ids, max_new_tokens=64))
 ```
 
 `examples/qwen35_chat.py` is an interactive chat over this loader. Two details are specific to the GGUF:
-the DeltaNet GQA key/query heads tile onto the value heads (`ggml_repeat`, not `repeat_interleave` — they
+the DeltaNet GQA key/query heads tile onto the value heads (`ggml_repeat`, not `repeat_interleave` - they
 disagree, and the GGUF is baked for tiling), and the residual stream is scaled by a constant to keep fp16
 from overflowing on this model's large deep-layer activations (exact, since every read goes through a
 scale-invariant RMSNorm).
 
-**Fidelity caveat.** The loader was validated by an **fp32 reference forward** that matches llama.cpp's
-logits exactly (correlation 1.0 at every position). The on-device decode, however, runs **int8 weights in
-fp16 compute**, and at 27B that is *coherent but lower-fidelity* than llama.cpp's fp32-accumulated Q4 —
-answers to harder prompts come out shallower. The cause is the fp16 compute, not the weights (per-channel
-int8 weights alone cost ~0.0001 of logit correlation); this model's large activation outliers make it
-fp16-precision-bound at this depth. No quantization setting closes the gap: `compress="blockwise"` adds
-per-block scales but only marginally helps and compiles far slower (Apple's ANE compiler is slow on the
-per-block ops). Treat on-ANE 27B decode as a working proof, not a llama.cpp-quality chat endpoint.
+Fidelity: an fp32 reference forward matches llama.cpp's logits exactly (correlation 1.0 at every position),
+but the on-device int8-weight/fp16-compute decode is coherent yet lower-fidelity than llama.cpp's
+fp32-accumulated Q4 - harder prompts come out shallower. The cost is the fp16 compute, not the weights:
+per-channel int8 weights alone move the logit correlation by ~0.0001, but this model's large deep-layer
+activation outliers leave it fp16-bound at this depth. `compress="blockwise"` adds per-block scales but
+helps little and compiles much slower.
 
 ## What's inside
 
 A pre-norm Llama/Qwen decoder block on the ANE:
-`RMSNorm → QKV → RoPE → grouped-query causal attention → SwiGLU MLP`, with residuals.
+`RMSNorm -> QKV -> RoPE -> grouped-query causal attention -> SwiGLU MLP`, with residuals.
 
-- RoPE: `x·cos + rotate_half(x)·sin`, from sin/cos/slice/concat (no new hardware op).
+- RoPE: `x*cos + rotate_half(x)*sin`, from sin/cos/slice/concat (no new hardware op).
 - GQA: KV heads repeated to the query-head count via a 0/1 expansion matmul.
-- Causal attention: decomposed `softmax(Q@Kᵀ·scale + mask)@V` in one fused program. The native
-  fused-attention op is avoided for prefill — its per-layer graph cut dominates, and the
-  big-matmul path is ~170× faster.
+- Causal attention: decomposed `softmax(Q@K^T*scale + mask)@V` in one fused program. The native
+  fused-attention op is avoided for prefill - its per-layer graph cut dominates, and the
+  big-matmul path is ~170x faster.
 
 ## Correctness
 
-Prefill matches Hugging Face's forward pass — next-token logits at cosine ~1.0 and identical
-argmax — validated on-device (`tests/test_llm.py`). On Qwen3-0.6B (28 layers), *"The capital of
-France is"* → *" Paris"*, the token HF predicts.
+Prefill matches Hugging Face's forward pass - next-token logits at cosine ~1.0 and identical
+argmax - validated on-device (`tests/test_llm.py`). On Qwen3-0.6B (28 layers), *"The capital of
+France is"* -> *" Paris"*, the token HF predicts.
 
-Qwen3 specifics handled: a separate `head_dim` (≠ `dim/n_heads`), QK-norm (per-head RMSNorm on Q/K
-before RoPE), and a large vocab — the layers run on the ANE; the lm_head projection runs on host
+Qwen3 specifics handled: a separate `head_dim` (!= `dim/n_heads`), QK-norm (per-head RMSNorm on Q/K
+before RoPE), and a large vocab - the layers run on the ANE; the lm_head projection runs on host
 (the vocab can exceed the ANE's per-op dimension limit).
 
 ## Scope

--- a/examples/qwen35_chat.py
+++ b/examples/qwen35_chat.py
@@ -51,8 +51,8 @@ def main():
   tokdir = sys.argv[2] if len(sys.argv) > 2 else _tokenizer_dir(gguf)
   if not tokdir:
     print(f"no tokenizer found next to {gguf}; pass a tokenizer dir (with tokenizer.json) as the 2nd arg"); return 1
-  compress = os.environ.get("ANEFORGE_COMPRESS", "int8")    # "blockwise" = per-block int8 scales, higher fidelity than
-  print(f"loading {os.path.basename(gguf)} ({compress}, ANE) ...")   # plain per-channel int8 (~same memory, ~6% scale overhead)
+  compress = os.environ.get("ANEFORGE_COMPRESS", "int8")    # "blockwise" = per-block int8 scales (~same memory)
+  print(f"loading {os.path.basename(gguf)} ({compress}, ANE) ...")
   m = load_gguf(gguf, compress=compress)
   m._chunk_bytes = 1.0e9                          # a couple of hybrid layers per program (under the ~2GB ANE ceiling)
   from transformers import AutoTokenizer

--- a/examples/qwen35_chat.py
+++ b/examples/qwen35_chat.py
@@ -62,6 +62,8 @@ def main():
   m.warmup(MAX_LEN)
   imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
   eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
+  samp = m.cfg.extra.get("sampling", {})                    # the model's own recommended sampling (from the GGUF);
+  if not samp.get("temperature"): samp = {"temperature": 0.6, "top_p": 0.95, "top_k": 20}  # greedy loops, so sample
   print(" done.")
   print("type a message (Ctrl-D or 'exit' to quit). full hybrid model, decoding on the ANE.\n")
 
@@ -78,6 +80,7 @@ def main():
     print("ane> ", end="", flush=True)
     n = [0]; t0 = time.perf_counter()
     m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos,
+               temperature=samp["temperature"], top_p=samp.get("top_p", 1.0), top_k=samp.get("top_k", 0),
                on_token=lambda t: (n.__setitem__(0, n[0] + 1), print(tok.decode([t]), end="", flush=True)))
     dt = time.perf_counter() - t0
     print(f"\n   [{n[0]} tokens, {n[0] / dt:.1f} tok/s on the ANE]\n")

--- a/examples/qwen35_chat.py
+++ b/examples/qwen35_chat.py
@@ -51,8 +51,9 @@ def main():
   tokdir = sys.argv[2] if len(sys.argv) > 2 else _tokenizer_dir(gguf)
   if not tokdir:
     print(f"no tokenizer found next to {gguf}; pass a tokenizer dir (with tokenizer.json) as the 2nd arg"); return 1
-  print(f"loading {os.path.basename(gguf)} (int8, ANE) ...")
-  m = load_gguf(gguf, compress="int8")
+  compress = os.environ.get("ANEFORGE_COMPRESS", "int8")    # "blockwise" = per-block int8 scales, higher fidelity than
+  print(f"loading {os.path.basename(gguf)} ({compress}, ANE) ...")   # plain per-channel int8 (~same memory, ~6% scale overhead)
+  m = load_gguf(gguf, compress=compress)
   m._chunk_bytes = 1.0e9                          # a couple of hybrid layers per program (under the ~2GB ANE ceiling)
   from transformers import AutoTokenizer
   tok = AutoTokenizer.from_pretrained(tokdir)

--- a/examples/qwen35_chat.py
+++ b/examples/qwen35_chat.py
@@ -1,0 +1,88 @@
+"""Interactive chat with a Qwen3.5 / Qwen3-Next hybrid model decoding ENTIRELY on the ANE. Loads a qwen35-arch
+GGUF (e.g. Qwen3.5-27B) at int8 and runs the full hybrid stack -- interleaved gated-DeltaNet (linear-attention)
+and gated full-attention layers -- as a segmented decode (a few layers per program); the first run compiles the
+chunks (cached under ~/Models).
+
+Run: python3 examples/qwen35_chat.py [gguf-path] [tokenizer-dir]
+  e.g. python3 examples/qwen35_chat.py ~/Models/Qwen3.5-27B-GGUF/Qwen3.5-27B-Q4_K_M.gguf
+No gguf-path picks the smallest qwen35 GGUF under ~/Models. The tokenizer is read from the sibling HF directory
+(the GGUF dir minus '-GGUF'), since transformers can't yet build the tokenizer from a qwen35 GGUF; override with
+a 2nd arg pointing at any directory holding tokenizer.json + chat_template."""
+import glob
+import os
+import sys
+import time
+
+import _common   # noqa: F401 - sets env + repo-root path; import before aneforge
+from aneforge.qwen35 import load_gguf
+
+MAX_LEN = 512
+
+
+def _default_gguf():
+  hits = glob.glob(os.path.expanduser("~/Models/*[Qq]wen3*-GGUF/*.gguf"))
+  hits = [h for h in hits if "incomplete" not in h]
+  return min(hits, key=os.path.getsize) if hits else None      # smallest = most likely to fit + compile fast
+
+
+def _tokenizer_dir(gguf):
+  """The HF tokenizer dir for a GGUF: the GGUF's parent with '-GGUF' stripped (Qwen3.5-27B-GGUF -> Qwen3.5-27B)."""
+  d = os.path.dirname(gguf)
+  cand = d[:-5] if d.endswith("-GGUF") else d
+  return cand if os.path.exists(os.path.join(cand, "tokenizer.json")) else None
+
+
+def _encode(tok, prompt):
+  """Apply the chat template (no 'thinking' block); returns a list of token ids."""
+  msgs = [{"role": "user", "content": prompt}]
+  try:
+    r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
+  except TypeError:
+    r = tok.apply_chat_template(msgs, add_generation_prompt=True)
+  if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]
+  if r and isinstance(r[0], (list, tuple)): r = r[0]
+  return [int(t) for t in r]
+
+
+def main():
+  gguf = sys.argv[1] if len(sys.argv) > 1 else _default_gguf()
+  if not gguf:
+    print("usage: python3 examples/qwen35_chat.py <gguf-path> [tokenizer-dir]  (no qwen3* GGUF found under ~/Models)"); return 1
+  tokdir = sys.argv[2] if len(sys.argv) > 2 else _tokenizer_dir(gguf)
+  if not tokdir:
+    print(f"no tokenizer found next to {gguf}; pass a tokenizer dir (with tokenizer.json) as the 2nd arg"); return 1
+  print(f"loading {os.path.basename(gguf)} (int8, ANE) ...")
+  m = load_gguf(gguf, compress="int8")
+  m._chunk_bytes = 1.0e9                          # a couple of hybrid layers per program (under the ~2GB ANE ceiling)
+  from transformers import AutoTokenizer
+  tok = AutoTokenizer.from_pretrained(tokdir)
+  e = m.cfg.extra
+  print(f"{m.cfg.n_layers}L dim {m.cfg.dim}, {e['nv']} DeltaNet value-heads, {m.cfg.n_heads}/{m.cfg.n_kv_heads} attn heads. "
+        f"compiling {len(m._layer_chunks())} chunks (one-time; cached under ~/Models) ...", end="", flush=True)
+  m.warmup(MAX_LEN)
+  imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
+  eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
+  print(" done.")
+  print("type a message (Ctrl-D or 'exit' to quit). full hybrid model, decoding on the ANE.\n")
+
+  while True:
+    try:
+      prompt = input("you> ").strip()
+    except EOFError:
+      print(); break
+    if not prompt: continue
+    if prompt in ("exit", "quit"): break
+    ids = _encode(tok, prompt)
+    if len(ids) >= MAX_LEN - 32:
+      print("ane> (prompt too long for the demo context)\n"); continue
+    print("ane> ", end="", flush=True)
+    n = [0]; t0 = time.perf_counter()
+    m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos,
+               on_token=lambda t: (n.__setitem__(0, n[0] + 1), print(tok.decode([t]), end="", flush=True)))
+    dt = time.perf_counter() - t0
+    print(f"\n   [{n[0]} tokens, {n[0] / dt:.1f} tok/s on the ANE]\n")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
## What

`aneforge.qwen35.load_gguf` loads a Qwen3.5 / Qwen3-Next hybrid GGUF (64 layers:
48 gated-DeltaNet linear-attention + 16 gated full-attention, full_attention_interval=4)
and runs the whole model as a segmented int8 decode on the ANE. Adds `examples/qwen35_chat.py`.

The real Qwen3.5-27B decodes coherently end-to-end on a pure ANE from its GGUF, no host
fallback. The fp32 reference forward matches llama.cpp's logits exactly (correlation 1.0 at
every position).

## Fixes (found by diffing op-by-op against llama.cpp's eval-callback)

- DeltaNet GQA head mapping: the GGUF is baked for `ggml_repeat` (tile: v-head h -> k-head
  h%nk), not `repeat_interleave` (h//g3, transformers' convention). They disagree; tile is
  correct, and this was the garbage->coherent fix. Validating against transformers could not
  catch it (HF shares the interleave choice); llama.cpp is the only independent reference.
- resid_scale: this 27B's deep-layer activation outliers exceed fp16 65504 and overflow to
  inf. Scaling the residual stream is exact (every read goes through a scale-invariant
  RMSNorm) and keeps it in range.
- M=512 compile: gated-attention GQA now uses a grouped matmul; the prior [H, M, dh] repeat
  flattened to M*dh, over the ANE 65536 per-op dim cap at head_dim 256 (Qwen3-8B's dh=128
  lands exactly at the cap, so the dense path never tripped it).
- Sampling: generate() gains optional temperature/top_p/top_k (greedy argmax by default, so
  existing callers are unchanged); the example uses the model's own recommended
  temp 0.6 / top_p 0.95 / top_k 20 (pure greedy loops on this model).

## Fidelity

On-device int8 weights + fp16 compute is coherent but lower-fidelity than llama.cpp's
fp32-accumulated Q4 at this scale - harder prompts come out shallower. The cost is the fp16
compute, not the weights (per-channel int8 weights alone move logit correlation by ~0.0001).
Documented in docs/llm.md and the README table.

## Gates

tests/test_qwen35.py passes (mixers match transformers), ruff clean, pyright 0/0/0 on
aneforge/, mkdocs --strict builds.