### PR TITLE
feat(bench): record macOS Energy Mode; allow battery perf runs

### DIFF
--- a/bench/_machine.py
+++ b/bench/_machine.py
@@ -156,16 +156,42 @@ def _git_info() -> dict:
     return info
 
 
+def _energy_mode() -> dict:
+    """macOS Energy Mode (Low Power / Automatic / High Power) currently in effect.
+
+    Reads the active `powermode` from `pmset -g`. High Power raises the sustained
+    power/thermal ceiling, so a battery run in High Power is close to AC over short
+    bench windows - which is why we record it rather than block battery runs. The
+    raw integer is kept alongside the label so a future macOS renumbering cannot
+    silently mislabel the data. Machines without the three-state Energy Mode (Airs,
+    base models) report mode None; some macOS versions expose only `lowpowermode`."""
+    try:
+        txt = subprocess.run(["pmset", "-g"], capture_output=True, text=True, timeout=5).stdout
+    except Exception:
+        return {"mode": None, "raw": None}
+    m = re.search(r"^\s*powermode\s+(\d+)", txt, re.M)
+    if m:
+        raw = int(m.group(1))
+        name = {0: "automatic", 1: "low_power", 2: "high_power"}.get(raw, f"powermode_{raw}")
+        return {"mode": name, "raw": raw, "key": "powermode"}
+    lp = re.search(r"^\s*lowpowermode\s+(\d+)", txt, re.M)
+    if lp:
+        raw = int(lp.group(1))
+        return {"mode": "low_power" if raw else "automatic", "raw": raw, "key": "lowpowermode"}
+    return {"mode": None, "raw": None}
+
+
 def _power_source() -> dict:
-    """AC vs battery + charge (a laptop on battery throttles clocks, shifting perf rooflines)."""
+    """AC vs battery + charge + Energy Mode (both shift perf rooflines; recorded, not blocked)."""
     try:
         txt = subprocess.run(["pmset", "-g", "ps"], capture_output=True, text=True, timeout=5).stdout
     except Exception:
-        return {"source": None, "is_laptop": None}
+        return {"source": None, "is_laptop": None, "energy_mode": _energy_mode()}
     is_laptop = "InternalBattery" in txt
     m = re.search(r"drawing from '([^']+)'", txt)
     info = {"source": ("ac" if (m and "AC" in m.group(1)) else "battery" if m else None),
-            "is_laptop": is_laptop}
+            "is_laptop": is_laptop,
+            "energy_mode": _energy_mode()}
     if is_laptop:
         pct = re.search(r"(\d+)%", txt)
         info["battery_pct"] = int(pct.group(1)) if pct else None

--- a/bench/aggregate_rooflines.py
+++ b/bench/aggregate_rooflines.py
@@ -65,6 +65,20 @@ def _fmt_cliff(nc: dict) -> tuple[str, str, str]:
     return (matmul, slice_cell, reduce_cell)
 
 
+def _power_label(pw: dict) -> str:
+    """Compact power cell: source (+ battery %) + Energy Mode when non-default.
+
+    High Power / Low Power materially change perf, so they are shown; 'automatic'
+    (the default) is omitted for brevity but is always in the JSON."""
+    src = pw.get("source", "?")
+    if pw.get("is_laptop") and pw.get("source") == "battery":
+        src += f" {pw.get('battery_pct')}%"
+    mode = (pw.get("energy_mode") or {}).get("mode")
+    if mode and mode != "automatic":
+        src += f" ({mode.replace('_', '-')})"
+    return src
+
+
 def _perf_summary(report: dict, script: str) -> dict | None:
     """The embedded summary JSON of one perf script in a submission, if it ran clean."""
     for e in (report.get("perf_rooflines") or []):
@@ -145,10 +159,7 @@ def render(reports: list[dict]) -> str:
         if mainrel.get("commits_behind"):
             drift.append(f"-{mainrel['commits_behind']}")
         code = base + (f" ({', '.join(drift)})" if drift else "")
-        pw = env.get("power", {})
-        power = pw.get("source", "?")
-        if pw.get("is_laptop") and pw.get("source") == "battery":
-            power += f" {pw.get('battery_pct')}%"
+        power = _power_label(env.get("power", {}))
         mem = f"{hw.get('ram_gb')} GB {hw.get('memory_architecture','')}".strip()
         # credit the most recent submission that named a contributor
         handle = next((r.get("contributor") for r in reversed(g["submissions"]) if r.get("contributor")), None)
@@ -198,10 +209,7 @@ def render(reports: list[dict]) -> str:
         if not any(v is not None for v in h.values()):
             continue
         hw = sub["machine"]["hardware"]
-        pw = sub["machine"]["environment"].get("power", {})
-        power = pw.get("source", "?")
-        if pw.get("is_laptop") and pw.get("source") == "battery":
-            power += f" {pw.get('battery_pct')}%"
+        power = _power_label(sub["machine"]["environment"].get("power", {}))
 
         def _c(v, fmt):
             return format(v, fmt) if isinstance(v, (int, float)) else "-"

--- a/bench/results/ROOFLINES.md
+++ b/bench/results/ROOFLINES.md
@@ -11,7 +11,7 @@ Thanks to [@sbryngelson](https://github.com/sbryngelson) for contributing datapo
 
 | Chip | Model | CPU (P+E) | GPU | Memory | macOS | Power | Code (main merge-base) | By | Runs |
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
-| Apple M5 Pro | Mac17,8 | 6+12 | 20 | 48 GB unified | 26.5.1 (25F80) | battery 89% | cab4c2bdf541 (dirty, +2) | [@sbryngelson](https://github.com/sbryngelson) | 1 |
+| Apple M5 Pro | Mac17,8 | 6+12 | 20 | 48 GB unified | 26.5.1 (25F80) | battery 82% (high-power) | 93501250062c (dirty) | [@sbryngelson](https://github.com/sbryngelson) | 1 |
 
 ## Numeric cliffs (correctness rooflines)
 

--- a/bench/results/rooflines/README.md
+++ b/bench/results/rooflines/README.md
@@ -44,6 +44,10 @@ Filenames include a `run_id`, so multiple runs of the same machine - and runs by
 different people on the same machine model - never collide. Submissions are
 immutable: add new ones, do not edit old ones.
 
-Please submit from a **clean, non-dirty** checkout where possible; a `dirty` or
-`battery` submission is accepted (the flags ride along) but is not comparable to
-clean/AC data for the performance rooflines.
+Please submit from a **clean, non-dirty** checkout where possible. Battery
+submissions are welcome and never blocked -- the power source, battery %, and
+**Energy Mode** (Low Power / Automatic / High Power) all ride along in the JSON
+and show in the table. For the performance rooflines, a battery run in **High
+Power** mode is close to AC over the short bench windows; Automatic or Low Power
+on battery will throttle, so those rows are labelled accordingly. The numeric
+cliffs are clock-independent and comparable regardless of power state.

--- a/bench/results/rooflines/roofline-apple-m5-pro-Mac17_8-c38210cfc8ea-06ec400a.json
+++ b/bench/results/rooflines/roofline-apple-m5-pro-Mac17_8-c38210cfc8ea-06ec400a.json
@@ -22,30 +22,35 @@
       "macos_build": "25F80",
       "aneforge_version": "0.1.4.dev32+gb8dc90fe6.d20260624",
       "aneforge_git": {
-        "commit": "f1eca0dfdd89e7a63465ac12ce52b6a602d432ec",
-        "short": "f1eca0dfdd89",
-        "branch": "bench/roofline-suite",
+        "commit": "93501250062ca869a4bfbf14221767dab462a3d3",
+        "short": "93501250062c",
+        "branch": "bench/energy-mode",
         "dirty": true,
         "main": {
           "ref": "origin/main",
-          "merge_base": "cab4c2bdf541cca2c6f4dcf687ddd9dfdb97778b",
-          "merge_base_short": "cab4c2bdf541",
-          "commits_ahead": 2,
+          "merge_base": "93501250062ca869a4bfbf14221767dab462a3d3",
+          "merge_base_short": "93501250062c",
+          "commits_ahead": 0,
           "commits_behind": 0
         }
       },
       "power": {
         "source": "battery",
         "is_laptop": true,
-        "battery_pct": 89,
+        "energy_mode": {
+          "mode": "high_power",
+          "raw": 2,
+          "key": "powermode"
+        },
+        "battery_pct": 82,
         "battery_state": "discharging"
       },
       "gpu_wired_limit_mb": 0,
       "thermal_state": "nominal",
       "have_sudo": true,
-      "timestamp_utc": "2026-08-01T12:41:49Z"
+      "timestamp_utc": "2026-08-01T13:06:42Z"
     },
-    "run_id": "db49f4a5"
+    "run_id": "06ec400a"
   },
   "numeric_cliffs": {
     "plane": "numeric",

--- a/bench/roofline_suite.py
+++ b/bench/roofline_suite.py
@@ -139,8 +139,14 @@ def main():
             print("\n[perf] WARNING: no passwordless sudo -> powermetrics watts will be missing.")
         pw = fp["environment"]["power"]
         if pw.get("is_laptop") and pw.get("source") == "battery":
-            print(f"\n[perf] WARNING: on battery ({pw.get('battery_pct')}%) -> clocks throttle; "
-                  "plug in for representative perf rooflines. (Numeric cliffs are unaffected.)")
+            mode = (pw.get("energy_mode") or {}).get("mode")
+            if mode == "high_power":
+                print(f"\n[perf] note: on battery ({pw.get('battery_pct')}%) but in High Power mode "
+                      "-> close to AC over short bench windows; the state is recorded in the report.")
+            else:
+                print(f"\n[perf] WARNING: on battery ({pw.get('battery_pct')}%), energy mode "
+                      f"'{mode}' -> clocks may throttle; High Power mode or AC gives cleaner perf "
+                      "rooflines. (Numeric cliffs are unaffected.) The state is recorded either way.")
         extra = ["--quick"] if args.quick else []
         collected = []
         for script, result_file in PERF_SCRIPTS:


### PR DESCRIPTION
Follow-up to #136. Makes battery `--perf` runs first-class by recording the power state fully, so a battery submission is legible rather than ambiguous.

- **Energy Mode capture** (`_machine.py`): the fingerprint's `power` block now includes the active macOS Energy Mode from `pmset` -- `{mode: "high_power"|"automatic"|"low_power", raw: 0|1|2, key}`. The raw integer rides alongside the label so a future macOS renumbering can't silently mislabel data. Machines without the three-state mode report `mode: null`; the older `lowpowermode` key is handled too.
- **Table** (`aggregate_rooflines.py`): the Power cell shows non-default modes, e.g. `battery 82% (high-power)` or `ac (low-power)`; `automatic` is omitted for brevity but always present in the JSON.
- **Suite** (`roofline_suite.py`): the `--perf` battery warning softens to a note when in High Power ("close to AC over short bench windows"); Automatic/Low Power on battery still warns. Battery runs were never blocked -- this just labels them.

Rationale: High Power mode raises the sustained power/thermal ceiling, so a battery run in High Power is close to AC over the short bench windows. Recording the exact state keeps every submission comparable instead of forcing an AC-only rule. The numeric cliffs are clock-independent regardless.

Verified on M5 Pro (in High Power on battery): detected `powermode 2 -> high_power`, table renders `battery 82% (high-power)`; ruff clean, `aggregate_rooflines.py --check` green.