### PR TITLE
onnx: Attention (opset 23) onto the native fused-attention layer

### DIFF
--- a/aneforge/onnx.py
+++ b/aneforge/onnx.py
@@ -663,6 +663,63 @@ def _matmul(node, ins, a, i):
   if not isinstance(ins[0], Tensor): raise NotImplementedError("ONNX MatMul: a constant first operand is not supported")
   b = ins[1]
   return ins[0] @ (np.asarray(b) if not isinstance(b, Tensor) else b)
+@onnx_op("Attention")
+def _attention(node, ins, a, i):
+  """Attention (opset 23) -> af.sdpa, i.e. the native fused-attention layer. Only the 4D
+  [B,H,S,D] form with batch 1 lands there, so everything the fused path cannot express is
+  rejected rather than silently decomposed: past/present KV, the optional qk_matmul_output,
+  softcap, GQA head-count mismatches, and 3D packed Q/K/V."""
+  from .graph import sdpa as _sdpa
+  q, k, v = ins[0], ins[1], ins[2]
+  mask = ins[3] if len(ins) > 3 and ins[3] is not None else None
+  if len(ins) > 4 and any(x is not None for x in ins[4:]):
+    raise NotImplementedError("ONNX Attention: past_key/past_value are not supported (the native "
+                              "layer has no KV-cache input; concatenate the cache in the graph "
+                              "and pass the full K/V)")
+  if len(node.output) > 1 and any(o for o in node.output[1:]):
+    raise NotImplementedError("ONNX Attention: only the Y output is supported "
+                              "(present_key/present_value/qk_matmul_output are not produced)")
+  for attr, why in (("softcap", "the native layer applies no softcap"),
+                    ("qk_matmul_output_mode", "the QK intermediate is not exposed"),
+                    ("softmax_precision", "softmax precision is fixed by the hardware")):
+    if a.get(attr): raise NotImplementedError(f"ONNX Attention: {attr} is not supported ({why})")
+  for t, nm in ((q, "Q"), (k, "K"), (v, "V")):
+    if not isinstance(t, Tensor):
+      raise NotImplementedError(f"ONNX Attention: {nm} must be an activation, not a constant")
+    if len(t.shape) != 4:
+      raise NotImplementedError(f"ONNX Attention: only the 4D [B,H,S,D] form is supported; "
+                                f"{nm} is {t.shape} (3D packed Q/K/V has no native path)")
+  qh, kh = int(a.get("q_num_heads", q.shape[1])), int(a.get("kv_num_heads", k.shape[1]))
+  if qh != q.shape[1] or kh != k.shape[1]:
+    raise NotImplementedError(f"ONNX Attention: q_num_heads/kv_num_heads ({qh}/{kh}) disagree with "
+                              f"the 4D layouts {q.shape}/{k.shape}")
+  if qh != kh:
+    raise NotImplementedError(f"ONNX Attention: grouped-query attention (q_num_heads={qh} != "
+                              f"kv_num_heads={kh}) is not supported; expand K/V to the query "
+                              f"head count in the graph")
+  # ONNX defaults scale to 1/sqrt(head_size); af.sdpa uses the same default when scale is None.
+  scale = float(a["scale"]) if a.get("scale") is not None else None
+  causal = bool(int(a.get("is_causal", 0)))
+  if mask is not None and not isinstance(mask, Tensor):
+    mask = np.asarray(mask)
+    if mask.dtype == bool:
+      raise NotImplementedError("ONNX Attention: a boolean attn_mask is not supported; pass an "
+                                "additive float mask (0 to keep, large negative to drop)")
+    # A constant additive mask that is exactly causal is the native causal path; anything else
+    # would have to ride the runtime 5th bottom, which needs a Tensor.
+    m = mask.astype(np.float32)
+    while m.ndim > 2 and m.shape[0] == 1: m = m[0]
+    if not (m.ndim == 2 and m.shape[0] == m.shape[1]
+            and (m[np.triu_indices(m.shape[0], 1)] < -1e3).all()
+            and (m[np.tril_indices(m.shape[0], 0)] > -1e3).all()):
+      raise NotImplementedError("ONNX Attention: only a causal constant attn_mask is supported; "
+                                "pass an arbitrary mask as a graph input (runtime tensor)")
+    causal, mask = True, None
+  if mask is not None and causal:
+    raise NotImplementedError("ONNX Attention: is_causal with an explicit attn_mask is not "
+                              "supported (the native layer takes one or the other)")
+  return _sdpa(q, k, v, scale=scale, is_causal=causal, attn_mask=mask)
+
 @onnx_op("Einsum")
 def _einsum_h(node, ins, a, i):
   """Routes to aneforge.einsum (matmul-reducible specs; diagonal/ellipsis reject as EinsumUnsupported)."""

--- a/docs/onnx.md
+++ b/docs/onnx.md
@@ -45,6 +45,7 @@ outside this set, so an unsupported model fails loudly with the offending op nam
 | Comparison / logic | `Equal`, `Greater`, `GreaterOrEqual`, `Less`, `LessOrEqual`, `Not` |
 | Convolution / pooling | `Conv`, `MaxPool`, `AveragePool`, `GlobalAveragePool`, `GlobalMaxPool` |
 | Linear | `Gemm` (full `alpha`/`beta`/`transA`/`transB`), `MatMul`, `Einsum` (matmul-reducible equations) |
+| Attention | `Attention` (opset 23) - 4D `[1,H,S,D]`, onto the native fused-attention layer |
 | Normalization | `BatchNormalization`, `InstanceNormalization`, `LayerNormalization`, `GroupNormalization`, `RMSNormalization`, `LpNormalization` (p=1/2) |
 | Shape / layout | `Reshape`, `Flatten`, `Transpose`, `Squeeze` (incl. squeeze-all), `Unsqueeze`, `Concat`, `Split`, `Expand`, `SpaceToDepth`, `DepthToSpace`, `Slice` (step 1; step -1 as a full-axis flip), `Shape`, `Trilu`, `Pad` (constant/edge/reflect/wrap) |
 | Normalization (cross-channel) | `LRN` |
@@ -163,3 +164,14 @@ mis-lower:
   output **only** - ONNX's second (indices) output is unsupported, so a model consuming the
   indices fails when that name is later looked up. `k` is read from the (opset 10+) input;
   `k` in `{3, 4}` is rejected by the ANE itself. Shipped shape-validated only.
+- **Attention** (opset 23): maps onto `af.sdpa`, i.e. the native fused-attention layer, so it
+  accepts only what that layer expresses: 4-D `[1,H,S,D]` Q/K/V with batch 1 and matching head
+  counts, the `scale` attribute (ONNX's `1/sqrt(D)` default is `af.sdpa`'s too), `is_causal`, and
+  an `attn_mask` that is either a runtime `[1,1,Sq,Skv]` additive plane or a constant that is
+  exactly the causal upper-triangular `-inf` (folded to the native causal path). `Sq < Skv`
+  (KV-cache decode) works with `is_causal=0`. Rejected with `NotImplementedError`: the 3-D packed
+  Q/K/V form, grouped-query attention (`q_num_heads != kv_num_heads` - expand K/V in the graph),
+  `past_key`/`past_value`, the `present_key`/`present_value`/`qk_matmul_output` outputs,
+  `softcap`, `qk_matmul_output_mode`, `softmax_precision`, boolean masks, and arbitrary constant
+  masks. Outside the reliable native regime `af.sdpa`'s own tiled decomposition takes over for
+  the non-causal case and raises for the causal one - see [capabilities](capabilities.md).

--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1331,3 +1331,77 @@ def test_mod_fmod_constant_divisor_matches_onnxruntime():
 def test_mod_tensor_divisor_raises():
   m = _model([helper.make_node("Mod", ["a", "b"], ["y"])], [_vi("a", [1, 4]), _vi("b", [1, 4])], [_vi("y", [1, 4])])
   with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+# ── Attention (opset 23) -> native fused-attention layer ──
+
+def _attn_model(inputs, outputs=("Y",), inits=(), **attrs):
+  """An opset-23 Attention graph. `inputs` is a list of (name, shape); "" names an omitted optional."""
+  n = helper.make_node("Attention", [nm for nm, _ in inputs], list(outputs), **attrs)
+  vis = [_vi(nm, sh) for nm, sh in inputs if nm and sh is not None]
+  outs = [_vi(nm, inputs[0][1]) for nm in outputs if nm]
+  g = helper.make_graph([n], "g", vis, outs, list(inits))
+  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", 23)])
+  m.ir_version = 10
+  return m
+
+def _attn_ort(m, feeds):
+  """onnxruntime reference for a multi-input Attention graph (fp32)."""
+  import onnxruntime
+  return onnxruntime.InferenceSession(m.SerializeToString()).run(None, feeds)[0]
+
+def test_attention_builds_causal_and_non_causal():
+  H, S, D = 2, 8, 16
+  qkv = [("Q", [1, H, S, D]), ("K", [1, H, S, D]), ("V", [1, H, S, D])]
+  for attrs, want in [({"is_causal": 1}, True), ({}, False)]:
+    _, out = af.onnx_to_tensor(_attn_model(qkv, **attrs))
+    assert out.op == "sdpa" and out.shape == (1, H, S, D), f"{attrs} -> {out.op} {out.shape}"
+    assert out.attrs["causal"] is want and out.attrs["scale"] == 1.0 / D**0.5   # ONNX default scale
+
+def test_attention_explicit_scale_and_runtime_mask_build():
+  H, S, D = 2, 8, 16
+  qkv = [("Q", [1, H, S, D]), ("K", [1, H, S, D]), ("V", [1, H, S, D])]
+  _, out = af.onnx_to_tensor(_attn_model(qkv, scale=0.5))
+  assert out.attrs["scale"] == 0.5
+  # A runtime attn_mask rides the native layer's 5th bottom as one shared [1,1,Sq,Skv] plane.
+  _, out = af.onnx_to_tensor(_attn_model(qkv + [("M", [1, 1, S, S])]))
+  assert out.op == "sdpa" and out.attrs.get("masked") is True
+
+def test_attention_causal_const_mask_folds_to_native_causal():
+  H, S, D = 2, 8, 16
+  qkv = [("Q", [1, H, S, D]), ("K", [1, H, S, D]), ("V", [1, H, S, D])]
+  mask = _init(np.triu(np.full((S, S), -1e4, np.float32), 1), "M")
+  _, out = af.onnx_to_tensor(_attn_model(qkv + [("M", None)], inits=[mask]))
+  assert out.op == "sdpa" and out.attrs["causal"] is True   # recognized, not left to a runtime mask
+
+def test_attention_unsupported_forms_raise():
+  H, S, D = 2, 8, 16
+  qkv = [("Q", [1, H, S, D]), ("K", [1, H, S, D]), ("V", [1, H, S, D])]
+  gqa = [("Q", [1, 4, S, D]), ("K", [1, 2, S, D]), ("V", [1, 2, S, D])]
+  packed = [("Q", [1, S, H * D]), ("K", [1, S, H * D]), ("V", [1, S, H * D])]
+  flat = _init(np.zeros((S, S), np.float32), "M")           # all-zeros: a mask, but not causal
+  for label, m in [
+      ("softcap", _attn_model(qkv, softcap=30.0)),
+      ("qk_matmul_output_mode", _attn_model(qkv, qk_matmul_output_mode=1)),
+      ("grouped-query", _attn_model(gqa)),
+      ("3D packed qkv", _attn_model(packed)),
+      ("present_key output", _attn_model(qkv, outputs=("Y", "present_key"))),
+      ("past_key input", _attn_model(qkv + [("", None), ("past_key", [1, H, S, D]),
+                                            ("past_value", [1, H, S, D])])),
+      ("non-causal const mask", _attn_model(qkv + [("M", None)], inits=[flat])),
+  ]:
+    with pytest.raises(NotImplementedError): af.onnx_to_tensor(m)
+
+@requires_ane
+def test_attention_matches_onnxruntime():
+  """Native fused-attention output vs onnxruntime's opset-23 Attention, causal and not."""
+  rng = np.random.default_rng(0)
+  for H, S, D in [(1, 4, 8), (2, 8, 16)]:
+    qkv = [("Q", [1, H, S, D]), ("K", [1, H, S, D]), ("V", [1, H, S, D])]
+    Q, K, V = (rng.standard_normal((1, H, S, D)).astype(np.float32) for _ in range(3))
+    for attrs in ({"is_causal": 1}, {}):
+      m = _attn_model(qkv, **attrs)
+      net = af.load_onnx(m)
+      got = np.asarray(net(*(a.astype(np.float16) for a in (Q, K, V)))).astype(np.float32).ravel()
+      ref = np.asarray(_attn_ort(m, {"Q": Q, "K": K, "V": V})).astype(np.float32).ravel()
+      cos = _cos(got, ref)
+      assert cos > 0.99, f"Attention H={H} S={S} D={D} {attrs} ANE vs onnxruntime cosine={cos}"


### PR DESCRIPTION
Fixes #104.

ONNX opset 23 standardized an `Attention` op. This registers a handler in `aneforge/onnx.py` that maps it onto `af.sdpa`, the native fused-attention layer Core ML never emits, and rejects loudly anything that layer cannot express instead of letting it fall through to a silent decomposition.

## What lands on the native layer

| | |
|---|---|
| Q/K/V | 4-D `[1,H,S,D]`, batch 1, matching head counts |
| `scale` | passed through; ONNX's `1/sqrt(D)` default is `af.sdpa`'s default too, so omitting it needs no special case |
| `is_causal` | native causal mask on the 5th bottom |
| `attn_mask` (runtime) | a single shared `[1,1,Sq,Skv]` additive plane, native |
| `attn_mask` (constant) | folded to the native causal path when it is exactly the upper-triangular `-inf`, reusing the recognizer shape of `_is_causal_mask` in the `fuse_attention` rewrite |
| `Sq < Skv` | KV-cache decode works with `is_causal=0` |

## What is rejected

Each raises `NotImplementedError` with the reason and, where one exists, the graph-level workaround.

- 3-D packed Q/K/V: no native path.
- Grouped-query attention (`q_num_heads != kv_num_heads`): the message says to expand K/V to the query head count in the graph.
- `past_key` / `past_value`: the native layer has no KV-cache input, so concatenate the cache in the graph and pass the full K/V.
- `present_key` / `present_value` / `qk_matmul_output` outputs: not produced, so a model consuming them would otherwise fail later at name lookup.
- `softcap`, `qk_matmul_output_mode`, `softmax_precision`: no native equivalent.
- Boolean `attn_mask`: points at the additive float form.
- Arbitrary constant `attn_mask`: points at passing it as a graph input so it can ride the runtime 5th bottom.

Also guarded: `q_num_heads`/`kv_num_heads` attributes that disagree with the actual 4-D layouts, and constant (non-activation) Q/K/V.

## Verification

Your onnxruntime build does support opset-23 `Attention`, so numerics are checked against it rather than a numpy reference. Apple M2 Pro, macOS 26.5.2, commit `d88a055`:

```
onnxruntime 1.28.0, opset-23 Attention as reference

config                 causal   cosine vs ORT
H=1 S=4 D=8            True          1.000000
H=1 S=4 D=8            False         1.000000
H=2 S=8 D=16           True          1.000000
H=2 S=8 D=16           False         1.000000
```

The runtime-mask, explicit-`scale`, and KV-decode (`Sq=1, Skv=8`) paths were also checked on device against a float64 softmax reference, cosine `1.000000` each. Those are exercised as build assertions in the suite rather than extra on-device tests, to keep the ANE-gated set small.

On-device tests passed locally, since CI cannot reach an ANE:

```
pytest tests/test_onnx.py -k attention   -> 8 passed
pytest tests/test_onnx.py                -> 178 passed, 1 failed
PYTHONPATH=. python3 tests/run_corpus.py -> GATE: GREEN (90/90 green, 0 red)
ruff check                               -> All checks passed
.githooks/pre-commit                     -> OK
```

The one failure is `test_resnet18_onnx_matches_onnxruntime`, which needs `torchvision`. It fails the same way on a clean checkout of the base commit, so it is unrelated.

## Tests added

- `test_attention_builds_causal_and_non_causal`: both lower to `sdpa` with the right shape and the ONNX default scale.
- `test_attention_explicit_scale_and_runtime_mask_build`: `scale` attribute, and the runtime mask setting `masked`.
- `test_attention_causal_const_mask_folds_to_native_causal`: a constant causal mask becomes `causal=True`, not a runtime mask.
- `test_attention_unsupported_forms_raise`: the seven reject paths above.
- `test_attention_matches_onnxruntime` (`@requires_ane`): the table above.

Four of the five fail on the base commit and pass with the handler. The reject test passes either way, since an unregistered op also raises `NotImplementedError`; it is there to pin which forms are refused once the op exists.

## Docs

Added an `Attention` row to the op-coverage table in `docs/onnx.md`, and a per-op limitations entry in the same style as the `TopK` entry, spelling out the accepted set and every rejection.
