### PR TITLE
onnx: LSTM / GRU / RNN, unrolled over the static sequence length

### DIFF
--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -129,10 +129,11 @@ def _run_nodes(g, vals, inits):
   for node in g.node:
     if node.op_type not in _ONNX:
       raise NotImplementedError(f"ONNX op '{node.op_type}' not supported")
-    ins = [vals.get(n) for n in node.input]
+    ins = [vals.get(n) if n else None for n in node.input]        # "" marks an omitted optional input
     outs = _ONNX[node.op_type](node, ins, _attrs(node), inits)
     outs = outs if isinstance(outs, (list, tuple)) else [outs]
-    for name, val in zip(node.output, outs): vals[name] = val
+    for name, val in zip(node.output, outs):
+      if name: vals[name] = val                                   # "" marks an unused optional output
 
 def _run_subgraph(sub, binding, inits):
   """Import a subgraph (If branch / Loop body): outer-scope names resolve per ONNX scoping, the
@@ -943,3 +944,116 @@ def _topk_h(node, ins, a, i):
   if isinstance(ins[1], Tensor): raise NotImplementedError("ONNX TopK: data-dependent k (non-constant) not supported")
   k = int(np.asarray(ins[1]).ravel()[0])
   return _topk(x, k, largest=bool(int(a.get("largest", 1))))
+
+
+# -- recurrent layers: LSTM / GRU / RNN unrolled over the static sequence length -- #
+
+_RNN_DEFAULT_ACTS = {"LSTM": ["sigmoid", "tanh", "tanh"], "GRU": ["sigmoid", "tanh"], "RNN": ["tanh"]}
+
+def _rnn_prep(node, ins, a, n_gates):
+  """Shared RNN-family validation/unpacking. Returns (x, dirs, W, R, B, h0, c0, seq, batch, isz, H)."""
+  op = node.op_type; x = ins[0]
+  if not isinstance(x, Tensor): raise NotImplementedError(f"ONNX {op}: constant X not supported")
+  if int(a.get("layout", 0)): raise NotImplementedError(f"ONNX {op}: layout=1 not supported")
+  if a.get("clip") is not None: raise NotImplementedError(f"ONNX {op}: clip not supported")
+  acts = a.get("activations")
+  if acts is not None:
+    want = _RNN_DEFAULT_ACTS[op]
+    got = [(v.decode() if isinstance(v, bytes) else v).lower() for v in acts]
+    if got != want * (len(got) // len(want)) or len(got) % len(want):
+      raise NotImplementedError(f"ONNX {op}: non-default activations {got} not supported")
+  for k, what in ((5, "initial_h"), (6, "initial_c")):
+    if len(ins) > k and isinstance(ins[k], Tensor):
+      raise NotImplementedError(f"ONNX {op}: tensor {what} not supported (constant or absent only)")
+  seq, batch, isz = x.shape
+  H = int(a["hidden_size"])
+  d = _sattr(a, "direction", "forward")
+  dirs = {"forward": [False], "reverse": [True], "bidirectional": [False, True]}.get(d)
+  if dirs is None: raise NotImplementedError(f"ONNX {op}: direction={d!r} not supported")
+  W = np.asarray(ins[1], np.float32); R = np.asarray(ins[2], np.float32)
+  B = np.asarray(ins[3], np.float32) if len(ins) > 3 and ins[3] is not None else np.zeros((len(dirs), 2 * n_gates * H), np.float32)
+  if len(ins) > 4 and ins[4] is not None:
+    sl = np.asarray(ins[4]).ravel()
+    if not (sl == seq).all(): raise NotImplementedError(f"ONNX {op}: per-sample sequence_lens not supported")
+  h0 = np.asarray(ins[5], np.float32) if len(ins) > 5 and ins[5] is not None else np.zeros((len(dirs), batch, H), np.float32)
+  c0 = np.asarray(ins[6], np.float32) if len(ins) > 6 and ins[6] is not None else np.zeros((len(dirs), batch, H), np.float32)
+  if op == "LSTM" and len(ins) > 7 and ins[7] is not None and np.any(np.asarray(ins[7])):
+    raise NotImplementedError("ONNX LSTM: peephole connections (P) not supported")
+  return x, dirs, W, R, B, h0, c0, seq, batch, isz, H
+
+def _rnn_assemble(ys_dirs, h_dirs, c_dirs):
+  """Stack per-direction results: Y [seq, nd, b, H], Y_h [nd, b, H], Y_c [nd, b, H]."""
+  from .graph import concat as _cat
+  ydirs = []
+  for ys in ys_dirs:                             # ys: per-timestep [b, H] in time order
+    steps = [h.expand_dims((0, 1)) for h in ys]  # -> [1, 1, b, H]
+    ydirs.append(_cat(steps, axis=0) if len(steps) > 1 else steps[0])
+  Y = _cat(ydirs, axis=1) if len(ydirs) > 1 else ydirs[0]
+  hs = [h.expand_dims((0,)) for h in h_dirs]
+  Yh = _cat(hs, axis=0) if len(hs) > 1 else hs[0]
+  if c_dirs is None: return Y, Yh
+  cs = [c.expand_dims((0,)) for c in c_dirs]
+  return Y, Yh, _cat(cs, axis=0) if len(cs) > 1 else cs[0]
+
+def _xt(x, t, batch, isz):
+  return x.slice_by_size([t, 0, 0], [1, batch, isz]).reshape(batch, isz)
+
+@onnx_op("LSTM")
+def _lstm(node, ins, a, i):
+  """LSTM unrolled: per step two fused linears ([b,4H] gates, iofc order), sliced per gate. Forward,
+  reverse, and bidirectional; default activations; constant weights/initial states; no peepholes/clip."""
+  x, dirs, W, R, B, h0, c0, seq, batch, isz, H = _rnn_prep(node, ins, a, 4)
+  def g(t2, k): return t2.slice_by_size([0, k * H], [batch, H])
+  ys_dirs, h_dirs, c_dirs = [], [], []
+  for d, rev in enumerate(dirs):
+    bsum = B[d][:4 * H] + B[d][4 * H:]
+    h, c = _baked(h0[d].astype(np.float16)), _baked(c0[d].astype(np.float16))
+    ys: list = [None] * seq
+    for t in (range(seq - 1, -1, -1) if rev else range(seq)):
+      gt = _xt(x, t, batch, isz).linear(W[d], bsum) + h.linear(R[d], None)
+      it, ot, ft = g(gt, 0).sigmoid(), g(gt, 1).sigmoid(), g(gt, 2).sigmoid()
+      c = ft * c + it * g(gt, 3).tanh()
+      h = ot * c.tanh()
+      ys[t] = h
+    ys_dirs.append(ys); h_dirs.append(h); c_dirs.append(c)
+  return list(_rnn_assemble(ys_dirs, h_dirs, c_dirs))
+
+@onnx_op("GRU")
+def _gru(node, ins, a, i):
+  """GRU unrolled (zrh gate order); both linear_before_reset forms; same scope as LSTM."""
+  x, dirs, W, R, B, h0, _, seq, batch, isz, H = _rnn_prep(node, ins, a, 3)
+  lbr = int(a.get("linear_before_reset", 0))
+  def g(t2, k): return t2.slice_by_size([0, k * H], [batch, H])
+  ys_dirs, h_dirs = [], []
+  for d, rev in enumerate(dirs):
+    Wb, Rb = B[d][:3 * H], B[d][3 * H:]
+    h = _baked(h0[d].astype(np.float16))
+    ys: list = [None] * seq
+    for t in (range(seq - 1, -1, -1) if rev else range(seq)):
+      xg = _xt(x, t, batch, isz).linear(W[d], Wb)
+      hg = h.linear(R[d], Rb if lbr else None)
+      z = (g(xg, 0) + g(hg, 0)).sigmoid()
+      r = (g(xg, 1) + g(hg, 1)).sigmoid()
+      if lbr:
+        hh = (g(xg, 2) + r * g(hg, 2)).tanh()
+      else:
+        hh = (g(xg, 2) + (r * h).linear(R[d][2 * H:], Rb[2 * H:])).tanh()
+      h = z * h + (z * -1.0 + 1.0) * hh
+      ys[t] = h
+    ys_dirs.append(ys); h_dirs.append(h)
+  return list(_rnn_assemble(ys_dirs, h_dirs, None))
+
+@onnx_op("RNN")
+def _rnn_h(node, ins, a, i):
+  """Vanilla tanh RNN unrolled; same scope as LSTM."""
+  x, dirs, W, R, B, h0, _, seq, batch, isz, H = _rnn_prep(node, ins, a, 1)
+  ys_dirs, h_dirs = [], []
+  for d, rev in enumerate(dirs):
+    bsum = B[d][:H] + B[d][H:]
+    h = _baked(h0[d].astype(np.float16))
+    ys: list = [None] * seq
+    for t in (range(seq - 1, -1, -1) if rev else range(seq)):
+      h = (_xt(x, t, batch, isz).linear(W[d], bsum) + h.linear(R[d], None)).tanh()
+      ys[t] = h
+    ys_dirs.append(ys); h_dirs.append(h)
+  return list(_rnn_assemble(ys_dirs, h_dirs, None))

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -40,7 +40,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 
 | Category | ONNX ops |
 | --- | --- |
-| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `Selu`, `Celu`, `Mish`, `Softsign`, `ThresholdedRelu`, `LeakyRelu`, `PRelu`, `Gelu` (exact/erf only), `Erf`, `HardSigmoid`, `HardSwish` |
+| Activations | `Relu`, `Sigmoid`, `Tanh`, `Clip` (`(0,6)`->relu6, `(0,inf)`->relu), `Elu`, `Selu`, `Celu`, `Mish`, `Softsign`, `ThresholdedRelu`, `LeakyRelu`, `PRelu`, `Gelu` (exact + tanh-approximate), `Erf`, `HardSigmoid`, `HardSwish` |
 | Elementwise | `Add`, `Sub`, `Mul`, `Div`, `Pow`, `Exp`, `Log`, `Sqrt` (constant operands supported), `Abs`, `Neg`, `Sign`, `Reciprocal`, `Sin`, `Cos`, `Atan`, `Softplus`, `Floor`, `Ceil`, `Round`, `Min`, `Max`, `Sum`, `Mean` (variadic), `Where`, `Tile`, `Shrink` |
 | Comparison / logic | `Equal`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Not` |
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool`, `GlobalMaxPool` |
@@ -54,6 +54,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Quantization | `DequantizeLinear`, `QuantizeLinear` (QDQ int8) |
 | Misc | `Softmax`, `LogSoftmax`, `Constant`, `ConstantOfShape`, `Range`, `EyeLike`, `Identity`, `Dropout` (inference no-op), `Cast` (import-level), `OneHot` (constant depth/values) |
 | Control flow | `If` (constant condition), `Loop` (static trip count, unrolled) |
+| Recurrent | `LSTM`, `GRU`, `RNN` (unrolled; forward/reverse/bidirectional, default activations) |
 
 Export at `opset_version=13` with constant folding on (the default), which resolves the
 `Shape`/`Gather`/dynamic-`Reshape` plumbing into static initializers before import.
@@ -103,7 +104,12 @@ mis-lower:
   carries any relu/saturation the quantizer fused in). Weights run at fp16 by default;
   pass `compress="int8"` to keep them on the ANE int8 weight datapath. Matches onnxruntime
   on-device (cosine ~1.0).
-- **Gelu:** exact erf-gelu only; `approximate="tanh"` raises.
+- **Gelu:** exact erf-gelu, plus the tanh approximation decomposed to primitives (#92).
+- **Recurrent layers unroll.** `LSTM`/`GRU`/`RNN` unroll over the static sequence
+  length into one program (two fused gate matmuls per step). Forward, reverse, and
+  bidirectional; both GRU `linear_before_reset` forms. Constant weights and initial
+  states; default activations only; `clip`, peepholes (`P`), per-sample
+  `sequence_lens`, and `layout=1` raise.
 - **Control flow folds at import.** `If` requires a constant condition (the taken branch
   imports inline; the other is never built) and `Loop` a constant trip count with a
   constant-true condition (the body unrolls into one program; scan outputs stack along a

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1218,3 +1218,49 @@ def test_loop_without_trip_count_raises():  # while-style loops cannot unroll st
   n = helper.make_node("Loop", ["", "c0", "acc0"], ["acc_final"], body=body)
   m = _model([n], [_vi("x", [1, 4])], [_vi("acc_final", [1, 4])], inits=[ci, a0])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+
+# -- recurrent layers: LSTM / GRU / RNN unrolled -- #
+
+def _rnn_model(op, seq, b, isz, H, direction="forward", n_gates=4, out="Y", **attrs):
+  import zlib
+  rng = np.random.default_rng(zlib.crc32(f"{op}-{direction}".encode()))   # deterministic (hash() is salted)
+  nd = 2 if direction == "bidirectional" else 1
+  W = _init(rng.standard_normal((nd, n_gates * H, isz)) * 0.4, "W")
+  R = _init(rng.standard_normal((nd, n_gates * H, H)) * 0.4, "R")
+  B = _init(rng.standard_normal((nd, 2 * n_gates * H)) * 0.2, "B")
+  outs = {"Y": _vi("Y", [seq, nd, b, H]), "Y_h": _vi("Y_h", [nd, b, H])}
+  names = ["Y", "Y_h", "Y_c"][:3 if op == "LSTM" else 2]
+  n = helper.make_node(op, ["x", "W", "R", "B"], names, hidden_size=H, direction=direction, **attrs)
+  return _model([n], [_vi("x", [seq, b, isz])], [outs[out]], inits=[W, R, B])
+
+def _rnn_check(m, seq, b, isz, tol):
+  rng = np.random.default_rng(0); x = (rng.standard_normal((seq, b, isz))).astype(np.float32)
+  got = np.asarray(af.load_onnx(m)(x.astype(np.float16))).astype(np.float32)
+  ref = np.asarray(onnx_run(m, x))
+  assert got.shape == ref.shape, f"{got.shape} != {ref.shape}"
+  assert np.abs(got - ref).max() < tol, f"max err {np.abs(got - ref).max():.4f}"
+
+def test_lstm_forward_matches_onnxruntime():
+  _rnn_check(_rnn_model("LSTM", 4, 2, 3, 5), 4, 2, 3, 5e-2)
+
+def test_lstm_bidirectional_matches_onnxruntime():
+  _rnn_check(_rnn_model("LSTM", 4, 2, 3, 5, direction="bidirectional"), 4, 2, 3, 5e-2)
+
+def test_lstm_yh_output_matches_onnxruntime():
+  _rnn_check(_rnn_model("LSTM", 4, 2, 3, 5, out="Y_h"), 4, 2, 3, 5e-2)
+
+def test_gru_both_reset_forms_match_onnxruntime():
+  for lbr in (0, 1):
+    m = _rnn_model("GRU", 4, 2, 3, 5, n_gates=3, linear_before_reset=lbr)
+    _rnn_check(m, 4, 2, 3, 5e-2)
+
+def test_rnn_reverse_matches_onnxruntime():
+  _rnn_check(_rnn_model("RNN", 4, 2, 3, 5, direction="reverse", n_gates=1), 4, 2, 3, 5e-2)
+
+def test_lstm_peephole_raises():
+  m = _rnn_model("LSTM", 2, 1, 3, 4)
+  P = onnx.numpy_helper.from_array(np.ones((1, 12), np.float32), "P")
+  m.graph.initializer.append(P)
+  m.graph.node[0].input.extend(["", "", "", "P"])   # seq_lens, initial_h, initial_c omitted; P present
+  with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)


### PR DESCRIPTION
The last big compositional tier: the recurrent family, unrolled the same way Loop (#91) proved out — the whole recurrence becomes one fused program.

## What

- **`LSTM`** — per timestep, one fused linear over the stacked input-side gate weights and one over the recurrent side (`iofc` order), sliced per gate. Forward, **reverse, and bidirectional**; `Y`, `Y_h`, `Y_c` outputs.
- **`GRU`** — `zrh` order, both `linear_before_reset` forms (the before-reset form reuses the fused recurrent matmul; the after-reset form takes one extra linear over the h-gate slice).
- **`RNN`** — vanilla tanh.
- Shared scope, rejected loudly: non-default activations, `clip`, LSTM peepholes, per-sample `sequence_lens`, `layout=1`, tensor-valued weights/initial states.
- **Importer hardening these forced**: ONNX marks omitted optional inputs and skipped outputs with empty-string names; `""` inputs now resolve to None and `""` outputs are no longer stored (previously they'd pollute the value table under the key `""`).
- Docs: table rows + scope note; also updates the two `Gelu` entries #92 made stale (exact + tanh-approximate now).

## Verification (on-device, M5)

`pytest tests/test_onnx.py`: **166 passed** — LSTM forward/bidirectional/`Y_h`, GRU in both reset forms, reverse RNN, all against onnxruntime at fp16 tolerance, plus the peephole reject. One test bug caught during rebase verification: the weight seeds used Python's salted `hash()`, making the numerics nondeterministic across processes — now `zlib.crc32`, verified stable across three consecutive runs. `ruff`, 2-space pylint, `pyright` (0 errors) clean.