### PR TITLE
CI: run all hardware-free suites via a real requires_ane marker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,8 +108,11 @@ jobs:
           cache: pip
           cache-dependency-path: pyproject.toml
       - run: pip install -e ".[dev]"
-      # The compile-backoff rate-limiter is a pure unit test (fake clock, no ANE).
-      - run: pytest tests/test_compile_breaker.py -q
+      # Every hardware-free suite. Device tests carry the `requires_ane` marker and are
+      # deselected here; what remains runs off-device (rate-limiter, cost-model projections,
+      # op catalog, target/family tables, build guards, graph-rewrite identities, route and
+      # preflight reconciliation, ...). New unmarked suites are picked up automatically.
+      - run: pytest -m "not requires_ane" -q
 
   docs:
     name: docs (mkdocs build)
@@ -144,6 +147,7 @@ jobs:
       - run: sh aneforge/_lib/build.sh
       - run: python -m compileall -q aneforge
       - run: pip install -e ".[dev]"
-      # Import + graph build on macOS, and the hardware-free unit test.
+      # Import + graph build on macOS, and every hardware-free suite (device tests, marked
+      # `requires_ane`, are deselected; the ANE is never dispatched on this runner).
       - run: python -c "import aneforge as af; print('aneforge', af.__version__); af.input((1, 3, 8, 8))"
-      - run: pytest tests/test_compile_breaker.py -q
+      - run: pytest -m "not requires_ane" -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,6 +118,12 @@ packages = ["aneforge"]
 # Collect only the tracked correctness suites. The RE/paper test tooling (fuzzers,
 # capability census) lives in the gitignored utils/ dir and is intentionally excluded.
 testpaths = ["tests"]
+# Device tests carry the `requires_ane` marker (registered here + in tests/conftest.py):
+# CI runs `pytest -m "not requires_ane"` to collect only the hardware-free suites, and the
+# conftest hook auto-skips any that are still collected on a machine without the ANE.
+markers = [
+  "requires_ane: needs real ANE hardware; auto-skipped when the e5rt dylib is unavailable",
+]
 # Run each test in its own forked subprocess: every compile allocates an ANE program
 # and a single process accumulates them across the suite (the training/streaming tests
 # build hundreds), approaching the per-PID program limit and causing sporadic

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -51,4 +51,10 @@ def ane_available() -> bool:
     return False
 
 
-requires_ane = pytest.mark.skipif(not ane_available(), reason="ANE/e5rt dylib unavailable")
+# A real, selectable marker (not a bare skipif): CI runs `pytest -m "not requires_ane"`
+# to collect only the hardware-free suites, and conftest's collection hook auto-skips any
+# requires_ane test that is still collected on a machine without the ANE (so a plain
+# `pytest` run off-device skips rather than errors). Applied per test (@requires_ane) or
+# per module (pytestmark = requires_ane). The ane_available() probe runs once in the hook,
+# not at import, so importing this helper never triggers a dylib build.
+requires_ane = pytest.mark.requires_ane

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,8 @@
 """Pytest config for the on-device suites: env vars set before tests fork/import aneforge."""
 import os
+import sys
+
+import pytest
 
 # Must be set before any fork/dylib load (Obj-C fork-safety; dup OpenMP).
 os.environ.setdefault("OBJC_DISABLE_INITIALIZE_FORK_SAFETY", "YES")
@@ -7,3 +10,26 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 # Single OpenMP thread: --forked os.fork() can't copy worker-thread pools.
 for _thread_var in ("OMP_NUM_THREADS", "MKL_NUM_THREADS", "OPENBLAS_NUM_THREADS", "VECLIB_MAXIMUM_THREADS"):
   os.environ.setdefault(_thread_var, "1")
+
+# The sibling helper modules (_helpers, _corpus) are imported bare by the suites; make
+# sure this directory is importable from conftest too (needed by the hook below).
+sys.path.insert(0, os.path.dirname(__file__))
+
+
+def pytest_configure(config):
+  config.addinivalue_line(
+    "markers", "requires_ane: needs real ANE hardware; auto-skipped when the e5rt dylib is unavailable")
+
+
+def pytest_collection_modifyitems(items):
+  """Auto-skip requires_ane tests when there is no ANE, so a plain off-device `pytest` run
+  skips them instead of erroring. CI additionally deselects them with -m "not requires_ane";
+  this covers a bare run (no -m) on a machine without the engine. Probe runs once, in the
+  main process before --forked forks the per-test subprocesses."""
+  from _helpers import ane_available
+  if ane_available():
+    return
+  skip = pytest.mark.skip(reason="ANE/e5rt dylib unavailable")
+  for item in items:
+    if "requires_ane" in item.keywords:
+      item.add_marker(skip)

--- a/tests/test_attention_tiles.py
+++ b/tests/test_attention_tiles.py
@@ -1,6 +1,9 @@
 """Attention query-tile autotune: heuristic by default, output-invariant across counts, cached."""
 import os
 import tempfile
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 os.environ["ANEFORGE_CACHE_DIR"] = tempfile.mkdtemp()      # hermetic: no prior tuned values
 
 import numpy as np

--- a/tests/test_autograd.py
+++ b/tests/test_autograd.py
@@ -6,6 +6,9 @@ import numpy as np
 import pytest
 import aneforge as af
 from aneforge import autograd as agrad
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def test_parameter_is_trainable_input():

--- a/tests/test_compile_targets.py
+++ b/tests/test_compile_targets.py
@@ -54,18 +54,21 @@ def _saturation_warnings(graph, target):
   return [w for w in rec if "4094" in str(w.message) or "saturat" in str(w.message).lower()]
 
 
+@requires_ane
 def test_h13_last_axis_offset_slice_warns():
   # last-axis-offset slice routes through the H13 Q.4 DMA that saturates at 4094; must warn
   g = af.input((1, 8)).slice_by_size([0, 2], [1, 4])   # last-axis begin=2 > 0
   assert _saturation_warnings(g, "h13")
 
 
+@requires_ane
 def test_h13_zero_offset_slice_does_not_warn():
   # begin=0 on the last axis avoids the offset-DMA path entirely (exact on H13)
   g = af.input((1, 8)).slice_by_size([0, 0], [1, 4])
   assert not _saturation_warnings(g, "h13")
 
 
+@requires_ane
 def test_m5_offset_slice_does_not_warn():
   # the saturation is H13-specific; M5 (family 5) stays in plain fp16
   g = af.input((1, 8)).slice_by_size([0, 2], [1, 4])

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -59,6 +59,7 @@ def test_emitter_accepts_compress_mode():
   assert em8.compress == "int8"
 
 
+@requires_ane
 def test_compress_none_matches_int8_false_mil():
   """compress=None must be byte-identical to the historical int8=False path."""
   import aneforge as af

--- a/tests/test_conv_int8.py
+++ b/tests/test_conv_int8.py
@@ -7,6 +7,8 @@ import aneforge as af
 from aneforge import _compile as C
 from aneforge.graph import conv, input as ainput
 
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
+
 
 rng = np.random.default_rng(0)
 

--- a/tests/test_cross_compile.py
+++ b/tests/test_cross_compile.py
@@ -3,6 +3,9 @@ import pytest
 import aneforge as af
 from aneforge._compile import cross_compile_check
 from aneforge._targets import detect_family
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 # cross_compile_check uses the HOST compiler, which can only emit ops the host's family
 # supports; native A15+ ops (e.g. sin) require an A15+/M5 host.

--- a/tests/test_cross_compile_matrix.py
+++ b/tests/test_cross_compile_matrix.py
@@ -11,6 +11,9 @@ from _corpus import _build_graph
 
 from aneforge import _targets as T
 from aneforge._compile import _lower_fused_to_dir, cross_compile_check
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 ARCHS = [("h13", 2), ("h14", 3), ("h15", 4), ("h16s", 5)]
 

--- a/tests/test_dispatch_floor_warning.py
+++ b/tests/test_dispatch_floor_warning.py
@@ -4,6 +4,9 @@ import warnings
 import numpy as np
 
 import aneforge as af
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def _warned(build):

--- a/tests/test_dynamic_conv.py
+++ b/tests/test_dynamic_conv.py
@@ -5,6 +5,8 @@ import pytest
 from _helpers import requires_ane
 import aneforge as af
 
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
+
 
 rng = np.random.default_rng(0)
 

--- a/tests/test_fft2.py
+++ b/tests/test_fft2.py
@@ -1,6 +1,9 @@
 """2-D FFT on the ANE: aneforge.fft.fft2/ifft2 as one fused program per transform."""
 from __future__ import annotations
 import os
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import numpy as np
 import pytest

--- a/tests/test_fp16_cross_chip.py
+++ b/tests/test_fp16_cross_chip.py
@@ -7,6 +7,9 @@ import aneforge as af
 from aneforge import autograd as ag
 from aneforge import _targets as TG
 from aneforge._compile import cross_compile_check
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def _crosschip_warnings(rec):

--- a/tests/test_image_input.py
+++ b/tests/test_image_input.py
@@ -7,6 +7,8 @@ from _helpers import requires_ane
 
 import aneforge as af
 
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
+
 
 rng = np.random.default_rng(0)
 

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -5,6 +5,9 @@ os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
 import numpy as np
 import pytest
 import aneforge.linalg as L
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 f16 = np.float16
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -3,6 +3,8 @@ import aneforge as af
 from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf
 from _helpers import requires_ane, make_random_llama_model as _random_model
 
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
+
 
 def test_rope_tables_shape():
   cos, sin = rope_tables(8, 16)

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -5,6 +5,8 @@ from aneforge.llm import LlamaConfig, LayerSpec, LlamaPrefill
 from aneforge.moe import _moe, _moe_adapter
 from _helpers import requires_ane
 
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
+
 
 def _cfg(dim=32, E=8, k=2):
   return LlamaConfig(dim=dim, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=16, vocab=16,

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -3,6 +3,8 @@ from onnx import helper, TensorProto
 import aneforge as af
 from _helpers import requires_ane  # noqa: F401  (on-device gate for later op tests)
 
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
+
 def _model(nodes, inputs, outputs, inits=()):
   g = helper.make_graph(nodes, "g", inputs, outputs, list(inits))
   m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 13)])

--- a/tests/test_rewrite_engine.py
+++ b/tests/test_rewrite_engine.py
@@ -2,6 +2,7 @@
 import aneforge as af
 from aneforge.graph import Tensor
 from aneforge._rewrite import Rule, graph_rewrite, NUMERIC_RULES, graph_rewrite as _gr
+from _helpers import requires_ane   # the two on-device tests below compile+run; the rest are pure
 
 def _noop_rules(): return []
 
@@ -137,6 +138,7 @@ def test_adds_chain_folds():
   out = _apply(y, {"adds_chain"})
   assert _ops(out).count("adds") == 1 and out.attrs["k"] == 7.0
 
+@requires_ane
 def test_scalar_fold_matches_fp32_reference():
   rng = np.random.default_rng(0); xv = rng.standard_normal((1, 16)).astype(np.float16)
   x = af.input((1, 16)); y = (x * 0.5) * 4.0
@@ -198,6 +200,7 @@ def test_apply_variant_noop_cfg_keeps_baseline():
 
 
 # -- Task 7: README-example canon-equivalence (on-device) -------------------- #
+@requires_ane
 def test_readme_example_canon_equivalent():
   rng = np.random.default_rng(1)
   img = rng.integers(0, 255, (1, 3, 32, 32)).astype(np.uint8).astype(np.float16)

--- a/tests/test_routes.py
+++ b/tests/test_routes.py
@@ -9,6 +9,7 @@ import aneforge as af
 from aneforge import _compile
 from aneforge import _capabilities as cap
 from aneforge._rewrite import _BRIDGE_DECOMPOSERS, decompose_bridge
+from _helpers import requires_ane   # the four route-equivalence tests compile+run; the reconciliation tests are pure
 
 
 # fp16 op-noise ceiling: well above per-op rounding, far below a semantic break
@@ -72,6 +73,7 @@ def _check_route(build_bridge, shapes, x, label):
   return re
 
 
+@requires_ane
 def test_sdpa_route_equivalent():
   rng = np.random.default_rng(1)
   H, S, D = 4, 8, 16
@@ -83,6 +85,7 @@ def test_sdpa_route_equivalent():
   print(f"  sdpa             relerr={re:.5g}")
 
 
+@requires_ane
 def test_minmax_norm_route_equivalent():
   rng = np.random.default_rng(2)
   for dim in ("Width", "Height"):
@@ -98,6 +101,7 @@ def test_minmax_norm_route_equivalent():
   print(f"  minmax_norm/degenerate  relerr={re:.5g}")
 
 
+@requires_ane
 def test_flatten_route_equivalent():
   rng = np.random.default_rng(3)
   C, H, W = 2, 3, 5
@@ -107,6 +111,7 @@ def test_flatten_route_equivalent():
   assert re == 0.0, "flatten<->reshape must be BIT-IDENTICAL"
 
 
+@requires_ane
 def test_lrn_route_equivalent():
   """native lrn bridge vs fused MIL local_response_norm; bit-equivalent by construction."""
   rng = np.random.default_rng(4)

--- a/tests/test_special_trig.py
+++ b/tests/test_special_trig.py
@@ -3,6 +3,9 @@ import numpy as np
 
 import aneforge as af
 from aneforge import special
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def _run(fn, xs):

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -4,6 +4,9 @@ import numpy as np
 import aneforge as af
 from aneforge import autograd as agrad
 from aneforge.streaming import CheckpointedStack
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def _cos(a, b):

--- a/tests/test_train_cifar.py
+++ b/tests/test_train_cifar.py
@@ -2,6 +2,9 @@ import numpy as np
 import pytest
 import aneforge as af
 from aneforge import autograd as agrad
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def _cos(a, b):

--- a/tests/test_vjp_sweep.py
+++ b/tests/test_vjp_sweep.py
@@ -6,6 +6,9 @@ import pytest
 
 from aneforge import autograd as agrad
 from test_autograd import _cos, _eval_grad_tensor
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 SH = (4, 8)
 

--- a/tests/test_zero_copy_io.py
+++ b/tests/test_zero_copy_io.py
@@ -5,6 +5,9 @@ import numpy as np
 import pytest
 
 import aneforge as af
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
 
 def test_zero_copy_matches_call():


### PR DESCRIPTION
## Problem

CI ran only `tests/test_compile_breaker.py` — 1 of the suite. Everything else needs the ANE and was gated behind the existing `_helpers.requires_ane`, which was a bare `skipif` (marker name `skipif`), so it auto-skipped but was **not** selectable via `pytest -m`.

## Change

Promote `requires_ane` to a real, registered, `-m`-selectable marker and have CI run `pytest -m "not requires_ane"`, so every hardware-free suite runs off-device — and new **unmarked** suites are picked up automatically (no CI-command or file-list edits).

- **`tests/_helpers.py`** — `requires_ane` is now `pytest.mark.requires_ane` (was `skipif`). It no longer probes the dylib *at import* (which could trigger a per-machine build); the probe runs once in the conftest hook.
- **`tests/conftest.py`** — registers the marker and, when `ane_available()` is `False`, auto-skips any `requires_ane` test still collected, so a bare off-device `pytest` **skips rather than errors**. The probe runs in the main process before `--forked` forks the per-test subprocesses.
- **`pyproject.toml`** — registers the marker (no unknown-mark warning under `-m`).
- **Device suites marked** — module-level `pytestmark = requires_ane` on the fully on-device files; per-test `@requires_ane` on just the compile/dispatch tests in the *mixed* files (`test_rewrite_engine`, `test_routes`, `test_compress`, `test_compile_targets`) so their pure-logic tests keep running in CI.
- **`.github/workflows/ci.yml`** — the ubuntu `unit-tests` job and the macOS smoke job run `pytest -m "not requires_ane" -q` instead of the single file.

## Result

Off-device CI coverage goes from **1 suite → 13**: `test_compile_breaker`, `test_targets`, `test_op_catalog`, `test_cost_model_analytic`, `test_builder_guards`, `test_tune_guards`, `test_mlperf_harness`, plus the pure-logic subsets of `test_rewrite_engine`, `test_routes`, `test_compress`, `test_compile_targets`, `test_group_norm_tiling`, `test_cross_chip_ops`.

## Verification

Forced `ane_available()` False (`ANEFORGE_CACHE=<tmp> ANEFORGE_NO_AUTOBUILD=1`, no bundled dylib) to emulate a runner with no engine:

- `pytest -m "not requires_ane"` → **169 passed, 0 failed** (1 self-skip), 542 deselected.
- Bare `pytest tests/test_llm.py` (no `-m`) → **skipped**, not errored (the hook).
- Full collection with `-W error::PytestUnknownMarkWarning` → 712 collected, no warning (marker registered).

On the **real ANE** (normal env): the off-device subset still passes, and marked tests **run** (not skipped) — the hook early-returns when the engine is present.

Collection safety: `-m` deselection still imports every module, but the only module-level optional imports are `onnx` (in the `dev` extra) and the pure-Python `loadgen_lite`; all `torch`/`transformers` imports are inside functions, and the corpus runners are `__main__`-guarded.

`ruff check` and the pylint 2-space/trailing-whitespace lock are both clean.

## Notes / follow-ups
- On the hosted **macOS** runner the dylib builds, so `ane_available()` is `True` there; the hardware tests are excluded by `-m` deselection (not the hook). A bare `pytest` on that runner would try to run them — CI never does this. Detecting actual engine presence (vs. dylib loadability) is a possible future refinement.
- The mixed files could be split further for even more CI coverage; this PR marks only the tests that actually compile/dispatch.