### PR TITLE
onnx: control flow — If (constant condition), Loop (static trip count, unrolled)

### DIFF
--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -109,13 +109,11 @@ def onnx_to_tensor(path, approx_resize=False):
     for vi in g.input:
       if vi.name in inits: continue              # initializers also listed as inputs in some exporters
       t = _input(_shape(vi)); vals[vi.name] = t; graph_inputs.append(t)
-    for node in g.node:                          # ONNX node list is topologically ordered
-      if node.op_type not in _ONNX:
-        raise NotImplementedError(f"ONNX op '{node.op_type}' not supported")
-      ins = [vals.get(n) for n in node.input]
-      outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
-      outs = outs if isinstance(outs, (list, tuple)) else [outs]
-      for name, val in zip(node.output, outs): vals[name] = val
+    _SCOPES.append(vals)                         # visible to If/Loop subgraphs (ONNX outer-scope names)
+    try:
+      _run_nodes(g, vals, inits)
+    finally:
+      _SCOPES.pop()
     name = g.output[0].name
     if name not in vals: raise ValueError(f"onnx: graph output '{name}' was never produced")
     out = vals[name]
@@ -123,6 +121,78 @@ def onnx_to_tensor(path, approx_resize=False):
     return graph_inputs, out
   finally:
     _APPROX_RESIZE = prev
+
+_SCOPES: list[dict] = []                         # enclosing-graph value environments, innermost last
+
+def _run_nodes(g, vals, inits):
+  """Run a (sub)graph's topologically-ordered node list against the value environment `vals`."""
+  for node in g.node:
+    if node.op_type not in _ONNX:
+      raise NotImplementedError(f"ONNX op '{node.op_type}' not supported")
+    ins = [vals.get(n) for n in node.input]
+    outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
+    outs = outs if isinstance(outs, (list, tuple)) else [outs]
+    for name, val in zip(node.output, outs): vals[name] = val
+
+def _run_subgraph(sub, binding, inits):
+  """Import a subgraph (If branch / Loop body): outer-scope names resolve per ONNX scoping, the
+  subgraph's formal inputs bind to `binding`, and its output values are returned in order."""
+  from onnx import numpy_helper
+  vals = dict(_SCOPES[-1]) if _SCOPES else {}
+  vals.update({t.name: numpy_helper.to_array(t) for t in sub.initializer})
+  vals.update(binding)
+  _SCOPES.append(vals)
+  try:
+    _run_nodes(sub, vals, inits)
+  finally:
+    _SCOPES.pop()
+  outs = []
+  for o in sub.output:
+    if o.name not in vals: raise ValueError(f"onnx: subgraph output '{o.name}' was never produced")
+    outs.append(vals[o.name])
+  return outs
+
+@onnx_op("If")
+def _if(node, ins, a, i):
+  """If with a CONSTANT condition: the taken branch imports inline (the other is never built).
+  A data-dependent condition has no ANE path (programs are single static graphs)."""
+  if isinstance(ins[0], Tensor):
+    raise NotImplementedError("ONNX If: data-dependent condition not supported (constant conditions fold at import)")
+  cond = bool(np.asarray(ins[0]).ravel()[0])
+  return _run_subgraph(a["then_branch"] if cond else a["else_branch"], {}, i)
+
+@onnx_op("Loop")
+def _loop(node, ins, a, i):
+  """Loop with a STATIC trip count: the body unrolls at import (M copies of its ops in one program).
+  Requires constant M, a constant-true (or absent) condition, and a body that keeps it true;
+  scan outputs stack along a new leading axis, per the ONNX spec."""
+  M = ins[0] if len(ins) > 0 else None
+  if isinstance(M, Tensor): raise NotImplementedError("ONNX Loop: data-dependent trip count not supported")
+  if M is None: raise NotImplementedError("ONNX Loop: a trip count is required (while-style loops cannot unroll)")
+  M = int(np.asarray(M).ravel()[0])
+  if M > 1024: raise NotImplementedError(f"ONNX Loop: trip count {M} too large to unroll into one program")
+  cond = ins[1] if len(ins) > 1 else None
+  if cond is not None and (isinstance(cond, Tensor) or not bool(np.asarray(cond).ravel()[0])):
+    raise NotImplementedError("ONNX Loop: only a constant-true (or absent) condition unrolls")
+  body = a["body"]; carried = list(ins[2:])
+  n_car = len(carried); n_scan = len(body.output) - 1 - n_car
+  scans: list[list] = [[] for _ in range(n_scan)]
+  for it in range(M):
+    binding = {body.input[0].name: np.array(it, np.int64), body.input[1].name: np.array(True)}
+    for k, v in enumerate(carried): binding[body.input[2 + k].name] = v
+    outs = _run_subgraph(body, binding, i)
+    cond_out = outs[0]
+    if isinstance(cond_out, Tensor) or not bool(np.asarray(cond_out).ravel()[0] if cond_out is not None else True):
+      raise NotImplementedError("ONNX Loop: the body's condition output must stay constant-true to unroll")
+    carried = outs[1:1 + n_car]
+    for k in range(n_scan): scans[k].append(outs[1 + n_car + k])
+  from .graph import concat as _cat
+  stacked = []
+  for parts in scans:                            # scan outputs concatenate along a new leading axis
+    if all(_isc(p) for p in parts): stacked.append(np.stack([np.asarray(p) for p in parts])); continue
+    ts = [(p if isinstance(p, Tensor) else _baked(np.asarray(p, np.float16))).expand_dims((0,)) for p in parts]
+    stacked.append(_cat(ts, axis=0) if len(ts) > 1 else ts[0])
+  return carried + stacked
 
 def onnx_to_features(path):
   """Import a classifier and return `(inputs, features)` where `features` is the input to the final

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -53,6 +53,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Indexing | `Gather` (static indices), `ArgMax`, `ArgMin`, `TopK` (2D, values only) |
 | Quantization | `DequantizeLinear`, `QuantizeLinear` (QDQ int8) |
 | Misc | `Softmax`, `LogSoftmax`, `Constant`, `ConstantOfShape`, `Range`, `EyeLike`, `Identity`, `Dropout` (inference no-op), `Cast` (import-level), `OneHot` (constant depth/values) |
+| Control flow | `If` (constant condition), `Loop` (static trip count, unrolled) |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
 `Shape`/`Gather`/dynamic-`Reshape` plumbing into static initializers before import.
@@ -103,6 +104,11 @@ mis-lower:
   pass `compress="int8"` to keep them on the ANE int8 weight datapath. Matches onnxruntime
   on-device (cosine ~1.0).
 - **Gelu:** exact erf-gelu only; `approximate="tanh"` raises.
+- **Control flow folds at import.** `If` requires a constant condition (the taken branch
+  imports inline; the other is never built) and `Loop` a constant trip count with a
+  constant-true condition (the body unrolls into one program; scan outputs stack along a
+  new leading axis). Data-dependent branching/termination has no ANE path: a compiled
+  program is one static graph.
 - **Boolean algebra has no ANE path.** `And`/`Or`/`Xor` cannot be implemented: MIL's
   `logical_and`/`logical_or`/`logical_xor` (and general `cast`, which would allow a
   bool->fp16 workaround) do not compile for the ANE backend (see the on-device MIL

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1145,3 +1145,66 @@ def test_onehot_tensor_matches_onnxruntime():
   import onnxruntime
   ref = np.asarray(onnxruntime.InferenceSession(m.SerializeToString()).run(None, {"x": idx.astype(np.int64)})[0])
   assert got.shape == ref.shape and np.abs(got - ref).max() < 1e-2
+
+
+# -- control flow: constant-condition If, static-trip Loop unrolling -- #
+
+def test_if_constant_cond_imports_taken_branch():  # branches read outer-scope x; only the taken one is built
+  for cond_v, want in ((True, "relu"), (False, "sigmoid")):
+    then_g = helper.make_graph([helper.make_node("Relu", ["x"], ["ty"])], "t", [], [_vi("ty", [1, 4])])
+    else_g = helper.make_graph([helper.make_node("Sigmoid", ["x"], ["ey"])], "e", [], [_vi("ey", [1, 4])])
+    ci = onnx.numpy_helper.from_array(np.array(cond_v), "c")
+    n = helper.make_node("If", ["c"], ["y"], then_branch=then_g, else_branch=else_g)
+    m = _model([n], [_vi("x", [1, 4])], [_vi("y", [1, 4])], inits=[ci])
+    _, out = af.onnx_to_tensor(m); assert out.op == want, f"cond={cond_v} -> {out.op}"
+
+def test_if_tensor_cond_raises():
+  then_g = helper.make_graph([helper.make_node("Relu", ["x"], ["ty"])], "t", [], [_vi("ty", [1, 4])])
+  else_g = helper.make_graph([helper.make_node("Sigmoid", ["x"], ["ey"])], "e", [], [_vi("ey", [1, 4])])
+  nodes = [helper.make_node("Greater", ["x", "x"], ["c"]),
+           helper.make_node("If", ["c"], ["y"], then_branch=then_g, else_branch=else_g)]
+  m = _model(nodes, [_vi("x", [1, 4])], [_vi("y", [1, 4])])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+def _loop_model(out_name):
+  body = helper.make_graph(
+    [helper.make_node("Identity", ["cin"], ["cout"]),
+     helper.make_node("Add", ["acc", "x"], ["acc_out"]),         # x resolves from the OUTER scope
+     helper.make_node("Identity", ["acc_out"], ["scan"])],
+    "body",
+    [helper.make_tensor_value_info("it", TensorProto.INT64, []),
+     helper.make_tensor_value_info("cin", TensorProto.BOOL, []),
+     _vi("acc", [1, 4])],
+    [helper.make_tensor_value_info("cout", TensorProto.BOOL, []), _vi("acc_out", [1, 4]), _vi("scan", [1, 4])])
+  mi = onnx.numpy_helper.from_array(np.array(3, np.int64), "M")
+  ci = onnx.numpy_helper.from_array(np.array(True), "c0")
+  a0 = onnx.numpy_helper.from_array(np.zeros((1, 4), np.float32), "acc0")
+  n = helper.make_node("Loop", ["M", "c0", "acc0"], ["acc_final", "scan_all"], body=body)
+  outs = {"acc_final": _vi("acc_final", [1, 4]), "scan_all": _vi("scan_all", [3, 1, 4])}
+  return _model([n], [_vi("x", [1, 4])], [outs[out_name]], inits=[mi, ci, a0])
+
+def test_loop_unrolls_and_matches_onnxruntime():  # carried accumulator: 3 iterations of acc += x
+  x = np.array([[1.0, 2.0, 3.0, 4.0]], np.float32)
+  m = _loop_model("acc_final")
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  assert np.abs(got - np.asarray(onnx_run(m, x))).max() < 1e-2   # = 3*x
+
+def test_loop_scan_output_stacks_matches_onnxruntime():  # scan outputs concatenate along a new leading axis
+  x = np.array([[1.0, 2.0, 3.0, 4.0]], np.float32)
+  m = _loop_model("scan_all")
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  ref = np.asarray(onnx_run(m, x))
+  assert got.shape == ref.shape == (3, 1, 4) and np.abs(got - ref).max() < 1e-2
+
+def test_loop_without_trip_count_raises():  # while-style loops cannot unroll statically
+  body = helper.make_graph(
+    [helper.make_node("Identity", ["cin"], ["cout"]), helper.make_node("Identity", ["acc"], ["acc_out"])],
+    "body",
+    [helper.make_tensor_value_info("it", TensorProto.INT64, []),
+     helper.make_tensor_value_info("cin", TensorProto.BOOL, []), _vi("acc", [1, 4])],
+    [helper.make_tensor_value_info("cout", TensorProto.BOOL, []), _vi("acc_out", [1, 4])])
+  ci = onnx.numpy_helper.from_array(np.array(True), "c0")
+  a0 = onnx.numpy_helper.from_array(np.zeros((1, 4), np.float32), "acc0")
+  n = helper.make_node("Loop", ["", "c0", "acc0"], ["acc_final"], body=body)
+  m = _model([n], [_vi("x", [1, 4])], [_vi("acc_final", [1, 4])], inits=[ci, a0])
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)


### PR DESCRIPTION
The control-flow tier of the coverage plan. One new piece of infrastructure, two handlers.

## Infrastructure

`_run_subgraph` imports an ONNX subgraph (If branch / Loop body) with proper ONNX scoping: a scope stack makes enclosing-graph names visible inside the subgraph, subgraph initializers and formal inputs bind on top, and the node walk is the same `_run_nodes` the top-level importer now uses.

## Handlers

- **`If`** — constant condition only; the taken branch imports inline and the untaken branch is never built. A tensor condition raises: a compiled program is one static graph.
- **`Loop`** — constant trip count (≤1024) with an absent/constant-true condition that the body keeps true. The body unrolls into the single fused program: iteration numbers bind as int64 constants (so iteration-dependent shape arithmetic folds through the existing const machinery), loop-carried values thread across iterations, and scan outputs stack along a new leading axis per the spec (`expand_dims` + concat for tensors, `np.stack` for constants). While-style loops raise with a message saying why.

`docs/onnx.md` gains a Control flow table row and a scope note.

## Verification (on-device, M5)
`pytest tests/test_onnx.py`: **159 passed** — If imports the correct branch for both condition values with the branch reading `x` from the outer scope; the Loop accumulator (3 unrolled iterations of `acc += x`) and the `[3,1,4]` stacked scan output both match onnxruntime; tensor-condition If and while-style Loop reject. `ruff`, 2-space pylint, `pyright` (0 errors) clean.