### PR TITLE
linalg: det/slogdet, rank-k pinv, solve_triangular; einsum ellipsis; dsp welch

### DIFF
--- a/aneforge/dsp.py
+++ b/aneforge/dsp.py
@@ -312,6 +312,29 @@ def _relerr(y, ref):
   return float(d / (n + 1e-30))
 
 
+def welch(x, fs: float = 1.0, nperseg: int = 256, noverlap=None, window: str = "hann",
+          scaling: str = "density"):
+  """Welch power spectral density from the on-ANE `stft`: window, segment, average the squared
+  magnitudes, normalize. Matches `scipy.signal.welch(..., detrend=False)` (no per-segment
+  detrending). `scaling`: 'density' (1/(fs*sum(w^2))) or 'spectrum' (1/sum(w)^2); the one-sided
+  spectrum doubles interior bins. Returns (f, Pxx)."""
+  if nperseg & (nperseg - 1):
+    raise ValueError("welch: nperseg must be a power of two (the staged on-ANE FFT pads to one, which would shift the bins)")
+  if noverlap is None: noverlap = nperseg // 2
+  w = get_window(window, nperseg)
+  Zr, Zi = stft(x, win=nperseg, hop=nperseg - noverlap, window=window)   # [n_freq, n_frames], FFTs on the engine
+  P = (Zr.astype(np.float64) ** 2 + Zi.astype(np.float64) ** 2).mean(axis=1)
+  if scaling == "density":
+    P /= fs * float(np.sum(w.astype(np.float64) ** 2))
+  elif scaling == "spectrum":
+    P /= float(np.sum(w.astype(np.float64))) ** 2
+  else:
+    raise ValueError(f"welch: scaling={scaling!r} (use 'density' or 'spectrum')")
+  P[1:-1 if nperseg % 2 == 0 else None] *= 2.0             # one-sided: double all but DC (and Nyquist if present)
+  f = np.arange(P.shape[0], dtype=np.float64) * (fs / nperseg)
+  return f, P.astype(np.float32)
+
+
 def _selftest():
   ss: Any = None  # pre-bound so pyright sees it as bound below (guarded by have_scipy)
   try:

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -58,6 +58,8 @@ def _expand_ellipsis(equation: str, operands) -> str:
     singles = "".join(sorted(ch for ch, c in counts.items() if c == 1 and ch not in batch))
     rhs = batch + singles                       # numpy: ellipsis dims first, then once-only letters
   else:
+    if E and "..." not in rhs:
+      raise ValueError("einsum: inputs carry '...' dims but the output subscript omits '...' (numpy rejects this)")
     rhs = rhs.replace("...", batch)
   return ",".join(new_ins) + "->" + rhs
 

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -17,6 +17,51 @@ class EinsumUnsupported(NotImplementedError):
 
 # equation parsing
 
+def _expand_ellipsis(equation: str, operands) -> str:
+  """Rewrite '...' into explicit batch letters (right-aligned per operand rank) so the v1 parser
+  never sees an ellipsis. Implicit output follows numpy's rule (ellipsis dims first, then the
+  once-only letters alphabetically). Ellipsis dims must match exactly - size-1 broadcast between
+  operands' ellipsis dims needs expand semantics the lowering does not have, and rejects."""
+  eq = equation.replace(" ", "")
+  if "..." not in eq: return eq
+  lhs, rhs = eq.split("->") if "->" in eq else (eq, None)
+  ins = lhs.split(",")
+  if len(ins) != len(operands):
+    raise ValueError(f"einsum: equation '{equation}' has {len(ins)} operand(s) "
+             f"but {len(operands)} tensor(s) were given")
+  ranks = []
+  for s, op in zip(ins, operands):
+    if "..." in s:
+      e = len(op.shape) - len(s.replace("...", ""))
+      if e < 0: raise ValueError(f"einsum: subscript '{s}' has more indices than operand rank {len(op.shape)}")
+      ranks.append(e)
+    else:
+      ranks.append(0)
+  E = max(ranks)
+  used = set(eq.replace(".", "").replace(",", "").replace("->", ""))
+  import string
+  pool = [c for c in string.ascii_letters if c not in used]
+  if len(pool) < E: raise EinsumUnsupported("einsum: not enough free letters to expand '...'")
+  batch = "".join(pool[:E])
+  sizes: dict[str, int] = {}
+  new_ins = []
+  for s, op, e in zip(ins, operands, ranks):
+    bletters = batch[E - e:] if "..." in s else ""
+    new_ins.append(s.replace("...", bletters))
+    for ch, d in zip(bletters, op.shape[:e]):
+      if ch in sizes and sizes[ch] != d:
+        raise EinsumUnsupported(f"einsum: ellipsis dims disagree ({sizes[ch]} vs {d}) - "
+                    "size-1 broadcast across '...' is unsupported")
+      sizes[ch] = d
+  if rhs is None:
+    counts = Counter("".join(new_ins))
+    singles = "".join(sorted(ch for ch, c in counts.items() if c == 1 and ch not in batch))
+    rhs = batch + singles                       # numpy: ellipsis dims first, then once-only letters
+  else:
+    rhs = rhs.replace("...", batch)
+  return ",".join(new_ins) + "->" + rhs
+
+
 def _parse(equation: str, n_operands: int) -> tuple[list[str], str]:
   """Return (input_subscripts, output_subscript); implied output is indices appearing once, alphabetical (numpy's rule)."""
   eq = equation.replace(" ", "")
@@ -166,12 +211,14 @@ def _expand_to(t: Tensor, present: list, target: list, _sizes) -> Tensor:
 # public API
 
 def einsum(equation: str, *operands: Tensor) -> Tensor:
-  """numpy-style einsum lowered to aneforge ops (matmul-reducible patterns); rejects diagonal/trace, repeated output indices, and ellipsis."""
+  """numpy-style einsum lowered to aneforge ops (matmul-reducible patterns, incl. '...' batch
+  dims); rejects diagonal/trace and repeated output indices."""
   if not operands:
     raise ValueError("einsum: at least one operand is required")
   if not all(isinstance(o, Tensor) for o in operands):
     raise TypeError("einsum: all operands must be aneforge Tensors (build them with af.input)")
 
+  equation = _expand_ellipsis(equation, operands)
   ins, out = _parse(equation, len(operands))
   for s, t in zip(ins, operands):
     if len(s) != len(t.shape):

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -572,6 +572,95 @@ def _diag_dominant(n, cond_scale, seed):
   return A16, b16, xref
 
 
+# Determinants, pseudoinverse, triangular solve, BiCGSTAB - composed from the routines above.
+
+def bicgstab(A, b, iters: int = 40):
+  """Solve A x = b for general (nonsymmetric) A by BiCGSTAB (van der Vorst 1992) with fixed `iters`,
+  the recurrence unrolled into one program. Denominator dots carry a small additive guard; fp16
+  breakdown surfaces as a non-finite iterate and falls back to zeros like the other solvers."""
+  A16 = np.asarray(A, f16); n = A16.shape[0]
+  AT = np.ascontiguousarray(A16.T); onen = np.ones((n, 1), f16)
+  b0 = np.asarray(b, np.float64).reshape(-1)
+  bn = float(np.linalg.norm(b0)) or 1.0                    # unit-scale b: keeps iterates in fp16 range
+  b16 = (b0 / bn).astype(f16).reshape(1, n)
+  bT = af.input((1, n))
+  dot = lambda u, v: (u * v) @ onen
+  Ax = lambda v: v @ AT
+  x, r = bT * 0.0, bT
+  rhat = bT                                                # fixed shadow residual r0^
+  rho, p = dot(bT, bT), bT
+  for _ in range(iters):
+    v = Ax(p)
+    alpha = rho / dot(rhat, v).adds(1e-7)
+    s = r - alpha * v
+    t = Ax(s)
+    omega = dot(t, s) / dot(t, t).adds(1e-7)
+    x = x + alpha * p + omega * s
+    r = s - omega * t
+    rho_new = dot(rhat, r)
+    beta = (rho_new / rho.adds(1e-7)) * (alpha / omega.adds(1e-7))
+    p = r + beta * (p - omega * v)
+    rho = rho_new
+  y = _solve_once(x, b16).ravel()
+  if not np.isfinite(y).all(): y = np.zeros(n)
+  return (y * bn).astype(np.float32)
+
+
+def solve_triangular(A, b, lower: bool = True):
+  """Solve T x = b for triangular T by substitution on the ANE, without forming the inverse
+  (the routed accessor keeps large entries finite, as in cholesky/lu)."""
+  A16 = np.asarray(A, f16); n = A16.shape[0]
+  b16 = np.asarray(b, f16).reshape(n, 1)
+  At = af.input((n, n)); bt = af.input((n, 1))
+  el = _els_routed(At, n)
+  bl = lambda i: bt.slice_by_size([i, 0], [1, 1])          # height-axis slice: begin stays 0 on the last axis
+  X: dict = {}
+  for i in (range(n) if lower else range(n - 1, -1, -1)):
+    s = bl(i)
+    for k in (range(i) if lower else range(i + 1, n)): s = s - el(i, k) * X[k]
+    X[i] = s / el(i, i)
+  out = af.concat([X[i] for i in range(n)], axis=0)
+  return _solve_once(out, A16, b16).ravel().astype(np.float32)
+
+
+def _perm_parity(perm) -> float:
+  """+1/-1 parity of a permutation via cycle decomposition."""
+  seen = np.zeros(len(perm), bool); sign = 1.0
+  for i in range(len(perm)):
+    if seen[i]: continue
+    j, clen = i, 0
+    while not seen[j]: seen[j] = True; j = int(perm[j]); clen += 1
+    if clen % 2 == 0: sign = -sign
+  return sign
+
+
+def det(A):
+  """det(A) via the on-ANE pivoted LU (P A = L U): permutation parity times prod(diag U)."""
+  P, _, U = lu_pivoted(A)
+  sign = _perm_parity(np.argmax(P, axis=1))
+  return float(sign * np.prod(np.diag(U).astype(np.float64)))
+
+
+def slogdet(A):
+  """(sign, log|det A|) via the on-ANE pivoted LU; the log-sum form stays finite where the raw
+  product over/underflows. Returns (0.0, -inf) for a singular U diagonal, like numpy."""
+  P, _, U = lu_pivoted(A)
+  d = np.diag(U).astype(np.float64)
+  if np.any(d == 0.0): return 0.0, float("-inf")
+  sign = _perm_parity(np.argmax(P, axis=1)) * float(np.prod(np.sign(d)))
+  return float(sign), float(np.sum(np.log(np.abs(d))))
+
+
+def pinv(A, k: int, oversample: int = 5, power_iters: int = 2, rcond: float = 1e-3):
+  """Rank-k pseudoinverse via randomized_svd: V diag(1/s) U^T with a relative cutoff on small
+  singular values. Rank-k by construction - for a full-rank dense pinv use a dense library."""
+  U, S, Vt = randomized_svd(A, k, oversample=oversample, power_iters=power_iters)
+  keep = S > rcond * (S[0] if S.size and S[0] > 0 else 1.0)
+  if not np.any(keep): return np.zeros((A.shape[1], A.shape[0]), np.float32)
+  W = (Vt[keep].T / S[keep]).astype(np.float32)            # [n, r]
+  return _ane_gemm(W.astype(f16), np.ascontiguousarray(U[:, keep].T, np.float32).astype(f16)).astype(np.float32)
+
+
 def main():
   print("=" * 90)
   print("aneforge.linalg - ITERATIVE linear algebra on the ANE  (matmuls=ANE, RNG/QR/SVD/loop=HOST)")

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -572,39 +572,7 @@ def _diag_dominant(n, cond_scale, seed):
   return A16, b16, xref
 
 
-# Determinants, pseudoinverse, triangular solve, BiCGSTAB - composed from the routines above.
-
-def bicgstab(A, b, iters: int = 40):
-  """Solve A x = b for general (nonsymmetric) A by BiCGSTAB (van der Vorst 1992) with fixed `iters`,
-  the recurrence unrolled into one program. Denominator dots carry a small additive guard; fp16
-  breakdown surfaces as a non-finite iterate and falls back to zeros like the other solvers."""
-  A16 = np.asarray(A, f16); n = A16.shape[0]
-  AT = np.ascontiguousarray(A16.T); onen = np.ones((n, 1), f16)
-  b0 = np.asarray(b, np.float64).reshape(-1)
-  bn = float(np.linalg.norm(b0)) or 1.0                    # unit-scale b: keeps iterates in fp16 range
-  b16 = (b0 / bn).astype(f16).reshape(1, n)
-  bT = af.input((1, n))
-  dot = lambda u, v: (u * v) @ onen
-  Ax = lambda v: v @ AT
-  x, r = bT * 0.0, bT
-  rhat = bT                                                # fixed shadow residual r0^
-  rho, p = dot(bT, bT), bT
-  for _ in range(iters):
-    v = Ax(p)
-    alpha = rho / dot(rhat, v).adds(1e-7)
-    s = r - alpha * v
-    t = Ax(s)
-    omega = dot(t, s) / dot(t, t).adds(1e-7)
-    x = x + alpha * p + omega * s
-    r = s - omega * t
-    rho_new = dot(rhat, r)
-    beta = (rho_new / rho.adds(1e-7)) * (alpha / omega.adds(1e-7))
-    p = r + beta * (p - omega * v)
-    rho = rho_new
-  y = _solve_once(x, b16).ravel()
-  if not np.isfinite(y).all(): y = np.zeros(n)
-  return (y * bn).astype(np.float32)
-
+# Determinants, pseudoinverse, triangular solve - composed from the routines above.
 
 def solve_triangular(A, b, lower: bool = True):
   """Solve T x = b for triangular T by substitution on the ANE, without forming the inverse

--- a/tests/test_dsp_welch.py
+++ b/tests/test_dsp_welch.py
@@ -1,0 +1,39 @@
+"""Welch PSD (aneforge.dsp.welch) against scipy.signal.welch."""
+import numpy as np
+import pytest
+
+import aneforge.dsp as dsp
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # the underlying stft dispatches its FFTs to the ANE
+scipy_signal = pytest.importorskip("scipy.signal")
+
+
+def _sig(n=4096, fs=1000.0):
+  t = np.arange(n) / fs
+  rng = np.random.default_rng(0)
+  return (np.sin(2 * np.pi * 50.0 * t) + 0.5 * np.sin(2 * np.pi * 120.0 * t)
+          + 0.1 * rng.standard_normal(n)).astype(np.float32), fs
+
+
+@pytest.mark.parametrize("scaling", ["density", "spectrum"])
+def test_welch_matches_scipy(scaling):
+  x, fs = _sig()
+  f, P = dsp.welch(x, fs=fs, nperseg=256, scaling=scaling)
+  fr, Pr = scipy_signal.welch(x, fs=fs, nperseg=256, detrend=False, scaling=scaling)
+  assert np.allclose(f, fr)
+  err = np.abs(P - Pr).max() / (np.abs(Pr).max() + 1e-12)
+  assert err <= 2e-2, f"scaling={scaling}: relerr {err:.2e}"
+
+
+def test_welch_finds_the_tones():
+  x, fs = _sig()
+  f, P = dsp.welch(x, fs=fs, nperseg=256)
+  for tone in (50.0, 120.0):
+    k = np.argmin(np.abs(f - tone))
+    assert P[k] > 10 * np.median(P)                     # the tones stand well out of the noise floor
+
+def test_welch_rejects_non_pow2_nperseg():
+  x, fs = _sig(1024)
+  with pytest.raises(ValueError):
+    dsp.welch(x, fs=fs, nperseg=200)

--- a/tests/test_einsum_ellipsis.py
+++ b/tests/test_einsum_ellipsis.py
@@ -31,8 +31,13 @@ def test_implicit_output_puts_batch_first():
   # numpy implicit mode: ellipsis dims lead the output
   _check("...ij,...jk", (2, 4, 5), (2, 5, 3))
 
-def test_explicit_output_can_reduce_batch():
-  _check("...i,...i->i", (3, 4), (3, 4))
+def test_empty_ellipsis_output_without_dots():
+  # E=0: the ellipsis matches zero dims, so an output without '...' is fine (numpy allows this)
+  _check("...i,...i->i", (4,), (4,))
+
+def test_output_dropping_nonempty_ellipsis_rejects():  # numpy semantics: ValueError
+  with pytest.raises(ValueError):
+    einsum("...i,...i->i", af.input((3, 4)), af.input((3, 4)))
 
 def test_expansion_is_pure_rewrite():
   class _T:  # shape-only stand-in

--- a/tests/test_einsum_ellipsis.py
+++ b/tests/test_einsum_ellipsis.py
@@ -1,0 +1,47 @@
+"""Ellipsis ('...') support in aneforge.einsum: expansion to explicit batch letters."""
+import numpy as np
+import pytest
+
+import aneforge as af
+from aneforge.einsum import einsum, EinsumUnsupported, _expand_ellipsis
+from _helpers import requires_ane
+
+pytestmark = requires_ane  # the equivalence checks compile and dispatch to the ANE
+
+
+def _check(eq, *shapes, seed=0):
+  rng = np.random.default_rng(seed)
+  vals = [rng.standard_normal(s).astype(np.float16) for s in shapes]
+  out = einsum(eq, *[af.input(s) for s in shapes])
+  got = np.asarray(af.compile(out)(*vals)).astype(np.float32)
+  ref = np.einsum(eq, *[v.astype(np.float32) for v in vals])
+  assert got.shape == ref.shape, f"{eq}: {got.shape} != {ref.shape}"
+  err = np.abs(got - ref).max() / (np.abs(ref).max() + 1e-6)
+  assert err <= 5e-3, f"{eq}: relerr {err:.2e}"
+
+
+def test_batched_matmul_ellipsis():
+  _check("...ij,...jk->...ik", (2, 4, 5), (2, 5, 3))
+
+def test_ellipsis_ranks_align_right():
+  # one operand has no batch dims; its '...' expands to nothing
+  _check("...i,i->...", (2, 3, 4), (4,))
+
+def test_implicit_output_puts_batch_first():
+  # numpy implicit mode: ellipsis dims lead the output
+  _check("...ij,...jk", (2, 4, 5), (2, 5, 3))
+
+def test_explicit_output_can_reduce_batch():
+  _check("...i,...i->i", (3, 4), (3, 4))
+
+def test_expansion_is_pure_rewrite():
+  class _T:  # shape-only stand-in
+    def __init__(s, sh): s.shape = sh
+  eq = _expand_ellipsis("...ij,...jk->...ik", [_T((2, 4, 5)), _T((2, 5, 3))])
+  assert "..." not in eq and eq.count(",") == 1 and "->" in eq
+
+def test_mismatched_ellipsis_dims_reject():
+  class _T:
+    def __init__(s, sh): s.shape = sh
+  with pytest.raises(EinsumUnsupported):
+    _expand_ellipsis("...i,...i->...", [_T((2, 4)), _T((3, 4))])

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -215,3 +215,48 @@ def test_lu_pivoted():                  # P A = L U with on-engine argmax pivoti
   assert relerr(P @ A, Lp @ Up) <= 3e-3
   assert np.allclose(P.sum(0), 1) and np.allclose(P.sum(1), 1)   # P is a permutation
   assert np.allclose(np.tril(Up, -1), 0)                          # U upper-triangular
+
+
+# ------------- det/slogdet, pinv, solve_triangular, bicgstab ------------- #
+
+@pytest.mark.parametrize("cond", [1e1, 1e2])
+def test_det_matches_numpy(cond):
+  A = _square(8, cond, int(cond) + 41)
+  ref = np.linalg.det(A)
+  assert abs(L.det(f16(A)) - ref) / (abs(ref) + 1e-30) <= 5e-2
+
+def test_slogdet_matches_numpy():
+  A = _square(8, 1e2, 43) * 3.0                       # scaled so the raw product is fp16-hostile
+  sr, lr = np.linalg.slogdet(A)
+  sg, lg = L.slogdet(f16(A))
+  assert sg == sr and abs(lg - lr) <= 5e-2 * max(1.0, abs(lr))
+
+def test_pinv_rank_k_matches_numpy():
+  r = np.random.default_rng(7)
+  Ul = np.linalg.qr(r.standard_normal((40, 6)))[0]; Vr = np.linalg.qr(r.standard_normal((30, 6)))[0]
+  A = (Ul * np.geomspace(8, 1, 6)) @ Vr.T             # exactly rank 6
+  P = L.pinv(f16(A), k=6)
+  assert relerr(P, np.linalg.pinv(A)) <= 5e-2
+  assert relerr(A @ P @ A, A) <= 5e-2                 # Moore-Penrose: A P A = A
+
+@pytest.mark.parametrize("lower", [True, False])
+def test_solve_triangular(lower):
+  r = np.random.default_rng(11); n = 8
+  T = np.tril(r.standard_normal((n, n))) + np.eye(n) * 4.0
+  if not lower: T = T.T
+  x = r.standard_normal(n); b = T @ x
+  assert relerr(L.solve_triangular(f16(T), f16(b), lower=lower), x) <= 5e-3
+
+def test_solve_triangular_large_entries():
+  # entries above the slice-x16 saturation threshold: the routed accessor keeps the solve finite
+  r = np.random.default_rng(12); n = 6
+  T = np.tril(r.standard_normal((n, n))) + np.eye(n) * 6.0
+  T = T / np.abs(T).max() * 5000.0
+  x = r.standard_normal(n); b = T @ x
+  y = L.solve_triangular(f16(T), f16(b))
+  assert np.isfinite(y).all() and relerr(y, x) <= 1e-2
+
+@pytest.mark.parametrize("cond,tol", [(1e1, 2e-2), (1e2, 8e-2)])
+def test_bicgstab_general_solve(cond, tol):
+  A = _square(10, cond, int(cond) + 5); x = np.random.default_rng(3).standard_normal(10)
+  assert relerr(L.bicgstab(f16(A), f16(A @ x), iters=40), x) <= tol

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -255,8 +255,3 @@ def test_solve_triangular_large_entries():
   x = r.standard_normal(n); b = T @ x
   y = L.solve_triangular(f16(T), f16(b))
   assert np.isfinite(y).all() and relerr(y, x) <= 1e-2
-
-@pytest.mark.parametrize("cond,tol", [(1e1, 2e-2), (1e2, 8e-2)])
-def test_bicgstab_general_solve(cond, tol):
-  A = _square(10, cond, int(cond) + 5); x = np.random.default_rng(3).standard_normal(10)
-  assert relerr(L.bicgstab(f16(A), f16(A @ x), iters=40), x) <= tol


### PR DESCRIPTION
Fixes #79, fixes #80, fixes #81, fixes #83, fixes #84.

Implements five of the seeded starter issues (the sixth of this group, #82 BiCGSTAB, is deliberately absent — see below). #76 was taken by @AnayGarodia in #92, which merged first.

## linalg
- **`det` / `slogdet`** (#79) — on-ANE pivoted LU, then permutation parity × diag(U) host-side; `slogdet` in log form so fp16-hostile magnitudes stay finite. Tested vs numpy at cond 10/100 including a scaled matrix whose raw product is fp16-hostile.
- **`pinv`** (#80) — rank-k pseudoinverse from `randomized_svd` with a relative cutoff, assembled through the ANE gemm. Tested vs `np.linalg.pinv` on an exactly-rank-k matrix plus the Moore–Penrose identity `A P A = A`.
- **`solve_triangular`** (#81) — substitution on-engine via the routed accessor (no inverse formed), both triangles; tested past the slice-×16 saturation threshold (entries ~5000 stay finite).

## einsum (#83)
`...` expands to explicit right-aligned batch letters before the v1 parser runs. Implicit outputs follow numpy's ellipsis-dims-first rule; an explicit output that omits a nonempty `...` raises exactly like numpy (verified against numpy's own error); mismatched ellipsis dims reject (`EinsumUnsupported`) since size-1 broadcast has no expand lowering. Batched matmul `'...ij,...jk->...ik'` and friends verified on-device against `np.einsum`.

## dsp (#84)
`welch`: PSD composed from the on-ANE `stft`, matching `scipy.signal.welch(detrend=False)` for both `density` and `spectrum` scalings at 2% relative; the two injected tones stand >10× out of the noise floor. `nperseg` must be a power of two — the staged FFT pads to one, which would silently shift the bins otherwise.

## Why no BiCGSTAB (#82)
Implemented three ways and measured: fully-unrolled fp16 diverges; an fp64 host recurrence over ANE matvecs plateaus at relerr **0.11** (cond 10) / **0.80** (cond 100) regardless of iteration budget; best-iterate tracking + outer residual correction doesn't move it. A noise-injection simulation reproduces the failure exactly — the identical code converges to 1e-10 with exact matvecs and falls apart at the ~5e-4 relative noise an fp16 matvec carries. BiCG-family short recurrences require matvec accuracy on the order of the target accuracy (inexact-Krylov theory, now measured on this hardware); GMRES's full orthogonalization tolerates the noise, and `gmres` remains the module's nonsymmetric solver. #82 should close as documented-infeasible rather than merge a solver that quietly returns 10–80% error.

## Verification (on-device, M5)
51 tests across `test_linalg.py` (full re-run, nothing regressed), `test_einsum_ellipsis.py`, `test_dsp_welch.py`. Off-device selection unchanged; ruff, 2-space pylint, pyright clean.