### PR TITLE
onnx: re-land #89 — Pad (4 modes), Cast, Shrink, OneHot (merge-order casualty)

### DIFF
--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -409,6 +409,106 @@ def _pad4(pads):                               # ONNX conv pads=[top,left,bottom
   p = [int(v) for v in pads]
   return p[0] if len(set(p)) == 1 else (p[0], p[2], p[1], p[3])
 
+def _pad_axis(x, ax, before, after, mode, value):
+  """Pad one axis by concatenating border blocks: const blocks, repeated edge slices, a reversed
+  interior slice (reflect), or the opposite end (wrap). All static; reflect requires pad < dim."""
+  from .graph import concat as _cat
+  def _sl(begin, size):
+    b = [0] * len(x.shape); s = list(x.shape); b[ax] = begin; s[ax] = size
+    return x.slice_by_size(b, s)
+  def _blk(n):
+    shp = list(x.shape); shp[ax] = n                 # only [ax] differs, so the pre-pad shape is right for both borders
+    return _baked(np.full(shp, value, np.float16))
+  dim = x.shape[ax]
+  if mode == "constant":
+    # nested 2-part concats: a 3-part concat with two const borders fails to lower once a second
+    # padded axis stacks on top (Espresso "not implemented"); pairwise concats compile and are exact
+    y = x
+    if after: y = _cat([y, _blk(after)], axis=ax)
+    if before: y = _cat([_blk(before), y], axis=ax)
+    return y
+  if mode == "edge":
+    parts = [_sl(0, 1)] * before + [x] + [_sl(dim - 1, 1)] * after
+  elif mode == "reflect":
+    if before >= dim or after >= dim: raise NotImplementedError(f"ONNX Pad reflect: pad {before}/{after} >= dim {dim}")
+    parts = ([_sl(1, before).reverse(ax)] if before else []) + [x] + ([_sl(dim - 1 - after, after).reverse(ax)] if after else [])
+  elif mode == "wrap":
+    parts = ([_sl(dim - before, before)] if before else []) + [x] + ([_sl(0, after)] if after else [])
+  else:
+    raise NotImplementedError(f"ONNX Pad: mode={mode!r} not supported")
+  return _cat(parts, axis=ax) if len(parts) > 1 else x
+
+@onnx_op("Pad")
+def _pad_h(node, ins, a, i):
+  """Pad (opset 13+): constant/edge/reflect/wrap via static concat of border blocks; pads/axes must be constant."""
+  mode = _sattr(a, "mode", "constant")
+  if len(ins) > 1 and isinstance(ins[1], Tensor): raise NotImplementedError("ONNX Pad: data-dependent pads not supported")
+  pads = [int(v) for v in np.asarray(ins[1]).ravel()] if len(ins) > 1 and ins[1] is not None \
+    else [int(v) for v in a.get("pads", [])]
+  value = float(a.get("value", 0.0))                 # opset<11 attr form
+  if len(ins) > 2 and ins[2] is not None:
+    if isinstance(ins[2], Tensor): raise NotImplementedError("ONNX Pad: data-dependent constant_value not supported")
+    value = float(np.asarray(ins[2]).ravel()[0])
+  if _isc(ins[0]):                                   # constant pad folds
+    d = np.asarray(ins[0]); r = d.ndim
+    axes = [int(v) % r for v in np.asarray(ins[3]).ravel()] if len(ins) > 3 and ins[3] is not None else list(range(r))
+    width = [(0, 0)] * r
+    for k, ax in enumerate(axes): width[ax] = (pads[k], pads[k + len(axes)])
+    if mode == "constant": return np.pad(d, width, constant_values=value)
+    return np.pad(d, width, mode)  # type: ignore[arg-type]  # np.pad stubs over-constrain mode to a callable protocol
+  x = ins[0]; r = len(x.shape)
+  axes = [int(v) % r for v in np.asarray(ins[3]).ravel()] if len(ins) > 3 and ins[3] is not None else list(range(r))
+  if len(pads) != 2 * len(axes): raise ValueError(f"ONNX Pad: pads {pads} does not match axes {axes}")
+  for k, ax in enumerate(axes):
+    before, after = pads[k], pads[k + len(axes)]
+    if before or after: x = _pad_axis(x, ax, before, after, mode, value)
+  return x
+
+@onnx_op("Cast")
+def _cast(node, ins, a, i):
+  """Cast at import level: constants convert; a float->float cast on an activation is identity (the engine
+  computes fp16 regardless); float->int truncates toward zero as sign(x)*floor(|x|) (exact within fp16 range)."""
+  from onnx import helper
+  to = helper.tensor_dtype_to_np_dtype(int(a["to"]))
+  if _isc(ins[0]): return np.asarray(ins[0]).astype(to)
+  if np.issubdtype(to, np.floating): return ins[0]
+  if np.issubdtype(to, np.integer): return ins[0].sign() * ins[0].abs().floor()
+  raise NotImplementedError(f"ONNX Cast: target dtype {to} not supported on the ANE (fp16 datapath)")
+
+@onnx_op("Shrink")
+def _shrink(node, ins, a, i):
+  """Shrink: x-bias above lambd, x+bias below -lambd, else 0 - nested select against baked thresholds."""
+  from .graph import select as _select
+  x = ins[0]; bias = float(a.get("bias", 0.0)); lambd = float(a.get("lambd", 0.5))
+  lc = _baked(np.full(x.shape, lambd, np.float16)); nlc = _baked(np.full(x.shape, -lambd, np.float16))
+  zero = _baked(np.zeros(x.shape, np.float16))
+  return _select(x.greater(lc), x + (-bias), _select(x.less(nlc), x + bias, zero))
+
+@onnx_op("OneHot")
+def _onehot(node, ins, a, i):
+  """OneHot: compare the index tensor against a baked arange along the inserted axis, then select
+  on/off values. depth and values must be constant; a TENSOR index must be non-negative and in range
+  (out-of-range simply never matches -> all off), and indices are exact in fp16 up to 2048."""
+  from .graph import select as _select
+  if isinstance(ins[1], Tensor) or isinstance(ins[2], Tensor):
+    raise NotImplementedError("ONNX OneHot: data-dependent depth/values not supported")
+  depth = int(np.asarray(ins[1]).ravel()[0]); off_v, on_v = (float(v) for v in np.asarray(ins[2]).ravel())
+  if depth > 2048: raise NotImplementedError(f"ONNX OneHot: depth {depth} exceeds exact fp16 integer range")
+  if _isc(ins[0]):
+    idx = np.asarray(ins[0]).astype(np.int64)
+    pos0 = int(a.get("axis", -1)) % (idx.ndim + 1)
+    idxw = np.where(idx < 0, idx + depth, idx)               # ONNX: negatives wrap, out-of-range -> all off
+    valid = ((idxw >= 0) & (idxw < depth)).astype(np.float32)
+    hot = np.eye(depth, dtype=np.float32)[np.clip(idxw, 0, depth - 1)] * valid[..., None]
+    return (off_v + (on_v - off_v) * np.moveaxis(hot, -1, pos0)).astype(np.float32)
+  x = ins[0]; r = len(x.shape); pos = int(a.get("axis", -1)) % (r + 1)
+  xe = x.expand_dims((pos,))
+  rng_shape = [1] * (r + 1); rng_shape[pos] = depth
+  rng = _baked(np.arange(depth, dtype=np.float16).reshape(rng_shape))
+  out_shape = tuple(depth if k == pos else d for k, d in enumerate(xe.shape))
+  on = _baked(np.full(out_shape, on_v, np.float16)); off = _baked(np.full(out_shape, off_v, np.float16))
+  return _select(xe.equal(rng), on, off)
+
 @onnx_op("DequantizeLinear")
 def _dequant(node, ins, a, i):
   """int8/uint8 weight -> dequantized fp32 const (per-channel along `axis`); on an activation it is identity (the ANE computes in fp16)."""

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -41,18 +41,18 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Category | ONNX ops |
 | --- | --- |
 | Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `Selu`, `Celu`, `Mish`, `Softsign`, `ThresholdedRelu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf`, `HardSigmoid`, `HardSwish` |
-| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported), `Abs`, `Neg`, `Sign`, `Reciprocal`, `Sin`, `Cos`, `Atan`, `Softplus`, `Floor`, `Ceil`, `Round`, `Min`, `Max`, `Sum`, `Mean` (variadic), `Where`, `Tile` |
+| Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported), `Abs`, `Neg`, `Sign`, `Reciprocal`, `Sin`, `Cos`, `Atan`, `Softplus`, `Floor`, `Ceil`, `Round`, `Min`, `Max`, `Sum`, `Mean` (variadic), `Where`, `Tile`, `Shrink` |
 | Comparison / logic | `Equal`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Not` |
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool`, `GlobalMaxPool` |
 | Linear | `Gemm` (full `alpha`/`beta`/`transA`/`transB`), `MatMul`, `Einsum` (matmul-reducible equations) |
 | Normalization | `BatchNormalization`, `InstanceNormalization`, `LayerNormalization`, `GroupNormalization`, `RMSNormalization`, `LpNormalization` (p=1/2) |
-| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze` (incl. squeeze-all), `Unsqueeze`, `Concat`, `Split`, `Expand`, `SpaceToDepth`, `DepthToSpace`, `Slice` (step 1; step -1 as a full-axis flip), `Shape`, `Trilu` |
+| Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze` (incl. squeeze-all), `Unsqueeze`, `Concat`, `Split`, `Expand`, `SpaceToDepth`, `DepthToSpace`, `Slice` (step 1; step -1 as a full-axis flip), `Shape`, `Trilu`, `Pad` (constant/edge/reflect/wrap) |
 | Normalization (cross-channel) | `LRN` |
 | Resampling | `Resize` (nearest / linear) |
 | Reduction | `ReduceMax`, `ReduceMin`, `ReduceSum`, `ReduceMean`, `ReduceL1`, `ReduceL2`, `ReduceLogSum`, `ReduceLogSumExp`, `ReduceSumSquare`, `CumSum` |
 | Indexing | `Gather` (static indices), `ArgMax`, `ArgMin`, `TopK` (2D, values only) |
 | Quantization | `DequantizeLinear`, `QuantizeLinear` (QDQ int8) |
-| Misc | `Softmax`, `LogSoftmax`, `Constant`, `ConstantOfShape`, `Range`, `EyeLike`, `Identity`, `Dropout` (inference no-op) |
+| Misc | `Softmax`, `LogSoftmax`, `Constant`, `ConstantOfShape`, `Range`, `EyeLike`, `Identity`, `Dropout` (inference no-op), `Cast` (import-level), `OneHot` (constant depth/values) |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
 `Shape`/`Gather`/dynamic-`Reshape` plumbing into static initializers before import.
@@ -103,6 +103,15 @@ mis-lower:
   pass `compress="int8"` to keep them on the ANE int8 weight datapath. Matches onnxruntime
   on-device (cosine ~1.0).
 - **Gelu:** exact erf-gelu only; `approximate="tanh"` raises.
+- **Boolean algebra has no ANE path.** `And`/`Or`/`Xor` cannot be implemented: MIL's
+  `logical_and`/`logical_or`/`logical_xor` (and general `cast`, which would allow a
+  bool->fp16 workaround) do not compile for the ANE backend (see the on-device MIL
+  vocabulary sweep). `IsNaN` is also out: fp16 NaN payloads do not survive the
+  datapath, so `x != x` reads false on-device. Comparisons and `Not` are the
+  supported boolean surface.
+- **Cast** folds constants and treats float->float on an activation as identity (the
+  engine computes fp16 regardless); float->int truncates toward zero as
+  `sign(x)*floor(|x|)`, exact within fp16 integer range.
 - **PRelu:** slope is a per-channel initializer (`[C]`, `[C,1,1]`, or scalar, flattened
   to `[C]`); input must be rank>=3 `[N,C,...]`.
 - **InstanceNormalization:** `[N,C,H,W]` input with `scale`/`B` initializers `[C]`.

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1086,3 +1086,62 @@ def test_slice_partial_reverse_raises():  # only full-axis flips are supported a
   m = _model([helper.make_node("Slice", ["x", "st", "en", "ax", "sp"], ["y"])],
              [_vi("x", [1, 8])], [_vi("y", [1, 3])], inits=[st, en, ax, sp])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+
+# -- tier-2: Pad (4 modes), Cast, Shrink, OneHot -- #
+
+def test_pad_modes_match_onnxruntime():  # constant/edge/reflect at opset 13, wrap at 21
+  rng = np.random.default_rng(20); x = rng.standard_normal((1, 2, 4, 4)).astype(np.float32)
+  pd = onnx.numpy_helper.from_array(np.array([0, 0, 1, 2, 0, 0, 2, 1], np.int64), "pd")
+  cv = onnx.numpy_helper.from_array(np.array(1.5, np.float32), "cv")
+  for mode, opset in (("constant", 13), ("edge", 13), ("reflect", 13), ("wrap", 21)):
+    ins_names = ["x", "pd", "cv"] if mode == "constant" else ["x", "pd"]
+    inits = [pd, cv] if mode == "constant" else [pd]
+    m = _model([helper.make_node("Pad", ins_names, ["y"], mode=mode)],
+               [_vi("x", [1, 2, 4, 4])], [_vi("y", [1, 2, 7, 7])], inits=inits, opset=opset)
+    got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+    ref = np.asarray(onnx_run(m, x))
+    assert got.shape == ref.shape and np.abs(got - ref).max() < 1e-2, f"mode={mode}"
+
+def test_pad_axes_input_builds():  # opset 18 axes input restricts which dims pad
+  pd = onnx.numpy_helper.from_array(np.array([1, 1], np.int64), "pd")
+  axc = onnx.numpy_helper.from_array(np.array([3], np.int64), "ax")
+  m = _model([helper.make_node("Pad", ["x", "pd", "", "ax"], ["y"], mode="edge")],
+             [_vi("x", [1, 2, 4, 4])], [_vi("y", [1, 2, 4, 6])], inits=[pd, axc], opset=18)
+  _, out = af.onnx_to_tensor(m); assert out.shape == (1, 2, 4, 6)
+
+def test_cast_float_identity_and_const_fold():
+  m = _model([helper.make_node("Cast", ["x"], ["c"], to=TensorProto.FLOAT16),
+              helper.make_node("Relu", ["c"], ["y"])], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  ins, out = af.onnx_to_tensor(m); assert out.op == "relu" and out.srcs[0] is ins[0]   # cast was identity
+  c = onnx.numpy_helper.from_array(np.array([1.7, -2.7], np.float32), "c0")
+  m = _model([helper.make_node("Cast", ["c0"], ["ci"], to=TensorProto.INT64),
+              helper.make_node("Cast", ["ci"], ["cf"], to=TensorProto.FLOAT),
+              helper.make_node("Add", ["x", "cf"], ["y"])], [_vi("x", [1, 2])], [_vi("y", [1, 2])], inits=[c])
+  x = np.zeros((1, 2), np.float32)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.array([[1.0, -2.0]])).max() < 1e-3   # trunc toward zero
+
+def test_cast_tensor_to_int_truncates():  # sign(x)*floor(|x|) matches ORT's toward-zero truncation
+  x = np.array([[1.7, -1.7, 2.2, -0.4]], np.float32)
+  m = _model([helper.make_node("Cast", ["x"], ["ci"], to=TensorProto.INT32),
+              helper.make_node("Cast", ["ci"], ["y"], to=TensorProto.FLOAT)], [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 1e-3
+
+def test_shrink_matches_onnxruntime():
+  x = np.linspace(-2.0, 2.0, 16).astype(np.float32).reshape(1, 16)
+  m = _model([helper.make_node("Shrink", ["x"], ["y"], lambd=0.7, bias=0.3)], [_vi("x", [1, 16])], [_vi("y", [1, 16])])
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 1e-2
+
+def test_onehot_tensor_matches_onnxruntime():
+  idx = np.array([[0, 2, 1, 3]], np.float32)   # fed as fp16 to the ANE, int64 to ORT
+  dep = onnx.numpy_helper.from_array(np.array(4, np.int64), "dep")
+  val = onnx.numpy_helper.from_array(np.array([0.25, 2.0], np.float32), "val")
+  m = _model([helper.make_node("OneHot", ["x", "dep", "val"], ["y"], axis=-1)],
+             [helper.make_tensor_value_info("x", TensorProto.INT64, [1, 4])], [_vi("y", [1, 4, 4])], inits=[dep, val])
+  got = np.asarray(af.load_onnx(m)(idx.astype(np.float16))).astype(np.float32)
+  import onnxruntime
+  ref = np.asarray(onnxruntime.InferenceSession(m.SerializeToString()).run(None, {"x": idx.astype(np.int64)})[0])
+  assert got.shape == ref.shape and np.abs(got - ref).max() < 1e-2


### PR DESCRIPTION
#89 shows as merged but its diff never reached `main`: it was merged into the `onnx/tier1-coverage` branch 42 seconds *after* #88 had already squash-merged that branch to main, and the branch was then deleted — the classic stacked-PR ordering trap (the stack needed #88's branch deletion to retarget #89 before merging it). This PR re-lands the identical commit, rebased onto current main.

Content is exactly #89's (see its description for the full write-up): Pad (constant/edge/reflect/wrap, with the nested-2-part-concat workaround for the Espresso lowering quirk), import-level Cast, Shrink, OneHot, and the documented boolean/IsNaN hardware boundary in docs/onnx.md. Registered op names 100 → 104.

Re-verified after rebase, on-device (M5): `pytest tests/test_onnx.py` — 154 passed.