### PR TITLE
feat(llm): batched prefill for ANE decode (45x lower TTFT)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -104,6 +104,26 @@ def _attn_prefill(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, cos, sin)
   return x + a.linear(w["wo"])
 
 
+def _attn_prefill_kv(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, cos, sin):
+  """Like `_attn_prefill`, but also emits the per-layer cache tensors (roped k, raw v) at `[KV, S, dh]` -- the
+  exact layout `_attn_decode`'s resident cache stores -- so a batched prefill can seed the decode KV cache.
+  Returns (hidden+residual, (k_cache, v_cache))."""
+  H, KV, dh, S = cfg.n_heads, cfg.n_kv_heads, cfg.dh, x.shape[0]
+  xn = x.rms_norm(w["attn_norm"], cfg.norm_eps)
+  q = xn.linear(w["wq"], w.get("q_bias")).reshape(S, H, dh)
+  k = xn.linear(w["wk"], w.get("k_bias")).reshape(S, KV, dh); v = xn.linear(w["wv"], w.get("v_bias")).reshape(S, KV, dh)
+  if ls.qk_norm:
+    q = q.reshape(S * H, dh).rms_norm(w["q_norm"], cfg.norm_eps).reshape(S, H, dh)
+    k = k.reshape(S * KV, dh).rms_norm(w["k_norm"], cfg.norm_eps).reshape(S, KV, dh)
+  q = q.transpose([1, 0, 2]).reshape(1, H, S, dh); k = k.transpose([1, 0, 2]).reshape(1, KV, S, dh)
+  v = v.transpose([1, 0, 2]).reshape(1, KV, S, dh)
+  q, k = rope(q, cos, sin), rope(k, cos, sin)
+  kc, vc = k.reshape(KV, S, dh), v.reshape(KV, S, dh)            # cache layout: pre-repeat, k roped, v raw
+  kr, vr = _repeat_kv(k, H // KV), _repeat_kv(v, H // KV)
+  a = _causal_attn(q, kr, vr).reshape(H, S, dh).transpose([1, 0, 2]).reshape(S, H * dh)
+  return x + a.linear(w["wo"]), (kc, vc)
+
+
 def _swiglu(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
   """SwiGLU MLP with its residual: `h + down(silu(gate(norm(h))) * up(norm(h)))`. Stateless and
   shape-agnostic, so one builder serves both prefill [S,dim] and decode [1,dim]."""
@@ -159,7 +179,7 @@ class LlamaPrefill:
   `prefill(token_ids)` returns next-token logits; `generate(...)` does resident-KV-cache decode. Weights are
   a dict of numpy arrays (see `from_pretrained`)."""
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None):
-    self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None
+    self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
     self._chunk_bytes = 1.6e9      # max fp16 weight bytes per decode program (under the ~2GB ANE ceiling)
 
@@ -262,8 +282,71 @@ class LlamaPrefill:
     `generate` streams immediately. Returns self."""
     self._decoder(int(max_len)); return self
 
+  def _prefiller(self, seq):
+    """Build (once, cached) the CHUNKED batched-prefill program(s) for prompt length `seq`: layers split under
+    the ANE program ceiling (like `_decoder`), each chunk a full-sequence forward emitting its attention layers'
+    (roped k, raw v) at `[KV, seq, dh]`, hidden chained chunk->chunk. Attention layers only. Cached by `seq`, so
+    padding prompts to a fixed bucket length reuses one compile across calls (amortizing the compile cost)."""
+    if self._pre is not None and self._pre["seq"] == seq: return self._pre
+    if self._pre is not None:
+      for c in self._pre["chunks"]: c["net"].release()
+    from ._compile import compile_multi
+    cfg = self.cfg
+    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)
+    chunks = []
+    for grp in self._layer_chunks():
+      x = _input((seq, cfg.dim)); h = x; kvts = []
+      for li in grp:
+        ls = self._spec(li)
+        if ls.mixer != "attention":
+          raise NotImplementedError("batched prefill supports attention layers only")
+        h, kv = _attn_prefill_kv(h, self.w["layers"][li], cfg, ls, cos, sin)
+        h = PREFILL_MLPS[ls.mlp](h, self.w["layers"][li], cfg, ls)
+        kvts.append((li, kv))
+      if grp[-1] == cfg.n_layers - 1: h = h.rms_norm(self.w["final_norm"], cfg.norm_eps)
+      net = compile_multi([h] + [t for _, kv in kvts for t in kv], compress=self.compress)
+      om = dict(net.output_ports); inm = {id(t): n for t, n in net.input_ports}
+      p = {"x": inm[id(x)], "h": om[h], "kv": [(li, om[kv[0]], om[kv[1]]) for li, kv in kvts]}
+      chunks.append({"net": net, "p": p})
+    self._pre = {"seq": seq, "chunks": chunks}
+    return self._pre
+
+  def _prefill_seed(self, token_ids, pad_to=None):
+    """Batched prefill via the cached chunked prefiller: run the whole prompt in one pass per chunk (full causal
+    attention -- the compute-bound matmuls the engine likes) instead of stepping the decode program per token.
+    `pad_to` right-pads the prompt to a fixed bucket length so ONE prefiller compile is reused across prompts of
+    different real length (causal attention ignores the trailing pads); the real length drives the returned
+    logits and the cache seed. Returns (next_logits [1, vocab], kv_by_layer) in the decode cache layout."""
+    f16 = np.float16; real = len(token_ids)
+    seq = max(int(pad_to), real) if pad_to else real
+    pre = self._prefiller(seq)
+    h = self.w["embed"][np.asarray(list(token_ids) + [0] * (seq - real))].astype(f16)   # [seq, dim], right-padded
+    kv_by_layer: list = [None] * self.cfg.n_layers
+    for c in pre["chunks"]:
+      pr = c["net"].prog; p = c["p"]
+      pr.set_input(p["x"], h); pr.execute()
+      h = np.asarray(pr.read_output(p["h"])).astype(f16)                      # hidden chained chunk -> chunk
+      for li, kport, vport in p["kv"]:                                        # keep only the real positions
+        kv_by_layer[li] = (np.asarray(pr.read_output(kport)).astype(f16)[:, :real, :],
+                           np.asarray(pr.read_output(vport)).astype(f16)[:, :real, :])
+    return self._logits(h[real - 1].astype(np.float32))[None], kv_by_layer
+
+  def _seed_cache(self, d, kv_by_layer, seq):
+    """Write a batched prefill's per-layer K/V into the resident decode cache buffers (positions [0:seq]), the
+    same `set_input` path `generate` uses to zero them. Decode chunks group layers exactly as `_layer_chunks`."""
+    M = d["M"]; f16 = np.float16; groups = self._layer_chunks()
+    for gi, c in enumerate(d["chunks"]):
+      ports, seeded = list(c["p"]["states"].keys()), []
+      for li in groups[gi]:                                   # states ordered K_li, V_li per attention layer
+        K, V = kv_by_layer[li]; KVh, _, dh = K.shape
+        pk = np.zeros((KVh, M, dh), f16); pk[:, :seq, :] = K
+        pv = np.zeros((KVh, M, dh), f16); pv[:, :seq, :] = V
+        seeded += [pk, pv]
+      for port, buf in zip(ports, seeded):
+        c["net"].prog.set_input(port, buf)
+
   def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None,
-               temperature=0.0, top_p=1.0, top_k=0):
+               temperature=0.0, top_p=1.0, top_k=0, batched_prefill=True, prefill_pad=None):
     """Autoregressive generation with a resident KV-cache. The decode program (compiled once and cached) runs
     all layers for one token attending to caches that stay on the ANE across steps, so each step feeds only the
     token embedding + a position one-hot. `on_token(id)` is called per token (streaming). Greedy by default
@@ -287,14 +370,26 @@ class LlamaPrefill:
           if k in p: pr.set_input(p[k], vals[k])
         pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
       return h.reshape(cfg.dim).astype(np.float32)
-    for pos, tok in enumerate(prompt[:-1]): step(tok, pos)      # prefill the cache (discard hidden)
-    cur = prompt[-1]; pos = len(prompt) - 1; out = []
-    for _ in range(max_new_tokens):                            # decode
+    use_batched = (batched_prefill and len(prompt) > 1
+                   and not hasattr(self.w["layers"], "free")     # streamed weights are freed by _decoder; can't re-bake
+                   and all(self._spec(i).mixer == "attention" for i in range(cfg.n_layers)))
+    out = []
+    if use_batched:                                            # one-pass prefill, then seed the resident cache
+      logits0, kv = self._prefill_seed(prompt, prefill_pad)
+      self._seed_cache(d, kv, len(prompt))
+      cur = self._sample(logits0[0], temperature, top_p, top_k); out.append(cur)
+      if cur == eos_id: return out
+      if on_token is not None: on_token(cur)
+      pos = len(prompt)
+    else:
+      for p, tok in enumerate(prompt[:-1]): step(tok, p)       # token-by-token prefill (fallback / oracle)
+      cur, pos = prompt[-1], len(prompt) - 1
+    while len(out) < max_new_tokens:                           # decode
       if pos >= M - 1: break                                   # cache full
       nxt = self._sample(self._logits(step(cur, pos)), temperature, top_p, top_k); out.append(nxt)
       if nxt == eos_id: break
       if on_token is not None: on_token(nxt)                   # stream the token
-      cur = nxt; pos += 1
+      cur, pos = nxt, pos + 1
     return out
 
 

--- a/bench/mlperf/llm_summarize.py
+++ b/bench/mlperf/llm_summarize.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""MLPerf-style LLM summarization on the ANE (quick look).
+
+Mirrors the MLPerf Inference small-LLM benchmark (v5.1: Llama3.1-8B, formerly GPT-J-6B) -- CNN/DailyMail
+articles summarized greedily, scored by ROUGE -- run here on the ANE via aneforge's chunked decode. This is a
+subset preview to see whether the summaries are coherent and ROUGE is in range; it is NOT the full 5,000-article
+edge set, NOT the canonical rouge_score/stemmer, and NOT an official MLPerf submission (see README.md).
+
+  PYTHONPATH=. python3 bench/mlperf/llm_summarize.py                        # cached Qwen3-8B, int8, 4 articles
+  PYTHONPATH=. python3 bench/mlperf/llm_summarize.py --n 20 --fp16
+  PYTHONPATH=. python3 bench/mlperf/llm_summarize.py --llm ~/Models/Qwen3-8B --n 8 --max-new 128
+"""
+from __future__ import annotations
+import argparse
+import json
+import os
+import re
+import sys
+import time
+from collections import Counter
+from pathlib import Path
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+os.environ.setdefault("TOKENIZERS_PARALLELISM", "false")
+
+REPO = Path(__file__).resolve().parents[2]
+if str(REPO) not in sys.path:
+    sys.path.insert(0, str(REPO))
+
+_PROMPT = ("Summarize the news article below in three short sentences. State only the key facts from the "
+           "article; add no commentary, and do not begin with phrases like \"The article\" or \"Summary\".\n\n"
+           "{article}")
+
+
+def _clean(text):
+    """Strip a leading 'Summary:' / '**Summary:**' preamble and markdown bold the chat model tends to add."""
+    t = re.sub(r"^\**\s*summary\s*:?\**\s*", "", text.strip(), flags=re.I)
+    return t.replace("**", "").strip()
+
+
+# --- ROUGE: canonical rouge_score (Porter stemmer, as MLPerf uses) if present, else a self-contained F1 ---
+def _toks(s):
+    return re.findall(r"[a-z0-9]+", s.lower())
+
+
+def _rouge_inline(pred, ref):
+    def grams(t, n):
+        return Counter(tuple(t[i:i + n]) for i in range(len(t) - n + 1))
+
+    def f1n(n):
+        p, r = grams(_toks(pred), n), grams(_toks(ref), n)
+        overlap, pt, rt = sum((p & r).values()), sum(grams(_toks(pred), n).values()), sum(grams(_toks(ref), n).values())
+        prec, rec = (overlap / pt if pt else 0.0), (overlap / rt if rt else 0.0)
+        return 2 * prec * rec / (prec + rec) if prec + rec else 0.0
+
+    a, b = _toks(pred), _toks(ref)
+    dp = [0] * (len(b) + 1)                                   # ROUGE-L: LCS via rolling DP
+    for x in a:
+        prev = 0
+        for j, y in enumerate(b, 1):
+            prev, dp[j] = dp[j], (prev + 1 if x == y else max(dp[j], dp[j - 1]))
+    lcs = dp[-1]
+    pl, rl = (lcs / len(a) if a else 0.0), (lcs / len(b) if b else 0.0)
+    rougeL = 2 * pl * rl / (pl + rl) if pl + rl else 0.0
+    return {"rouge1": f1n(1), "rouge2": f1n(2), "rougeL": rougeL}
+
+
+try:
+    from rouge_score import rouge_scorer as _rs
+    _SCORER = _rs.RougeScorer(["rouge1", "rouge2", "rougeL"], use_stemmer=True)
+
+    def rouge(pred, ref):
+        s = _SCORER.score(ref, pred)
+        return {k: s[k].fmeasure for k in ("rouge1", "rouge2", "rougeL")}
+    _ROUGE = "rouge_score (stemmer)"
+except Exception:
+    rouge = _rouge_inline
+    _ROUGE = "inline (no stemmer)"
+
+
+def load_cnndm(n):
+    """First `n` CNN/DailyMail validation articles (streamed, no full download). Returns [(article, reference)]."""
+    from datasets import load_dataset
+    ds = load_dataset("abisee/cnn_dailymail", "3.0.0", split="validation", streaming=True)
+    out = []
+    for ex in ds:
+        out.append((ex["article"], ex["highlights"]))
+        if len(out) >= n:
+            break
+    return out
+
+
+class SummarizeSUT:
+    """An aneforge LLM (chunked ANE decode) + its HF tokenizer, wrapped to summarize one article and time it."""
+    def __init__(self, model_path, compress=None, max_input=512, max_new=96):
+        import aneforge as af
+        from transformers import AutoTokenizer
+        self.tok = AutoTokenizer.from_pretrained(model_path)
+        self.model = af.load_llm(model_path, compress=compress)
+        self.max_input, self.max_new = max_input, max_new
+        self.prefill_pad = max_input + 96          # fixed bucket so batched prefill compiles once, reused per article
+        self.name = os.path.basename(str(model_path).rstrip("/")) + "-ane-" + (compress or "fp16")
+
+    def _prompt_ids(self, article):
+        art = self.tok(article, truncation=True, max_length=self.max_input)["input_ids"]
+        text = _PROMPT.format(article=self.tok.decode(art, skip_special_tokens=True))
+        msgs = [{"role": "user", "content": text}]
+        try:                                                 # Qwen3: no chain-of-thought, just the summary
+            s = self.tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False, tokenize=False)
+        except TypeError:
+            s = self.tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
+        return [int(t) for t in self.tok(s, add_special_tokens=False)["input_ids"]]   # template already has specials
+
+    def summarize(self, article):
+        ids = self._prompt_ids(article)
+        times = []
+        t0 = time.perf_counter()
+        out = self.model.generate(list(ids), max_new_tokens=self.max_new, max_len=len(ids) + self.max_new,
+                                  eos_id=self.tok.eos_token_id, temperature=0.0, prefill_pad=self.prefill_pad,
+                                  on_token=lambda _t: times.append(time.perf_counter()))
+        summary = _clean(self.tok.decode(out, skip_special_tokens=True))
+        ttft = (times[0] - t0) if times else float("nan")
+        dtoks = max(0, len(times) - 1)
+        tok_s = dtoks / (times[-1] - times[0]) if dtoks > 0 else float("nan")
+        return {"summary": summary, "prompt_tokens": len(ids), "gen_tokens": len(out),
+                "ttft_s": ttft, "decode_tok_s": tok_s}
+
+
+def main():
+    ap = argparse.ArgumentParser(description="MLPerf-style LLM summarization on the ANE (quick look)")
+    ap.add_argument("--llm", default=os.path.expanduser("~/Models/Qwen3-8B"), help="HF model dir/name")
+    ap.add_argument("--n", type=int, default=4, help="articles (subset preview; the edge set is 5000)")
+    ap.add_argument("--max-input-tokens", type=int, default=512)
+    ap.add_argument("--max-new", type=int, default=128)
+    ap.add_argument("--fp16", action="store_true", help="fp16 weights (default int8, for memory headroom)")
+    ap.add_argument("--out", default=None)
+    args = ap.parse_args()
+
+    compress = None if args.fp16 else "int8"
+    print(f"loading {os.path.basename(args.llm)} ({compress or 'fp16'}, chunked ANE decode) ...", flush=True)
+    sut = SummarizeSUT(args.llm, compress=compress, max_input=args.max_input_tokens, max_new=args.max_new)
+    data = load_cnndm(args.n)
+    print(f"summarizing {len(data)} CNN/DailyMail articles ...\n", flush=True)
+
+    rows = []
+    for i, (article, ref) in enumerate(data):
+        r = sut.summarize(article)
+        sc = rouge(r["summary"], ref)
+        rows.append({**r, **sc})
+        print(f"[{i + 1}/{len(data)}] prompt {r['prompt_tokens']} tok, gen {r['gen_tokens']} tok, "
+              f"TTFT {r['ttft_s']:.2f}s, {r['decode_tok_s']:.1f} tok/s, "
+              f"R1 {sc['rouge1']:.3f} R2 {sc['rouge2']:.3f} RL {sc['rougeL']:.3f}", flush=True)
+        print(f"      summary: {r['summary'][:220]}", flush=True)
+
+    n = len(rows)
+    mean = {k: sum(x[k] for x in rows) / n for k in ("rouge1", "rouge2", "rougeL")}
+    mtok = sum(x["decode_tok_s"] for x in rows) / n
+    print(f"\nmean ROUGE-1 {mean['rouge1']:.3f}  ROUGE-2 {mean['rouge2']:.3f}  ROUGE-L {mean['rougeL']:.3f}"
+          f"   |  mean decode {mtok:.1f} tok/s   ({sut.name}, {n} articles, ROUGE: {_ROUGE})")
+    print("(subset preview -- not the official 5000-article MLPerf gate)")
+
+    out = args.out or os.path.join(Path(__file__).resolve().parent, "results", "llm_summarize_preview.json")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w") as f:
+        json.dump({"model": sut.name, "n": n, "mean_rouge": mean, "mean_decode_tok_s": mtok, "rows": rows},
+                  f, indent=2, allow_nan=True)
+    print(f"wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/bench/mlperf/results/llm_summarize_fp16_batched.json
+++ b/bench/mlperf/results/llm_summarize_fp16_batched.json
@@ -1,0 +1,42 @@
+{
+  "model": "Qwen3-8B-ane-fp16",
+  "n": 3,
+  "mean_rouge": {
+    "rouge1": 0.323351992434118,
+    "rouge2": 0.10670701388000965,
+    "rougeL": 0.25212790430181736
+  },
+  "mean_decode_tok_s": 7.126220726754204,
+  "rows": [
+    {
+      "summary": "Zully Broussard donated one of her kidneys to a stranger. Her donation, combined with genetic data matching, resulted in six patients receiving transplants.",
+      "prompt_tokens": 372,
+      "gen_tokens": 33,
+      "ttft_s": 269.7521523339674,
+      "decode_tok_s": 5.87097819932738,
+      "rouge1": 0.43478260869565216,
+      "rouge2": 0.18181818181818182,
+      "rougeL": 0.391304347826087
+    },
+    {
+      "summary": "On April 6, 1996, the first Major League Soccer match was played in San Jose. The league has grown significantly, expanding from 10 to 20 teams by 2015.",
+      "prompt_tokens": 372,
+      "gen_tokens": 47,
+      "ttft_s": 4.068945792037994,
+      "decode_tok_s": 7.797309010553874,
+      "rouge1": 0.21428571428571427,
+      "rouge2": 0.037037037037037035,
+      "rougeL": 0.14285714285714285
+    },
+    {
+      "summary": "Bafetimbi Gomis collapsed during a Premier League match but is now feeling well. He was treated on the pitch and spent the night in hospital as a precaution. Swansea confirmed Gomis was fine and had undergone medical tests.",
+      "prompt_tokens": 372,
+      "gen_tokens": 50,
+      "ttft_s": 1.3076140829361975,
+      "decode_tok_s": 7.710374970381358,
+      "rouge1": 0.32098765432098764,
+      "rouge2": 0.10126582278481013,
+      "rougeL": 0.2222222222222222
+    }
+  ]
+}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -65,6 +65,16 @@ def test_segmented_decode_matches_single():  # splitting the decode across chunk
   assert m2.generate([1, 2, 3], max_new_tokens=6) == out1, "segmented decode diverged from single-program"
 
 @requires_ane
+def test_batched_prefill_matches_token_by_token():  # batched prefill (KV-bridge -> seed -> decode) == token-by-token
+  cfg = LlamaConfig(dim=64, n_layers=4, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
+  prompt = list(range(1, 9))
+  oracle = _random_model(cfg).generate(prompt, max_new_tokens=8, batched_prefill=False)   # token-by-token prefill
+  assert _random_model(cfg).generate(prompt, max_new_tokens=8, batched_prefill=True) == oracle
+  assert _random_model(cfg).generate(prompt, max_new_tokens=8, batched_prefill=True, prefill_pad=16) == oracle  # bucketed
+  m = _random_model(cfg); m._chunk_bytes = 1                       # force one layer per prefill/decode chunk
+  assert m.generate(prompt, max_new_tokens=8, batched_prefill=True) == oracle, "chunked batched prefill diverged"
+
+@requires_ane
 def test_prefill_matches_huggingface_llama():  # the definitive check: ANE prefill == HF LlamaForCausalLM
   import torch
   from transformers import LlamaConfig as HF, LlamaForCausalLM


### PR DESCRIPTION
## Summary

`generate()` prefilled the prompt **one token at a time** through the decode program -- O(prompt_len) ANE dispatches, ~38 s TTFT for a 372-token prompt on an 8B model. This adds a **batched prefill** path: ingest the whole prompt in one compute-bound pass (the big matmuls the ANE likes), then seed the resident decode KV cache and continue.

**Measured (Qwen3-8B): TTFT 38 s -> 0.85 s (int8) / ~1.3 s (fp16), ~45x.**

## How it works

The prefill program and the decode cache already store the *same* K/V (roped `k`, raw `v`); they were just disconnected. This bridges them:

- **`_attn_prefill_kv`** -- prefill attention mixer that also emits per-layer `(k, v)` at `[KV, seq, dh]`, the exact decode-cache layout.
- **`_prefiller`** -- cached, chunked batched-prefill program(s). Mirrors `_decoder`: splits layers under the ANE program ceiling and chains hidden chunk->chunk, so it fits 8B+.
- **`_seed_cache`** -- writes the prefill K/V into the resident decode buffers (the same `set_input` path `generate()` uses to zero them), then decode runs from `pos = seq`.
- **`generate(batched_prefill=True, prefill_pad=N)`** -- `prefill_pad` right-pads to a fixed bucket so one compile serves all prompt lengths (causal attention ignores the trailing pads).

## Correctness

Batched prefill is **token-identical** to the token-by-token path. New on-hardware test `test_batched_prefill_matches_token_by_token` asserts batched, bucketed, and forced-chunked generation all equal the oracle; the existing `test_llm.py` + `test_speculative.py` suites still pass (11/11). Guarded off for streamed/GGUF weights (the decoder frees them, so the prefiller can't re-bake).

## Also here

`bench/mlperf/llm_summarize.py` -- an MLPerf-style CNN/DailyMail summarization + ROUGE harness (the small-LLM benchmark shape: Llama3.1-8B / formerly GPT-J), a preview of LLM summarization on the ANE. Finding along the way: **fp16 is required for generation quality** (int8 compounds autoregressive error into hallucination); a committed fp16+batched result is included.

Note: the on-hardware LLM tests are not in CI (CI runs only the off-device `test_compile_breaker.py`); validated locally on M5 Pro.
