### PR TITLE
onnx: tier-1 coverage — 21 more ops, Slice full-axis flip, squeeze-all

### DIFF
--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -287,6 +287,24 @@ def _gelu(node, ins, a, i):
   return ins[0].gelu()
 @onnx_op("PRelu")
 def _prelu(node, ins, a, i): return ins[0].prelu(np.asarray(ins[1]).reshape(-1))   # slope=ins[1], [C,1,1]->[C]
+@onnx_op("Selu")
+def _selu(node, ins, a, i):
+  """selu = gamma * elu(x, alpha) exactly (ONNX defaults are the Klambauer et al. constants)."""
+  alpha = float(a.get("alpha", 1.6732632423543772)); gamma = float(a.get("gamma", 1.0507009873554805))
+  return ins[0].elu(alpha) * gamma
+@onnx_op("Celu")
+def _celu(node, ins, a, i):
+  """celu(x, alpha) = alpha * elu(x/alpha, 1): the positive branch recovers x, the negative alpha*(exp(x/alpha)-1)."""
+  alpha = float(a.get("alpha", 1.0))
+  return (ins[0] * (1.0 / alpha)).elu(1.0) * alpha
+@onnx_op("Mish")
+def _mish(node, ins, a, i): return ins[0] * ins[0].softplus().tanh()
+@onnx_op("Softsign")
+def _softsign(node, ins, a, i): return ins[0].softsign()
+@onnx_op("ThresholdedRelu")
+def _thresholded_relu(node, ins, a, i): return ins[0].thresholded_relu(float(a.get("alpha", 1.0)))
+@onnx_op("Atan")
+def _atan(node, ins, a, i): return ins[0].atan()
 @onnx_op("Pow")
 def _pow(node, ins, a, i): x, y = _binops(ins); return x.pow(y)
 @onnx_op("InstanceNormalization")
@@ -452,6 +470,14 @@ def _matmul(node, ins, a, i):
   if not isinstance(ins[0], Tensor): raise NotImplementedError("ONNX MatMul: a constant first operand is not supported")
   b = ins[1]
   return ins[0] @ (np.asarray(b) if not isinstance(b, Tensor) else b)
+@onnx_op("Einsum")
+def _einsum_h(node, ins, a, i):
+  """Routes to aneforge.einsum (matmul-reducible specs; diagonal/ellipsis reject as EinsumUnsupported)."""
+  from .einsum import einsum as _es
+  eq = _sattr(a, "equation", None)
+  if not eq: raise ValueError("ONNX Einsum: missing equation attribute")
+  ts = [v if isinstance(v, Tensor) else _baked(np.asarray(v, np.float32)) for v in ins]
+  return _es(eq, *ts)  # type: ignore[arg-type]  # einsum.py imports Tensor absolutely; same class at runtime
 @onnx_op("BatchNormalization")
 def _bnorm(node, ins, a, i):
   x, s, bb, mean, var = ins[0], np.asarray(ins[1]), np.asarray(ins[2]), np.asarray(ins[3]), np.asarray(ins[4])
@@ -464,6 +490,27 @@ def _layernorm(node, ins, a, i):
   bias = np.asarray(ins[2]).reshape(-1) if len(ins) > 2 and ins[2] is not None else np.zeros_like(scale)
   m, d = prod(x.shape[:ax]) or 1, prod(x.shape[ax:])
   return x.reshape(m, d).layer_norm(scale, bias, float(a.get("epsilon", 1e-5))).reshape(*x.shape)
+@onnx_op("LpNormalization")
+def _lpnorm(node, ins, a, i):
+  """p=2 maps to the native per-axis l2_norm; p=1 divides by the keepdims L1 reduce."""
+  x = ins[0]; ax = int(a.get("axis", -1)) % len(x.shape); p = int(a.get("p", 2))
+  if p == 2: return x.l2_norm(ax)
+  if p == 1: return x / x.l1_norm((ax,))
+  raise NotImplementedError(f"ONNX LpNormalization: p={p} not supported (only 1/2)")
+@onnx_op("GroupNormalization")
+def _groupnorm(node, ins, a, i):
+  """GroupNormalization (opset 21 semantics: per-channel scale/bias) on NCHW via native group_norm."""
+  x = ins[0]
+  if len(x.shape) != 4: raise NotImplementedError("ONNX GroupNormalization: 4D NCHW inputs only")
+  return x.group_norm(np.asarray(ins[1]).reshape(-1), np.asarray(ins[2]).reshape(-1),
+                      int(a["num_groups"]), eps=float(a.get("epsilon", 1e-5)))
+@onnx_op("RMSNormalization")
+def _rmsnorm(node, ins, a, i):
+  """RMSNorm over the trailing axes [axis:], like the LayerNormalization handler: 2-D view, native rms_norm, reshape back."""
+  x = ins[0]; ax = int(a.get("axis", -1)) % len(x.shape)
+  scale = np.asarray(ins[1]).reshape(-1)
+  m, d = prod(x.shape[:ax]) or 1, prod(x.shape[ax:])
+  return x.reshape(m, d).rms_norm(scale, eps=float(a.get("epsilon", 1e-5))).reshape(*x.shape)
 @onnx_op("Reshape")
 def _reshape(node, ins, a, i):
   shape = [int(v) for v in np.asarray(ins[1])]
@@ -481,7 +528,9 @@ def _transpose(node, ins, a, i):
 def _squeeze(node, ins, a, i):
   axes = a.get("axes")                               # opset<13 attr; opset>=13 axes input
   if axes is None and len(ins) > 1 and ins[1] is not None: axes = [int(v) for v in np.asarray(ins[1])]
-  if axes is None: raise NotImplementedError("ONNX Squeeze: squeeze-all (no axes) not supported")
+  if axes is None:                                   # squeeze-all: static shapes make it well-defined
+    axes = [k for k, d in enumerate(ins[0].shape) if d == 1]
+    if not axes: return ins[0]
   return ins[0].squeeze(tuple(axes))
 @onnx_op("Unsqueeze")
 def _unsqueeze(node, ins, a, i):
@@ -493,6 +542,26 @@ def _concat_h(node, ins, a, i):
   if all(_isc(v) for v in ins):                                             # concat of constant shape pieces folds
     return np.concatenate([np.atleast_1d(np.asarray(v)) for v in ins], axis=int(a["axis"]))
   return _concat(list(ins), axis=int(a["axis"]))
+@onnx_op("Split")
+def _split_h(node, ins, a, i):
+  """Split along `axis`: equal parts use the native split; uneven sizes (the `split` attr/input) slice."""
+  x = ins[0]; ax = int(a.get("axis", 0)) % len(x.shape)
+  sizes = a.get("split")
+  if sizes is None and len(ins) > 1 and ins[1] is not None:
+    if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Split: data-dependent split sizes not supported")
+    sizes = [int(v) for v in np.asarray(ins[1]).ravel()]
+  if sizes is None:                                  # equal parts from the output count (last chunk may be smaller)
+    n = int(a.get("num_outputs", len(node.output))); chunk = -(-x.shape[ax] // n)
+    sizes = [chunk] * (n - 1) + [x.shape[ax] - chunk * (n - 1)]
+  if sum(sizes) != x.shape[ax]: raise ValueError(f"ONNX Split: sizes {sizes} do not cover axis {ax} of {x.shape}")
+  if len(set(sizes)) == 1:
+    from .graph import split as _gsplit
+    return _gsplit(x, len(sizes), axis=ax)
+  outs, off = [], 0
+  for s in sizes:
+    begin = [0] * len(x.shape); size = list(x.shape); begin[ax] = off; size[ax] = s
+    outs.append(x.slice_by_size(begin, size)); off += s
+  return outs
 @onnx_op("Shape")
 def _shape_op(node, ins, a, i):
   """Static shape as an int64 constant (the channel-shuffle shape subgraph folds at import)."""
@@ -508,12 +577,19 @@ def _slice(node, ins, a, i):
     d = np.asarray(ins[0]); sl = [slice(None)] * d.ndim
     for ax, s0, e0, st0 in zip(axes, starts, ends, steps): sl[ax % d.ndim] = slice(s0, e0, st0)
     return d[tuple(sl)]
-  if any(st != 1 for st in steps): raise NotImplementedError("ONNX Slice: step != 1 on a tensor not supported")
   x = ins[0]; rank = len(x.shape); begin = [0] * rank; size = list(x.shape)   # activation slice -> static slice_by_size
-  for ax, s0, e0 in zip(axes, starts, ends):
+  rev = []
+  for ax, s0, e0, st0 in zip(axes, starts, ends, steps):
     ax %= rank; dim = x.shape[ax]
+    if st0 == -1:                                    # full-extent flip -> native reverse (partial reversed slices stay unsupported)
+      full = (s0 == -1 or s0 >= dim - 1) and e0 < -dim
+      if not full: raise NotImplementedError("ONNX Slice: step=-1 is supported only as a full-axis flip")
+      rev.append(ax); continue
+    if st0 != 1: raise NotImplementedError(f"ONNX Slice: step={st0} on a tensor not supported")
     s0 = s0 + dim if s0 < 0 else min(s0, dim); e0 = e0 + dim if e0 < 0 else min(e0, dim)
     begin[ax] = max(0, s0); size[ax] = max(0, e0 - begin[ax])
+  if rev: x = x.reverse(tuple(rev))
+  if begin == [0] * rank and size == list(x.shape): return x
   return x.slice_by_size(begin, size)
 @onnx_op("Softmax")
 def _softmax(node, ins, a, i): return ins[0].softmax(int(a.get("axis", -1)))
@@ -528,6 +604,41 @@ def _const(node, ins, a, i):
   return numpy_helper.to_array(a["value"])         # returns np.ndarray (folded by consumers)
 @onnx_op("Identity")
 def _identity(node, ins, a, i): return ins[0]      # pass-through (Tensor or array)
+@onnx_op("ConstantOfShape")
+def _const_of_shape(node, ins, a, i):
+  """Constant fill from a static shape input; folds like Constant (consumers bake it)."""
+  if isinstance(ins[0], Tensor): raise NotImplementedError("ONNX ConstantOfShape: data-dependent shape not supported")
+  shape = tuple(int(v) for v in np.asarray(ins[0]).ravel())
+  v = a.get("value")
+  if v is None: return np.zeros(shape, np.float32)
+  from onnx import numpy_helper
+  arr = numpy_helper.to_array(v)
+  return np.full(shape, arr.ravel()[0], dtype=arr.dtype)
+@onnx_op("Range")
+def _range(node, ins, a, i):
+  """Constant-input Range folds to np.arange (shape-arithmetic plumbing)."""
+  if any(isinstance(v, Tensor) for v in ins[:3]): raise NotImplementedError("ONNX Range: data-dependent bounds not supported")
+  s, l, d = (np.asarray(v).ravel()[0] for v in ins[:3])
+  return np.arange(s, l, d)
+@onnx_op("EyeLike")
+def _eyelike(node, ins, a, i):
+  """Identity matrix of the input's (static) shape; only the shape is consumed, so a Tensor input is fine."""
+  shape = ins[0].shape if isinstance(ins[0], Tensor) else np.asarray(ins[0]).shape
+  if len(shape) != 2: raise NotImplementedError("ONNX EyeLike: 2D inputs only")
+  return np.eye(shape[0], shape[1], k=int(a.get("k", 0)), dtype=np.float32)
+@onnx_op("Trilu")
+def _trilu(node, ins, a, i):
+  """Upper/lower triangle. A constant folds; a Tensor multiplies by the baked 0/1 triangle mask."""
+  k = 0
+  if len(ins) > 1 and ins[1] is not None:
+    if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Trilu: data-dependent k not supported")
+    k = int(np.asarray(ins[1]).ravel()[0])
+  tri = np.triu if int(a.get("upper", 1)) else np.tril
+  if _isc(ins[0]): return tri(np.asarray(ins[0]), k)
+  x = ins[0]
+  if len(x.shape) < 2: raise NotImplementedError("ONNX Trilu: rank >= 2 required")
+  mask = tri(np.ones(x.shape[-2:], np.float16), k)
+  return x * _baked(np.ascontiguousarray(np.broadcast_to(mask, x.shape)))
 @onnx_op("Dropout")
 def _dropout(node, ins, a, i):
   """Inference no-op. Rejects training mode and a declared mask output (both training-time artifacts)."""
@@ -598,6 +709,16 @@ def _rmin(node, ins, a, i): return _reduce_op(ins, a, Tensor.amin)
 def _rsum(node, ins, a, i): return _reduce_op(ins, a, Tensor.sum)
 @onnx_op("ReduceMean")
 def _rmean(node, ins, a, i): return _reduce_op(ins, a, Tensor.mean)
+@onnx_op("ReduceL1")
+def _rl1(node, ins, a, i): return _reduce_op(ins, a, Tensor.l1_norm)
+@onnx_op("ReduceL2")
+def _rl2(node, ins, a, i): return _reduce_op(ins, a, lambda x, axes: x.sum_square(axes).sqrt())
+@onnx_op("ReduceLogSum")
+def _rlogsum(node, ins, a, i): return _reduce_op(ins, a, Tensor.log_sum)
+@onnx_op("ReduceLogSumExp")
+def _rlse(node, ins, a, i): return _reduce_op(ins, a, Tensor.reduce_log_sum_exp)
+@onnx_op("ReduceSumSquare")
+def _rss(node, ins, a, i): return _reduce_op(ins, a, Tensor.sum_square)
 @onnx_op("CumSum")
 def _cumsum(node, ins, a, i):
   """CumSum along `axis` (input 1, constant), via the tril-ones matmul lowering; a non-last axis is
@@ -629,6 +750,16 @@ def _argmax_h(node, ins, a, i):
   if int(a.get("select_last_index", 0)): raise NotImplementedError("ONNX ArgMax: select_last_index=1 not supported")
   ax = int(a.get("axis", 0)) % 2
   y = x.argmax(ax)
+  if not int(a.get("keepdims", 1)): y = y.squeeze(ax)
+  return y
+@onnx_op("ArgMin")
+def _argmin_h(node, ins, a, i):
+  """ArgMin as argmax(-x) (same 2D [C,W] bridge and index encoding as ArgMax)."""
+  x = ins[0]
+  if len(x.shape) != 2: raise NotImplementedError("ONNX ArgMin: only 2D inputs supported on the ANE")
+  if int(a.get("select_last_index", 0)): raise NotImplementedError("ONNX ArgMin: select_last_index=1 not supported")
+  ax = int(a.get("axis", 0)) % 2
+  y = (x * -1.0).argmax(ax)
   if not int(a.get("keepdims", 1)): y = y.squeeze(ax)
   return y
 @onnx_op("TopK")

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -40,18 +40,19 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 
 | Category | ONNX ops |
 | --- | --- |
-| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf`, `HardSigmoid`, `HardSwish` |
-| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported), `Abs`, `Neg`, `Sign`, `Reciprocal`, `Sin`, `Cos`, `Softplus`, `Floor`, `Ceil`, `Round`, `Min`, `Max`, `Where`, `Tile` |
-| Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool` |
-| Linear | `Gemm`, `MatMul` |
-| Normalization | `BatchNormalization`, `InstanceNormalization` |
-| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze`, `Unsqueeze`, `Concat`, `SpaceToDepth`, `DepthToSpace`, `Slice`, `Shape` |
+| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `Selu`, `Celu`, `Mish`, `Softsign`, `ThresholdedRelu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf`, `HardSigmoid`, `HardSwish` |
+| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported), `Abs`, `Neg`, `Sign`, `Reciprocal`, `Sin`, `Cos`, `Atan`, `Softplus`, `Floor`, `Ceil`, `Round`, `Min`, `Max`, `Sum`, `Mean` (variadic), `Where`, `Tile` |
+| Comparison / logic | `Equal`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Not` |
+| Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool`, `GlobalMaxPool` |
+| Linear | `Gemm` (full `alpha`/`beta`/`transA`/`transB`), `MatMul`, `Einsum` (matmul-reducible equations) |
+| Normalization | `BatchNormalization`, `InstanceNormalization`, `LayerNormalization`, `GroupNormalization`, `RMSNormalization`, `LpNormalization` (p=1/2) |
+| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze` (incl. squeeze-all), `Unsqueeze`, `Concat`, `Split`, `Expand`, `SpaceToDepth`, `DepthToSpace`, `Slice` (step 1; step -1 as a full-axis flip), `Shape`, `Trilu` |
 | Normalization (cross-channel) | `LRN` |
 | Resampling | `Resize` (nearest / linear) |
-| Reduction | `ReduceMax`, `ReduceMin`, `ReduceSum`, `ReduceMean` |
-| Indexing | `Gather` (static indices), `ArgMax`, `TopK` (2D, values only) |
+| Reduction | `ReduceMax`, `ReduceMin`, `ReduceSum`, `ReduceMean`, `ReduceL1`, `ReduceL2`, `ReduceLogSum`, `ReduceLogSumExp`, `ReduceSumSquare`, `CumSum` |
+| Indexing | `Gather` (static indices), `ArgMax`, `ArgMin`, `TopK` (2D, values only) |
 | Quantization | `DequantizeLinear`, `QuantizeLinear` (QDQ int8) |
-| Misc | `Softmax`, `Constant`, `Identity` |
+| Misc | `Softmax`, `LogSoftmax`, `Constant`, `ConstantOfShape`, `Range`, `EyeLike`, `Identity`, `Dropout` (inference no-op) |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
 `Shape`/`Gather`/dynamic-`Reshape` plumbing into static initializers before import.

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -5,9 +5,9 @@ from _helpers import requires_ane  # noqa: F401  (on-device gate for later op te
 
 pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
 
-def _model(nodes, inputs, outputs, inits=()):
+def _model(nodes, inputs, outputs, inits=(), opset=13):
   g = helper.make_graph(nodes, "g", inputs, outputs, list(inits))
-  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 13)])
+  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", opset)])
   m.ir_version = 9
   return m
 
@@ -308,10 +308,10 @@ def test_hardsigmoid_builds():
   m = _model([helper.make_node("HardSigmoid", ["x"], ["y"])], [_vi("x", [1, 3])], [_vi("y", [1, 3])])
   _, out = af.onnx_to_tensor(m); assert out.shape == (1, 3) and out.op == "clip"
 
-def test_squeeze_no_axes_raises():  # squeeze-all has no static lowering
+def test_squeeze_no_axes_squeezes_all_unit_dims():  # static shapes make squeeze-all well-defined
   n = helper.make_node("Squeeze", ["x"], ["y"])
-  m = _model([n], [_vi("x", [1, 1, 4])], [_vi("y", [4])])
-  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+  m = _model([n], [_vi("x", [1, 4, 1, 3])], [_vi("y", [4, 3])])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (4, 3)
 
 def test_maxpool_ceil_mode_builds():  # ceil_mode rounds the output size up (native MIL ceil_mode)
   n = helper.make_node("MaxPool", ["x"], ["y"], kernel_shape=[2, 2], strides=[2, 2], ceil_mode=1)
@@ -960,3 +960,129 @@ def test_expand_rank_raise_builds():  # shape with higher rank prepends axes: (4
   shp = onnx.numpy_helper.from_array(np.array([2, 4], np.int64), "s")
   m = _model([helper.make_node("Expand", ["x", "s"], ["y"])], [_vi("x", [4])], [_vi("y", [2, 4])], inits=[shp])
   _, out = af.onnx_to_tensor(m); assert out.shape == (2, 4)
+
+
+# -- tier-1 coverage: activations, reduces, Split, const folds, norms, Einsum, Slice flip, ArgMin -- #
+
+def test_tier1_activations_match_onnxruntime():
+  rng = np.random.default_rng(10); x = (rng.standard_normal((1, 32)) * 2).astype(np.float32)
+  cases = [("Selu", {}, 13), ("Celu", {"alpha": 2.0}, 13), ("Softsign", {}, 13),
+           ("ThresholdedRelu", {"alpha": 0.5}, 13), ("Atan", {}, 13), ("Mish", {}, 18)]
+  for op, attrs, opset in cases:
+    m = _model([helper.make_node(op, ["x"], ["y"], **attrs)], [_vi("x", [1, 32])], [_vi("y", [1, 32])], opset=opset)
+    got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+    ref = np.asarray(onnx_run(m, x))
+    assert np.abs(got - ref).max() < 2e-2, f"{op}: {np.abs(got - ref).max()}"
+
+def test_tier1_reduces_match_onnxruntime():  # axes attr form (opset 13); positive input keeps ReduceLogSum defined
+  rng = np.random.default_rng(11); x = (np.abs(rng.standard_normal((1, 4, 8))) + 0.1).astype(np.float32)
+  for op in ("ReduceL1", "ReduceL2", "ReduceLogSum", "ReduceLogSumExp", "ReduceSumSquare"):
+    for keep in (1, 0):
+      m = _model([helper.make_node(op, ["x"], ["y"], axes=[2], keepdims=keep)],
+                 [_vi("x", [1, 4, 8])], [_vi("y", [1, 4, 1] if keep else [1, 4])])
+      got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+      ref = np.asarray(onnx_run(m, x))
+      assert got.shape == ref.shape and np.abs(got - ref).max() < 5e-2, f"{op} keepdims={keep}"
+
+def test_argmin_matches_onnxruntime():  # argmax(-x) bridge; compare index values as floats
+  rng = np.random.default_rng(12); x = rng.standard_normal((4, 16)).astype(np.float32)
+  m = _model([helper.make_node("ArgMin", ["x"], ["y"], axis=1)], [_vi("x", [4, 16])],
+             [helper.make_tensor_value_info("y", TensorProto.INT64, [4, 1])])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  ref = np.asarray(onnx_run(m, x)).astype(np.float32)
+  assert got.shape == ref.shape and np.abs(got - ref).max() < 0.5
+
+def test_split_equal_concat_roundtrip_matches_onnxruntime():  # native split path
+  rng = np.random.default_rng(13); x = rng.standard_normal((1, 8, 4)).astype(np.float32)
+  nodes = [helper.make_node("Split", ["x"], ["a", "b"], axis=1),
+           helper.make_node("Concat", ["b", "a"], ["y"], axis=1)]   # swap halves so the split is observable
+  m = _model(nodes, [_vi("x", [1, 8, 4])], [_vi("y", [1, 8, 4])])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 1e-2
+
+def test_split_uneven_sizes_builds():  # split input (opset 13) with uneven sizes -> slice path
+  sp = onnx.numpy_helper.from_array(np.array([3, 5], np.int64), "sp")
+  nodes = [helper.make_node("Split", ["x", "sp"], ["a", "b"], axis=1),
+           helper.make_node("Concat", ["b", "a"], ["y"], axis=1)]
+  m = _model(nodes, [_vi("x", [1, 8])], [_vi("y", [1, 8])], inits=[sp])
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 8)
+
+def test_constantofshape_range_eyelike_fold():  # const generators fold and bake into consumers
+  cofs = helper.make_node("ConstantOfShape", ["s"], ["c"],
+                          value=onnx.numpy_helper.from_array(np.array([2.5], np.float32), "v"))
+  s = onnx.numpy_helper.from_array(np.array([1, 4], np.int64), "s")
+  m = _model([cofs, helper.make_node("Add", ["x", "c"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])], inits=[s])
+  x = np.ones((1, 4), np.float32)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - 3.5).max() < 1e-2
+  st = onnx.numpy_helper.from_array(np.array(0.0, np.float32), "st")
+  li = onnx.numpy_helper.from_array(np.array(4.0, np.float32), "li")
+  de = onnx.numpy_helper.from_array(np.array(1.0, np.float32), "de")
+  m = _model([helper.make_node("Range", ["st", "li", "de"], ["r"]),
+              helper.make_node("Add", ["x", "r"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])], inits=[st, li, de])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - (1.0 + np.arange(4))).max() < 1e-2
+  m = _model([helper.make_node("EyeLike", ["x"], ["e"]), helper.make_node("Add", ["x", "e"], ["y"])],
+             [_vi("x", [4, 4])], [_vi("y", [4, 4])])
+  x4 = np.zeros((4, 4), np.float32)
+  got = np.asarray(af.load_onnx(m)(x4.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.eye(4)).max() < 1e-3
+
+def test_trilu_tensor_matches_onnxruntime():  # mask-multiply path on an activation
+  rng = np.random.default_rng(14); x = rng.standard_normal((1, 6, 6)).astype(np.float32)
+  m = _model([helper.make_node("Trilu", ["x"], ["y"], upper=0)], [_vi("x", [1, 6, 6])], [_vi("y", [1, 6, 6])], opset=14)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 1e-2
+
+def test_lpnormalization_matches_onnxruntime():
+  rng = np.random.default_rng(15); x = rng.standard_normal((2, 16)).astype(np.float32)
+  for p in (2, 1):
+    m = _model([helper.make_node("LpNormalization", ["x"], ["y"], axis=-1, p=p)], [_vi("x", [2, 16])], [_vi("y", [2, 16])])
+    got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+    assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 2e-2, f"p={p}"
+
+def test_groupnorm_matches_onnxruntime():  # opset 21 per-channel scale/bias
+  rng = np.random.default_rng(16); x = rng.standard_normal((1, 4, 4, 4)).astype(np.float32)
+  sc = _init(np.abs(rng.standard_normal(4)) + 0.5, "sc"); bi = _init(rng.standard_normal(4), "bi")
+  m = _model([helper.make_node("GroupNormalization", ["x", "sc", "bi"], ["y"], num_groups=2)],
+             [_vi("x", [1, 4, 4, 4])], [_vi("y", [1, 4, 4, 4])], inits=[sc, bi], opset=21)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 5e-2
+
+def test_rmsnormalization_matches_reference():  # numpy reference (keeps the test independent of ORT opset-23 support)
+  rng = np.random.default_rng(17); x = rng.standard_normal((2, 16)).astype(np.float32)
+  sc = _init(np.abs(rng.standard_normal(16)) + 0.5, "sc")
+  m = _model([helper.make_node("RMSNormalization", ["x", "sc"], ["y"])], [_vi("x", [2, 16])], [_vi("y", [2, 16])],
+             inits=[sc], opset=23)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  scv = onnx.numpy_helper.to_array(sc)
+  ref = x / np.sqrt((x ** 2).mean(-1, keepdims=True) + 1e-5) * scv
+  assert np.abs(got - ref).max() < 3e-2
+
+def test_einsum_matmul_matches_onnxruntime():
+  rng = np.random.default_rng(18); x = rng.standard_normal((4, 8)).astype(np.float32)
+  w = _init(rng.standard_normal((8, 6)), "w")
+  m = _model([helper.make_node("Einsum", ["x", "w"], ["y"], equation="ij,jk->ik")],
+             [_vi("x", [4, 8])], [_vi("y", [4, 6])], inits=[w])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 5e-2
+
+def test_slice_full_flip_matches_onnxruntime():  # step=-1 over the whole axis -> native reverse
+  rng = np.random.default_rng(19); x = rng.standard_normal((1, 8)).astype(np.float32)
+  st = onnx.numpy_helper.from_array(np.array([-1], np.int64), "st")
+  en = onnx.numpy_helper.from_array(np.array([np.iinfo(np.int64).min], np.int64), "en")
+  ax = onnx.numpy_helper.from_array(np.array([1], np.int64), "ax")
+  sp = onnx.numpy_helper.from_array(np.array([-1], np.int64), "sp")
+  m = _model([helper.make_node("Slice", ["x", "st", "en", "ax", "sp"], ["y"])],
+             [_vi("x", [1, 8])], [_vi("y", [1, 8])], inits=[st, en, ax, sp])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 1e-3
+
+def test_slice_partial_reverse_raises():  # only full-axis flips are supported at step=-1
+  st = onnx.numpy_helper.from_array(np.array([5], np.int64), "st")
+  en = onnx.numpy_helper.from_array(np.array([2], np.int64), "en")
+  ax = onnx.numpy_helper.from_array(np.array([1], np.int64), "ax")
+  sp = onnx.numpy_helper.from_array(np.array([-1], np.int64), "sp")
+  m = _model([helper.make_node("Slice", ["x", "st", "en", "ax", "sp"], ["y"])],
+             [_vi("x", [1, 8])], [_vi("y", [1, 3])], inits=[st, en, ax, sp])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)


### PR DESCRIPTION
The compositional remainder of the importer gap, per the coverage plan: everything here builds on existing graph ops, no new lowering. Deliberately does not touch the seeded starter issues (#76 stays open for a newcomer).

## Added (66 → 100 registered op names)

- **Activations**: `Selu` (= gamma·elu(x, alpha), exact), `Celu` (= alpha·elu(x/alpha, 1)), `Mish` (x·tanh(softplus x)), `Softsign`, `ThresholdedRelu`, `Atan` — all direct graph methods or two-op compositions.
- **Reduce family**: `ReduceL1`/`ReduceL2`/`ReduceLogSum`/`ReduceLogSumExp`/`ReduceSumSquare` via the existing `_reduce_op` wrapper over native reduces (`ReduceL2` composes `sum_square → sqrt`).
- **`ArgMin`** as `argmax(-x)` — same 2D bridge and index encoding as ArgMax.
- **`Split`** — native `split` for equal parts, `slice_by_size` for uneven (`split` attr/input and opset-18 `num_outputs` incl. the smaller last chunk).
- **Const generators**: `ConstantOfShape`, `Range`, `EyeLike` fold at import like `Constant`; `Trilu` folds constants and mask-multiplies activations with the baked 0/1 triangle.
- **Normalization**: `LpNormalization` (p=2 → native `l2_norm`; p=1 → divide by keepdims L1), `GroupNormalization` (opset-21 per-channel scale/bias → native `group_norm`), `RMSNormalization` (2-D view + native `rms_norm`, mirroring the LayerNormalization handler).
- **`Einsum`** routed to `aneforge.einsum` (matmul-reducible equations; diagonal/ellipsis reject cleanly as `EinsumUnsupported`, a `NotImplementedError`).

## Lifted restrictions

- `Squeeze` with no axes now squeezes all unit dims — well-defined because shapes are static (the old `NotImplementedError` test became a positive test).
- `Slice` accepts `step=-1` as a **full-axis flip** via the native `reverse`; partial reversed slices still reject with a precise message.

## Verification (on-device, M5)
- `pytest tests/test_onnx.py`: **148 passed** (13 new tests), numeric checks against onnxruntime for the activations, all five reduces (both keepdims forms), ArgMin, Split round-trip, Trilu, LpNormalization (p=1 and 2), GroupNormalization, Einsum, and the Slice flip. RMSNormalization checks against a numpy reference to stay independent of ORT's opset-23 support.
- Off-device selection: 169 passed, unchanged. `ruff`, 2-space pylint, `pyright` (0 new errors) clean.
- `docs/onnx.md` supported-operators table brought current — it also gains `LayerNormalization` and the #86 ops, which it had been missing.