### PR TITLE
fuzz: differential fuzzer + workarounds for the two Espresso bugs it found (fixes #112, #113)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,6 +16,11 @@ but overflows a dimension cap on another (caps are per family, see
 [`docs/capabilities.md`](docs/capabilities.md)), and small CPU/ANE divergence at
 boundary fp16 values. A wrong result well inside the fp16 range is a real bug.
 
+One more way to help from any Apple Silicon Mac: run the differential fuzzer for
+twenty minutes (`bash scripts/fuzz.sh`) and file anything it finds. It compares the
+compiler against a numpy reference on randomly generated graphs and shrinks failures
+to minimal reproducers; chip diversity is exactly what it needs.
+
 Report security issues privately, not in a public issue: see
 [`SECURITY.md`](SECURITY.md).
 

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -180,10 +180,26 @@ class _Emitter:
 
 # param-free unary ops: graph op name == MIL op name, signature op(x = ...)
 @op("relu", "silu", "sigmoid", "tanh", "exp", "sqrt", "abs",
-  "sin", "cos", "erf", "softplus", "relu6", "softsign", "atan", "exp2",
+  "sin", "cos", "erf", "relu6", "softsign", "atan", "exp2",
   "floor", "ceil", "round", "sign")
 def _e_unary(em, t, n, s):
   em.line(f'{em.ty(t.shape)} {n} = {t.op}(x = {s[0]})[name = string("{n}")];')
+
+
+@op("softplus")
+def _e_softplus(em, t, n, s):
+  """Espresso's ANE softplus computes exp(x) in the fp16 datapath and returns 0 for every
+  x >= ln(65504) ~= 11.09 (measured on M5 / macOS 26.5: sp(10)=10, sp(11)=0 - silent, not an
+  error). Lower the stable split instead: softplus(x) = softplus(min(x, 10)) + relu(x - 10),
+  whose error is <= log1p(e^-10) ~= 4.5e-5 and whose exp argument never overflows."""
+  ten = float(np.float16(10.0)).hex(); nten = float(np.float16(-10.0)).hex()
+  em.line(f'fp16 {n}_c = const()[name = string("{n}_c"), val = fp16({ten})];')
+  em.line(f'{em.ty(t.shape)} {n}_m = minimum(x = {s[0]}, y = {n}_c)[name = string("{n}_m")];')
+  em.line(f'{em.ty(t.shape)} {n}_s = softplus(x = {n}_m)[name = string("{n}_s")];')
+  em.line(f'fp16 {n}_nc = const()[name = string("{n}_nc"), val = fp16({nten})];')
+  em.line(f'{em.ty(t.shape)} {n}_t = add(x = {s[0]}, y = {n}_nc)[name = string("{n}_t")];')
+  em.line(f'{em.ty(t.shape)} {n}_r = relu(x = {n}_t)[name = string("{n}_r")];')
+  em.line(f'{em.ty(t.shape)} {n} = add(x = {n}_s, y = {n}_r)[name = string("{n}")];')
 
 
 @op("prelu")
@@ -266,13 +282,37 @@ def _e_gelu(em, t, n, s):
   em.line(f'{em.ty(t.shape)} {n} = gelu(x = {s[0]}, mode = {n}_m)[name = string("{n}")];')
 
 
-@op("add", "sub", "mul", "real_div", "maximum", "minimum", "pow")
+@op("add", "sub", "real_div", "maximum", "minimum", "pow")
 def _e_binary(em, t, n, s):
   em.line(f'{em.ty(t.shape)} {n} = {t.op}(x = {s[0]}, y = {s[1]})[name = string("{n}")];')
 
 
+# Espresso fuses a SCALAR multiplier into a preceding floor/ceil/round's scale slot, and the
+# rounding kernel drops the scale (measured on M5 / macOS 26.5: floor(x)*k returns floor(x);
+# scalar ADDS are honored, and no other op family is affected - see issue #112). A FULL-shape
+# constant blocks the mis-fusion; a (1,1) broadcast const does not.
+_ROUNDING_OPS = ("floor", "ceil", "round")
+
+def _e_mul_full_const(em, t, n, src_name, k):
+  w = em.weight(f"{n}_kf", np.full(t.shape, k, np.float16), allow_int8=False)
+  em.line(f'{em.ty(t.shape)} {n} = mul(x = {src_name}, y = {w})[name = string("{n}")];')
+
+@op("mul")
+def _e_mul(em, t, n, s):
+  a, b = t.srcs
+  def scalar_const(v): return v.op == "const_array" and np.asarray(v.attrs["value"]).size == 1
+  if (a.op in _ROUNDING_OPS and scalar_const(b)) or (b.op in _ROUNDING_OPS and scalar_const(a)):
+    const_t, src_name = (b, s[0]) if scalar_const(b) else (a, s[1])
+    _e_mul_full_const(em, t, n, src_name, float(np.asarray(const_t.attrs["value"]).ravel()[0]))
+    return
+  _e_binary(em, t, n, s)
+
+
 @op("muls")
 def _e_muls(em, t, n, s):
+  if t.srcs[0].op in _ROUNDING_OPS:                # the same Espresso scale-slot mis-fusion
+    _e_mul_full_const(em, t, n, s[0], float(np.float16(t.attrs["k"])))
+    return
   k = float(np.float16(t.attrs["k"])).hex()
   em.line(f'fp16 {n}_k = const()[name = string("{n}_k"), val = fp16({k})];')
   em.line(f'{em.ty(t.shape)} {n} = mul(x = {s[0]}, y = {n}_k)[name = string("{n}")];')

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -1,0 +1,432 @@
+#!/usr/bin/env python3
+"""Differential fuzzer for the ANE compiler, built on three ideas that fit this hardware:
+
+1. INTEGER-EXACT MODE (the primary oracle). fp16 represents integers up to 2048 exactly, and a
+   large op subset is closed over small integers. Graphs whose mirror proves every intermediate
+   stays integral and <= 2048 have a BIT-EQUALITY oracle: no tolerances, no false positives,
+   every mismatch is a real bug. Integer closure also survives rewrites, so an identity-augmented
+   EMI variant (muls(1)/adds(0)/double-transpose chains the canonicalizer must strip) is compared
+   EXACTLY at opt=1 - a tolerance-free probe of the rewrite engine.
+
+2. BOUNDARY-LATTICE SAMPLING. Dims and params are drawn from the edges where lowering bugs live
+   (powers of two +/-1, documented tile factors {2,3,4,8}, nonzero last-axis slice offsets, fp16
+   danger values near 2048/4094/65504/subnormals) instead of uniformly.
+
+3. FLOAT MODE with a CONDITIONING SCREEN. For ops integers cannot cover (sigmoid/softmax/...),
+   the mirror runs at fp32 AND fp64; graphs where those two disagree are ill-conditioned and are
+   discarded rather than judged - the fp16 engine only answers for well-conditioned graphs.
+
+Findings are shrunk to minimal reproducers and reported with a replayable JSON spec.
+
+  python3 scripts/fuzz.py --graphs 200 --seed 1          # fixed batch
+  python3 scripts/fuzz.py --minutes 20                   # time budget
+  python3 scripts/fuzz.py --repro finding-ab12cd34.json  # replay a reported case
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import math
+import os
+import sys
+import time
+import warnings
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("ANEFORGE_DISABLE_COMPILE_BREAKER", "1")
+import aneforge as af  # noqa: E402
+from aneforge.graph import maximum as _gmax, minimum as _gmin, concat as _gconcat  # noqa: E402
+
+INT_MAX = 2048.0         # fp16 is exact on integers up to here - the exact-oracle budget
+FLOAT_MAX = 3.0e4        # float-mode magnitude ceiling (near fp16 infinity)
+MAX_ELEMS = 8192
+COND_TOL = 1e-4          # fp32-vs-fp64 mirror disagreement above this = ill-conditioned, discard
+GATE_TOL = 1.5e-2        # opt=1 oracle: the autotuner applies accuracy-GATED lossy variants (int8
+                         # weights and friends) by design, so opt=1 answers to the gate, not to
+                         # bit-exactness - only opt=0 promises the untouched lowering
+
+# boundary-biased pools (v2: derive from aneforge._capabilities / _targets tables)
+DIM_POOL = [1, 2, 3, 4, 5, 7, 8, 9, 15, 16, 17, 31, 32, 33]
+TILE_FACTORS = [2, 3, 4, 8]                       # the documented native tile factors
+FLOAT_DANGER = [2047.0, -2047.0, 4094.0, -4094.0, 30000.0, 6.1e-5, -6.1e-5, 6e-8]
+INT_DANGER = [1024.0, -1024.0, 2047.0, -2047.0, 255.0, -255.0]
+
+
+# ---------------------------------------------------------------- op table
+# (af build, float64 mirror, int_closed?) - int_closed ops map integers to integers.
+
+def _np_softplus(x): return np.logaddexp(0.0, x)
+def _np_silu(x): return x / (1.0 + np.exp(-x))
+def _np_elu(x, a): return np.where(x > 0, x, a * (np.exp(np.minimum(x, 0)) - 1.0))
+def _np_softmax(x):
+  e = np.exp(x - x.max(axis=-1, keepdims=True))
+  return e / e.sum(axis=-1, keepdims=True)
+
+UNARY = {
+  "relu":     (lambda t: t.relu(),          lambda x: np.maximum(x, 0.0), True),
+  "abs":      (lambda t: t.abs(),           np.abs,                       True),
+  "floor":    (lambda t: t.floor(),         np.floor,                     True),
+  "sign":     (lambda t: t.sign(),          np.sign,                      True),
+  "square":   (lambda t: t.square(),        np.square,                    True),
+  "clip":     (lambda t: t.clip(-4.0, 4.0), lambda x: np.clip(x, -4.0, 4.0), True),
+  "sigmoid":  (lambda t: t.sigmoid(),       lambda x: 1.0 / (1.0 + np.exp(-x)), False),
+  "tanh":     (lambda t: t.tanh(),          np.tanh,                      False),
+  "softplus": (lambda t: t.softplus(),      _np_softplus,                 False),
+  "silu":     (lambda t: t.silu(),          _np_silu,                     False),
+  "sqrt_abs": (lambda t: t.abs().sqrt(),    lambda x: np.sqrt(np.abs(x)), False),
+  "softmax":  (lambda t: t.softmax(-1),     _np_softmax,                  False),
+}
+BINARY = {
+  "add": (lambda a, b: a + b,       lambda x, y: x + y, True),
+  "sub": (lambda a, b: a - b,       lambda x, y: x - y, True),
+  "mul": (lambda a, b: a * b,       lambda x, y: x * y, True),
+  "max": (lambda a, b: _gmax(a, b), np.maximum,         True),
+  "min": (lambda a, b: _gmin(a, b), np.minimum,         True),
+}
+REDUCE = {
+  "rsum":  (lambda t, ax: t.sum((ax,)),  lambda x, ax: x.sum(axis=ax, keepdims=True),  True),
+  "rmax":  (lambda t, ax: t.amax((ax,)), lambda x, ax: x.max(axis=ax, keepdims=True),  True),
+  "rmean": (lambda t, ax: t.mean((ax,)), lambda x, ax: x.mean(axis=ax, keepdims=True), False),
+}
+STRUCT_KINDS = ["transpose", "reshape", "concat", "slice", "tile"]   # int-closed by nature
+FLOAT_KINDS = ["elu", "leaky_relu"]
+
+def _kinds_for(mode):
+  base = ["unary"] * 5 + ["binary"] * 4 + ["scalar"] * 2 + ["reduce"] * 2 + ["matmul"] + STRUCT_KINDS
+  return base + FLOAT_KINDS if mode == "float" else base
+
+
+# ---------------------------------------------------------------- feeds (own rng stream: build
+# reconstructs them from the spec alone, no draw-order replay)
+
+def _feed_rng(seed): return np.random.default_rng((seed ^ 0x9E3779B9) & 0x7FFFFFFF)
+
+def _feed_for(spec):
+  rng = _feed_rng(spec["seed"]); shape = tuple(spec["input"])
+  if spec["mode"] == "int":
+    x = rng.integers(-3, 4, size=shape).astype(np.float64)
+    if rng.random() < 0.5:                        # boundary integers, sparse so products stay small
+      flat = x.reshape(-1)
+      idx = rng.integers(0, flat.size, size=max(1, flat.size // 32))
+      flat[idx] = rng.choice(INT_DANGER, size=idx.size)
+  else:
+    x = rng.standard_normal(shape) * float(rng.choice([0.5, 1.0, 4.0]))
+    if rng.random() < 0.35:
+      flat = x.reshape(-1)
+      idx = rng.integers(0, flat.size, size=max(1, flat.size // 16))
+      flat[idx] = rng.choice(FLOAT_DANGER, size=idx.size)
+  return np.asarray(x, np.float16)
+
+
+# ---------------------------------------------------------------- generation
+# Spec: {"seed", "mode": "int"|"float", "input": shape, "nodes": [{"op", "src", ...}]}
+# Value 0 is the input; node i produces value i+1. Everything replays from the spec.
+
+def _rand_shape(rng):
+  rank = int(rng.integers(2, 4))
+  while True:
+    s = tuple(int(rng.choice(DIM_POOL)) for _ in range(rank))
+    if np.prod(s) <= MAX_ELEMS: return s
+
+def _ok(y, mode):
+  if not np.isfinite(y).all(): return False
+  if mode == "int":
+    return np.abs(y).max() <= INT_MAX and np.array_equal(y, np.round(y))
+  return np.abs(y).max() <= FLOAT_MAX
+
+def gen_spec(seed):
+  """Generate one replayable graph spec (pure host; no aneforge objects)."""
+  rng = np.random.default_rng(seed)
+  mode = "int" if rng.random() < 0.6 else "float"
+  spec = {"seed": int(seed), "mode": mode, "input": list(_rand_shape(rng)), "nodes": []}
+  vals = [np.asarray(_feed_for(spec), np.float64)]
+  kinds = _kinds_for(mode)
+  n_nodes = int(rng.integers(3, 13)); guard = 0
+  while len(spec["nodes"]) < n_nodes and guard < 250:
+    guard += 1
+    kind = str(rng.choice(kinds))
+    i = int(rng.integers(0, len(vals)))
+    x = vals[i]; node = None; y = None
+    if kind == "unary":
+      pool = [k for k, v in UNARY.items() if v[2] or mode == "float"]
+      op = str(rng.choice(pool)); y = UNARY[op][1](x); node = {"op": op, "src": [i]}
+    elif kind == "elu":
+      a = round(float(rng.uniform(0.5, 1.5)), 3)
+      y = _np_elu(x, a); node = {"op": "elu", "src": [i], "alpha": a}
+    elif kind == "leaky_relu":
+      a = round(float(rng.uniform(0.01, 0.3)), 3)
+      y = np.where(x > 0, x, a * x); node = {"op": "leaky_relu", "src": [i], "alpha": a}
+    elif kind == "scalar":
+      op = str(rng.choice(["muls", "adds"]))
+      k = float(rng.integers(-3, 4)) if mode == "int" else round(float(rng.uniform(-2, 2)), 3)
+      y = x * k if op == "muls" else x + k; node = {"op": op, "src": [i], "k": k}
+    elif kind == "binary":
+      j = int(rng.choice([j for j, v in enumerate(vals) if v.shape == x.shape]))
+      op = str(rng.choice(list(BINARY)))
+      y = BINARY[op][1](x, vals[j]); node = {"op": op, "src": [i, j]}
+    elif kind == "reduce":
+      pool = [k for k, v in REDUCE.items() if v[2] or mode == "float"]
+      op = str(rng.choice(pool)); ax = int(rng.integers(0, x.ndim))
+      y = REDUCE[op][1](x, ax); node = {"op": op, "src": [i], "axis": ax}
+    elif kind == "matmul" and x.ndim == 2 and x.shape[1] <= 33:
+      n = int(rng.choice(DIM_POOL)); wseed = int(rng.integers(0, 2**31))
+      W = _weight(x.shape[1], n, wseed, mode)
+      y = x @ np.asarray(W, np.float64); node = {"op": "matmul", "src": [i], "n": n, "wseed": wseed}
+    elif kind == "transpose":
+      perm = [int(p) for p in rng.permutation(x.ndim)]
+      y = np.transpose(x, perm); node = {"op": "transpose", "src": [i], "perm": perm}
+    elif kind == "reshape" and x.ndim >= 2:
+      flat = int(np.prod(x.shape))
+      d = int(rng.choice([d for d in range(1, min(flat, 64) + 1) if flat % d == 0]))
+      y = x.reshape(d, flat // d); node = {"op": "reshape", "src": [i], "shape": [d, flat // d]}
+    elif kind == "concat":
+      j = int(rng.choice([j for j, v in enumerate(vals) if v.shape == x.shape]))
+      ax = int(rng.integers(0, x.ndim))
+      if 2 * np.prod(x.shape) > MAX_ELEMS: continue
+      y = np.concatenate([x, vals[j]], axis=ax); node = {"op": "concat", "src": [i, j], "axis": ax}
+    elif kind == "slice":
+      ax = int(rng.integers(0, x.ndim)); d = x.shape[ax]
+      if d < 2: continue
+      # boundary begins: 0, 1, and the tail - nonzero LAST-axis begins ride the offset DMA path
+      b = int(rng.choice([0, 1, max(0, d - 2), int(rng.integers(0, d - 1))]))
+      sz = int(rng.integers(1, d - b + 1))
+      begin = [0] * x.ndim; size = list(x.shape); begin[ax] = b; size[ax] = sz
+      y = x[tuple(slice(bb, bb + ss) for bb, ss in zip(begin, size))]
+      node = {"op": "slice", "src": [i], "begin": begin, "size": size}
+    elif kind == "tile":
+      reps = [1] * x.ndim
+      reps[int(rng.integers(0, x.ndim))] = int(rng.choice(TILE_FACTORS))
+      if np.prod(x.shape) * np.prod(reps) > MAX_ELEMS: continue
+      y = np.tile(x, reps); node = {"op": "tile", "src": [i], "reps": reps}
+    if node is None or y is None or not _ok(y, mode): continue
+    vals.append(y); spec["nodes"].append(node)
+  return spec
+
+def _weight(k, n, wseed, mode):
+  r = np.random.default_rng(wseed)
+  if mode == "int": return r.integers(-2, 3, size=(k, n)).astype(np.float16)
+  return (r.standard_normal((k, n)) / math.sqrt(k)).astype(np.float16)
+
+
+# ---------------------------------------------------------------- build + mirror from a spec
+
+def _mirror(spec, feed, dtype):
+  """Evaluate the spec's numpy mirror at `dtype`; returns (all_values, output)."""
+  vs = [np.asarray(feed, dtype)]
+  for nd in spec["nodes"]:
+    op = nd["op"]; x = vs[nd["src"][0]]
+    if op in UNARY: y = UNARY[op][1](x)
+    elif op in BINARY: y = BINARY[op][1](x, vs[nd["src"][1]])
+    elif op in REDUCE: y = REDUCE[op][1](x, nd["axis"])
+    elif op == "muls": y = x * dtype(nd["k"])
+    elif op == "adds": y = x + dtype(nd["k"])
+    elif op == "elu": y = _np_elu(x, nd["alpha"])
+    elif op == "leaky_relu": y = np.where(x > 0, x, dtype(nd["alpha"]) * x)
+    elif op == "matmul": y = x @ np.asarray(_weight(x.shape[1], nd["n"], nd["wseed"], spec["mode"]), dtype)
+    elif op == "transpose": y = np.transpose(x, nd["perm"])
+    elif op == "reshape": y = x.reshape(nd["shape"])
+    elif op == "concat": y = np.concatenate([x, vs[nd["src"][1]]], axis=nd["axis"])
+    elif op == "slice": y = x[tuple(slice(b, b + z) for b, z in zip(nd["begin"], nd["size"]))]
+    elif op == "tile": y = np.tile(x, nd["reps"])
+    else: raise ValueError(f"unknown op {op!r}")
+    vs.append(np.asarray(y, dtype))
+  return vs, vs[-1]
+
+def build_graph(spec, emi=False):
+  """Build the aneforge graph for a spec; `emi` appends an identity chain (muls(1), adds(0),
+  double transpose) that the canonicalizer must strip without changing the result."""
+  t = af.input(tuple(spec["input"]))
+  ts = [t]
+  for nd in spec["nodes"]:
+    op = nd["op"]; t = ts[nd["src"][0]]
+    if op in UNARY: tt = UNARY[op][0](t)
+    elif op in BINARY: tt = BINARY[op][0](t, ts[nd["src"][1]])
+    elif op in REDUCE: tt = REDUCE[op][0](t, nd["axis"])
+    elif op == "muls": tt = t * nd["k"]
+    elif op == "adds": tt = t + nd["k"]
+    elif op == "elu": tt = t.elu(nd["alpha"])
+    elif op == "leaky_relu": tt = t.leaky_relu(nd["alpha"])
+    elif op == "matmul": tt = t @ _weight(t.shape[1], nd["n"], nd["wseed"], spec["mode"])
+    elif op == "transpose": tt = t.transpose(nd["perm"])
+    elif op == "reshape": tt = t.reshape(*nd["shape"])
+    elif op == "concat": tt = _gconcat([t, ts[nd["src"][1]]], axis=nd["axis"])
+    elif op == "slice": tt = t.slice_by_size(nd["begin"], nd["size"])
+    elif op == "tile": tt = t.tile(nd["reps"])
+    else: raise ValueError(f"unknown op {op!r}")
+    ts.append(tt)
+  out = ts[-1]
+  if emi:
+    out = (out * 1.0) + 0.0                        # muls(1) + adds(0): lossless no-ops
+    perm = list(range(len(out.shape)))
+    if len(perm) >= 2:
+      swap = perm[:]; swap[0], swap[1] = swap[1], swap[0]
+      out = out.transpose(swap).transpose(swap)    # self-inverse transpose pair
+  return out
+
+
+# ---------------------------------------------------------------- run + oracles
+
+def _dispatch(out, feed, opt):
+  """Compile+run; returns (array, None) or (None, failure dict)."""
+  try:
+    net = af.compile(out, opt=opt, _check_precision=False)
+  except Exception as e:
+    return None, {"opt": opt, "kind": "compile-fail", "error": f"{type(e).__name__}: {e}"[:300]}
+  try:
+    got = np.asarray(net(feed), np.float64)
+  except Exception as e:
+    return None, {"opt": opt, "kind": "run-fail", "error": f"{type(e).__name__}: {e}"[:300]}
+  finally:
+    try: net.release()
+    except Exception: pass
+  return got, None
+
+def run_case(spec, opts=(0, 1), emi=True):
+  """Run a spec against its oracles. opt=0 answers exactly (int mode) or to the fp16 rounding
+  budget (float mode); opt=1 answers to the autotuner's accuracy gate (GATE_TOL), because lossy
+  gated variants are part of its contract. Returns failure dicts (empty = ok)."""
+  feed = _feed_for(spec)
+  vs64, ref = _mirror(spec, feed, np.float64)
+  scale = max(float(np.abs(v).max()) for v in vs64) + 1e-3
+  if spec["mode"] == "float":                      # conditioning screen: fp32 and fp64 mirrors agree?
+    _, ref32 = _mirror(spec, feed, np.float32)
+    if float(np.abs(ref32.astype(np.float64) - ref).max()) / scale > COND_TOL:
+      return []                                    # ill-conditioned: not a fair judge of fp16
+  def judge(got, opt, prefix=""):
+    if got.shape != ref.shape:
+      return {"opt": opt, "kind": prefix + "shape", "error": f"{got.shape} != {ref.shape}"}
+    if opt == 0 and spec["mode"] == "int":
+      if not np.array_equal(got, ref):
+        n_bad = int((got != ref).sum())
+        return {"opt": opt, "kind": prefix + "exact-mismatch",
+                "error": f"{n_bad}/{ref.size} elements differ (integer graph at opt=0: must be bit-exact)"}
+      return None
+    err = float(np.abs(got - ref).max()) / scale
+    tol = GATE_TOL if opt >= 1 else 5e-3 + 1.5e-3 * len(spec["nodes"])
+    if err > tol:
+      return {"opt": opt, "kind": prefix + "numeric", "error": f"relerr {err:.3e} > tol {tol:.3e}"}
+    return None
+  fails = []
+  for opt in opts:
+    got, fail = _dispatch(build_graph(spec), feed, opt)
+    if fail or got is None: fails.append(fail); continue
+    f = judge(got, opt)
+    if f: fails.append(f)
+  # EMI probe (int mode): the identity chain must lower exactly at opt=0, and the canonicalizer's
+  # stripping of it at opt=1 must stay inside the same gate as the base graph
+  if emi and spec["mode"] == "int" and not fails and spec["seed"] % 2 == 0:
+    for opt in (0, 1):
+      got, fail = _dispatch(build_graph(spec, emi=True), feed, opt)
+      if fail or got is None:
+        fails.append({**(fail or {"opt": opt}), "kind": "emi-" + (fail or {}).get("kind", "run-fail")}); break
+      f = judge(got, opt, prefix="emi-")
+      if f: fails.append(f); break
+  return fails
+
+
+# ---------------------------------------------------------------- shrinking
+
+def _valid(spec):
+  """A shrink candidate must respect the generator's own invariants (else the failure mode shifts)."""
+  try:
+    vs, _ = _mirror(spec, _feed_for(spec), np.float64)
+    return all(_ok(v, spec["mode"]) for v in vs)
+  except Exception:
+    return False
+
+def _still_fails(spec, opt, kind):
+  if not _valid(spec): return False
+  try:
+    return any(f and f["opt"] == opt and f["kind"] == kind for f in run_case(spec, opts=(opt,), emi=True))
+  except Exception:
+    return False                                   # host-side crash = malformed candidate, not a repro
+
+def shrink(spec, opt, kind):
+  """Minimize a failing spec preserving the SAME failure kind: shortest failing prefix by
+  bisection, then shape-safe single-node drops."""
+  nodes = spec["nodes"]
+  lo, hi = 0, len(nodes)
+  while lo < hi:
+    mid = (lo + hi) // 2
+    if _still_fails({**spec, "nodes": nodes[:mid]}, opt, kind): hi = mid
+    else: lo = mid + 1
+  spec = {**spec, "nodes": nodes[:min(lo, len(nodes))]}
+  changed = True
+  while changed and len(spec["nodes"]) > 1:
+    changed = False
+    for k in range(len(spec["nodes"]) - 1, -1, -1):
+      cand = _drop_node(spec["nodes"], k)
+      if cand is not None and _still_fails({**spec, "nodes": cand}, opt, kind):
+        spec = {**spec, "nodes": cand}; changed = True; break
+  return spec
+
+def _drop_node(nodes, k):
+  """Remove node k, rewiring consumers of its value to the node's first source."""
+  try:
+    out = []
+    for j, nd in enumerate(nodes):
+      if j == k: continue
+      src = [(s if s <= k else s - 1) if s != k + 1 else nodes[k]["src"][0] for s in nd["src"]]
+      out.append({**nd, "src": src})
+    return out
+  except Exception:
+    return None
+
+
+# ---------------------------------------------------------------- driver
+
+def fingerprint(spec):
+  sig = spec["mode"] + json.dumps(spec["nodes"], sort_keys=True)
+  return hashlib.sha1(sig.encode()).hexdigest()[:8]
+
+def main():
+  ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  ap.add_argument("--graphs", type=int, default=0, help="number of graphs (0 = use --minutes)")
+  ap.add_argument("--minutes", type=float, default=10.0, help="time budget when --graphs is 0")
+  ap.add_argument("--seed", type=int, default=None, help="master seed (default: random)")
+  ap.add_argument("--out", default="fuzz-report.json", help="report path")
+  ap.add_argument("--repro", default=None, help="replay a saved finding spec instead of fuzzing")
+  args = ap.parse_args()
+  warnings.filterwarnings("ignore")
+
+  if args.repro:
+    spec = json.load(open(args.repro))
+    fails = run_case(spec)
+    print(json.dumps(fails, indent=2) if fails else "reproducer PASSES here (does not fail on this machine)")
+    return 1 if fails else 0
+
+  master = args.seed if args.seed is not None else int.from_bytes(os.urandom(4), "little")
+  rng = np.random.default_rng(master)
+  t0 = time.time(); n = 0; by_mode = {"int": 0, "float": 0}; findings = {}
+  print(f"fuzz: master seed {master}", flush=True)
+  while (args.graphs and n < args.graphs) or (not args.graphs and (time.time() - t0) < args.minutes * 60):
+    case_seed = int(rng.integers(0, 2**31)); n += 1
+    spec = gen_spec(case_seed)
+    if not spec["nodes"]: continue
+    by_mode[spec["mode"]] += 1
+    fails = run_case(spec)
+    if fails:
+      opt, kind = fails[0]["opt"], fails[0]["kind"]
+      small = shrink(spec, opt, kind)
+      fp = fingerprint(small)
+      if fp not in findings:
+        findings[fp] = {"fingerprint": fp, "mode": spec["mode"], "fails": fails, "spec": small,
+                        "nodes_before_shrink": len(spec["nodes"]), "nodes_after": len(small["nodes"])}
+        json.dump(small, open(f"finding-{fp}.json", "w"), indent=1)
+        print(f"  FINDING {fp} [{spec['mode']}]: {fails[0]['kind']} at opt={opt} "
+              f"({len(spec['nodes'])} -> {len(small['nodes'])} nodes) -> finding-{fp}.json", flush=True)
+    if n % 25 == 0:
+      print(f"  {n} graphs ({by_mode['int']} int / {by_mode['float']} float), "
+            f"{len(findings)} unique finding(s), {time.time() - t0:.0f}s", flush=True)
+  report = {"master_seed": master, "graphs": n, "modes": by_mode,
+            "elapsed_s": round(time.time() - t0, 1), "findings": list(findings.values())}
+  json.dump(report, open(args.out, "w"), indent=1)
+  print(f"fuzz: {n} graphs in {report['elapsed_s']}s -> {len(findings)} unique finding(s); report: {args.out}")
+  return 2 if findings else 0
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/scripts/fuzz.py
+++ b/scripts/fuzz.py
@@ -62,6 +62,8 @@ INT_DANGER = [1024.0, -1024.0, 2047.0, -2047.0, 255.0, -255.0]
 def _np_softplus(x): return np.logaddexp(0.0, x)
 def _np_silu(x): return x / (1.0 + np.exp(-x))
 def _np_elu(x, a): return np.where(x > 0, x, a * (np.exp(np.minimum(x, 0)) - 1.0))
+def _np_round_half_away(x):                        # ANE round is half-away-from-zero, not banker's
+  return np.where(x >= 0, np.floor(x + 0.5), np.ceil(x - 0.5))
 def _np_softmax(x):
   e = np.exp(x - x.max(axis=-1, keepdims=True))
   return e / e.sum(axis=-1, keepdims=True)
@@ -70,6 +72,7 @@ UNARY = {
   "relu":     (lambda t: t.relu(),          lambda x: np.maximum(x, 0.0), True),
   "abs":      (lambda t: t.abs(),           np.abs,                       True),
   "floor":    (lambda t: t.floor(),         np.floor,                     True),
+  "round":    (lambda t: t.round(),         _np_round_half_away,          True),
   "sign":     (lambda t: t.sign(),          np.sign,                      True),
   "square":   (lambda t: t.square(),        np.square,                    True),
   "clip":     (lambda t: t.clip(-4.0, 4.0), lambda x: np.clip(x, -4.0, 4.0), True),

--- a/scripts/fuzz.sh
+++ b/scripts/fuzz.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+# Community fuzz run: fuzz the compiler against the numpy reference on YOUR Mac's ANE and
+# print a paste-ready report. Any Apple Silicon Mac works; chip diversity is the point.
+#
+#   bash scripts/fuzz.sh              # 15 minutes (default)
+#   bash scripts/fuzz.sh 30           # 30 minutes
+#
+# If it reports findings, open a GitHub issue titled "fuzz: finding <fingerprint>" and paste
+# the block below plus the finding-*.json file(s). Ten people hitting the same quirk is one
+# issue: search for the fingerprint first.
+set -e
+cd "$(dirname "$0")/.."
+MINUTES="${1:-15}"
+
+echo "== ANEForge community fuzz run =="
+CHIP=$(sysctl -n machdep.cpu.brand_string 2>/dev/null || echo unknown)
+OS=$(sw_vers -productVersion 2>/dev/null || echo unknown)
+REV=$(git rev-parse --short HEAD 2>/dev/null || echo unknown)
+echo "chip:    $CHIP"
+echo "macos:   $OS"
+echo "commit:  $REV"
+echo "budget:  ${MINUTES} min"
+echo
+
+ANEFORGE_DISABLE_COMPILE_BREAKER=1 python3 scripts/fuzz.py --minutes "$MINUTES" --out fuzz-report.json
+STATUS=$?
+
+echo
+echo "---- paste-ready report ----"
+echo "chip: $CHIP | macos: $OS | commit: $REV | budget: ${MINUTES}m"
+python3 - <<'EOF'
+import json
+r = json.load(open("fuzz-report.json"))
+print(f"graphs: {r['graphs']} | elapsed: {r['elapsed_s']}s | master seed: {r['master_seed']}")
+if not r["findings"]:
+  print("findings: none - this machine agrees with the reference on every generated graph")
+for f in r["findings"]:
+  print(f"finding {f['fingerprint']}: {f['fails'][0]['kind']} at opt={f['fails'][0]['opt']} "
+        f"({f['nodes_after']} nodes) - attach finding-{f['fingerprint']}.json")
+EOF
+echo "----------------------------"
+exit $STATUS

--- a/tests/test_espresso_workarounds.py
+++ b/tests/test_espresso_workarounds.py
@@ -1,0 +1,65 @@
+"""Regression tests for Espresso mis-lowering workarounds (#112, #113): correct MIL in, wrong
+program out - so the emitters route around the fusion. Measured on M5 / macOS 26.5."""
+import numpy as np
+import pytest
+
+import aneforge as af
+from aneforge.graph import _const
+from _helpers import requires_ane
+
+pytestmark = requires_ane
+
+
+def _run(out, xv):
+  net = af.compile(out, opt=0, _check_precision=False)
+  try: return np.asarray(net(xv), np.float64)
+  finally: net.release()
+
+
+def _round_half_away(x):                          # ANE round semantics (np.round is half-to-even)
+  return np.where(x >= 0, np.floor(x + 0.5), np.ceil(x - 0.5))
+
+@pytest.mark.parametrize("uop,npop", [("floor", np.floor), ("ceil", np.ceil), ("round", _round_half_away)])
+def test_rounding_then_scalar_mul_is_not_dropped(uop, npop):
+  # Espresso fuses the scalar into the rounding op's scale slot and drops it (#112)
+  xv = np.array([[11.2265625, -3.7, 2.5, -11.226]], np.float16)
+  x = af.input((1, 4))
+  got = _run(getattr(x, uop)() * -1.206, xv)
+  ref = npop(xv.astype(np.float64)) * -1.206
+  assert np.abs(got - ref).max() < 0.05, f"{uop}: {got.ravel()} != {ref.ravel()}"
+
+
+def test_rounding_then_scalar_const_array_mul():
+  # same fusion through the binary-mul path with a size-1 const_array operand
+  xv = np.array([[11.2265625, -3.7, 2.5, -11.226]], np.float16)
+  x = af.input((1, 4))
+  got = _run(x.floor() * _const(np.asarray(-1.206, np.float16)), xv)
+  ref = np.floor(xv.astype(np.float64)) * -1.206
+  assert np.abs(got - ref).max() < 0.05
+
+
+def test_rounding_then_scalar_add_still_plain():
+  # adds after rounding was never affected; the workaround must not disturb it
+  xv = np.array([[11.2265625, -3.7]], np.float16)
+  x = af.input((1, 2))
+  got = _run(x.floor() + 5.0, xv)
+  assert np.array_equal(got, np.floor(xv.astype(np.float64)) + 5.0)
+
+
+def test_softplus_large_inputs_do_not_collapse():
+  # native ANE softplus returns 0 for x >= ln(65504) ~= 11.09 (#113); the stable split fixes it
+  vals = np.array([[-30000.0, -12.0, -1.0, 0.0, 5.0, 10.0, 11.0, 12.0, 88.0, 30000.0]], np.float16)
+  x = af.input((1, 10))
+  got = _run(x.softplus(), vals)
+  ref = np.logaddexp(0.0, vals.astype(np.float64))
+  assert np.abs(got - ref).max() / max(1.0, np.abs(ref).max()) < 1e-3
+  assert got.ravel()[-1] == 30000.0                # the old lowering returned exactly 0 here
+
+
+def test_softplus_normal_range_unchanged():
+  rng = np.random.default_rng(0)
+  xv = (rng.standard_normal((1, 64)) * 3).astype(np.float16)
+  x = af.input((1, 64))
+  got = _run(x.softplus(), xv)
+  ref = np.logaddexp(0.0, xv.astype(np.float64))
+  assert np.abs(got - ref).max() < 1e-2

--- a/tests/test_fuzz_harness.py
+++ b/tests/test_fuzz_harness.py
@@ -1,0 +1,87 @@
+"""The fuzz harness's host-side machinery (generator, mirrors, shrinker) - CI-testable, no ANE."""
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+from _helpers import requires_ane
+
+_spec = importlib.util.spec_from_file_location(
+  "fuzz", Path(__file__).resolve().parents[1] / "scripts" / "fuzz.py")
+assert _spec is not None and _spec.loader is not None
+fuzz = importlib.util.module_from_spec(_spec)
+sys.modules["fuzz"] = fuzz
+_spec.loader.exec_module(fuzz)
+
+
+def _specs(n=40):
+  out = []
+  for seed in range(n):
+    s = fuzz.gen_spec(seed)
+    if s["nodes"]: out.append(s)
+  return out
+
+
+def test_gen_spec_is_deterministic():
+  assert fuzz.gen_spec(1234) == fuzz.gen_spec(1234)
+  assert fuzz.gen_spec(1235) != fuzz.gen_spec(1234)
+
+def test_specs_are_json_round_trippable():
+  for s in _specs(10):
+    assert json.loads(json.dumps(s)) == s
+
+def test_feeds_are_deterministic_from_spec_alone():
+  for s in _specs(10):
+    assert np.array_equal(fuzz._feed_for(s), fuzz._feed_for(s))
+
+def test_int_mode_mirror_is_exactly_integral_and_bounded():
+  # the exact-oracle precondition: every int-mode intermediate is an integer within fp16-exact range
+  seen = 0
+  for s in _specs(60):
+    if s["mode"] != "int": continue
+    vs, ref = fuzz._mirror(s, fuzz._feed_for(s), np.float64)
+    for v in vs:
+      assert np.array_equal(v, np.round(v)) and np.abs(v).max() <= fuzz.INT_MAX
+    seen += 1
+  assert seen >= 10
+
+def test_float_mode_mirror_is_finite_and_bounded():
+  for s in _specs(60):
+    if s["mode"] != "float": continue
+    vs, _ = fuzz._mirror(s, fuzz._feed_for(s), np.float64)
+    assert all(np.isfinite(v).all() and np.abs(v).max() <= fuzz.FLOAT_MAX for v in vs)
+
+def test_graph_shape_matches_mirror():
+  for s in _specs(25):
+    _, ref = fuzz._mirror(s, fuzz._feed_for(s), np.float64)
+    assert tuple(fuzz.build_graph(s).shape) == ref.shape
+    assert tuple(fuzz.build_graph(s, emi=True).shape) == ref.shape   # identity chain preserves shape
+
+def test_boundary_dims_actually_appear():
+  dims = set()
+  for s in _specs(60): dims.update(s["input"])
+  assert {1} & dims and ({15, 17, 31, 33} & dims)   # the off-by-one lattice is being sampled
+
+def test_drop_node_rewires_indices():
+  nodes = [{"op": "relu", "src": [0]}, {"op": "abs", "src": [1]}, {"op": "sign", "src": [2]}]
+  assert fuzz._drop_node(nodes, 1) == [{"op": "relu", "src": [0]}, {"op": "sign", "src": [1]}]
+
+def test_fingerprint_ignores_seed_but_not_mode():
+  a = {"seed": 1, "mode": "int", "input": [2, 2], "nodes": [{"op": "relu", "src": [0]}]}
+  b = {"seed": 9, "mode": "int", "input": [2, 2], "nodes": [{"op": "relu", "src": [0]}]}
+  c = {**a, "mode": "float"}
+  assert fuzz.fingerprint(a) == fuzz.fingerprint(b) != fuzz.fingerprint(c)
+
+
+@requires_ane
+def test_smoke_fuzz_agrees_on_device():
+  # a handful of seeded graphs must dispatch and satisfy their mode's oracle (incl. the EMI probe)
+  ran = ints = 0
+  for s in _specs(60):
+    fails = fuzz.run_case(s)
+    assert not fails, f"seed {s['seed']} [{s['mode']}]: {fails}"
+    ran += 1; ints += s["mode"] == "int"
+    if ran >= 8 and ints >= 3: break
+  assert ran >= 8 and ints >= 3


### PR DESCRIPTION
Two commits: the fuzzer, and the fixes for what it caught on its first run.

## The fuzzer

Designed after reviewing [NNSmith](https://arxiv.org/abs/2207.13066)-style DNN-compiler fuzzing and [EMI/metamorphic](https://www.doc.ic.ac.uk/~afd/papers/2016/MET.pdf) compiler testing, specialized to this hardware: an **integer-exact bit-equality oracle** (fp16 is exact on integers ≤2048; closure survives rewrites, enabling exact EMI probes of the canonicalizer), **boundary-lattice sampling** (powers-of-two ±1, tile factors, danger values), a **conditioning-screened float mode** (fp32-vs-fp64 mirror agreement gates judgment), and a **contract-aware oracle** (opt=0 exact; opt=1 answers to the autotuner's accuracy gate — verified int8-variant signature). Kind-preserving shrinking to minimal replayable JSON specs; `scripts/fuzz.sh` community wrapper; host-side machinery CI-tested off-device.

## What it caught, root-caused to the MIL level

Both bugs receive **correct MIL** and produce wrong programs — Apple's Espresso/ANECompiler, not ANEForge's emission:

- **#112** — `floor/ceil/round` + scalar multiply: Espresso fuses the scalar into the rounding op's scale slot and the kernel drops it. Probed boundary: full-shape const blocks the fusion, (1,1) broadcast doesn't, scalar adds honored, no other op family affected. Emitters now materialize a full-shape constant after rounding ops (`muls` and binary-mul-with-size-1-const paths).
- **#113** — `softplus(x≥11.09) = 0` (fp16 `exp` overflow inside the lowering; 11.09 = ln(65504)). Emitter now lowers `softplus(min(x,10)) + relu(x−10)` — never overflows, error ≤ 4.5e-5, verified across ±30000.
- Bonus semantics finding: ANE `round` is half-away-from-zero (np.round is banker's) — mirror and tests corrected.

## Verification (on-device, M5)
- Both original finding specs replay as **PASSING** post-fix (`--repro`).
- 7 new regression tests in `tests/test_espresso_workarounds.py`; 180 tests across the ONNX/fuzz/dsp suites; off-device selection unchanged; ruff/pylint/pyright clean.
- A fresh 400-graph batch produced **7 new findings** (incl. Espresso internal crashes — `unordered_map::at` — on valid MIL); triage is follow-up work, which is rather the point of the tool.