### PR TITLE
onnx: eight importer additions (Dropout, Sum/Mean, GlobalMaxPool, comparisons, CumSum, LogSoftmax, general Gemm, Expand)

### DIFF
--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -245,8 +245,35 @@ def _where(node, ins, a, i):
   from .graph import select as _select
   return _select(ins[0], ins[1] if isinstance(ins[1], Tensor) else _baked(ins[1]),
                  ins[2] if isinstance(ins[2], Tensor) else _baked(ins[2]))
+@onnx_op("Equal", "Greater", "GreaterOrEqual", "Less", "LessOrEqual")
+def _compare(node, ins, a, i):
+  """Elementwise comparison -> a BOOL tensor (feeds Where/Not); a constant operand bakes in."""
+  x, y = _binops(ins)
+  meth = {"Equal": "equal", "Greater": "greater", "GreaterOrEqual": "greater_equal",
+          "Less": "less", "LessOrEqual": "less_equal"}[node.op_type]
+  return getattr(x, meth)(y)
+@onnx_op("Not")
+def _not(node, ins, a, i): return ins[0].logical_not()
 @onnx_op("Tile")
 def _tile(node, ins, a, i): return ins[0].tile([int(v) for v in np.asarray(ins[1])])
+@onnx_op("Expand")
+def _expand(node, ins, a, i):
+  """Broadcast-to-shape via expand_dims + tile; the target shape (input 1) must be constant. ONNX
+  semantics: the output shape is broadcast(input.shape, shape), so a target dim of 1 keeps the input dim."""
+  if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Expand: data-dependent shape not supported")
+  shape = [int(v) for v in np.asarray(ins[1]).ravel()]
+  if _isc(ins[0]):                                   # constant (shape-arithmetic) expand folds
+    x0 = np.asarray(ins[0]); return np.broadcast_to(x0, np.broadcast_shapes(x0.shape, tuple(shape)))
+  x = ins[0]; xs = list(x.shape)
+  if len(shape) < len(xs): shape = [1] * (len(xs) - len(shape)) + shape
+  if len(shape) > len(xs):
+    x = x.expand_dims(tuple(range(len(shape) - len(xs)))); xs = [1] * (len(shape) - len(xs)) + xs
+  reps = []
+  for dx, dt in zip(xs, shape):
+    if dt in (1, dx): reps.append(1)
+    elif dx == 1: reps.append(dt)
+    else: raise ValueError(f"ONNX Expand: cannot broadcast {tuple(xs)} to {tuple(shape)}")
+  return x.tile(reps) if any(r != 1 for r in reps) else x
 @onnx_op("Elu")
 def _elu(node, ins, a, i): return ins[0].elu(float(a.get("alpha", 1.0)))
 @onnx_op("LeakyRelu")
@@ -289,6 +316,14 @@ def _div(node, ins, a, i):
     x0, x1 = np.asarray(ins[0]), np.asarray(ins[1])
     return x0 // x1 if np.issubdtype(x0.dtype, np.integer) else x0 / x1     # ONNX integer Div truncates
   x, y = _binops(ins); return x / y
+@onnx_op("Sum", "Mean")
+def _sum_mean(node, ins, a, i):
+  """Variadic elementwise Sum/Mean: folded with add; Mean scales by 1/N (a constant, exact)."""
+  if all(_isc(v) for v in ins):                                                # shape arithmetic folds
+    s = reduce(lambda p, q: p + q, (np.asarray(v) for v in ins))
+    return s / len(ins) if node.op_type == "Mean" else s
+  y = reduce(lambda p, q: p + q, (v if isinstance(v, Tensor) else _baked(v) for v in ins))
+  return y * (1.0 / len(ins)) if node.op_type == "Mean" else y
 @onnx_op("HardSigmoid")
 def _hardsigmoid(node, ins, a, i):
   """ONNX HardSigmoid = clip(alpha*x + beta, 0, 1); defaults alpha=0.2, beta=0.5."""
@@ -397,13 +432,20 @@ def _avgpool(node, ins, a, i):
                          exclude_pad=not int(a.get("count_include_pad", 0)))   # ONNX default count_include_pad=0 -> exclude pad cells
 @onnx_op("GlobalAveragePool")
 def _gap(node, ins, a, i): return ins[0].mean((2, 3))     # keepdims -> [N,C,1,1]
+@onnx_op("GlobalMaxPool")
+def _gmp(node, ins, a, i): return ins[0].amax((2, 3))     # keepdims -> [N,C,1,1]
 
 @onnx_op("Gemm")
 def _gemm(node, ins, a, i):
-  if float(a.get("alpha", 1.0)) != 1.0 or float(a.get("beta", 1.0)) != 1.0 or int(a.get("transA", 0)):
-    raise NotImplementedError("ONNX Gemm: only alpha=1, beta=1, transA=0 supported")
-  x = ins[0]; W = np.asarray(ins[1]); B = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
+  """Y = alpha*op(A)@op(B) + beta*C. alpha folds into the weight and beta into the bias (both constants),
+  so the general form still lowers to one linear; transA is a transpose on the activation."""
+  x = ins[0]
+  if int(a.get("transA", 0)): x = x.transpose((1, 0))
+  W = np.asarray(ins[1]); B = np.asarray(ins[2]) if len(ins) > 2 and ins[2] is not None else None
   if not int(a.get("transB", 0)): W = W.T            # x.linear expects [out,in]
+  alpha, beta = float(a.get("alpha", 1.0)), float(a.get("beta", 1.0))
+  if alpha != 1.0: W = (W * alpha).astype(W.dtype)
+  if beta != 1.0 and B is not None: B = (B * beta).astype(B.dtype)
   return x.linear(W, B)
 @onnx_op("MatMul")
 def _matmul(node, ins, a, i):
@@ -475,12 +517,24 @@ def _slice(node, ins, a, i):
   return x.slice_by_size(begin, size)
 @onnx_op("Softmax")
 def _softmax(node, ins, a, i): return ins[0].softmax(int(a.get("axis", -1)))
+@onnx_op("LogSoftmax")
+def _logsoftmax(node, ins, a, i):
+  """log_softmax = x - logsumexp(x, axis): the native stable reduce, where log(softmax(x)) underflows fp16."""
+  x = ins[0]; ax = int(a.get("axis", -1)) % len(x.shape)
+  return x - x.reduce_log_sum_exp((ax,))
 @onnx_op("Constant")
 def _const(node, ins, a, i):
   from onnx import numpy_helper
   return numpy_helper.to_array(a["value"])         # returns np.ndarray (folded by consumers)
 @onnx_op("Identity")
 def _identity(node, ins, a, i): return ins[0]      # pass-through (Tensor or array)
+@onnx_op("Dropout")
+def _dropout(node, ins, a, i):
+  """Inference no-op. Rejects training mode and a declared mask output (both training-time artifacts)."""
+  if len(node.output) > 1: raise NotImplementedError("ONNX Dropout: mask output not supported")
+  if len(ins) > 2 and ins[2] is not None and bool(np.asarray(ins[2])):
+    raise NotImplementedError("ONNX Dropout: training_mode=1 not supported")
+  return ins[0]
 @onnx_op("LRN")
 def _lrn(node, ins, a, i):
   """LRN; ANE local_response_norm folds alpha/size internally, so ONNX alpha maps raw and k=bias (validated on-device)."""
@@ -544,6 +598,17 @@ def _rmin(node, ins, a, i): return _reduce_op(ins, a, Tensor.amin)
 def _rsum(node, ins, a, i): return _reduce_op(ins, a, Tensor.sum)
 @onnx_op("ReduceMean")
 def _rmean(node, ins, a, i): return _reduce_op(ins, a, Tensor.mean)
+@onnx_op("CumSum")
+def _cumsum(node, ins, a, i):
+  """CumSum along `axis` (input 1, constant), via the tril-ones matmul lowering; a non-last axis is
+  transposed to last and back (the swap perm is its own inverse)."""
+  if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX CumSum: data-dependent axis not supported")
+  if int(a.get("exclusive", 0)) or int(a.get("reverse", 0)):
+    raise NotImplementedError("ONNX CumSum: exclusive/reverse not supported")
+  x = ins[0]; r = len(x.shape); ax = int(np.asarray(ins[1])) % r
+  if ax == r - 1: return x.cumsum(-1)
+  perm = list(range(r)); perm[ax], perm[-1] = perm[-1], perm[ax]
+  return x.transpose(perm).cumsum(-1).transpose(perm)
 @onnx_op("Gather")
 def _gather_h(node, ins, a, i):
   """Static-index gather along `axis`; constant scalar/1-D integer indices only (data-dependent indices have no ANE path)."""

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -292,11 +292,11 @@ def test_conv_auto_pad_raises():
   m = _model([n], [_vi("x", [1, 3, 32, 32])], [_vi("y", [1, 8, 32, 32])], inits=[w])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
 
-def test_gemm_alpha_raises():
+def test_gemm_alpha_beta_builds():  # alpha/beta fold into the constant weight/bias -> still one linear
   w = _init(np.zeros((10, 16)), "W"); b = _init(np.zeros(10), "B")
-  n = helper.make_node("Gemm", ["x", "W", "B"], ["y"], transB=1, alpha=2.0)
+  n = helper.make_node("Gemm", ["x", "W", "B"], ["y"], transB=1, alpha=2.0, beta=0.5)
   m = _model([n], [_vi("x", [1, 16])], [_vi("y", [1, 10])], inits=[w, b])
-  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 10)
 
 def test_add_constant_operand_builds():  # a constant operand bakes in as a fused const_array
   c = _init(np.zeros((1, 3)), "c")
@@ -866,3 +866,97 @@ def test_resize_half_pixel_approx_close():  # the opt-in approximation is ~0.99 
   got = np.asarray(af.load_onnx(m, approx_resize=True)(x.astype(np.float16))).astype(np.float32).ravel()
   ref = np.asarray(onnx_run(m, x)).astype(np.float32).ravel()
   cos = _cos(got, ref); assert cos > 0.95, f"half-pixel approx Resize ANE vs onnxruntime cosine={cos}"
+
+
+# -- starter ops: Dropout, Sum/Mean, GlobalMaxPool, comparisons, CumSum, LogSoftmax, Gemm, Expand -- #
+
+def test_dropout_is_identity():  # inference no-op: passes its input straight through
+  m = _model([helper.make_node("Dropout", ["x"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  ins, out = af.onnx_to_tensor(m); assert out is ins[0]
+
+def test_dropout_mask_output_raises():  # a declared mask output is a training-time artifact
+  m = _model([helper.make_node("Dropout", ["x"], ["y", "mask"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_sum_mean_variadic_build():  # 3-input fold
+  for op in ("Sum", "Mean"):
+    m = _model([helper.make_node(op, ["a", "b", "c"], ["y"])],
+               [_vi("a", [1, 4]), _vi("b", [1, 4]), _vi("c", [1, 4])], [_vi("y", [1, 4])])
+    _, out = af.onnx_to_tensor(m); assert out.shape == (1, 4)
+
+def test_mean_matches_onnxruntime():  # constant operands bake in; 1/N scale is exact
+  rng = np.random.default_rng(0); x = rng.standard_normal((1, 8)).astype(np.float32)
+  c1 = _init(rng.standard_normal((1, 8)), "c1"); c2 = _init(rng.standard_normal((1, 8)), "c2")
+  m = _model([helper.make_node("Mean", ["x", "c1", "c2"], ["y"])], [_vi("x", [1, 8])], [_vi("y", [1, 8])], inits=[c1, c2])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - onnx_run(m, x)).max() < 1e-2
+
+def test_global_max_pool_builds():
+  m = _model([helper.make_node("GlobalMaxPool", ["x"], ["y"])], [_vi("x", [1, 3, 8, 8])], [_vi("y", [1, 3, 1, 1])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3, 1, 1) and out.op == "reduce_max"
+
+def test_global_max_pool_matches_onnxruntime():
+  rng = np.random.default_rng(1); x = rng.standard_normal((1, 3, 8, 8)).astype(np.float32)
+  m = _model([helper.make_node("GlobalMaxPool", ["x"], ["y"])], [_vi("x", [1, 3, 8, 8])], [_vi("y", [1, 3, 1, 1])])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - onnx_run(m, x)).max() < 1e-2
+
+def test_comparison_ops_build():
+  for op, want in [("Equal", "equal"), ("Greater", "greater"), ("GreaterOrEqual", "greater_equal"),
+                   ("Less", "less"), ("LessOrEqual", "less_equal")]:
+    m = _model([helper.make_node(op, ["a", "b"], ["y"])], [_vi("a", [1, 4]), _vi("b", [1, 4])], [_vi("y", [1, 4])])
+    _, out = af.onnx_to_tensor(m); assert out.op == want, f"{op} -> {out.op}"
+
+def test_not_builds():
+  m = _model([helper.make_node("Greater", ["a", "b"], ["c"]), helper.make_node("Not", ["c"], ["y"])],
+             [_vi("a", [1, 4]), _vi("b", [1, 4])], [_vi("y", [1, 4])])
+  _, out = af.onnx_to_tensor(m); assert out.op == "logical_not"
+
+def test_greater_where_matches_onnxruntime():  # Greater(x, c) selecting via Where == elementwise max vs ORT
+  rng = np.random.default_rng(2); x = rng.standard_normal((1, 16)).astype(np.float32)
+  c = _init(rng.standard_normal((1, 16)), "c")
+  m = _model([helper.make_node("Greater", ["x", "c"], ["cond"]), helper.make_node("Where", ["cond", "x", "c"], ["y"])],
+             [_vi("x", [1, 16])], [_vi("y", [1, 16])], inits=[c])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - onnx_run(m, x)).max() < 1e-2
+
+def test_cumsum_matches_onnxruntime():  # last axis and (via the transpose wrap) axis 0
+  rng = np.random.default_rng(3); x = rng.standard_normal((4, 8)).astype(np.float32)
+  for ax in (1, 0):
+    axc = onnx.numpy_helper.from_array(np.array(ax, np.int64), "ax")
+    m = _model([helper.make_node("CumSum", ["x", "ax"], ["y"])], [_vi("x", [4, 8])], [_vi("y", [4, 8])], inits=[axc])
+    got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+    assert np.abs(got - onnx_run(m, x)).max() < 2e-2, f"axis={ax}"
+
+def test_cumsum_exclusive_raises():
+  axc = onnx.numpy_helper.from_array(np.array(1, np.int64), "ax")
+  m = _model([helper.make_node("CumSum", ["x", "ax"], ["y"], exclusive=1)], [_vi("x", [4, 8])], [_vi("y", [4, 8])], inits=[axc])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def test_logsoftmax_matches_onnxruntime():  # spread logits: log(softmax) would underflow fp16, x - lse does not
+  x = np.linspace(-8.0, 8.0, 16).astype(np.float32).reshape(1, 16)
+  m = _model([helper.make_node("LogSoftmax", ["x"], ["y"])], [_vi("x", [1, 16])], [_vi("y", [1, 16])])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - onnx_run(m, x)).max() < 3e-2
+
+def test_gemm_alpha_beta_transA_matches_onnxruntime():  # Y = alpha*A.T@B + beta*C in one linear
+  rng = np.random.default_rng(4)
+  x = rng.standard_normal((16, 2)).astype(np.float32)
+  w = _init(rng.standard_normal((10, 16)), "W"); b = _init(rng.standard_normal(10), "B")
+  n = helper.make_node("Gemm", ["x", "W", "B"], ["y"], transA=1, transB=1, alpha=2.0, beta=0.5)
+  m = _model([n], [_vi("x", [16, 2])], [_vi("y", [2, 10])], inits=[w, b])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert got.shape == (2, 10) and np.abs(got - onnx_run(m, x)).max() < 5e-2
+
+def test_expand_builds_and_matches_onnxruntime():  # (1,1,4) -> (1,3,4): expand_dims rank align + tile
+  rng = np.random.default_rng(5); x = rng.standard_normal((1, 1, 4)).astype(np.float32)
+  shp = onnx.numpy_helper.from_array(np.array([1, 3, 4], np.int64), "s")
+  m = _model([helper.make_node("Expand", ["x", "s"], ["y"])], [_vi("x", [1, 1, 4])], [_vi("y", [1, 3, 4])], inits=[shp])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3, 4)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - onnx_run(m, x)).max() < 1e-2
+
+def test_expand_rank_raise_builds():  # shape with higher rank prepends axes: (4,) -> (2, 4)
+  shp = onnx.numpy_helper.from_array(np.array([2, 4], np.int64), "s")
+  m = _model([helper.make_node("Expand", ["x", "s"], ["y"])], [_vi("x", [4])], [_vi("y", [2, 4])], inits=[shp])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (2, 4)


### PR DESCRIPTION
Fixes #70, fixes #71, fixes #72, fixes #73, fixes #74, fixes #75, fixes #77, fixes #78.

All eight are `@onnx_op` handler-table extensions over existing graph ops — no new engine lowering. The interesting choices:

- **Gemm** (#77): alpha folds into the constant weight and beta into the bias, so the general `alpha*op(A)@op(B) + beta*C` form still compiles to a single `linear`; transA is one transpose on the activation. The old `test_gemm_alpha_raises` (which asserted alpha≠1 raises) becomes a supported-form test.
- **LogSoftmax** (#75): lowered as `x - reduce_log_sum_exp(x)` (native stable reduce) rather than `log(softmax(x))`, which underflows fp16 on spread logits — the test uses ±8 logits to exercise exactly that.
- **CumSum** (#74): the graph lowering is a tril-ones matmul on the last axis; a non-last axis is transposed to last and back (the swap perm is its own inverse). `exclusive`/`reverse` reject explicitly.
- **Expand** (#78): rank-aligns with `expand_dims`, then `tile`s where the target dim differs; target dims of 1 keep the input dim per ONNX broadcast semantics; constant inputs fold with `np.broadcast_to`.
- **Dropout** (#70): inference no-op; a declared mask output or `training_mode=1` rejects loudly instead of importing wrong.
- **Sum/Mean** (#71), **GlobalMaxPool** (#72), **comparisons + Not** (#73): direct compositions (`reduce`-folded add, `amax((2,3))`, and the existing `equal/greater/less/...` graph methods via `_binops` const-baking).

## Verification (on-device, M5)
- `pytest tests/test_onnx.py`: **135 passed** (119 existing + 16 new), including onnxruntime comparisons for Mean, GlobalMaxPool, Greater→Where, CumSum on both axes, LogSoftmax, Gemm with alpha/beta/transA/transB, and Expand.
- `pytest -m "not requires_ane"`: 169 passed (off-device subset unchanged).
- `ruff`, the 2-space pylint lock, and `pyright` (0 errors) all clean.