### PR TITLE
chore: code-quality sweep (dedup, hardening, test coverage)

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ private `aned` stack CoreML, MPSGraph, and Espresso use internally. From there:
 - A CNN trains from scratch on CIFAR-10 to 71%, on a chip Apple ships for inference only.
 - **Hardware layers CoreML can't reach.** `af.sdpa` drives the engine's fused-attention layer directly, the one Apple's compiler decomposes and never emits; 18 other native layers (`argmax`, `topk`, `sort`, geometry) come the same way.
 - **The engine, never a fallback.** A pretrained ResNet-18 runs end-to-end in 0.33 ms, matching the reference to cosine 1.0000, at a fraction of the GPU's energy (table below).
+- **LLMs run on the engine.** Prefill and KV-cache decode for Llama/Qwen, exact speculative decoding, Mixture-of-Experts from GGUF, and the hybrid Qwen3.5-27B (DeltaNet + attention), decoding end to end on a pure ANE.
 - **Cross-compilation for chips you don't own.** Lower and gate a graph for any of 28 ANE targets (M1-M5) from one machine, and estimate its latency without running it.
 
 ```python

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -75,6 +75,7 @@ class _Emitter:
       self._auto_streams = frozenset({"int4", "int8", "sparse", "blockwise"})
     self.blob = BlobWriter()
     self.lines: list[str] = []
+    self._split_cache: dict = {}       # (src, num_splits, axis) -> emitted part names, so split is emitted once
 
   def line(self, text: str) -> None:
     self.lines.append("        " + text)
@@ -529,15 +530,15 @@ def _e_split(em, t, n, s):
   # emit the N-output split once; later split nodes alias its ports by name.
   ns, ax, which = t.attrs["num_splits"], t.attrs["axis"], t.attrs["which"]
   src = s[0]
-  key = f"_split_{src}_{ns}_{ax}"
-  names = getattr(em, key, None)
+  key = (src, ns, ax)
+  names = em._split_cache.get(key)
   if names is None:
     names = [f"{n}_part{i}" for i in range(ns)]
     decl = ", ".join(f"{em.ty(t.shape)} {names[i]}" for i in range(ns))
     em.line(f'int32 {n}_ns = const()[name = string("{n}_ns"), val = int32({ns})];')
     em.line(f'int32 {n}_ax = const()[name = string("{n}_ax"), val = int32({ax})];')
     em.line(f'{decl} = split(axis = {n}_ax, num_splits = {n}_ns, x = {src})[name = string("{n}_split")];')
-    setattr(em, key, names)
+    em._split_cache[key] = names
   t._name = names[which]
 
 

--- a/aneforge/_gguf.py
+++ b/aneforge/_gguf.py
@@ -1,0 +1,46 @@
+"""Shared GGUF reader helpers for the model loaders (moe, qwen35). `GGUFView` opens a GGUF once and exposes
+the accessors both loaders need: arch-scoped scalar metadata, raw fields by full key, tensors by name,
+dequantize-to-fp16, and an mmap page-dropper to keep the warmup memory peak low."""
+from __future__ import annotations
+import mmap as _mmap
+from typing import Any
+import numpy as np
+
+
+class GGUFView:
+  """A thin view over a `gguf.GGUFReader`. `arch` is the model architecture (the `*.block_count` prefix)."""
+  def __init__(self, path: str):
+    import gguf
+    from gguf.quants import dequantize
+    self._F32 = gguf.GGMLQuantizationType.F32
+    self._dequant = dequantize
+    self.reader = r = gguf.GGUFReader(path)
+    self.meta = {f.name: f for f in r.fields.values()}
+    self.arch = next(k.split(".")[0] for k in self.meta if k.endswith(".block_count"))
+    self.tn = {t.name: t for t in r.tensors}
+
+  def field(self, key, default=None) -> Any:
+    """A raw scalar metadata field by FULL key (e.g. 'general.sampling.temp'); `default` if absent."""
+    f = self.meta.get(key)
+    return f.parts[f.data[-1]][0] if f is not None else default
+
+  def sc(self, key, default=None) -> Any:
+    """An arch-scoped scalar field: `field` with the 'arch.' prefix added (e.g. sc('block_count'))."""
+    return self.field(self.arch + "." + key, default)
+
+  def has(self, name: str) -> bool:
+    return name in self.tn
+
+  def get(self, name: str, dtype: np.typing.DTypeLike = np.float16) -> np.ndarray:
+    """Dequantize tensor `name` to a numpy array of `dtype` (fp16 by default, to halve resident memory)."""
+    t = self.tn[name]; d = np.asarray(t.data)
+    if t.tensor_type != self._F32:
+      d = self._dequant(d, t.tensor_type)
+    return d.astype(dtype)
+
+  def drop_pages(self) -> None:
+    """madvise(DONTNEED) the GGUF mmap so the dequantized layers don't also pin the raw file in RAM."""
+    mm = getattr(self.reader.data, "_mmap", None)
+    if mm is not None:
+      try: mm.madvise(_mmap.MADV_DONTNEED)
+      except (AttributeError, OSError): pass

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -81,15 +81,20 @@ def _load_cache() -> dict:
   p = _cache_path()
   if p.exists():
     try: return json.loads(p.read_text())
-    except Exception: return {}
+    except Exception as e:
+      warnings.warn(f"autotune cache unreadable, ignoring it: {e}")     # a truncated file must not poison every run
+      return {}
   return {}
 
 
 def _save_cache(cache: dict) -> None:
+  p = _cache_path()
   try:
-    _cache_path().write_text(json.dumps(cache, indent=2, sort_keys=True))
-  except Exception:
-    pass
+    tmp = p.with_suffix(".json.tmp")                                    # write-then-rename: a crash can't truncate the cache
+    tmp.write_text(json.dumps(cache, indent=2, sort_keys=True))
+    os.replace(tmp, p)
+  except Exception as e:
+    warnings.warn(f"autotune cache not saved: {e}")
 
 
 # attention query-tile autotune
@@ -314,7 +319,8 @@ def measure(out, inputs, cfg, baseline_out=None, reps: int = 20, warmup: int = 5
   try:
     variant_out, int8 = _apply_variant(out, cfg)
     net = _raw_compile(variant_out, int8=int8, opt=0, _check_precision=False)
-  except Exception:
+  except Exception as e:                                   # a variant the ANE rejects is expected; an emitter bug is not
+    if os.environ.get("ANEFORGE_TUNE_DEBUG"): warnings.warn(f"[tune] variant compile failed: {e!r}")
     return float("inf"), None
   try:
     res = None

--- a/aneforge/autograd.py
+++ b/aneforge/autograd.py
@@ -542,11 +542,12 @@ def conv2d(x: Tensor, weight: Tensor, stride: int = 1, pad: int = 0) -> Tensor:
   if Cin_w != Cin:
     raise ValueError(f"conv2d: weight Cin {Cin_w} != input Cin {Cin}")
   if pad:
-    # in-graph zero padding: concat zero-constant borders onto H then W.
-    zh = graph.input((N, Cin, pad, W)); zh.attrs["value"] = np.zeros((N, Cin, pad, W), np.float32)
+    # in-graph zero padding: concat baked zero borders onto H then W. const_array (not graph.input), so a
+    # standalone compile(conv2d(...)) bakes them instead of exposing phantom zero-pad input ports.
+    zh = graph._const(np.zeros((N, Cin, pad, W), np.float16))
     x = graph.concat([zh, x, zh], axis=2)            # [N, Cin, H+2pad, W]
     H = H + 2 * pad
-    zw = graph.input((N, Cin, H, pad)); zw.attrs["value"] = np.zeros((N, Cin, H, pad), np.float32)
+    zw = graph._const(np.zeros((N, Cin, H, pad), np.float16))
     x = graph.concat([zw, x, zw], axis=3)            # [N, Cin, H+2pad, W+2pad]
     W = W + 2 * pad
   Hout, Wout = H - kH + 1, W - kW + 1

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -104,8 +104,9 @@ def _attn_prefill(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, cos, sin)
   return x + a.linear(w["wo"])
 
 
-def _swiglu_prefill(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
-  """SwiGLU MLP with its residual: `h + down(silu(gate(norm(h))) * up(norm(h)))`."""
+def _swiglu(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
+  """SwiGLU MLP with its residual: `h + down(silu(gate(norm(h))) * up(norm(h)))`. Stateless and
+  shape-agnostic, so one builder serves both prefill [S,dim] and decode [1,dim]."""
   hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)
   return h + (hn.linear(w["wgate"]).silu() * hn.linear(w["wup"])).linear(w["wdown"])
 
@@ -145,15 +146,10 @@ def _attn_decode(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, ctx: dict,
   return x + a.linear(w["wo"]), [(Kout, Kin), (Vout, Vin)]
 
 
-def _swiglu_decode(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
-  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)
-  return h + (hn.linear(w["wgate"]).silu() * hn.linear(w["wup"])).linear(w["wdown"])
-
-
 PREFILL_MIXERS = {"attention": _attn_prefill}
-PREFILL_MLPS = {"swiglu": _swiglu_prefill}
+PREFILL_MLPS = {"swiglu": _swiglu}
 DECODE_MIXERS = {"attention": _attn_decode}
-DECODE_MLPS = {"swiglu": _swiglu_decode}
+DECODE_MLPS = {"swiglu": _swiglu}
 # Per-position decode inputs a mixer may read from `ctx` (created per chunk, shared across its layers).
 _DECODE_CTX = ("oh", "inv", "mask", "cosp", "sinp")
 

--- a/aneforge/moe.py
+++ b/aneforge/moe.py
@@ -123,44 +123,23 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
   tensor to fp16. Arch features are detected from the tensors (QK-norm, QKV biases + shared expert, GQA,
   head_dim). The reader returns PyTorch [out,in] order, so the only re-layout is ffn_down_exps -> [E,ffn,dim].
   `n_layers` truncates the model (the full 30B is ~60GB fp16 > RAM); layers load lazily and free after baking."""
-  import gguf
-  from gguf.quants import dequantize
-  r = gguf.GGUFReader(path)
-  meta = {f.name: f for f in r.fields.values()}
-  arch = next(k.split(".")[0] for k in meta if k.endswith(".block_count"))
-  def sc(key, default=None):
-    f = meta.get(arch + "." + key)
-    return f.parts[f.data[-1]][0] if f is not None else default
-  tn = {t.name: t for t in r.tensors}
-  has = lambda name: name in tn
-
-  def get(name, dtype: np.typing.DTypeLike = np.float16):    # dequantize -> fp16 (halves resident memory)
-    t = tn[name]; d = np.asarray(t.data)
-    if t.tensor_type != gguf.GGMLQuantizationType.F32:
-      d = dequantize(d, t.tensor_type)
-    return d.astype(dtype)
-  opt = lambda name: get(name) if has(name) else None
+  from ._gguf import GGUFView
+  gg = GGUFView(path); sc, get, tn, arch = gg.sc, gg.get, gg.tn, gg.arch
+  opt = lambda name: get(name) if gg.has(name) else None     # weight if present, else None (optional tensors)
 
   n_total = int(sc("block_count", 0)); n = n_total if n_layers is None else min(n_layers, n_total)
   E, k = int(sc("expert_count", 0)), int(sc("expert_used_count", 0))
   dim, vocab = int(sc("embedding_length", 0)), int(tn["token_embd.weight"].data.shape[0])
   heads = int(sc("attention.head_count", 0))
   moe_ffn = int(tn["blk.0.ffn_gate_exps.weight"].shape[1])   # GGUF [dim, ffn, E] -> ffn (no metadata key on Qwen1.5)
-  qk = has("blk.0.attn_q_norm.weight")                       # Qwen3 has QK-norm; Qwen2 doesn't
-  shared = has("blk.0.ffn_gate_shexp.weight")                # Qwen2-MoE shared expert
+  qk = gg.has("blk.0.attn_q_norm.weight")                    # Qwen3 has QK-norm; Qwen2 doesn't
+  shared = gg.has("blk.0.ffn_gate_shexp.weight")             # Qwen2-MoE shared expert
   cfg = llm.LlamaConfig(
     dim=dim, n_layers=n, n_heads=heads, n_kv_heads=int(sc("attention.head_count_kv", heads)),
     ffn_dim=moe_ffn, vocab=vocab, rope_base=float(sc("rope.freq_base", 10000.0)),
     norm_eps=float(sc("attention.layer_norm_rms_epsilon", 1e-6)), head_dim=int(sc("attention.key_length") or dim // heads),
     layers=[llm.LayerSpec(mixer="attention", mlp="moe", qk_norm=qk) for _ in range(n)],
     extra={"n_experts": E, "n_experts_per_tok": k, "norm_topk_prob": arch != "qwen2moe"})  # Qwen1.5 doesn't renorm
-
-  import mmap as _mmap
-  def _drop_mmap():                                          # release the GGUF's resident pages (low warmup peak)
-    mm = getattr(r.data, "_mmap", None)
-    if mm is not None:
-      try: mm.madvise(_mmap.MADV_DONTNEED)
-      except (AttributeError, OSError): pass
 
   def layer(L):                                             # materialize one layer's fp16 weights on demand
     b = f"blk.{L}."
@@ -176,7 +155,7 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     if shared:                                               # Qwen2-MoE shared expert (SwiGLU FFN + sigmoid gate)
       d["wgate_sh"] = get(b + "ffn_gate_shexp.weight"); d["wup_sh"] = get(b + "ffn_up_shexp.weight")
       d["wdown_sh"] = get(b + "ffn_down_shexp.weight"); d["shared_gate"] = get(b + "ffn_gate_inp_shexp.weight").reshape(1, dim)
-    _drop_mmap()
+    gg.drop_pages()
     return d
 
   # embed (host gather) and lm_head (host matmul) stay fp32: numpy has no fp16 BLAS, so an fp16 lm_head at

--- a/aneforge/qwen35.py
+++ b/aneforge/qwen35.py
@@ -132,22 +132,9 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
   ~54GB > RAM). `resid_scale` shrinks the residual by S so this 27B's deep-layer outliers stay under fp16's
   65504; exact, since scaling `embed` + the residual-writing projections (wo, out_proj, wdown) by 1/S cancels
   in the scale-invariant rms_norm every read goes through."""
-  import gguf
-  import mmap as _mmap
-  from gguf.quants import dequantize
+  from ._gguf import GGUFView
   from .moe import _LazyLayers
-  r = gguf.GGUFReader(path)
-  meta = {f.name: f for f in r.fields.values()}
-  arch = next(k.split(".")[0] for k in meta if k.endswith(".block_count"))
-  def sc(key, default=None):
-    f = meta.get(arch + "." + key)
-    return f.parts[f.data[-1]][0] if f is not None else default
-  tn = {t.name: t for t in r.tensors}
-  def get(name, dtype: np.typing.DTypeLike = np.float16):       # dequantize -> fp16 (halves resident memory)
-    t = tn[name]; d = np.asarray(t.data)
-    if t.tensor_type != gguf.GGMLQuantizationType.F32:
-      d = dequantize(d, t.tensor_type)
-    return d.astype(dtype)
+  v = GGUFView(path); sc, get, tn = v.sc, v.get, v.tn
 
   n_total = int(sc("block_count", 0)); n = n_total if n_layers is None else min(n_layers, n_total)
   dim, heads = int(sc("embedding_length", 0)), int(sc("attention.head_count", 0))
@@ -161,15 +148,9 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
     head_dim=int(sc("attention.key_length", 0)), rotary_dim=int(sc("rope.dimension_count", 0)),
     layers=[llm.LayerSpec(mixer="gated_attention" if is_attn(L) else "gated_deltanet") for L in range(n)],
     extra={"nk": nk, "nv": nv, "dk": dk, "dv": dv, "conv_k": conv_k, "gqa_repeat": "tile"})  # GGUF: ggml_repeat tiles
-  gm = lambda key, d: (meta[key].parts[meta[key].data[-1]][0] if key in meta else d)   # the model's own
-  cfg.extra["sampling"] = {"temperature": float(gm("general.sampling.temp", 0.0)),     # recommended sampling
-                           "top_p": float(gm("general.sampling.top_p", 1.0)), "top_k": int(gm("general.sampling.top_k", 0))}
-
-  def _drop_mmap():                                             # release the GGUF's resident pages (low warmup peak)
-    mm = getattr(r.data, "_mmap", None)
-    if mm is not None:
-      try: mm.madvise(_mmap.MADV_DONTNEED)
-      except (AttributeError, OSError): pass
+  cfg.extra["sampling"] = {"temperature": float(v.field("general.sampling.temp", 0.0)),   # the model's own
+                           "top_p": float(v.field("general.sampling.top_p", 1.0)),         # recommended sampling
+                           "top_k": int(v.field("general.sampling.top_k", 0))}
 
   S = np.float16(1.0 / resid_scale)                            # residual-writing projections carry the 1/S factor
   def layer(L):                                                # materialize one hybrid layer's fp16 weights
@@ -185,7 +166,7 @@ def load_gguf(path: str, n_layers: int | None = None, compress: str | None = Non
             "conv1d": get(b + "ssm_conv1d.weight", np.float32), "neg_exp_A": get(b + "ssm_a", np.float32),
             "dt_bias": get(b + "ssm_dt.bias", np.float32), "ssm_norm": get(b + "ssm_norm.weight"),
             "out_proj": get(b + "ssm_out.weight") * S}
-    _drop_mmap()
+    v.drop_pages()
     return d
 
   # embed: host gather, fp16 (saves ~2.5GB at vocab ~248k; cast to fp16 anyway) and *S to match the residual.

--- a/aneforge/speculative.py
+++ b/aneforge/speculative.py
@@ -13,7 +13,7 @@ import numpy as np
 
 from .graph import input as _input, concat as _cat, _const
 from . import _compile
-from .llm import rope_tables, _repeat_kv3
+from .llm import rope_tables, _repeat_kv3, _DECODE_CTX
 
 f16 = np.float16
 
@@ -45,6 +45,11 @@ def _build_verifier(m, M, Kq):
   """Build (cached on `m`) the segmented Kq-token verify program for context length `M`, mirroring the decode
   chunking so each chunk's KV cache stays resident via `share_buffer` and the hidden chains chunk -> chunk."""
   cfg = m.cfg; KV, dh, D = cfg.n_kv_heads, cfg.dh, cfg.dim
+  if cfg.layers:                                          # the verify block is hardcoded for dense attention + SwiGLU
+    assert all(ls.mixer == "attention" and ls.mlp == "swiglu" for ls in cfg.layers), \
+      "spec_generate target must be a dense attention + SwiGLU model (got a non-dense layer plan)"
+  assert not cfg.rope_interleaved and cfg.rotary_dim in (0, dh), \
+    "spec_generate verifier assumes full neox RoPE (rotary_dim == head_dim)"
   groups = m._layer_chunks(); chunks = []
   for gi, grp in enumerate(groups):
     x = _input((Kq, D)); place = _input((KV, M, Kq)); invc = _input((1, M, 1)); mask = _input((1, Kq, M))
@@ -61,7 +66,7 @@ def _build_verifier(m, M, Kq):
     p = {"x": inm[id(x)], "place": inm[id(place)], "invc": inm[id(invc)], "mask": inm[id(mask)],
          "cosp": inm[id(cosp)], "sinp": inm[id(sinp)], "h": om[h], "states": {inm[id(t)]: t.shape for t in Kin + Vin}}
     chunks.append({"net": net, "p": p})
-  cos_t, sin_t = rope_tables(M, dh, cfg.rope_base)        # dense full RoPE (speculative target is a dense model)
+  cos_t, sin_t = rope_tables(M, dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)  # match the decode tables
   return {"M": M, "Kq": Kq, "chunks": chunks, "cos": cos_t, "sin": sin_t, "lmhead": _build_lm_head(m, Kq)}
 
 
@@ -109,10 +114,11 @@ def _draft_step(draft, d, tok, pos):
   invv = np.ones((1, M, 1), f16); invv[0, pos, 0] = 0.0
   mv = np.full((1, 1, M), -1e4, f16); mv[..., :pos + 1] = 0.0
   h = np.asarray(draft.w["embed"][tok])[None].astype(f16)
+  vals = {"oh": ohv, "inv": invv, "mask": mv, "cosp": d["cos"][pos][None], "sinp": d["sin"][pos][None]}
   for c in d["chunks"]:
     p = c["p"]; pr = c["net"].prog; pr.set_input(p["x"], h)
-    for kk, vv in (("oh", ohv), ("inv", invv), ("mask", mv), ("cosp", d["cos"][pos][None]), ("sinp", d["sin"][pos][None])):
-      if kk in p: pr.set_input(p[kk], vv)
+    for kk in _DECODE_CTX:
+      if kk in p: pr.set_input(p[kk], vals[kk])
     pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
   return int((h.reshape(cfg.dim).astype(np.float32) @ np.asarray(draft.w["lm_head"]).T).argmax())
 

--- a/examples/_common.py
+++ b/examples/_common.py
@@ -51,6 +51,19 @@ def _colour_showwarning(message, category, filename, lineno, file=None, line=Non
 warnings.showwarning = _colour_showwarning
 
 
+def encode_chat(tok, prompt):
+    """Apply a chat template (no 'thinking' block) and return the prompt token ids. Tolerates tokenizers
+    without the enable_thinking kwarg and unwraps BatchEncoding / nested [[ids]] outputs."""
+    msgs = [{"role": "user", "content": prompt}]
+    try:
+        r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
+    except TypeError:                                    # tokenizers without the enable_thinking kwarg
+        r = tok.apply_chat_template(msgs, add_generation_prompt=True)
+    if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]   # BatchEncoding -> ids
+    if r and isinstance(r[0], (list, tuple)): r = r[0]                       # [[ids]] -> [ids]
+    return [int(t) for t in r]
+
+
 def relerr(a, b):
     """L2 relative error of `a` against the reference `b`."""
     a = np.asarray(a, np.float64).ravel()

--- a/examples/llm_chat.py
+++ b/examples/llm_chat.py
@@ -16,18 +16,6 @@ def _default_model():
     return hits[0] if hits else None
 
 
-def _encode(tok, prompt):
-    """Apply the chat template (no 'thinking' block) so the model answers as an assistant; returns a list of ids."""
-    msgs = [{"role": "user", "content": prompt}]
-    try:
-        r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
-    except TypeError:                                    # tokenizers without the enable_thinking kwarg
-        r = tok.apply_chat_template(msgs, add_generation_prompt=True)
-    if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]   # BatchEncoding -> ids
-    if r and isinstance(r[0], (list, tuple)): r = r[0]                       # [[ids]] -> [ids]
-    return [int(t) for t in r]
-
-
 def main():
     argv = [a for a in sys.argv[1:] if not a.startswith("--")]
     compress = "int8" if "--int8" in sys.argv else ("int4" if "--int4" in sys.argv else None)
@@ -51,7 +39,7 @@ def main():
             print(); break
         if not prompt: continue
         if prompt in ("exit", "quit"): break
-        ids = _encode(tok, prompt)
+        ids = _common.encode_chat(tok, prompt)
         if len(ids) >= MAX_LEN - 8:
             print("ane> (prompt too long for the demo context)\n"); continue
         print("ane> ", end="", flush=True)

--- a/examples/moe_chat.py
+++ b/examples/moe_chat.py
@@ -18,62 +18,53 @@ MAX_LEN = 512
 
 
 def _default_gguf():
-  hits = glob.glob(os.path.expanduser("~/Models/*MoE*-GGUF/*.gguf")) + glob.glob(os.path.expanduser("~/Models/*-A*B-GGUF/*.gguf"))
-  hits = [h for h in hits if "incomplete" not in h]
-  return min(hits, key=os.path.getsize) if hits else None      # smallest = most likely to fit + compile fast
-
-
-def _encode(tok, prompt):
-  """Apply the chat template (no 'thinking' block); returns a list of token ids."""
-  msgs = [{"role": "user", "content": prompt}]
-  try:
-    r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
-  except TypeError:
-    r = tok.apply_chat_template(msgs, add_generation_prompt=True)
-  if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]
-  if r and isinstance(r[0], (list, tuple)): r = r[0]
-  return [int(t) for t in r]
+    hits = glob.glob(os.path.expanduser("~/Models/*MoE*-GGUF/*.gguf")) + glob.glob(os.path.expanduser("~/Models/*-A*B-GGUF/*.gguf"))
+    hits = [h for h in hits if "incomplete" not in h]
+    return min(hits, key=os.path.getsize) if hits else None      # smallest = most likely to fit + compile fast
 
 
 def main():
-  gguf = sys.argv[1] if len(sys.argv) > 1 else _default_gguf()
-  if not gguf:
-    print("usage: python3 examples/moe_chat.py <gguf-path> [tokenizer-path]  (no MoE GGUF found under ~/Models)"); return 1
-  print(f"loading {os.path.basename(gguf)} (int8, ANE) ...")
-  m = load_gguf(gguf, compress="int8")
-  m._chunk_bytes = 1.0e9                          # one MoE layer per program (two MoE blocks/program won't compile)
-  from transformers import AutoTokenizer
-  if len(sys.argv) > 2:                            # override tokenizer (HF dir)
-    tok = AutoTokenizer.from_pretrained(sys.argv[2])
-  else:                                           # read the model's own tokenizer from the GGUF (matching chat template)
-    tok = AutoTokenizer.from_pretrained(os.path.dirname(gguf), gguf_file=os.path.basename(gguf))
-  e = m.cfg.extra
-  print(f"{m.cfg.n_layers}L dim {m.cfg.dim}, {e['n_experts']} experts / top-{e['n_experts_per_tok']}. "
-        f"compiling {len(m._layer_chunks())} chunks (one-time; cached under ~/Models) ...", end="", flush=True)
-  m.warmup(MAX_LEN)
-  imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
-  eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
-  print(" done.")
-  print("type a message (Ctrl-D or 'exit' to quit). full MoE model, decoding on the ANE.\n")
+    gguf = sys.argv[1] if len(sys.argv) > 1 else _default_gguf()
+    if not gguf:
+        print("usage: python3 examples/moe_chat.py <gguf-path> [tokenizer-path]  (no MoE GGUF found under ~/Models)"); return 1
+    print(f"loading {os.path.basename(gguf)} (int8, ANE) ...")
+    m = load_gguf(gguf, compress="int8")
+    m._chunk_bytes = 1.0e9                          # one MoE layer per program (two MoE blocks/program won't compile)
+    from transformers import AutoTokenizer
+    if len(sys.argv) > 2:                            # override tokenizer (HF dir)
+        tok = AutoTokenizer.from_pretrained(sys.argv[2])
+    else:                                           # read the model's own tokenizer from the GGUF (matching chat template)
+        tok = AutoTokenizer.from_pretrained(os.path.dirname(gguf), gguf_file=os.path.basename(gguf))
+    e = m.cfg.extra
+    print(f"{m.cfg.n_layers}L dim {m.cfg.dim}, {e['n_experts']} experts / top-{e['n_experts_per_tok']}. "
+          f"compiling {len(m._layer_chunks())} chunks (one-time; cached under ~/Models) ...", end="", flush=True)
+    m.warmup(MAX_LEN)
+    imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
+    eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
+    print(" done.")
+    print("type a message (Ctrl-D or 'exit' to quit). full MoE model, decoding on the ANE.\n")
 
-  while True:
-    try:
-      prompt = input("you> ").strip()
-    except EOFError:
-      print(); break
-    if not prompt: continue
-    if prompt in ("exit", "quit"): break
-    ids = _encode(tok, prompt)
-    if len(ids) >= MAX_LEN - 32:
-      print("ane> (prompt too long for the demo context)\n"); continue
-    print("ane> ", end="", flush=True)
-    n = [0]; t0 = time.perf_counter()
-    m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos,
-               on_token=lambda t: (n.__setitem__(0, n[0] + 1), print(tok.decode([t]), end="", flush=True)))
-    dt = time.perf_counter() - t0
-    print(f"\n   [{n[0]} tokens, {n[0] / dt:.1f} tok/s on the ANE]\n")
-  return 0
+    while True:
+        try:
+            prompt = input("you> ").strip()
+        except EOFError:
+            print(); break
+        if not prompt: continue
+        if prompt in ("exit", "quit"): break
+        ids = _common.encode_chat(tok, prompt)
+        if len(ids) >= MAX_LEN - 32:
+            print("ane> (prompt too long for the demo context)\n"); continue
+        print("ane> ", end="", flush=True)
+        count = 0
+        def on_tok(t):
+            nonlocal count; count += 1
+            print(tok.decode([t]), end="", flush=True)
+        t0 = time.perf_counter()
+        m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos, on_token=on_tok)
+        dt = time.perf_counter() - t0
+        print(f"\n   [{count} tokens, {count / dt:.1f} tok/s on the ANE]\n")
+    return 0
 
 
 if __name__ == "__main__":
-  sys.exit(main())
+    sys.exit(main())

--- a/examples/qwen35_chat.py
+++ b/examples/qwen35_chat.py
@@ -20,73 +20,65 @@ MAX_LEN = 512
 
 
 def _default_gguf():
-  hits = glob.glob(os.path.expanduser("~/Models/*[Qq]wen3*-GGUF/*.gguf"))
-  hits = [h for h in hits if "incomplete" not in h]
-  return min(hits, key=os.path.getsize) if hits else None      # smallest = most likely to fit + compile fast
+    hits = glob.glob(os.path.expanduser("~/Models/*[Qq]wen3*-GGUF/*.gguf"))
+    hits = [h for h in hits if "incomplete" not in h]
+    return min(hits, key=os.path.getsize) if hits else None      # smallest = most likely to fit + compile fast
 
 
 def _tokenizer_dir(gguf):
-  """The HF tokenizer dir for a GGUF: the GGUF's parent with '-GGUF' stripped (Qwen3.5-27B-GGUF -> Qwen3.5-27B)."""
-  d = os.path.dirname(gguf)
-  cand = d[:-5] if d.endswith("-GGUF") else d
-  return cand if os.path.exists(os.path.join(cand, "tokenizer.json")) else None
-
-
-def _encode(tok, prompt):
-  """Apply the chat template (no 'thinking' block); returns a list of token ids."""
-  msgs = [{"role": "user", "content": prompt}]
-  try:
-    r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
-  except TypeError:
-    r = tok.apply_chat_template(msgs, add_generation_prompt=True)
-  if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]
-  if r and isinstance(r[0], (list, tuple)): r = r[0]
-  return [int(t) for t in r]
+    """The HF tokenizer dir for a GGUF: the GGUF's parent with '-GGUF' stripped (Qwen3.5-27B-GGUF -> Qwen3.5-27B)."""
+    d = os.path.dirname(gguf)
+    cand = d[:-5] if d.endswith("-GGUF") else d
+    return cand if os.path.exists(os.path.join(cand, "tokenizer.json")) else None
 
 
 def main():
-  gguf = sys.argv[1] if len(sys.argv) > 1 else _default_gguf()
-  if not gguf:
-    print("usage: python3 examples/qwen35_chat.py <gguf-path> [tokenizer-dir]  (no qwen3* GGUF found under ~/Models)"); return 1
-  tokdir = sys.argv[2] if len(sys.argv) > 2 else _tokenizer_dir(gguf)
-  if not tokdir:
-    print(f"no tokenizer found next to {gguf}; pass a tokenizer dir (with tokenizer.json) as the 2nd arg"); return 1
-  compress = os.environ.get("ANEFORGE_COMPRESS", "int8")    # "blockwise" = per-block int8 scales (~same memory)
-  print(f"loading {os.path.basename(gguf)} ({compress}, ANE) ...")
-  m = load_gguf(gguf, compress=compress)
-  m._chunk_bytes = 1.0e9                          # a couple of hybrid layers per program (under the ~2GB ANE ceiling)
-  from transformers import AutoTokenizer
-  tok = AutoTokenizer.from_pretrained(tokdir)
-  e = m.cfg.extra
-  print(f"{m.cfg.n_layers}L dim {m.cfg.dim}, {e['nv']} DeltaNet value-heads, {m.cfg.n_heads}/{m.cfg.n_kv_heads} attn heads. "
-        f"compiling {len(m._layer_chunks())} chunks (one-time; cached under ~/Models) ...", end="", flush=True)
-  m.warmup(MAX_LEN)
-  imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
-  eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
-  samp = m.cfg.extra.get("sampling", {})                    # the model's own recommended sampling (from the GGUF);
-  if not samp.get("temperature"): samp = {"temperature": 0.6, "top_p": 0.95, "top_k": 20}  # greedy loops, so sample
-  print(" done.")
-  print("type a message (Ctrl-D or 'exit' to quit). full hybrid model, decoding on the ANE.\n")
+    gguf = sys.argv[1] if len(sys.argv) > 1 else _default_gguf()
+    if not gguf:
+        print("usage: python3 examples/qwen35_chat.py <gguf-path> [tokenizer-dir]  (no qwen3* GGUF found under ~/Models)"); return 1
+    tokdir = sys.argv[2] if len(sys.argv) > 2 else _tokenizer_dir(gguf)
+    if not tokdir:
+        print(f"no tokenizer found next to {gguf}; pass a tokenizer dir (with tokenizer.json) as the 2nd arg"); return 1
+    compress = os.environ.get("ANEFORGE_COMPRESS", "int8")    # "blockwise" = per-block int8 scales (~same memory)
+    print(f"loading {os.path.basename(gguf)} ({compress}, ANE) ...")
+    m = load_gguf(gguf, compress=compress)
+    m._chunk_bytes = 1.0e9                          # a couple of hybrid layers per program (under the ~2GB ANE ceiling)
+    from transformers import AutoTokenizer
+    tok = AutoTokenizer.from_pretrained(tokdir)
+    e = m.cfg.extra
+    print(f"{m.cfg.n_layers}L dim {m.cfg.dim}, {e['nv']} DeltaNet value-heads, {m.cfg.n_heads}/{m.cfg.n_kv_heads} attn heads. "
+          f"compiling {len(m._layer_chunks())} chunks (one-time; cached under ~/Models) ...", end="", flush=True)
+    m.warmup(MAX_LEN)
+    imend = tok.convert_tokens_to_ids("<|im_end|>")           # ChatML turn-end (cleaner stop than eos_token_id)
+    eos = imend if isinstance(imend, int) and imend >= 0 else tok.eos_token_id
+    samp = m.cfg.extra.get("sampling", {})                    # the model's own recommended sampling (from the GGUF);
+    if not samp.get("temperature"): samp = {"temperature": 0.6, "top_p": 0.95, "top_k": 20}  # greedy loops, so sample
+    print(" done.")
+    print("type a message (Ctrl-D or 'exit' to quit). full hybrid model, decoding on the ANE.\n")
 
-  while True:
-    try:
-      prompt = input("you> ").strip()
-    except EOFError:
-      print(); break
-    if not prompt: continue
-    if prompt in ("exit", "quit"): break
-    ids = _encode(tok, prompt)
-    if len(ids) >= MAX_LEN - 32:
-      print("ane> (prompt too long for the demo context)\n"); continue
-    print("ane> ", end="", flush=True)
-    n = [0]; t0 = time.perf_counter()
-    m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos,
-               temperature=samp["temperature"], top_p=samp.get("top_p", 1.0), top_k=samp.get("top_k", 0),
-               on_token=lambda t: (n.__setitem__(0, n[0] + 1), print(tok.decode([t]), end="", flush=True)))
-    dt = time.perf_counter() - t0
-    print(f"\n   [{n[0]} tokens, {n[0] / dt:.1f} tok/s on the ANE]\n")
-  return 0
+    while True:
+        try:
+            prompt = input("you> ").strip()
+        except EOFError:
+            print(); break
+        if not prompt: continue
+        if prompt in ("exit", "quit"): break
+        ids = _common.encode_chat(tok, prompt)
+        if len(ids) >= MAX_LEN - 32:
+            print("ane> (prompt too long for the demo context)\n"); continue
+        print("ane> ", end="", flush=True)
+        count = 0
+        def on_tok(t):
+            nonlocal count; count += 1
+            print(tok.decode([t]), end="", flush=True)
+        t0 = time.perf_counter()
+        m.generate(ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN, eos_id=eos,
+                   temperature=samp["temperature"], top_p=samp.get("top_p", 1.0), top_k=samp.get("top_k", 0),
+                   on_token=on_tok)
+        dt = time.perf_counter() - t0
+        print(f"\n   [{count} tokens, {count / dt:.1f} tok/s on the ANE]\n")
+    return 0
 
 
 if __name__ == "__main__":
-  sys.exit(main())
+    sys.exit(main())

--- a/examples/spec_chat.py
+++ b/examples/spec_chat.py
@@ -22,18 +22,6 @@ def _cached_06b():
     return hits[0] if hits else None
 
 
-def _encode(tok, prompt):
-    """Apply the chat template (no 'thinking' block); returns a list of token ids."""
-    msgs = [{"role": "user", "content": prompt}]
-    try:
-        r = tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False)
-    except TypeError:                                    # tokenizers without the enable_thinking kwarg
-        r = tok.apply_chat_template(msgs, add_generation_prompt=True)
-    if isinstance(r, dict) or hasattr(r, "input_ids"): r = r["input_ids"]   # BatchEncoding -> ids
-    if r and isinstance(r[0], (list, tuple)): r = r[0]                       # [[ids]] -> [ids]
-    return [int(t) for t in r]
-
-
 def main():
     if len(sys.argv) < 2:
         print("usage: python3 examples/spec_chat.py <target-model> [draft-model]"); return 1
@@ -47,7 +35,7 @@ def main():
     tok = AutoTokenizer.from_pretrained(target_path)
     print(f"target {target.cfg.n_layers}L dim {target.cfg.dim}; draft {draft.cfg.n_layers}L. Speculative decode on the ANE.")
     print("compiling the verifier (one-time; minutes for a big target) ...", end="", flush=True)
-    spec_generate(target, draft, _encode(tok, "hi"), max_new_tokens=1, max_len=MAX_LEN)   # build + cache the verifier
+    spec_generate(target, draft, _common.encode_chat(tok, "hi"), max_new_tokens=1, max_len=MAX_LEN)   # build + cache the verifier
     print(" done.")
     print("type a message (Ctrl-D or 'exit' to quit). replies stream; speculative is exact (== greedy decode).\n")
 
@@ -58,16 +46,19 @@ def main():
             print(); break
         if not prompt: continue
         if prompt in ("exit", "quit"): break
-        ids = _encode(tok, prompt)
+        ids = _common.encode_chat(tok, prompt)
         if len(ids) >= MAX_LEN - 16:
             print("ane> (prompt too long for the demo context)\n"); continue
         print("ane> ", end="", flush=True)
-        n = [0]; t0 = time.perf_counter()
+        count = 0
+        def on_tok(t):
+            nonlocal count; count += 1
+            print(tok.decode([t]), end="", flush=True)
+        t0 = time.perf_counter()
         spec_generate(target, draft, ids, max_new_tokens=MAX_LEN - len(ids) - 1, max_len=MAX_LEN,
-                      eos_id=tok.eos_token_id, n_draft=4,
-                      on_token=lambda t: (n.__setitem__(0, n[0] + 1), print(tok.decode([t]), end="", flush=True)))
+                      eos_id=tok.eos_token_id, n_draft=4, on_token=on_tok)
         dt = time.perf_counter() - t0
-        print(f"\n   [{n[0]} tokens, {n[0] / dt:.1f} tok/s -- speculative, identical to greedy]\n")
+        print(f"\n   [{count} tokens, {count / dt:.1f} tok/s -- speculative, identical to greedy]\n")
     return 0
 
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -23,6 +23,24 @@ def onehot_select(t: af.Tensor, i: int, w: int | None = None) -> af.Tensor:
   return t @ sel.astype(np.float16)
 
 
+def make_random_llama_model(cfg, compress=None, seed=0):
+  """A dense Llama-style LlamaPrefill with reproducible random weights (1/sqrt(fan-in) scaled). Shared by the
+  decode and speculative tests so the weight layout stays in one place."""
+  from aneforge.llm import LlamaPrefill, _weights_from_state_dict
+  rng = np.random.default_rng(seed); dh = cfg.dh
+  R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
+  sd = {"model.embed_tokens.weight": R(cfg.vocab, cfg.dim), "model.norm.weight": np.ones(cfg.dim, np.float32),
+        "lm_head.weight": R(cfg.vocab, cfg.dim)}
+  for L in range(cfg.n_layers):
+    p = f"model.layers.{L}."
+    for nm, sh in [("self_attn.q_proj", (cfg.n_heads * dh, cfg.dim)), ("self_attn.k_proj", (cfg.n_kv_heads * dh, cfg.dim)),
+                   ("self_attn.v_proj", (cfg.n_kv_heads * dh, cfg.dim)), ("self_attn.o_proj", (cfg.dim, cfg.n_heads * dh)),
+                   ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
+      sd[p + nm + ".weight"] = R(*sh)
+    sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
+  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), compress=compress)
+
+
 def ane_available() -> bool:
   """True iff the ANE/e5rt dispatch dylib can be located (device tests can run)."""
   try:

--- a/tests/op_smoketest.py
+++ b/tests/op_smoketest.py
@@ -6,7 +6,9 @@ from pathlib import Path
 import numpy as np
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))  # repo root -> import aneforge
+sys.path.insert(0, str(Path(__file__).resolve().parent))      # tests/ -> import _helpers
 import aneforge as af
+from _helpers import requires_ane
 
 
 def check(name, build, ref, *ins, tol=0.02):
@@ -19,7 +21,7 @@ def check(name, build, ref, *ins, tol=0.02):
   return relerr < tol
 
 
-def main():
+def _run_all():
   rng = np.random.default_rng(0)
   x = rng.standard_normal((4, 8)).astype(np.float16)
   xp = (np.abs(rng.standard_normal((4, 8))) + 0.5).astype(np.float16)  # positive domain
@@ -85,8 +87,14 @@ def main():
   ok.append(check("batch_norm", lambda: af.batch_norm(af.input((1, 4, 8, 8)), g, b, m, v, eps=1e-3), bn_ref, img))
 
   print(f"\n{sum(ok)}/{len(ok)} ops correct on the ANE")
-  sys.exit(0 if all(ok) else 1)
+  return ok
+
+
+@requires_ane
+def test_op_smoketest():   # pytest entry: every one-op graph compiles + matches numpy on the ANE
+  ok = _run_all()
+  assert all(ok), f"only {sum(ok)}/{len(ok)} ops correct on the ANE"
 
 
 if __name__ == "__main__":
-  main()
+  sys.exit(0 if all(_run_all()) else 1)

--- a/tests/test_compile_targets.py
+++ b/tests/test_compile_targets.py
@@ -3,8 +3,10 @@ import numpy as np
 import pytest
 
 import aneforge as af
+from _helpers import requires_ane
 
 
+@requires_ane
 def test_compile_decomposes_sin_for_h13_and_runs():
   # h13 lacks native sin -> compile substitutes the special.py polynomial; runs on M5
   xv = np.linspace(-1.0, 1.0, 64).astype(np.float16).reshape(1, 64)
@@ -13,6 +15,7 @@ def test_compile_decomposes_sin_for_h13_and_runs():
   assert np.abs(out - np.sin(xv.astype(np.float32))).max() < 3e-3
 
 
+@requires_ane
 def test_compile_decomposes_cos_for_h13_and_runs():
   xv = np.linspace(-1.0, 1.0, 64).astype(np.float16).reshape(1, 64)
   net = af.compile(af.input((1, 64)).cos(), target="h13")
@@ -33,6 +36,7 @@ def test_compile_rejects_below_mil_floor():
     af.compile(af.input((1, 64)).relu(), target="h11")
 
 
+@requires_ane
 def test_compile_default_target_is_native_noop_on_m5():
   # no target -> host M5: sin native, no rewrite
   xv = np.linspace(-1.0, 1.0, 64).astype(np.float16).reshape(1, 64)

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -1,6 +1,16 @@
 import numpy as np
+import pytest
 from _helpers import requires_ane
 from aneforge import _blob
+
+
+@pytest.fixture
+def mkdir(tmp_path):
+  """A factory for fresh build dirs that are auto-removed with the pytest tmp_path (no /tmp leak)."""
+  n = [0]
+  def _new():
+    n[0] += 1; d = tmp_path / f"d{n[0]}"; d.mkdir(); return str(d)
+  return _new
 
 
 def _dequant_lut4(packed: bytes, lut: bytes, out: int, inn: int) -> np.ndarray:
@@ -123,13 +133,12 @@ def test_int4_matmul_runs_on_ane_and_is_close():
 
 
 @requires_ane
-def test_int4_weights_are_smaller():
+def test_int4_weights_are_smaller(mkdir):
   """The int4 program's weights.bin is markedly smaller than the fp16 one."""
   import aneforge as af
   from pathlib import Path
-  import tempfile
   W = np.random.default_rng(5).standard_normal((512, 256)).astype(np.float32)   # [IN, OUT]
-  d16, d4 = tempfile.mkdtemp(), tempfile.mkdtemp()
+  d16, d4 = mkdir(), mkdir()
   af.compile(af.input((1, 512)) @ W, compress=None, build_dir=d16).release()
   af.compile(af.input((1, 512)) @ W, compress="int4", compress_atol=0.5, build_dir=d4).release()
   s16 = Path(d16, "weights.bin").stat().st_size
@@ -138,14 +147,13 @@ def test_int4_weights_are_smaller():
 
 
 @requires_ane
-def test_compress_none_is_byte_identical_weights():
+def test_compress_none_is_byte_identical_weights(mkdir):
   """compress=None must produce the SAME weights.bin as the historical default."""
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(6)
   W = rng.standard_normal((128, 64)).astype(np.float32)        # [IN, OUT]
-  da, db = tempfile.mkdtemp(), tempfile.mkdtemp()
+  da, db = mkdir(), mkdir()
   af.compile(af.input((1, 128)) @ W, build_dir=da).release()                 # historical
   af.compile(af.input((1, 128)) @ W, compress=None, build_dir=db).release()  # explicit off
   assert Path(da, "weights.bin").read_bytes() == Path(db, "weights.bin").read_bytes()
@@ -153,16 +161,15 @@ def test_compress_none_is_byte_identical_weights():
 
 
 @requires_ane
-def test_int4_conv_runs_on_ane_and_is_close():
+def test_int4_conv_runs_on_ane_and_is_close(mkdir):
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(7)
   W = rng.standard_normal((16, 8, 3, 3)).astype(np.float32)     # flat inner = 8*3*3 = 72 (even)
   x = rng.standard_normal((1, 8, 16, 16)).astype(np.float32)
   base = af.compile(af.conv(af.input((1, 8, 16, 16)), W, pad=1), compress=None)
   ref = base(x); base.release()
-  d = tempfile.mkdtemp()
+  d = mkdir()
   net = af.compile(af.conv(af.input((1, 8, 16, 16)), W, pad=1),
                    compress="int4", compress_atol=0.6, build_dir=d)
   got = net(x); net.release()
@@ -209,16 +216,15 @@ def test_weight_sparse_falls_back_when_dense():
 
 
 @requires_ane
-def test_sparse_matmul_runs_on_ane_and_is_close():
+def test_sparse_matmul_runs_on_ane_and_is_close(mkdir):
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(12)
   W = rng.standard_normal((256, 128)).astype(np.float32)       # [IN, OUT]
   W[np.abs(W) < 1.0] = 0.0                                     # ~68% zeros
   x = rng.standard_normal((1, 256)).astype(np.float32)
   ref = (x @ W).astype(np.float32)
-  d = tempfile.mkdtemp()
+  d = mkdir()
   net = af.compile(af.input((1, 256)) @ W, compress="sparse", build_dir=d)
   got = net(x)
   cos = float((got.ravel() @ ref.ravel()) /
@@ -268,11 +274,10 @@ def test_auto_falls_to_int8_then_fp16():
 
 
 @requires_ane
-def test_auto_none_byte_identical():
+def test_auto_none_byte_identical(mkdir):
   """compress="auto" picking fp16 does not regress; compress=None stays byte-identical to default."""
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(22)
   # rms_norm gamma: forced to fp16 (allow_int8=False, no int4/sparse)
   g = rng.standard_normal((16,)).astype(np.float32)
@@ -287,7 +292,7 @@ def test_auto_none_byte_identical():
 
   # byte-identity of compress=None vs historical default
   W = rng.standard_normal((128, 64)).astype(np.float32)
-  da, db = tempfile.mkdtemp(), tempfile.mkdtemp()
+  da, db = mkdir(), mkdir()
   af.compile(af.input((1, 128)) @ W, build_dir=da).release()
   af.compile(af.input((1, 128)) @ W, compress=None, build_dir=db).release()
   assert Path(da, "weights.bin").read_bytes() == Path(db, "weights.bin").read_bytes()
@@ -364,16 +369,15 @@ def test_explicit_modes_not_filtered_by_family():
 
 
 @requires_ane
-def test_auto_target_h13_compiles_native_stream():
+def test_auto_target_h13_compiles_native_stream(mkdir):
   """End-to-end: compile(compress='auto', target='h13') -> sparse-eligible weight comes out sparse, runs."""
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(31)
   W = rng.standard_normal((256, 128)).astype(np.float32)
   W[np.abs(W) < 1.0] = 0.0                                     # ~68% zeros
   x = rng.standard_normal((1, 256)).astype(np.float32)
-  d = tempfile.mkdtemp()
+  d = mkdir()
   net = af.compile(af.input((1, 256)) @ W, compress="auto", compress_atol=0.5,
                    target="h13", build_dir=d)
   mil = Path(d, "model.mil").read_bytes()
@@ -389,17 +393,16 @@ def test_auto_target_h13_compiles_native_stream():
 
 # Feature 2 - conv-sparse (allow_sparse on conv); 4-D mask unverified on device
 @requires_ane
-def test_sparse_conv_runs_on_ane():
+def test_sparse_conv_runs_on_ane(mkdir):
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(24)
   W = rng.standard_normal((16, 8, 3, 3)).astype(np.float32)    # flat inner = 72 (even)
   W[np.abs(W) < 1.0] = 0.0                                     # ~68% zeros
   x = rng.standard_normal((1, 8, 16, 16)).astype(np.float32)
   base = af.compile(af.conv(af.input((1, 8, 16, 16)), W, pad=1), compress=None)
   ref = base(x); base.release()
-  d = tempfile.mkdtemp()
+  d = mkdir()
   net = af.compile(af.conv(af.input((1, 8, 16, 16)), W, pad=1),
                    compress="sparse", build_dir=d)
   got = net(x); net.release()
@@ -451,15 +454,14 @@ def test_weight_blockwise_falls_back_when_disallowed():
 
 
 @requires_ane
-def test_blockwise_matmul_runs_on_ane_and_is_close():
+def test_blockwise_matmul_runs_on_ane_and_is_close(mkdir):
   import aneforge as af
   from pathlib import Path
-  import tempfile
   rng = np.random.default_rng(34)
   W = rng.standard_normal((256, 128)).astype(np.float32)       # [IN, OUT]
   x = rng.standard_normal((1, 256)).astype(np.float32)
   ref = (x @ W).astype(np.float32)
-  d = tempfile.mkdtemp()
+  d = mkdir()
   net = af.compile(af.input((1, 256)) @ W, compress="blockwise",
                    block_size=32, compress_atol=0.5, build_dir=d)
   got = net(x)
@@ -471,13 +473,12 @@ def test_blockwise_matmul_runs_on_ane_and_is_close():
 
 
 @requires_ane
-def test_blockwise_weights_are_smaller():
+def test_blockwise_weights_are_smaller(mkdir):
   """The blockwise program's weights.bin is smaller than fp16 (int8 data + tiny scales)."""
   import aneforge as af
   from pathlib import Path
-  import tempfile
   W = np.random.default_rng(35).standard_normal((512, 256)).astype(np.float32)   # [IN, OUT]
-  d16, db = tempfile.mkdtemp(), tempfile.mkdtemp()
+  d16, db = mkdir(), mkdir()
   af.compile(af.input((1, 512)) @ W, compress=None, build_dir=d16).release()
   af.compile(af.input((1, 512)) @ W, compress="blockwise", block_size=32,
              compress_atol=0.5, build_dir=db).release()
@@ -487,13 +488,12 @@ def test_blockwise_weights_are_smaller():
 
 
 @requires_ane
-def test_blockwise_compress_none_unaffected():
+def test_blockwise_compress_none_unaffected(mkdir):
   """Adding compress='blockwise' must not perturb the compress=None default."""
   import aneforge as af
   from pathlib import Path
-  import tempfile
   W = np.random.default_rng(36).standard_normal((128, 64)).astype(np.float32)
-  da, db = tempfile.mkdtemp(), tempfile.mkdtemp()
+  da, db = mkdir(), mkdir()
   af.compile(af.input((1, 128)) @ W, build_dir=da).release()
   af.compile(af.input((1, 128)) @ W, compress=None, build_dir=db).release()
   assert Path(da, "weights.bin").read_bytes() == Path(db, "weights.bin").read_bytes()

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,7 +1,7 @@
 import numpy as np
 import aneforge as af
 from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf
-from _helpers import requires_ane
+from _helpers import requires_ane, make_random_llama_model as _random_model
 
 
 def test_rope_tables_shape():
@@ -33,25 +33,16 @@ def test_rope_matches_numpy():
   cos_sim = float(got.ravel() @ ref.ravel() / (np.linalg.norm(got) * np.linalg.norm(ref) + 1e-9))
   assert cos_sim > 0.999, f"RoPE vs reference cosine={cos_sim}"
 
-def _random_model(cfg, compress=None):
-  rng = np.random.default_rng(0); dh = cfg.dh
-  R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
-  sd = {"model.embed_tokens.weight": R(cfg.vocab, cfg.dim), "model.norm.weight": np.ones(cfg.dim, np.float32),
-        "lm_head.weight": R(cfg.vocab, cfg.dim)}
-  for L in range(cfg.n_layers):
-    p = f"model.layers.{L}."
-    for nm, sh in [("self_attn.q_proj", (cfg.n_heads * dh, cfg.dim)), ("self_attn.k_proj", (cfg.n_kv_heads * dh, cfg.dim)),
-                   ("self_attn.v_proj", (cfg.n_kv_heads * dh, cfg.dim)), ("self_attn.o_proj", (cfg.dim, cfg.n_heads * dh)),
-                   ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
-      sd[p + nm + ".weight"] = R(*sh)
-    sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
-  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), compress=compress)
-
 @requires_ane
-def test_generate_runs():  # the decode loop produces the requested number of valid tokens
+def test_generate_matches_prefill_argmax():  # decode step 0 must equal the prefill argmax (catches a broken KV-cache step)
   cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
-  out = _random_model(cfg).generate([1, 2, 3], max_new_tokens=5)
+  m = _random_model(cfg); prompt = [1, 2, 3]
+  first = m.generate(prompt, max_new_tokens=1)[0]
+  ref = int(np.asarray(m.prefill(prompt)).ravel().argmax())   # P(next | prompt) via the independent prefill program
+  assert first == ref, f"decode first token {first} != prefill argmax {ref}"
+  out = m.generate(prompt, max_new_tokens=5)
   assert len(out) == 5 and all(0 <= t < cfg.vocab for t in out)
+  assert m.generate(prompt, max_new_tokens=5) == out          # greedy is deterministic
 
 @requires_ane
 def test_int8_decode_matches_fp16():  # int8-quantized ANE weights stay faithful to fp16 (prefill + decode both run)

--- a/tests/test_multilayer_resident.py
+++ b/tests/test_multilayer_resident.py
@@ -3,7 +3,7 @@ import os, sys
 import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-requires_ane = pytest.mark.skipif(os.environ.get("ANEFORGE_NO_ANE") == "1", reason="needs ANE")
+from _helpers import requires_ane   # skips when the ANE dylib is absent (not only when ANEFORGE_NO_ANE is set)
 
 
 @requires_ane

--- a/tests/test_op_catalog.py
+++ b/tests/test_op_catalog.py
@@ -3,7 +3,7 @@ from aneforge import _op_catalog as oc
 
 
 def test_catalog_complete():
-  assert len(oc.OP_CATALOG) == 187
+  assert len(oc.OP_CATALOG) >= 187      # grows as ops are added; the per-entry field check below is the real gate
   assert len(oc.categories()) == 14
   for n, d in oc.OP_CATALOG.items():
     for k in ("m1", "m2", "m3", "m4_m5"):

--- a/tests/test_qwen35.py
+++ b/tests/test_qwen35.py
@@ -38,7 +38,7 @@ def test_gated_deltanet_decode_matches_transformers():
     outs[t] = np.asarray(net.prog.read_output(om[h])).reshape(D)
   delta = outs - xs                                                 # strip the residual -> out_proj(deltanet)
   cos = float(delta.ravel() @ ref.ravel() / (np.linalg.norm(delta) * np.linalg.norm(ref)))
-  assert cos > 0.95, f"gated_deltanet decode vs transformers: cosine {cos}"
+  assert cos > 0.96, f"gated_deltanet decode vs transformers: cosine {cos}"   # ~0.972 here: fp16 recurrence noise at tiny T=6 (the real model hits 0.999999 at 512 tok)
 
 
 @requires_ane
@@ -85,7 +85,7 @@ def test_gated_attention_decode_matches_transformers():
     outs[t] = np.asarray(net.prog.read_output(om[h])).reshape(D)
   delta = outs - xs
   cos_ = float(delta.ravel() @ ref.ravel() / (np.linalg.norm(delta) * np.linalg.norm(ref)))
-  assert cos_ > 0.95, f"gated_attention decode vs transformers: cosine {cos_}"
+  assert cos_ > 0.99, f"gated_attention decode vs transformers: cosine {cos_}"
 
 
 @requires_ane
@@ -122,4 +122,4 @@ def test_qwen35_hybrid_model_matches_transformers():
       pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
     outs[pos] = h.reshape(cfg.dim).astype(np.float32)
   cos = float((outs.ravel() @ ref.ravel()) / (np.linalg.norm(outs) * np.linalg.norm(ref)))
-  assert cos > 0.95, f"qwen3.5 hybrid model vs transformers: cosine {cos}"
+  assert cos > 0.99, f"qwen3.5 hybrid model vs transformers: cosine {cos}"

--- a/tests/test_speculative.py
+++ b/tests/test_speculative.py
@@ -1,30 +1,32 @@
 """Speculative decoding: must emit the same tokens as greedy (it's exact), for any draft."""
-import numpy as np
-from _helpers import requires_ane
-from aneforge.llm import LlamaConfig, LlamaPrefill, _weights_from_state_dict
-
-
-def _rand_model(cfg, seed):
-  rng = np.random.default_rng(seed); dh = cfg.dh
-  R = lambda *s: (rng.standard_normal(s) / np.sqrt(s[-1])).astype(np.float32)
-  sd = {"model.embed_tokens.weight": R(cfg.vocab, cfg.dim), "model.norm.weight": np.ones(cfg.dim, np.float32),
-        "lm_head.weight": R(cfg.vocab, cfg.dim)}
-  for L in range(cfg.n_layers):
-    p = f"model.layers.{L}."
-    for nm, sh in [("self_attn.q_proj", (cfg.n_heads * dh, cfg.dim)), ("self_attn.k_proj", (cfg.n_kv_heads * dh, cfg.dim)),
-                   ("self_attn.v_proj", (cfg.n_kv_heads * dh, cfg.dim)), ("self_attn.o_proj", (cfg.dim, cfg.n_heads * dh)),
-                   ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
-      sd[p + nm + ".weight"] = R(*sh)
-    sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
-  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg))
+from _helpers import requires_ane, make_random_llama_model
+from aneforge.llm import LlamaConfig
 
 
 @requires_ane
 def test_spec_generate_matches_greedy():
   from aneforge.speculative import spec_generate
   cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
-  tgt = _rand_model(cfg, 0); drf = _rand_model(cfg, 1)        # different draft -> exercises the rejection path
+  tgt = make_random_llama_model(cfg, seed=0); drf = make_random_llama_model(cfg, seed=1)   # different draft -> exercises rejection
   prompt = [1, 2, 3, 4]
   g = tgt.generate(list(prompt), max_new_tokens=12, max_len=40)
   s = spec_generate(tgt, drf, prompt, max_new_tokens=12, max_len=40, n_draft=3)
   assert g == s, f"spec != greedy:\n  greedy {g}\n  spec   {s}"
+
+
+@requires_ane
+def test_spec_accepts_drafts_when_draft_equals_target(monkeypatch):
+  # identical draft+target -> every draft is accepted, so the multi-token verify runs far fewer times than the
+  # tokens it emits. If acceptance were broken (always rejected) it would verify once per token instead.
+  from aneforge import speculative as sp
+  cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
+  tgt = make_random_llama_model(cfg, seed=0); drf = make_random_llama_model(cfg, seed=0)   # identical models
+  verifies = {"n": 0}; real_verify = sp._verify
+  def counting_verify(*a, **k):
+    verifies["n"] += 1
+    return real_verify(*a, **k)
+  monkeypatch.setattr(sp, "_verify", counting_verify)
+  out = sp.spec_generate(tgt, drf, [1, 2, 3, 4], max_new_tokens=16, max_len=48, n_draft=3)
+  g = tgt.generate([1, 2, 3, 4], max_new_tokens=16, max_len=48)
+  assert out == g                                                   # still exact
+  assert verifies["n"] < len(out), f"no speculative batching: {verifies['n']} verifies for {len(out)} tokens"

--- a/web/index.html
+++ b/web/index.html
@@ -228,12 +228,16 @@ vec = <span class="af">enc</span>(tokens)                 <span class="c"># cosi
   <section id="what">
     <div class="wrap">
       <span class="label">What it does</span>
-      <h2 style="margin-top:10px">Training, native layers, compression, and arbitrary workloads.</h2>
+      <h2 style="margin-top:10px">Training, LLMs, native layers, compression, and more.</h2>
       <p class="sub">Apple exposes the Neural Engine only through CoreML, and only for inference. ANEForge dispatches through the same private <code>aned</code> stack that CoreML uses internally, from a normal user process.</p>
       <div class="caps">
         <div class="cap">
           <h4>Training runs on the engine <em>CIFAR-10 → 71%</em></h4>
           <p>The forward pass, backward pass, and Adam update all compile to ANE programs, so a model trains end to end on the engine.</p>
+        </div>
+        <div class="cap">
+          <h4>LLMs on the engine <em>27B on a pure ANE</em></h4>
+          <p>Prefill and KV-cache decode for Llama/Qwen, exact speculative decoding, Mixture-of-Experts from GGUF, and the hybrid Qwen3.5-27B (DeltaNet + attention), decoding end to end on the engine.</p>
         </div>
         <div class="cap">
           <h4>Layers CoreML can’t reach <em>+19 bridge ops</em></h4>
@@ -246,6 +250,10 @@ vec = <span class="af">enc</span>(tokens)                 <span class="c"># cosi
         <div class="cap">
           <h4>Run arbitrary workloads <em>FFT, BLAS</em></h4>
           <p>Not just neural nets. FFTs, linear algebra, and fluid sims compile straight to the engine.</p>
+        </div>
+        <div class="cap">
+          <h4>Cross-compile across silicon <em>28 targets</em></h4>
+          <p>Lower and gate a graph for any M1 to M5 ANE from one machine, and estimate its latency without running it.</p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
A review-driven cleanup pass over the source, examples, and tests. No public API changes; `docs/llm.md` stays accurate. Full suite green under the project's `--forked` config (696 passed) plus 100 autograd/conv tests for the conv2d change.

## Real bugs / footguns
- **speculative**: guard that the target is a dense attention+SwiGLU model (was a bare `KeyError` on an MoE target) and assert full neox RoPE; forward `rotary_dim`/`interleaved` to the verify tables.
- **_optimize**: autotune cache writes atomically (temp + `os.replace`) and warns on unreadable/unsaved cache, so a truncated file no longer silently re-tunes every run. Variant compile failures surface under `ANEFORGE_TUNE_DEBUG`.
- **autograd**: conv2d zero-pad baked as `const_array` instead of fed `graph.input` nodes, so a standalone `compile(conv2d(...))` no longer exposes phantom zero-pad input ports. Backward is unchanged (`_reverse` skips srcs-less leaves; verified by 100 autograd/training/conv tests).
- **tests/skip guards**: `test_multilayer_resident` now uses `_helpers.requires_ane` (was an inverted env-only guard that errored instead of skipping off-device); `test_compile_targets` adds `@requires_ane` to its three on-device tests.

## Duplication removed
- New `aneforge/_gguf.py` (`GGUFView`) replaces four copy-pasted reader helper sets across `moe.py`/`qwen35.py`.
- Collapsed byte-identical `_swiglu_prefill`/`_swiglu_decode` into one `_swiglu`.
- `examples/_common.encode_chat` replaces the same 10-line helper copy-pasted in all four chat demos; reindented `moe_chat`/`qwen35_chat` to 4-space and swapped `__setitem__` counters for `nonlocal`.
- Shared `make_random_llama_model` in `tests/_helpers.py` for the llm/speculative tests.

## Test coverage strengthened
- `test_llm`: assert decode-step-0 == prefill argmax + determinism (was a contract check an RNG would pass).
- `test_speculative`: assert drafts are actually accepted (verify-count < tokens with an identical draft).
- `op_smoketest`: now collectable as a real test (was invisible to pytest).
- `test_op_catalog`: `>= 187` instead of a frozen count.
- `test_qwen35`: tightened to measured thresholds (DeltaNet 0.96, attn/hybrid 0.99).
- `test_compress`: build dirs routed through an auto-cleaning `tmp_path` fixture (was leaking ~10 `/tmp` dirs).