### PR TITLE
einsum: diagonal extraction via mask-and-reduce

### DIFF
--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -115,7 +115,12 @@ def _diag_pairs(sub: str) -> dict[str, tuple[int, int]]:
     raise EinsumUnsupported(
       f"einsum: index {over!r} appears {counts[over[0]]} times in operand '{sub}'; only a "
       f"doubly-repeated index reduces to a mask-and-reduce diagonal - unsupported on the ANE.")
-  return {ch: tuple(i for i, c in enumerate(sub) if c == ch) for ch, c in counts.items() if c == 2}
+  out: dict[str, tuple[int, int]] = {}
+  for ch, c in counts.items():
+    if c != 2: continue
+    p, q = (i for i, x in enumerate(sub) if x == ch)
+    out[ch] = (p, q)
+  return out
 
 
 def _extract_diagonals(t: Tensor, sub: str) -> tuple[Tensor, str]:

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -8,11 +8,11 @@ from collections import Counter
 
 import numpy as np
 
-from aneforge.graph import Tensor
+from aneforge.graph import Tensor, _const
 
 
 class EinsumUnsupported(NotImplementedError):
-  """Raised for equations not lowerable to ANE matmul/reduce ops (diagonal/trace, ellipsis, invented output dims)."""
+  """Raised for equations not lowerable to ANE matmul/reduce ops (diagonal-write, triple repeats, ellipsis)."""
 
 
 # equation parsing
@@ -99,13 +99,42 @@ def _parse(equation: str, n_operands: int) -> tuple[list[str], str]:
 
 
 def _reduce_repeats_check(sub: str) -> None:
-  """A repeated index within one operand is a diagonal extraction (gather)."""
+  """Invariant guard: operands reach the contraction with distinct indices (`_extract_diagonals` ran first)."""
   if len(set(sub)) != len(sub):
     dup = sorted({ch for ch in sub if sub.count(ch) > 1})
     raise EinsumUnsupported(
-      f"einsum: repeated index {dup} within operand '{sub}' is a diagonal/trace "
-      f"extraction, which needs gather - unsupported on the ANE. "
-      f"(Reject rather than return wrong results.)")
+      f"einsum: repeated index {dup} within operand '{sub}' reached the contraction "
+      f"undiagonalized (internal invariant).")
+
+
+def _diag_pairs(sub: str) -> dict[str, tuple[int, int]]:
+  """Map each index repeated exactly twice in `sub` to its two positions; a higher multiplicity rejects."""
+  counts = Counter(sub)
+  over = sorted(ch for ch, c in counts.items() if c > 2)
+  if over:
+    raise EinsumUnsupported(
+      f"einsum: index {over!r} appears {counts[over[0]]} times in operand '{sub}'; only a "
+      f"doubly-repeated index reduces to a mask-and-reduce diagonal - unsupported on the ANE.")
+  return {ch: tuple(i for i, c in enumerate(sub) if c == ch) for ch, c in counts.items() if c == 2}
+
+
+def _extract_diagonals(t: Tensor, sub: str) -> tuple[Tensor, str]:
+  """Rewrite each doubly-repeated index in one operand as its diagonal, dropping the second axis.
+
+  No gather needed: `(x * eye).sum(axis)` IS the diagonal, from ops the lowering already has. The baked
+  identity zeroes every off-diagonal term, so each output element keeps exactly one survivor - the
+  reduce adds only zeros and the extraction is bit-exact in fp16 (unlike a true multi-term sum)."""
+  while True:
+    pairs = _diag_pairs(sub)
+    if not pairs: return t, sub
+    ch, (p, q) = min(pairs.items())
+    n = t.shape[p]
+    if t.shape[q] != n:
+      raise ValueError(f"einsum: repeated index {ch!r} in operand '{sub}' spans dims "
+               f"{n} and {t.shape[q]}; a diagonal needs them equal")
+    mshape = [n if i in (p, q) else 1 for i in range(len(sub))]   # eye over the pair, size-1 elsewhere
+    t = (t * _const(np.eye(n, dtype=np.float16).reshape(mshape))).sum(q).squeeze(q)
+    sub = sub[:q] + sub[q + 1:]
 
 
 # operand-level helpers
@@ -214,7 +243,7 @@ def _expand_to(t: Tensor, present: list, target: list, _sizes) -> Tensor:
 
 def einsum(equation: str, *operands: Tensor) -> Tensor:
   """numpy-style einsum lowered to aneforge ops (matmul-reducible patterns, incl. '...' batch
-  dims); rejects diagonal/trace and repeated output indices."""
+  dims and diagonal/trace extraction); rejects diagonal-WRITE and repeated output indices."""
   if not operands:
     raise ValueError("einsum: at least one operand is required")
   if not all(isinstance(o, Tensor) for o in operands):
@@ -226,7 +255,11 @@ def einsum(equation: str, *operands: Tensor) -> Tensor:
     if len(s) != len(t.shape):
       raise ValueError(f"einsum: subscript '{s}' has {len(s)} indices but operand "
                f"shape {t.shape} has {len(t.shape)} dims")
-    _reduce_repeats_check(s)
+
+  # a doubly-repeated index within an operand is a diagonal: take it before contracting, so
+  # everything downstream sees operands whose indices are distinct.
+  operands, ins = zip(*(_extract_diagonals(t, s) for t, s in zip(operands, ins)))
+  ins = list(ins)
 
   # single operand: pure transpose / reduce
   if len(operands) == 1:
@@ -293,14 +326,19 @@ def _selftest() -> int:
     ("rand-A",            "abc,cd->abd",      [(2, 3, 4), (4, 5)]),
     ("rand-B",            "ij,ik->jk",        [(7, 4), (7, 5)]),
     ("rand-C",            "abcd,abce->abde",  [(2, 2, 3, 4), (2, 2, 3, 5)]),
+    ("diag",              "ii->i",            [(5, 5)]),
+    ("trace",             "ii->",             [(5, 5)]),
+    ("diag-batch",        "bii->bi",          [(3, 5, 5)]),
+    ("diag-then-contract", "ii,ij->j",        [(5, 5), (5, 6)]),
+    ("diag-both-operands", "ii,jj->ij",       [(4, 4), (5, 5)]),
+    ("diag-middle",       "ibi->bi",          [(4, 3, 4)]),
+    ("two-diag-pairs",    "iijj->ij",         [(3, 3, 4, 4)]),
+    ("ellipsis",          "...ij->...ji",     [(2, 3, 4)]),   # supported since _expand_ellipsis landed
   ]
 
   rejected = [
-    ("diag",   "ii->i",   [(5, 5)]),
-    ("trace",  "ii->",    [(5, 5)]),
-    ("diag-batch", "bii->bi", [(3, 5, 5)]),
-    ("ellipsis", "...ij->...ji", [(2, 3, 4)]),
     ("diag-write", "ij->ii", [(5, 5)]),
+    ("triple-repeat", "iii->i", [(4, 4, 4)]),
   ]
 
   print("SUPPORTED battery (relerr vs numpy.einsum on the ANE):")

--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -115,12 +115,12 @@ def _diag_pairs(sub: str) -> dict[str, tuple[int, int]]:
     raise EinsumUnsupported(
       f"einsum: index {over!r} appears {counts[over[0]]} times in operand '{sub}'; only a "
       f"doubly-repeated index reduces to a mask-and-reduce diagonal - unsupported on the ANE.")
-  out: dict[str, tuple[int, int]] = {}
+  pairs: dict[str, tuple[int, int]] = {}
   for ch, c in counts.items():
-    if c != 2: continue
-    p, q = (i for i, x in enumerate(sub) if x == ch)
-    out[ch] = (p, q)
-  return out
+    if c == 2:
+      p, q = (i for i, ci in enumerate(sub) if ci == ch)   # exactly two positions
+      pairs[ch] = (p, q)
+  return pairs
 
 
 def _extract_diagonals(t: Tensor, sub: str) -> tuple[Tensor, str]:

--- a/tests/test_einsum_diagonal.py
+++ b/tests/test_einsum_diagonal.py
@@ -1,0 +1,111 @@
+"""Diagonal extraction in aneforge.einsum: a doubly-repeated operand index via mask-and-reduce."""
+import numpy as np
+import pytest
+
+import aneforge as af
+from aneforge.einsum import einsum, EinsumUnsupported, _diag_pairs, _extract_diagonals
+from _helpers import requires_ane
+
+
+def _check(eq, *shapes, seed=0, tol=5e-3):
+  """Compare against np.einsum on the ANE (fp32 reference, relative max error)."""
+  rng = np.random.default_rng(seed)
+  vals = [rng.standard_normal(s).astype(np.float16) for s in shapes]
+  out = einsum(eq, *[af.input(s) for s in shapes])
+  got = np.asarray(af.compile(out)(*vals)).astype(np.float32)
+  ref = np.atleast_1d(np.einsum(eq, *[v.astype(np.float32) for v in vals]))
+  got = got.reshape(ref.shape)
+  err = np.abs(got - ref).max() / (np.abs(ref).max() + 1e-6)
+  assert err <= tol, f"{eq}: relerr {err:.2e}"
+  return got, ref
+
+
+# -- shape/rewrite level (off-device) ----------------------------------- #
+
+def test_diag_pairs_finds_the_repeated_pair():
+  assert _diag_pairs("ii") == {"i": (0, 1)}
+  assert _diag_pairs("bii") == {"i": (1, 2)}
+  assert _diag_pairs("ibi") == {"i": (0, 2)}
+  assert _diag_pairs("iijj") == {"i": (0, 1), "j": (2, 3)}
+  assert _diag_pairs("ijk") == {}
+
+def test_extract_drops_one_axis_per_repeated_index():
+  t, sub = _extract_diagonals(af.input((5, 5)), "ii")
+  assert sub == "i" and t.shape == (5,)
+  t, sub = _extract_diagonals(af.input((3, 3, 4, 4)), "iijj")
+  assert sub == "ij" and t.shape == (3, 4)
+
+def test_extract_is_a_noop_without_repeats():
+  x = af.input((3, 4))
+  t, sub = _extract_diagonals(x, "ij")
+  assert t is x and sub == "ij"
+
+@pytest.mark.parametrize("eq,shapes,want", [
+  ("ii->i",     [(5, 5)],           (5,)),
+  ("bii->bi",   [(3, 5, 5)],        (3, 5)),
+  ("ibi->bi",   [(4, 3, 4)],        (3, 4)),
+  ("iijj->ij",  [(3, 3, 4, 4)],     (3, 4)),
+  ("ii,ij->j",  [(5, 5), (5, 6)],   (6,)),
+  ("ii,jj->ij", [(4, 4), (5, 5)],   (4, 5)),
+])
+def test_output_shape_matches_numpy(eq, shapes, want):
+  assert einsum(eq, *[af.input(s) for s in shapes]).shape == want
+
+
+# -- rejects that must survive the rewrite ------------------------------ #
+
+def test_triple_repeat_rejects():
+  with pytest.raises(EinsumUnsupported, match="appears 3 times"):
+    einsum("iii->i", af.input((4, 4, 4)))
+
+def test_diagonal_write_still_rejects():
+  with pytest.raises(EinsumUnsupported, match="repeated output index"):
+    einsum("ij->ii", af.input((5, 5)))
+
+def test_non_square_repeated_index_rejects():
+  with pytest.raises(ValueError, match="spans dims"):
+    einsum("ii->i", af.input((5, 6)))
+
+
+# -- numerics on the ANE ------------------------------------------------ #
+
+@requires_ane
+@pytest.mark.parametrize("eq,shapes", [
+  ("ii->i",             [(5, 5)]),
+  ("ii->",              [(5, 5)]),
+  ("bii->bi",           [(3, 5, 5)]),
+  ("bii->b",            [(3, 5, 5)]),
+  ("ibi->bi",           [(4, 3, 4)]),
+  ("iijj->ij",          [(3, 3, 4, 4)]),
+  ("ii,ij->j",          [(5, 5), (5, 6)]),
+  ("ii,jj->ij",         [(4, 4), (5, 5)]),
+  ("bii,bij->bj",       [(2, 4, 4), (2, 4, 5)]),
+])
+def test_matches_numpy_on_ane(eq, shapes):
+  _check(eq, *shapes)
+
+@requires_ane
+def test_pure_diagonal_is_bit_exact():
+  """The identity mask leaves exactly one survivor per output element, so the reduce adds only
+  zeros: extraction introduces no fp16 rounding of its own."""
+  for eq, shape in [("ii->i", (6, 6)), ("bii->bi", (3, 5, 5)), ("ibi->bi", (4, 3, 4))]:
+    got, ref = _check(eq, shape)
+    assert np.array_equal(got, ref), f"{eq}: expected bit-exact diagonal, max |d| {np.abs(got-ref).max()}"
+
+@requires_ane
+def test_trace_equals_numpy_trace():
+  rng = np.random.default_rng(3)
+  a = rng.standard_normal((8, 8)).astype(np.float16)
+  got = float(np.asarray(af.compile(einsum("ii->", af.input((8, 8))))(a)).reshape(()))
+  ref = float(np.trace(a.astype(np.float32)))
+  assert abs(got - ref) / (abs(ref) + 1e-6) <= 5e-3, f"trace {got} vs {ref}"
+
+@requires_ane
+def test_diagonal_of_known_matrix():
+  """A matrix whose diagonal is 1..n and whose off-diagonal is large: catches an extraction that
+  leaks off-diagonal mass (a wrong axis, or a mask that is not the identity)."""
+  n = 6
+  a = np.full((n, n), 100.0, np.float16)
+  a[np.diag_indices(n)] = np.arange(1, n + 1)
+  got = np.asarray(af.compile(einsum("ii->i", af.input((n, n))))(a)).astype(np.float32).reshape(n)
+  assert np.array_equal(got, np.arange(1, n + 1, dtype=np.float32)), got


### PR DESCRIPTION
Fixes #107.

## Summary

`einsum` rejected a doubly-repeated index within one operand (`'ii->i'`, `'bii->bi'`) as "needs gather -- unsupported". It doesn't need gather. Multiplying by a baked identity over the repeated pair and summing one of the axes is the diagonal, from ops the lowering already has.

`_extract_diagonals` does that rewrite on each operand before contraction, so the pairwise contraction and the single-operand transpose/reduce path only ever see operands whose indices are distinct. It loops until no doubly-repeated index remains, so multiple pairs in one operand (`'iijj->ij'`) work, and it returns the same `Tensor` object unchanged when there are no repeats.

The rewrite composes with the rest of the pipeline for free: `'ii,ij->j'` takes the diagonal, then contracts through the existing matmul path.

One consequence worth stating. The identity mask zeroes every off-diagonal term, so each output element keeps exactly one survivor and the reduce adds only zeros. A pure diagonal extraction is bit-exact in fp16, not just within tolerance. The test asserts `array_equal` rather than a relative-error bound.

## High-level changes

`aneforge/einsum.py` (+50 / -12)

- `_diag_pairs(sub)`: maps each index repeated exactly twice to its two positions. Higher multiplicity raises `EinsumUnsupported`.
- `_extract_diagonals(t, sub)`: `(x * eye).sum(q).squeeze(q)` per repeated pair, with the identity reshaped to size-1 on the untouched axes so it broadcasts.
- Wired into `einsum` in place of the per-operand `_reduce_repeats_check` call. That function stays as an internal invariant guard, and its message now says so, so a future path that skips the rewrite fails loudly instead of computing a wrong result.
- Docstrings on `EinsumUnsupported` and `einsum` updated to describe what is actually rejected now.
- `_selftest`: the 3 diagonal cases move from `rejected` into the battery, plus 4 new compositions. `triple-repeat` added to `rejected`.

`tests/test_einsum_diagonal.py` (new, 24 tests): off-device shape and rewrite tests, reject tests, and on-device numerics against `np.einsum`.

## Evaluation

All on-device work run locally on Apple M2 Pro, macOS 26.5.2. CI can't reach an ANE, per CONTRIBUTING.

Self-test (`python aneforge/einsum.py`): 33/33 supported patterns correct on the ANE, 2/2 unsupported correctly rejected.

```
  diag                 ii->i             OK  relerr 0.00000  shape (5,)
  trace                ii->              OK  relerr 0.00000  shape (1,)
  diag-batch           bii->bi           OK  relerr 0.00000  shape (3, 5)
  diag-middle          ibi->bi           OK  relerr 0.00000  shape (3, 4)
  two-diag-pairs       iijj->ij          OK  relerr 0.00000  shape (3, 4)
  diag-then-contract   ii,ij->j          OK  relerr 0.00025  shape (6,)
  diag-both-operands   ii,jj->ij         OK  relerr 0.00032  shape (4, 5)
```

The five pure extractions are exactly 0.00000. The mixed specs carry only the normal fp16 matmul error of the contraction they feed.

| Check | Result |
|---|---|
| `tests/test_einsum_diagonal.py` | 24 passed |
| `test_einsum_ellipsis.py` + new file | 31 passed |
| `test_shapes`, `test_broad`, `test_op_coverage`, `test_corners` | 78 passed |
| `tests/run_corpus.py` | GATE: GREEN, 90/90, 0 red |
| `ruff check` / `.githooks/pre-commit` | clean |

The tests fail without the fix. I verified this by probing `main` through the public API, since a bare `git stash` run only produces a collection error from the new helper imports and proves nothing. All 9 behavioral equations (`ii->i`, `ii->`, `bii->bi`, `bii->b`, `ibi->bi`, `iijj->ij`, `ii,ij->j`, `ii,jj->ij`, `bii,bij->bj`) raise `EinsumUnsupported` on `main` and pass here.

Rejects preserved, as the issue asks:

- `'ij->ii'` (diagonal-WRITE) raises `EinsumUnsupported`, existing message unchanged.
- `'iii->i'` (triple repeat) raises `EinsumUnsupported` with a new explicit message.
- `'ii->i'` on a non-square `(5, 6)` operand raises `ValueError` naming both dims.

## One out-of-scope line

The self-test listed `ellipsis` (`'...ij->...ji'`) under `rejected`, but ellipsis has been supported since `_expand_ellipsis` landed. So `python aneforge/einsum.py` exits nonzero on current `main`, before this change. I confirmed that on a clean tree. It sits in the same list this PR edits and would otherwise keep the self-test red, so I moved it to the battery, where it passes. Happy to split it out if you'd rather keep this PR to #107 alone.

## Risk assessment

Low. The change is additive on a path that previously always raised, so no equation that worked before takes a different route. The only behavior change is that a formerly-rejected class now computes. Contained to `einsum.py`, no ops added, no lowering touched.

- Cost is one `mul` plus one `reduce_sum` per repeated pair, on-engine and inside the same fused program.
- The mask is a baked `const_array` of size `n^2` per pair, folded at compile time.
- `_extract_diagonals` also guards the mismatched-dims case that was previously unreachable, so a malformed `'ii'` over unequal dims gets a clear `ValueError` instead of a shape error deeper in the graph.
- Rank never increases (the mask is rank-equal to the operand and the reduce drops an axis), so the rank<=5 ANE cap isn't approached.

## Pre-merge steps

None. No new dependency, no API break, `coverage` and the dylib untouched.

## Post-merge steps

None required. Two optional follow-ups, left out to keep the diff minimal:

1. `'ij->ii'` (diagonal-write / broadcast-back) is still unsupported and is the natural next step if you want it.
2. `_selftest` duplicates what `tests/` covers and nothing in CI runs it, which is why the stale `ellipsis` entry went unnoticed. Folding it into the pytest suite would stop that recurring. I can open a separate issue.
