### PR TITLE
docs(site): surface LLMs on the landing page and README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ private `aned` stack CoreML, MPSGraph, and Espresso use internally. From there:
 - A CNN trains from scratch on CIFAR-10 to 71%, on a chip Apple ships for inference only.
 - **Hardware layers CoreML can't reach.** `af.sdpa` drives the engine's fused-attention layer directly, the one Apple's compiler decomposes and never emits; 18 other native layers (`argmax`, `topk`, `sort`, geometry) come the same way.
 - **The engine, never a fallback.** A pretrained ResNet-18 runs end-to-end in 0.33 ms, matching the reference to cosine 1.0000, at a fraction of the GPU's energy (table below).
+- **LLMs run on the engine.** Prefill and KV-cache decode for Llama/Qwen, exact speculative decoding, Mixture-of-Experts from GGUF, and the hybrid Qwen3.5-27B (DeltaNet + attention), decoding end to end on a pure ANE.
 - **Cross-compilation for chips you don't own.** Lower and gate a graph for any of 28 ANE targets (M1-M5) from one machine, and estimate its latency without running it.
 
 ```python

--- a/web/index.html
+++ b/web/index.html
@@ -228,12 +228,16 @@ vec = <span class="af">enc</span>(tokens)                 <span class="c"># cosi
   <section id="what">
     <div class="wrap">
       <span class="label">What it does</span>
-      <h2 style="margin-top:10px">Training, native layers, compression, and arbitrary workloads.</h2>
+      <h2 style="margin-top:10px">Training, LLMs, native layers, compression, and more.</h2>
       <p class="sub">Apple exposes the Neural Engine only through CoreML, and only for inference. ANEForge dispatches through the same private <code>aned</code> stack that CoreML uses internally, from a normal user process.</p>
       <div class="caps">
         <div class="cap">
           <h4>Training runs on the engine <em>CIFAR-10 → 71%</em></h4>
           <p>The forward pass, backward pass, and Adam update all compile to ANE programs, so a model trains end to end on the engine.</p>
+        </div>
+        <div class="cap">
+          <h4>LLMs on the engine <em>27B on a pure ANE</em></h4>
+          <p>Prefill and KV-cache decode for Llama/Qwen, exact speculative decoding, Mixture-of-Experts from GGUF, and the hybrid Qwen3.5-27B (DeltaNet + attention), decoding end to end on the engine.</p>
         </div>
         <div class="cap">
           <h4>Layers CoreML can’t reach <em>+19 bridge ops</em></h4>
@@ -246,6 +250,10 @@ vec = <span class="af">enc</span>(tokens)                 <span class="c"># cosi
         <div class="cap">
           <h4>Run arbitrary workloads <em>FFT, BLAS</em></h4>
           <p>Not just neural nets. FFTs, linear algebra, and fluid sims compile straight to the engine.</p>
+        </div>
+        <div class="cap">
+          <h4>Cross-compile across silicon <em>28 targets</em></h4>
+          <p>Lower and gate a graph for any M1 to M5 ANE from one machine, and estimate its latency without running it.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
0.2.0 brought LLMs to the ANE (prefill/decode, speculative, MoE, hybrid Qwen3.5-27B),
but the aneforge.com caps grid and the README hero did not mention them.

- web/index.html: add an "LLMs on the engine" capability card (slotted 2nd, after Training),
  plus a "Cross-compile across silicon" card so the 2-column grid stays a clean 2x3. Section
  heading updated to "Training, LLMs, native layers, compression, and more."
- README.md: one hero bullet for LLMs on the engine.

Copy only; ASCII; no behavior change. The site deploys from web/ only on merge to main
(pages.yml), so this PR does not deploy until merged - review the rendered card first by
opening web/index.html locally.