### PR TITLE
Restore pristine MIT LICENSE (fix detection) + ship py.typed

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,13 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-NOTE ON SCOPE. ANEForge is an independent research project. It dispatches to the
-Apple Neural Engine through private, undocumented system symbols (the e5rt
-runtime) and is not an Apple product, is not endorsed by Apple, and relies on no
-Apple API contract. "Apple", "Apple Neural Engine", and related marks belong to
-Apple Inc. The MIT grant above covers this project's own source only; it confers
-no rights in Apple software, and the private interfaces it calls may change or
-break without notice. Use is intended for research and interoperability.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,13 @@
+ANEForge
+Copyright (c) 2026 Spencer H. Bryngelson
+
+Licensed under the MIT License; see LICENSE for the full text.
+
+NOTE ON SCOPE. ANEForge is an independent research project. It dispatches to the
+Apple Neural Engine through private, undocumented system symbols (the e5rt
+runtime) and is not an Apple product, is not endorsed by Apple, and relies on no
+Apple API contract. "Apple", "Apple Neural Engine", and related marks belong to
+Apple Inc. The MIT grant in LICENSE covers this project's own source only; it
+confers no rights in Apple software, and the private interfaces it calls may
+change or break without notice. Use is intended for research and
+interoperability.

--- a/README.md
+++ b/README.md
@@ -216,4 +216,4 @@ Report security issues privately per the [`SECURITY.md`](SECURITY.md) guidelines
 ## License
 
 [MIT](LICENSE). The Apple Neural Engine is proprietary hardware, and the framework symbols this project calls are private, undocumented, and may change at any time.
-Nothing here is endorsed by, or constitutes an API contract from, Apple.
+Nothing here is endorsed by, or constitutes an API contract from, Apple. See [`NOTICE`](NOTICE) for the scope of the grant with respect to Apple's software and marks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ readme = "README.md"
 # annotations``, which requires Python >= 3.10. Developed/verified on Python 3.14.
 requires-python = ">=3.10"
 license = "MIT"
-license-files = ["LICENSE"]
+license-files = ["LICENSE", "NOTICE"]
 authors = [{ name = "Spencer Bryngelson", email = "shb@gatech.edu" }]
 keywords = ["apple-neural-engine", "ane", "apple-silicon", "machine-learning", "inference", "espresso", "e5rt"]
 


### PR DESCRIPTION
Two small, independent fixes.

## 1. License detected as "Other" → MIT

GitHub's `licensee` reported the repo license as **Other** because the trailing `NOTE ON SCOPE` paragraph appended after the MIT text (separated by `---`) pushed `LICENSE` below the template-match similarity threshold. This affects the repo sidebar, the GitHub license API, and downstream license scanners.

- `LICENSE` is restored to the exact MIT template (pristine text + copyright line), which licensee matches.
- The scope note moves to a new `NOTICE` file.
- `NOTICE` still ships: `license-files` in `pyproject.toml` now globs `["LICENSE", "NOTICE"]`, so both land in the wheel's `dist-info/licenses/`.
- README's License section now points at `NOTICE` for the Apple-scope language.

## 2. Ship `py.typed` (PEP 561)

CI gates `pyright aneforge` at zero errors, but without a `py.typed` marker downstream users' type checkers treat the package as untyped — so that work is invisible to them. Adds the conventional empty `aneforge/py.typed`.

## Verification

Built the wheel locally and confirmed:

```
aneforge/py.typed                                (in package)
aneforge-*.dist-info/licenses/LICENSE
aneforge-*.dist-info/licenses/NOTICE
METADATA: License-Expression: MIT
          License-File: LICENSE
          License-File: NOTICE
```

No functional/code changes; nothing to run on-device.