### PR TITLE
CI: test Python 3.14; add CHANGELOG and Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Keep pinned dependencies current so they don't silently age. Two ecosystems:
+# GitHub Actions (e.g. actions/checkout, setup-python, pypa/gh-action-pypi-publish)
+# and pip (the pinned dev tooling in pyproject.toml, e.g. pyright).
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+    groups:
+      python:
+        patterns: ["*"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python: ["3.10", "3.11", "3.12", "3.13"]
+        python: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+The per-release notes on GitHub are the source of truth; this file is a thin
+index into them. Releases are cut by tagging `vX.Y.Z` (the version is derived
+from the git tag by hatch-vcs), and the notes live on the corresponding
+[GitHub Releases](https://github.com/sbryngelson/ANEForge/releases) page.
+
+The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+Changes on `main` not yet tagged. See the
+[compare view](https://github.com/sbryngelson/ANEForge/compare/v0.2.0...HEAD).
+
+## Releases
+
+- [v0.2.0](https://github.com/sbryngelson/ANEForge/releases/tag/v0.2.0) — 2026-06-28 — LLMs on the Apple Neural Engine
+- [v0.1.4](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.4) — 2026-06-25
+- [v0.1.3](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.3) — 2026-06-22
+- [v0.1.2](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.2) — 2026-06-22
+- [v0.1.1](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.1) — 2026-06-14
+- [v0.1.0](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.0) — 2026-06-12


### PR DESCRIPTION
Three small, independent maintenance items.

## Test Python 3.14 in CI

The classifiers and `requires-python` advertise 3.14 (and pyproject notes the package is developed/verified on 3.14), but the `compile-import` matrix stopped at 3.13, so the claim went untested. Adds `"3.14"` to the matrix.

## `CHANGELOG.md`

Now that the project publishes to PyPI, a changelog is an expected artifact. This is intentionally thin: an index into the GitHub release notes (the source of truth), with an Unreleased compare link and a line per release. Follows Keep a Changelog / SemVer conventions loosely.

## `.github/dependabot.yml`

Weekly, grouped bump PRs for two ecosystems so pinned things don't silently age:
- **github-actions** — `actions/checkout`, `actions/setup-python`, `pypa/gh-action-pypi-publish`, etc.
- **pip** — the pinned dev tooling in `pyproject.toml` (e.g. `pyright==1.1.410`).

Grouped so each ecosystem lands as one PR per week rather than one PR per dependency.

Both YAML files validated locally with `yaml.safe_load`.