### PR TITLE
linalg: matrix norms (fro, 1, inf) and matrix_power

### DIFF
--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -629,6 +629,55 @@ def pinv(A, k: int, oversample: int = 5, power_iters: int = 2, rcond: float = 1e
   return _ane_gemm(W.astype(f16), np.ascontiguousarray(U[:, keep].T, np.float32).astype(f16)).astype(np.float32)
 
 
+def norm(A, order="fro"):
+  """Matrix norm of a 2-D A, composed on-engine as one fused graph.
+
+  `order="fro"` is `sqrt(sum_square(A))`; `order=1` is the max absolute column sum and
+  `order=inf` the max absolute row sum, each an abs, a matmul against a ones vector (the
+  wide accumulator does the summing), and an `amax`. Oracle is `np.linalg.norm` (whose
+  argument is spelled `ord`; renamed here only to avoid shadowing the builtin).
+  """
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2: raise ValueError(f"linalg.norm: expected a 2-D matrix; got shape {A16.shape}")
+  m, n = A16.shape
+  X = af.input((m, n))
+  if order == "fro":
+    out = X.sum_square((0, 1)).sqrt()
+  elif order == 1:
+    # column sums: |A|^T @ ones[m,1] -> [n,1]
+    out = (X.abs().transpose([1, 0]) @ np.ones((m, 1), f16)).amax((0, 1))
+  elif order in (np.inf, float("inf")):
+    out = (X.abs() @ np.ones((n, 1), f16)).amax((0, 1))     # row sums -> [m,1]
+  else:
+    raise ValueError(f"linalg.norm: order must be 'fro', 1, or inf; got {order!r}")
+  net = af.compile(out, _check_precision=False)
+  v = float(np.ravel(np.asarray(net(A16), np.float64))[0])
+  net.release()
+  return v
+
+
+def matrix_power(A, n: int):
+  """A**n for integer n >= 0 by binary exponentiation over `_ane_gemm`, so it costs
+  O(log n) on-engine gemms rather than n-1. n=0 is the identity.
+
+  fp16 error compounds with each squaring, so this is for modest powers on
+  well-conditioned matrices; negative n needs an inverse and is rejected.
+  Oracle is `np.linalg.matrix_power`.
+  """
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2 or A16.shape[0] != A16.shape[1]:
+    raise ValueError(f"linalg.matrix_power: expected a square matrix; got shape {A16.shape}")
+  if n < 0:
+    raise ValueError("linalg.matrix_power: negative powers need a matrix inverse; not supported")
+  if n == 0: return np.eye(A16.shape[0], dtype=np.float32)
+  acc, base = None, A16                                     # square-and-multiply
+  while n:
+    if n & 1: acc = base.copy() if acc is None else _ane_gemm(acc, base)
+    n >>= 1
+    if n: base = _ane_gemm(base, base)
+  return np.asarray(acc, np.float32)
+
+
 def main():
   print("=" * 90)
   print("aneforge.linalg - ITERATIVE linear algebra on the ANE  (matmuls=ANE, RNG/QR/SVD/loop=HOST)")

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -255,3 +255,35 @@ def test_solve_triangular_large_entries():
   x = r.standard_normal(n); b = T @ x
   y = L.solve_triangular(f16(T), f16(b))
   assert np.isfinite(y).all() and relerr(y, x) <= 1e-2
+
+@pytest.mark.parametrize("shape", [(6, 5), (16, 16), (32, 8)])
+@pytest.mark.parametrize("order", ["fro", 1, np.inf])
+def test_norm_matches_numpy(shape, order):
+  m, n = shape
+  A = f16(np.random.default_rng(m * 100 + n).standard_normal((m, n)))
+  got, ref = L.norm(A, order), np.linalg.norm(A.astype(np.float64), order)
+  assert abs(got - ref) / abs(ref) <= 5e-3, f"norm(order={order!r}) {shape}: {got} vs {ref}"
+
+
+def test_norm_rejects_bad_input():
+  with pytest.raises(ValueError): L.norm(np.zeros((2, 2, 2), f16))       # not 2-D
+  with pytest.raises(ValueError): L.norm(np.zeros((2, 2), f16), 2)       # spectral norm: use svdvals
+
+
+@pytest.mark.parametrize("k", [0, 1, 2, 3, 5, 8])
+def test_matrix_power_matches_numpy(k):
+  # well-conditioned (cond 2) so the fp16 error from repeated squaring stays bounded
+  r = np.random.default_rng(7); n = 8
+  Q = np.linalg.qr(r.standard_normal((n, n)))[0]
+  A = f16((Q * np.geomspace(1.0, 2.0, n)) @ Q.T)
+  got = L.matrix_power(A, k)
+  ref = np.linalg.matrix_power(A.astype(np.float64), k)
+  assert relerr(got, ref) <= 5e-3, f"matrix_power(A, {k}): relerr {relerr(got, ref)}"
+
+
+def test_matrix_power_identity_and_rejects():
+  A = f16(np.random.default_rng(8).standard_normal((5, 5)))
+  assert np.array_equal(L.matrix_power(A, 0), np.eye(5, dtype=np.float32))   # n=0 -> I
+  assert relerr(L.matrix_power(A, 1), A) == 0.0                              # n=1 -> A itself
+  with pytest.raises(ValueError): L.matrix_power(np.zeros((2, 3), f16), 2)   # not square
+  with pytest.raises(ValueError): L.matrix_power(A, -1)                      # needs an inverse


### PR DESCRIPTION
Fixes #102. Fixes #103.

Two `aneforge.linalg` additions that share a test file and a review. Happy to split them if you would rather review separately.

## `norm(A, order="fro" | 1 | inf)`

Composed on-engine as one fused graph, using the reduce machinery already in the module:

- `"fro"`: `sum_square` over both axes, then `sqrt`.
- `1`: max absolute column sum, via `abs`, `|A|ᵀ @ ones[m,1]` so the wide accumulator does the summing, then `amax`.
- `inf`: the same with `|A| @ ones[n,1]`.

Rejects a non-2-D input, and any other `order`; the spectral norm belongs to `svdvals`.

One naming note: numpy spells this argument `ord`, but ruff's `A002` rejects shadowing the builtin, so it is `order` here. The docstring says so, since the difference from `np.linalg.norm` is otherwise surprising.

## `matrix_power(A, n)`

Binary exponentiation over `_ane_gemm`, so `A**n` costs O(log n) on-engine gemms instead of n-1; `k=8` is 3 gemms rather than 7. `n=0` returns the identity, `n=1` returns `A` untouched with no gemm so it is bit-exact, and negative `n` is rejected since it needs an inverse, which pairs with a future `inv` (#106).

## Verification

On device, Apple M2 Pro, macOS 26.5.2, commit `4bc18e9`. Oracle is fp64 numpy on the same fp16-rounded matrix, so this measures the algorithm rather than the fp16 storage error, matching the `tests/test_linalg.py` convention.

```
norm vs np.linalg.norm

     shape  order           ANE         numpy        rel
       6x5    fro      5.097656      5.095926   3.40e-04
       6x5      1      6.906250      6.907593   1.94e-04
       6x5    inf      5.140625      5.142029   2.73e-04
     16x16    fro     16.125000     16.124658   2.12e-05
     16x16      1     17.546875     17.540442   3.67e-04
     16x16    inf     18.359375     18.357422   1.06e-04
      32x8    fro     15.929688     15.928001   1.06e-04
      32x8      1     28.609375     28.609375   0.00e+00
      32x8    inf      9.070312      9.073975   4.04e-04
```

```
matrix_power vs np.linalg.matrix_power  (n=8, cond 2)

  k  gemms     relerr
  0      0   0.00e+00
  1      0   0.00e+00
  2      1   2.22e-04
  3      2   3.43e-04
  5      3   6.47e-04
  8      3   7.74e-04
```

The `matrix_power` error compounds with each squaring exactly as #103 anticipated, 2.2e-4 at k=2 rising to 7.7e-4 at k=8, so the tests stay at modest powers on a well-conditioned matrix and the tolerance acknowledges it rather than pretending to fp32 accuracy.

On-device tests passed locally, since CI runs only the off-device subset:

```
pytest tests/test_linalg.py -k "norm or matrix_power"  -> 17 passed
pytest tests/test_linalg.py                            -> 57 passed (14m37s)
PYTHONPATH=. python3 tests/run_corpus.py               -> GATE: GREEN (90/90 green, 0 red)
ruff check                                             -> All checks passed
.githooks/pre-commit                                   -> OK
```

All 17 new tests fail on the base commit and pass with the change.

## Tests added

- `test_norm_matches_numpy`: parametrized over `(6,5)`, `(16,16)`, `(32,8)` by `fro`/`1`/`inf`, 9 cases.
- `test_norm_rejects_bad_input`: non-2-D, and `order=2`.
- `test_matrix_power_matches_numpy`: k in {0,1,2,3,5,8}.
- `test_matrix_power_identity_and_rejects`: `n=0` is exactly `I`, `n=1` is bit-exact, non-square and negative `n` raise.

No doc changes: `docs/api/math.md` renders `aneforge.linalg` through mkdocstrings, so both docstrings surface automatically.
