### PR TITLE
fix(llm): lift the 512-token ANE attention context ceiling

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -67,12 +67,13 @@ def rope(x: Tensor, cos, sin) -> Tensor:
 
 
 def _repeat_kv(k: Tensor, g: int) -> Tensor:
-  """Grouped-query repeat: [1, KV, S, dh] -> [1, KV*g, S, dh], each kv head repeated `g` times (via a 0/1 expansion matmul; any `g`)."""
+  """Grouped-query repeat: [1, KV, S, dh] -> [1, KV*g, S, dh], each kv head repeated `g` times (a 0/1 expansion
+  matmul on the KV axis; any `g`). S and dh stay separate axes -- flattening them into one (S*dh) trips the ANE
+  65536 per-axis limit, capping context at S*dh <= 65536 (e.g. 512 at dh=128)."""
   if g == 1: return k
   _, KV, S, dh = k.shape
-  M = np.repeat(np.eye(KV, dtype=np.float16), g, axis=0)        # [KV*g, KV]: M[h, kv] = 1 iff kv == h // g
-  k2 = k.reshape(KV, S * dh).transpose([1, 0])                  # [S*dh, KV]
-  return k2.linear(M).transpose([1, 0]).reshape(1, KV * g, S, dh)
+  Mx = np.repeat(np.eye(KV, dtype=np.float16), g, axis=0)       # [KV*g, KV]: Mx[h, kv] = 1 iff kv == h // g
+  return k.reshape(KV, S, dh).transpose([1, 2, 0]).linear(Mx).transpose([2, 0, 1]).reshape(1, KV * g, S, dh)
 
 
 def _causal_attn(q: Tensor, k: Tensor, v: Tensor) -> Tensor:
@@ -138,11 +139,12 @@ def prefill_block(x: Tensor, w: dict, cfg: LlamaConfig, cos, sin, ls: LayerSpec 
 
 
 def _repeat_kv3(k: Tensor, g: int) -> Tensor:
-  """Grouped-query repeat for the decode cache: [KV, M, dh] -> [KV*g, M, dh] (0/1 expansion matmul)."""
+  """Grouped-query repeat for the decode cache: [KV, M, dh] -> [KV*g, M, dh] (0/1 expansion matmul on the KV
+  axis). M and dh stay separate axes -- flattening to M*dh trips the ANE 65536 per-axis limit (context cap
+  M*dh <= 65536, i.e. 512 at dh=128)."""
   if g == 1: return k
-  KV, M, dh = k.shape
-  Mx = np.repeat(np.eye(KV, dtype=np.float16), g, axis=0)
-  return k.reshape(KV, M * dh).transpose([1, 0]).linear(Mx).transpose([1, 0]).reshape(KV * g, M, dh)
+  Mx = np.repeat(np.eye(k.shape[0], dtype=np.float16), g, axis=0)
+  return k.transpose([1, 2, 0]).linear(Mx).transpose([2, 0, 1])   # [KV,M,dh]->[M,dh,KV]->[M,dh,KV*g]->[KV*g,M,dh]
 
 
 def _attn_decode(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, ctx: dict, M: int):

--- a/bench/mlperf/results/llm_summarize_fp16_longctx.json
+++ b/bench/mlperf/results/llm_summarize_fp16_longctx.json
@@ -1,0 +1,42 @@
+{
+  "model": "Qwen3-8B-ane-fp16",
+  "n": 3,
+  "mean_rouge": {
+    "rouge1": 0.33544001754137054,
+    "rouge2": 0.11685499058380415,
+    "rougeL": 0.22179085355105269
+  },
+  "mean_decode_tok_s": 6.333645140941489,
+  "rows": [
+    {
+      "summary": "Zully Broussard donated a kidney to a stranger, leading to six patients receiving transplants. The success was enabled by data analysis of genetic profiles. The surgeries involved multiple medical professionals and were part of a larger organ donation initiative.",
+      "prompt_tokens": 564,
+      "gen_tokens": 49,
+      "ttft_s": 290.689783000038,
+      "decode_tok_s": 4.715226369863756,
+      "rouge1": 0.4193548387096774,
+      "rouge2": 0.16666666666666666,
+      "rougeL": 0.2903225806451613
+    },
+    {
+      "summary": "On April 6, 1996, the first Major League Soccer match was played in San Jose. The league has grown significantly, expanding to 20 teams by 2015, with more set to join by 2020.",
+      "prompt_tokens": 564,
+      "gen_tokens": 55,
+      "ttft_s": 5.772784083033912,
+      "decode_tok_s": 7.420931722108427,
+      "rouge1": 0.19672131147540986,
+      "rouge2": 0.03389830508474576,
+      "rougeL": 0.13114754098360656
+    },
+    {
+      "summary": "Bafetimbi Gomis collapsed during Swansea's match against Tottenham but was conscious after treatment. He was wearing an oxygen mask and spent the night in hospital as a precaution. Gomis has scored two league goals for Swansea this season.",
+      "prompt_tokens": 564,
+      "gen_tokens": 51,
+      "ttft_s": 2.265440084040165,
+      "decode_tok_s": 6.864777330852285,
+      "rouge1": 0.3902439024390244,
+      "rouge2": 0.15,
+      "rougeL": 0.24390243902439024
+    }
+  ]
+}

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -65,6 +65,12 @@ def test_segmented_decode_matches_single():  # splitting the decode across chunk
   assert m2.generate([1, 2, 3], max_new_tokens=6) == out1, "segmented decode diverged from single-program"
 
 @requires_ane
+def test_attention_context_above_512():  # M*dh > 65536 formerly tripped the ANE per-axis limit in the GQA repeat
+  cfg = LlamaConfig(dim=256, n_layers=2, n_heads=2, n_kv_heads=1, ffn_dim=128, vocab=48)   # dh=128 -> old cap M=512
+  out = _random_model(cfg).generate([1, 2, 3, 4], max_new_tokens=4, max_len=600)           # M=600 -> M*dh=76800
+  assert len(out) == 4 and all(0 <= t < cfg.vocab for t in out)
+
+@requires_ane
 def test_batched_prefill_matches_token_by_token():  # batched prefill (KV-bridge -> seed -> decode) == token-by-token
   cfg = LlamaConfig(dim=64, n_layers=4, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=48)
   prompt = list(range(1, 9))


### PR DESCRIPTION
## Summary

The ANE has a **65536 (2^16) per-axis limit**. The grouped-query repeat reshaped the K/V to `[KV, S*dh]` before its 0/1 expansion matmul, so that axis blew the limit once `S*dh > 65536` -- a hard **512-token context cap at dh=128**, with attention failing to compile (`Espresso "Not implemented": some ops not supported on any backend`).

Confirmed the scaling with a two-head-dim probe: **dh=128 caps at 512, dh=64 at 1024 -- both at exactly `M*dh = 65536`.**

## Fix

Do the group-repeat with `S`/`M` and `dh` as **separate axes** instead of flattening them:

`[KV, S, dh] -> transpose [S, dh, KV] -> expansion matmul -> [KV*g, S, dh]`

Identical math, no oversized axis. Applies to **both** `_repeat_kv` (prefill) and `_repeat_kv3` (decode), so the ceiling is lifted for the whole attention path.

## Validation

- Decode now compiles at **M = 640 / 1024 / 2048** (`M*dh` up to 262144), where >512 failed before.
- The GQA correctness suite is unchanged (all `test_llm.py` pass, 10/10 on-hardware).
- New test `test_attention_context_above_512` exercises `M*dh > 65536`.
- End to end: Qwen3-8B CNN/DailyMail summarization at **564-token prompts** (M~692) now runs and improves ROUGE (mean R1 0.323 -> 0.335), where it couldn't compile before.

Not MLPerf-specific: this raises the usable context length for every LLM on the ANE. On-hardware tests aren't in CI (which runs only off-device `test_compile_breaker.py`); validated on M5 Pro.
