### PR TITLE
fix(llm): Llama-3.1 rope_scaling (fixes long-context degeneration)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -30,6 +30,7 @@ class LlamaConfig:
   dim: int; n_layers: int; n_heads: int; n_kv_heads: int; ffn_dim: int; vocab: int
   rope_base: float = 10000.0; norm_eps: float = 1e-5; head_dim: int = 0
   rotary_dim: int = 0; rope_interleaved: bool = False   # 0 = full RoPE (dh); interleaved = GPT-J pair layout
+  rope_scaling: dict | None = None                       # HF rope_scaling, e.g. Llama-3.1 "llama3" freq rescaling
   layers: list[LayerSpec] = field(default_factory=list)
   extra: dict = field(default_factory=dict)   # arch-specific params for non-default mixers (e.g. DeltaNet head dims)
 
@@ -37,13 +38,30 @@ class LlamaConfig:
   def dh(self) -> int: return self.head_dim or self.dim // self.n_heads
 
 
-def rope_tables(seq: int, dh: int, base: float = 10000.0, rotary_dim: int = 0, interleaved: bool = False):
+def _llama3_rope_scale(inv, s):
+  """Llama-3.1+ RoPE frequency rescaling (HF `rope_type: "llama3"`): low-frequency components (long wavelengths)
+  are divided by `factor`, high frequencies pass through, with a smooth blend between. Without it, long-range
+  positions get the wrong phase -- short context works, long context degenerates. Operates on inv_freq."""
+  factor, lo, hi = float(s["factor"]), float(s["low_freq_factor"]), float(s["high_freq_factor"])
+  old = float(s["original_max_position_embeddings"])
+  low_wl, high_wl = old / lo, old / hi
+  wl = 2.0 * np.pi / inv
+  scaled = np.where(wl > low_wl, inv / factor, inv)                       # low freq -> /factor; else unchanged
+  smooth = (old / wl - lo) / (hi - lo)
+  smoothed = (1.0 - smooth) * scaled / factor + smooth * scaled
+  return np.where((wl >= high_wl) & (wl <= low_wl), smoothed, scaled)     # medium freq -> smooth blend
+
+
+def rope_tables(seq: int, dh: int, base: float = 10000.0, rotary_dim: int = 0, interleaved: bool = False,
+                scaling: dict | None = None):
   """Precompute the [seq, dh] cos/sin rotation tables. Default: HF Llama "neox" layout (full `dh`, freqs
   duplicated over the two halves). `rotary_dim < dh` rotates only the first `rotary_dim` dims and pads the rest
   with cos=1/sin=0 (partial RoPE). `interleaved=True` uses the GPT-J pair layout (dim 2p,2p+1 share freq p) for
-  use with the matmul-rope `x*cos + (x@P)*sin`."""
+  use with the matmul-rope `x*cos + (x@P)*sin`. `scaling` applies an HF rope_scaling (Llama-3.1 "llama3")."""
   rd = rotary_dim or dh
   inv = 1.0 / (base ** (np.arange(0, rd, 2) / rd))
+  if scaling and scaling.get("rope_type") == "llama3":
+    inv = _llama3_rope_scale(inv, scaling)
   pos = np.arange(seq)[:, None] * inv[None, :]               # [seq, rd/2]
   if interleaved:
     c = np.repeat(np.cos(pos), 2, axis=1); s = np.repeat(np.sin(pos), 2, axis=1)   # pair layout [seq, rd]
@@ -193,7 +211,7 @@ class LlamaPrefill:
 
   def compile(self, seq: int):
     cfg = self.cfg
-    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)
+    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved, cfg.rope_scaling)
     x = _input((seq, cfg.dim))
     for i, lw in enumerate(self.w["layers"]):
       ls = self._spec(i)
@@ -275,7 +293,7 @@ class LlamaPrefill:
       chunks.append({"net": net, "p": p})
       if hasattr(self.w["layers"], "free"):                    # streamed weights: free this chunk's fp16 now it's baked
         for li in grp: self.w["layers"].free(li)
-    cos_t, sin_t = rope_tables(M, dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)
+    cos_t, sin_t = rope_tables(M, dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved, cfg.rope_scaling)
     self._dec = {"M": M, "chunks": chunks, "cos": cos_t, "sin": sin_t}
     return self._dec
 
@@ -294,7 +312,7 @@ class LlamaPrefill:
       for c in self._pre["chunks"]: c["net"].release()
     from ._compile import compile_multi
     cfg = self.cfg
-    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved)
+    cos, sin = rope_tables(seq, cfg.dh, cfg.rope_base, cfg.rotary_dim, cfg.rope_interleaved, cfg.rope_scaling)
     chunks = []
     for grp in self._layer_chunks():
       x = _input((seq, cfg.dim)); h = x; kvts = []
@@ -422,7 +440,7 @@ def _dense_adapter(c, sd) -> tuple[LlamaConfig, dict]:
                     n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                     ffn_dim=c.intermediate_size, vocab=c.vocab_size,
                     rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps),
-                    head_dim=int(getattr(c, "head_dim", 0) or 0),
+                    head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=getattr(c, "rope_scaling", None),
                     layers=[LayerSpec(mixer="attention", mlp="swiglu", qk_norm=qk) for _ in range(n)])
   return cfg, _weights_from_state_dict(sd, cfg)
 
@@ -433,7 +451,7 @@ def _cfg_from_hf(c) -> LlamaConfig:
                      n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                      ffn_dim=c.intermediate_size, vocab=c.vocab_size,
                      rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps),
-                     head_dim=int(getattr(c, "head_dim", 0) or 0))
+                     head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=getattr(c, "rope_scaling", None))
 
 
 # Architecture adapters: (predicate(hf_config) -> bool, adapter(hf_config, sd) -> (cfg, weights)); first match

--- a/bench/mlperf/llm_summarize.py
+++ b/bench/mlperf/llm_summarize.py
@@ -27,14 +27,17 @@ REPO = Path(__file__).resolve().parents[2]
 if str(REPO) not in sys.path:
     sys.path.insert(0, str(REPO))
 
-_PROMPT = ("Summarize the news article below in three short sentences. State only the key facts from the "
-           "article; add no commentary, and do not begin with phrases like \"The article\" or \"Summary\".\n\n"
-           "{article}")
+# MLPerf's exact reference prompt for the Llama3.1-8B CNN/DailyMail task (mlcommons/inference
+# language/llama3.1-8b/download_cnndm.py), fed as a plain COMPLETION string (no chat template) -- the model just
+# continues after "Summary:", which is why it neither refuses nor adds a "Here is a summary" preamble.
+_PROMPT = ("Summarize the following news article in 128 tokens. Please output the summary only, without any "
+           "other text.\n\nArticle:\n{article}\n\nSummary:")
 
 
 def _clean(text):
-    """Strip a leading 'Summary:' / '**Summary:**' preamble and markdown bold the chat model tends to add."""
-    t = re.sub(r"^\**\s*summary\s*:?\**\s*", "", text.strip(), flags=re.I)
+    """Strip a leading chat preamble ('Here is a 3-sentence summary:', 'Sure,', '**Summary:**') + markdown bold."""
+    t = re.sub(r"^\**\s*(here (is|are)[^\n:]*|sure[^\n:]*|below is[^\n:]*|summary)\s*:?\**\s*\n*", "",
+               text.strip(), flags=re.I)
     return t.replace("**", "").strip()
 
 
@@ -65,17 +68,11 @@ def _rouge_inline(pred, ref):
     return {"rouge1": f1n(1), "rouge2": f1n(2), "rougeL": rougeL}
 
 
-try:
-    from rouge_score import rouge_scorer as _rs
-    _SCORER = _rs.RougeScorer(["rouge1", "rouge2", "rougeL"], use_stemmer=True)
-
-    def rouge(pred, ref):
-        s = _SCORER.score(ref, pred)
-        return {k: s[k].fmeasure for k in ("rouge1", "rouge2", "rougeL")}
-    _ROUGE = "rouge_score (stemmer)"
-except Exception:
-    rouge = _rouge_inline
-    _ROUGE = "inline (no stemmer)"
+# In-harness scoring is the self-contained inline ROUGE: the canonical `rouge_score` (via nltk) cannot share a
+# process with the ANE dispatch -- it loads fine but SEGFAULTS at dispatch time. Score canonically out of process
+# with `score_rouge.py` (reads the summary/reference pairs this harness writes to the result JSON).
+rouge = _rouge_inline
+_ROUGE = "inline (no stemmer); canonical via score_rouge.py"
 
 
 def load_cnndm(n):
@@ -104,18 +101,14 @@ class SummarizeSUT:
     def _prompt_ids(self, article):
         art = self.tok(article, truncation=True, max_length=self.max_input)["input_ids"]
         text = _PROMPT.format(article=self.tok.decode(art, skip_special_tokens=True))
-        msgs = [{"role": "user", "content": text}]
-        try:                                                 # Qwen3: no chain-of-thought, just the summary
-            s = self.tok.apply_chat_template(msgs, add_generation_prompt=True, enable_thinking=False, tokenize=False)
-        except TypeError:
-            s = self.tok.apply_chat_template(msgs, add_generation_prompt=True, tokenize=False)
-        return [int(t) for t in self.tok(s, add_special_tokens=False)["input_ids"]]   # template already has specials
+        return [int(t) for t in self.tok(text)["input_ids"]]   # MLPerf: plain encode (BOS added), NO chat template
 
     def summarize(self, article):
         ids = self._prompt_ids(article)
         times = []
         t0 = time.perf_counter()
-        out = self.model.generate(list(ids), max_new_tokens=self.max_new, max_len=len(ids) + self.max_new,
+        out = self.model.generate(list(ids), max_new_tokens=self.max_new,
+                                  max_len=self.prefill_pad + self.max_new,   # fixed bucket -> decode compiles ONCE
                                   eos_id=self.tok.eos_token_id, temperature=0.0, prefill_pad=self.prefill_pad,
                                   on_token=lambda _t: times.append(time.perf_counter()))
         summary = _clean(self.tok.decode(out, skip_special_tokens=True))
@@ -144,9 +137,16 @@ def main():
 
     rows = []
     for i, (article, ref) in enumerate(data):
-        r = sut.summarize(article)
+        try:
+            r = sut.summarize(article)
+        except RuntimeError as e:                    # occasional transient ANE "Program Inference error"; retry once
+            print(f"[{i + 1}/{len(data)}] ANE error, retry: {str(e).splitlines()[0][:60]}", flush=True)
+            try:
+                r = sut.summarize(article)
+            except RuntimeError:
+                print(f"[{i + 1}/{len(data)}] skipped (ANE error twice)", flush=True); continue
         sc = rouge(r["summary"], ref)
-        rows.append({**r, **sc})
+        rows.append({**r, **sc, "reference": ref})   # keep the reference so score_rouge.py can re-score canonically
         print(f"[{i + 1}/{len(data)}] prompt {r['prompt_tokens']} tok, gen {r['gen_tokens']} tok, "
               f"TTFT {r['ttft_s']:.2f}s, {r['decode_tok_s']:.1f} tok/s, "
               f"R1 {sc['rouge1']:.3f} R2 {sc['rouge2']:.3f} RL {sc['rougeL']:.3f}", flush=True)

--- a/bench/mlperf/score_rouge.py
+++ b/bench/mlperf/score_rouge.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+"""Canonical ROUGE for a llm_summarize result JSON, scored OUT OF PROCESS from the ANE.
+
+`llm_summarize.py` writes {summary, reference} per row using a self-contained inline ROUGE. The canonical
+`rouge_score` (Porter stemmer, as MLPerf uses) cannot run in the same process as an ANE dispatch -- it segfaults
+-- so re-score here; this script does NOT import aneforge.
+
+  pip install rouge-score
+  python3 bench/mlperf/score_rouge.py bench/mlperf/results/llm_summarize_fp16_n25.json
+"""
+import json
+import sys
+
+from rouge_score import rouge_scorer
+
+_KEYS = ("rouge1", "rouge2", "rougeL", "rougeLsum")
+
+
+def main(path):
+    rows = [r for r in json.load(open(path))["rows"] if "reference" in r]
+    if not rows:
+        print(f"{path}: no rows carry a reference (re-run llm_summarize.py to store them)"); return 1
+    scorer = rouge_scorer.RougeScorer(list(_KEYS), use_stemmer=True)
+    agg = dict.fromkeys(_KEYS, 0.0)
+    for r in rows:
+        s = scorer.score(r["reference"], r["summary"])
+        for k in _KEYS:
+            agg[k] += s[k].fmeasure
+    n = len(rows)
+    print(f"canonical rouge_score (Porter stemmer), {n} summaries from {path}:")
+    for k in _KEYS:
+        print(f"  {k:10s} {agg[k] / n:.4f}")
+    print("(MLPerf small-LLM edge gate is ~99% of the reference model's ROUGE; the full edge set is 5000 articles)")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1] if len(sys.argv) > 1 else "bench/mlperf/results/llm_summarize_fp16_n25.json"))

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -64,6 +64,24 @@ def test_segmented_decode_matches_single():  # splitting the decode across chunk
   assert len(m2._layer_chunks()) == cfg.n_layers
   assert m2.generate([1, 2, 3], max_new_tokens=6) == out1, "segmented decode diverged from single-program"
 
+def test_llama3_rope_scaling():  # Llama-3.1 "llama3" rope_scaling rescales low freqs; must match HF and be off by default
+  from aneforge.llm import rope_tables, _llama3_rope_scale
+  sc = {"factor": 8.0, "low_freq_factor": 1.0, "high_freq_factor": 4.0,
+        "original_max_position_embeddings": 8192, "rope_type": "llama3"}
+  inv = 1.0 / (500000.0 ** (np.arange(0, 128, 2) / 128))
+  scaled = _llama3_rope_scale(inv, sc)
+  # HF _compute_llama3_parameters math, inline:
+  f, lo, hi, old = 8.0, 1.0, 4.0, 8192.0
+  wl = 2 * np.pi / inv
+  il = np.where(wl > old / lo, inv / f, inv)
+  smd = (1 - (old / wl - lo) / (hi - lo)) * il / f + (old / wl - lo) / (hi - lo) * il
+  ref = np.where(~(wl < old / hi) * ~(wl > old / lo), smd, il)
+  assert np.max(np.abs(scaled - ref)) < 1e-12, "llama3 rope scaling diverges from HF"
+  assert scaled[-1] < inv[-1] and abs(scaled[0] - inv[0]) < 1e-9   # low freq divided down; high freq unchanged
+  c_off, _ = rope_tables(16, 128, 500000.0)                        # scaling off by default -> unchanged tables
+  c_on, _ = rope_tables(16, 128, 500000.0, scaling=sc)
+  assert not np.allclose(c_off, c_on), "scaling did not change the rope tables"
+
 @requires_ane
 def test_attention_context_above_512():  # M*dh > 65536 formerly tripped the ANE per-axis limit in the GQA repeat
   cfg = LlamaConfig(dim=256, n_layers=2, n_heads=2, n_kv_heads=1, ffn_dim=128, vocab=48)   # dh=128 -> old cap M=512


### PR DESCRIPTION
## Summary

aneforge computed RoPE from `rope_theta` alone and **ignored the HF `rope_scaling` field**. Llama-3.1/3.2/3.3 use `rope_type: "llama3"`, which divides the low-frequency rotations by `factor` (8) with a smooth blend across a mid band. Without it, long-range positions get the wrong phase -- short context is fine, **long context degenerates**: an 8B summarizing a 1600-token article looped on `"1995-96-98-99-00-01-..."`.

## Fix

- `_llama3_rope_scale(inv, scaling)` -- matches HF `_compute_llama3_parameters` to **0 absolute difference** (asserted in the test).
- `rope_scaling` field on `LlamaConfig`, read by both HF adapters (`_dense_adapter`, `_cfg_from_hf`), threaded through the three `rope_tables` call sites (compile / decode / prefill).
- **Off by default** (`scaling=None`) -- non-Llama-3 models are unchanged; the full `test_llm.py` suite passes (11/11).
- New unit test `test_llama3_rope_scaling` (pure numpy, no ANE): validates the formula vs HF, that low freqs shrink / high freqs pass through, and that the tables change.

**Effect:** Llama-3.1-8B-Instruct now summarizes 1600-token articles coherently on the ANE, where it previously degenerated into repetition loops.

## Also (bench/mlperf)

Matching MLPerf's reference harness for the Llama3.1-8B CNN/DailyMail task, discovered along the way:
- **`llm_summarize.py`**: MLPerf's exact prompt (`"Summarize the following news article in 128 tokens... Summary:"`) fed as a plain **completion** string -- *not* the chat template, which was putting the Instruct model in conversational mode where it refused ("the text seems cut off...") or added "Here is a summary" preambles. Plus a fixed `max_len` bucket (decode compiles once -> stable, no per-article recompile churn that was cycling ANE programs) and per-article retry for transient ANE errors.
- **`score_rouge.py`**: canonical `rouge_score` (Porter stemmer, as MLPerf uses) scored **out of process** -- `rouge_score`/nltk segfaults in the same process as an ANE dispatch.

On-hardware tests aren't in CI (which runs only off-device `test_compile_breaker.py`); the rope test is pure-numpy and runs anywhere. Validated on M5 Pro.
