### PR TITLE
CI: weekly drift watch + macOS matrix (14/15/latest)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,13 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Weekly drift watch: this project links private Apple framework symbols, so a macOS or
+  # Xcode update on the hosted images can break the dispatch-dylib build with no code change
+  # on our side. Re-running CI on a schedule turns "did Apple break us" into an automated
+  # signal instead of something noticed at the next commit. Mondays 07:00 UTC.
+  schedule:
+    - cron: "0 7 * * 1"
+  workflow_dispatch:   # allow a manual run (e.g. to exercise the scheduled path on demand)
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -127,8 +134,15 @@ jobs:
       - run: mkdocs build --strict
 
   macos:
-    name: macOS build + smoke (Apple Silicon, no ANE)
-    runs-on: macos-14
+    name: macOS build + smoke (${{ matrix.os }}, no ANE)
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false   # one OS image breaking must not mask the others' status
+      matrix:
+        # macos-14 = oldest supported (README: macOS 14+); macos-15 = current; macos-latest
+        # auto-tracks the newest hosted image, so a future macOS/Xcode bump is caught by the
+        # weekly run without editing this list. latest may alias 15 today; the overlap is cheap.
+        os: [macos-14, macos-15, macos-latest]
     steps:
       - uses: actions/checkout@v6
         with:


### PR DESCRIPTION
## Why

ANEForge links private Apple framework symbols, so a macOS or Xcode update on GitHub's hosted images can break the Objective-C++ dispatch-dylib build with **no change on our side**. CI only ran on push/PR, so that class of breakage would surface at the next commit rather than when Apple shipped it.

## Change

- **Weekly `schedule` trigger** (Mondays 07:00 UTC) + **`workflow_dispatch`** so the scheduled path can also be run on demand. Turns "did Apple break us" into an automated signal.
- **macOS job matrixed** over three images with `fail-fast: false`:
  - `macos-14` — oldest supported (README: macOS 14+)
  - `macos-15` — current
  - `macos-latest` — auto-tracks the newest hosted image, so a future macOS/Xcode bump is caught by the weekly run without editing the matrix

The macOS job proves the dispatch shim (`aneforge/_lib/build.sh`) compiles against Apple frameworks; running it across images + weekly is the drift signal. `macos-latest` may alias `macos-15` today — the small overlap is intentional and self-heals as `latest` advances.

## Notes
- The whole workflow runs on the weekly cron (not just macOS). The lint/build/docs jobs are cheap on ubuntu and catch dependency/toolchain drift as a bonus; the macOS matrix is the primary target. I can gate the non-macOS jobs behind `if: github.event_name != 'schedule'` if you'd prefer a macOS-only cron.
- Overlaps `ci.yml` with the two other open CI PRs (#62 the compile-import matrix line, #63 the job run-commands). This PR edits only the `on:` block and the macOS job header, so all three touch different regions and should merge cleanly in any order; whichever lands last may want a trivial rebase.