### PR TITLE
onnx: pin negative-axis handling with regression tests

### DIFF
--- a/tests/test_onnx.py
+++ b/tests/test_onnx.py
@@ -1405,3 +1405,63 @@ def test_attention_matches_onnxruntime():
       ref = np.asarray(_attn_ort(m, {"Q": Q, "K": K, "V": V})).astype(np.float32).ravel()
       cos = _cos(got, ref)
       assert cos > 0.99, f"Attention H={H} S={S} D={D} {attrs} ANE vs onnxruntime cosine={cos}"
+# ── negative axis attributes (ONNX allows them everywhere) ──
+
+def _neg_axis_pair(mk, feeds, neg, pos):
+  """Build the same graph with a negative axis and its positive equivalent; return both outputs."""
+  outs = []
+  for ax in (neg, pos):
+    net = af.load_onnx(mk(ax))
+    outs.append(np.asarray(net(*[v.astype(np.float16) for v in feeds.values()]), np.float32))
+  return outs
+
+@requires_ane
+def test_negative_axis_matches_positive_equivalent():
+  """A negative `axis`/`axes` attribute must build the same graph as its positive equivalent.
+
+  Normalization lives in the graph layer (`Tensor.softmax`, `af.concat`, `Tensor.squeeze`, ...
+  all do `axis % rank`), so the ONNX handlers can pass the raw attribute through. This pins
+  that: it fails if a handler ever starts consuming the axis before normalizing, or if a graph
+  op drops its `% rank`.
+  """
+  rng = np.random.default_rng(0)
+  sh = [2, 3, 4, 5]
+  x = rng.standard_normal(sh).astype(np.float32)
+  i64 = lambda v, n: onnx.numpy_helper.from_array(np.asarray(v, np.int64), n)
+  cases = [
+    ("Softmax", lambda ax: _model([helper.make_node("Softmax", ["x"], ["y"], axis=ax)],
+                                  [_vi("x", sh)], [_vi("y", sh)]), {"x": x}, -2, 2),
+    ("LogSoftmax", lambda ax: _model([helper.make_node("LogSoftmax", ["x"], ["y"], axis=ax)],
+                                     [_vi("x", sh)], [_vi("y", sh)]), {"x": x}, -2, 2),
+    ("LpNormalization", lambda ax: _model([helper.make_node("LpNormalization", ["x"], ["y"], axis=ax, p=2)],
+                                          [_vi("x", sh)], [_vi("y", sh)]), {"x": x}, -1, 3),
+    ("Flatten", lambda ax: _model([helper.make_node("Flatten", ["x"], ["y"], axis=ax)],
+                                  [_vi("x", sh)], [_vi("y", [24, 5])]), {"x": x}, -1, 3),
+    ("Concat", lambda ax: _model([helper.make_node("Concat", ["x", "x2"], ["y"], axis=ax)],
+                                 [_vi("x", sh), _vi("x2", sh)], [_vi("y", [2, 3, 4, 10])]),
+     {"x": x, "x2": x}, -1, 3),
+    ("Split", lambda ax: _model([helper.make_node("Split", ["x"], ["y1", "y2"], axis=ax, split=[2, 3])],
+                                [_vi("x", sh)], [_vi("y1", [2, 3, 4, 2]), _vi("y2", [2, 3, 4, 3])]),
+     {"x": x}, -1, 3),
+    ("CumSum", lambda ax: _model([helper.make_node("CumSum", ["x", "a"], ["y"])],
+                                 [_vi("x", sh)], [_vi("y", sh)], inits=[i64(ax, "a")]), {"x": x}, -1, 3),
+    ("Gather", lambda ax: _model([helper.make_node("Gather", ["x", "i"], ["y"], axis=ax)],
+                                 [_vi("x", sh)], [_vi("y", [2, 3, 4, 2])], inits=[i64([0, 2], "i")]),
+     {"x": x}, -1, 3),
+    ("ReduceSum", lambda ax: _model([helper.make_node("ReduceSum", ["x", "a"], ["y"], keepdims=0)],
+                                    [_vi("x", sh)], [_vi("y", [2, 3, 4])], inits=[i64([ax], "a")]),
+     {"x": x}, -1, 3),
+    ("ReduceMean", lambda ax: _model([helper.make_node("ReduceMean", ["x", "a"], ["y"], keepdims=1)],
+                                     [_vi("x", sh)], [_vi("y", [2, 3, 4, 1])], inits=[i64([ax], "a")]),
+     {"x": x}, -1, 3),
+    ("Squeeze", lambda ax: _model([helper.make_node("Squeeze", ["x", "a"], ["y"])],
+                                  [_vi("x", [2, 3, 4, 1])], [_vi("y", [2, 3, 4])], inits=[i64([ax], "a")]),
+     {"x": x[:, :, :, :1]}, -1, 3),
+    ("Unsqueeze", lambda ax: _model([helper.make_node("Unsqueeze", ["x", "a"], ["y"])],
+                                    [_vi("x", [2, 3, 4])], [_vi("y", [2, 3, 4, 1])], inits=[i64([ax], "a")]),
+     {"x": x[:, :, :, 0]}, -1, 3),
+  ]
+  for label, mk, feeds, neg, pos in cases:
+    a, b = _neg_axis_pair(mk, feeds, neg, pos)
+    assert a.shape == b.shape, f"{label}: axis {neg} shape {a.shape} != axis {pos} shape {b.shape}"
+    assert np.allclose(a, b, atol=1e-3), f"{label}: axis {neg} output differs from axis {pos}"

--- a/tests/test_onnx_axis_attrs.py
+++ b/tests/test_onnx_axis_attrs.py
@@ -1,0 +1,47 @@
+"""Build-level assertions that ONNX negative axis attributes are normalized in the graph.
+
+Separate from `test_onnx.py` on purpose: that module is `pytestmark = requires_ane`, because every
+test there compiles and dispatches. These are pure builder checks with no dispatch, so they run in
+CI (`pytest -m "not requires_ane"`) and lock the invariant on machines without an ANE.
+"""
+import numpy as np, onnx, pytest  # noqa: F401
+from onnx import helper, TensorProto
+import aneforge as af
+
+
+def _model(nodes, inputs, outputs, inits=(), opset=13):
+  g = helper.make_graph(nodes, "g", inputs, outputs, list(inits))
+  m = helper.make_model(g, opset_imports=[helper.make_opsetid("", opset)])
+  m.ir_version = 9
+  return m
+
+def _vi(name, shape): return helper.make_tensor_value_info(name, TensorProto.FLOAT, shape)
+
+
+def test_negative_axis_normalized_in_graph_attrs():
+  """The built graph must carry a normalized (non-negative) axis attribute.
+
+  Output equality alone cannot catch every regression here: MIL tolerates a negative `axis`, and
+  for `concat` a raw -1 indexes the same list slot as rank-1, so a dropped `% rank` would still
+  produce correct numbers while leaking -1 into the op attrs. Assert on the attribute.
+  """
+  sh = [2, 3, 4, 5]
+  m = _model([helper.make_node("Concat", ["a", "b"], ["y"], axis=-1)],
+             [_vi("a", sh), _vi("b", sh)], [_vi("y", [2, 3, 4, 10])])
+  _, out = af.onnx_to_tensor(m)
+  assert out.op == "concat" and out.attrs["axis"] == 3, f"concat axis attr = {out.attrs.get('axis')}"
+  m = _model([helper.make_node("Softmax", ["x"], ["y"], axis=-2)], [_vi("x", sh)], [_vi("y", sh)])
+  _, out = af.onnx_to_tensor(m)
+  assert out.attrs["axis"] == 2, f"softmax axis attr = {out.attrs.get('axis')}"
+
+
+def test_negative_axis_argmax_argmin_match_positive():
+  """ArgMax/ArgMin are 2-D only and shipped shape-validated, so check the built graph, not values."""
+  for op in ("ArgMax", "ArgMin"):
+    shapes = []
+    for ax in (-1, 1):
+      m = _model([helper.make_node(op, ["x"], ["y"], axis=ax, keepdims=1)], [_vi("x", [3, 5])],
+                 [helper.make_tensor_value_info("y", TensorProto.INT64, [3, 1])])
+      _, out = af.onnx_to_tensor(m)
+      shapes.append(out.shape)
+    assert shapes[0] == shapes[1], f"{op}: axis -1 -> {shapes[0]}, axis 1 -> {shapes[1]}"


### PR DESCRIPTION
Tests only, per #97. No handler changes, because the audit found no handler bug: all 16 pass a negative `axis`/`axes` through unchanged, which is correct by construction since normalization is centralized one layer down (`Tensor.softmax`, `Tensor.squeeze`, `af.concat` and friends all do `axis % rank`).

Closes #97 as fixed-by-tests.

## What lands

**`tests/test_onnx_axis_attrs.py`** (new, 2 tests, off-device). The attrs-level assertion you called out. Asserts the *built* attribute is normalized, so a future path that skips a `% rank` fails even though the numbers stay right.

**`tests/test_onnx.py`** (+60, on-device). The value half: 12 ops built twice, once with a negative axis and once with its positive equivalent, asserting identical shape and values. Covers `Softmax`, `LogSoftmax`, `LpNormalization`, `Flatten`, `Concat`, `Split`, `CumSum`, `Gather`, `ReduceSum`, `ReduceMean`, `Squeeze`, `Unsqueeze`, plus a build-level pair for `ArgMax`/`ArgMin` (2-D only, so shape not values).

## Why the attrs assertions are in a separate module

This is the one design choice worth flagging. `test_onnx.py` is `pytestmark = requires_ane` at module level, so **anything added there is invisible to `pytest -m "not requires_ane"`**, which is what CI runs. I confirmed it: with the assertions inside `test_onnx.py`, the off-device selection deselects all 182 tests and collects zero.

Since the whole point you raised is that this locks the invariant in CI without an ANE, they had to move to a module without that marker. `test_onnx_axis_attrs.py` does no dispatch, only `af.onnx_to_tensor`, so it runs everywhere.

## Verification

Apple M2 Pro, macOS 26.5.2.

| Check | Result |
|---|---|
| `pytest tests/test_onnx_axis_attrs.py -m "not requires_ane"` | 2 passed (runs in CI) |
| `pytest tests/test_onnx.py -k negative_axis` | 1 passed (on-device) |
| `ruff check` | clean |

**The attrs assertion bites.** Verified by stubbing the normalization out of the `_concat` the handler actually calls, keeping everything else identical:

```
axis attr without % rank: -1
assertion (== 3) fails correctly: True
```

The output stays numerically correct in that state, which is exactly your point: a raw `-1` indexes the same slot, MIL tolerates it, and only an assertion on the built attribute catches the leak.

## Risk

None to library behavior; no `aneforge/` file is touched. The new module adds ~0.3 s to the off-device CI job.

## Note on the branch

Initially pushed from a branch based on `713452d`, which conflicted with the `Attention` tests (#117)
that now sit at the tail of `test_onnx.py`. Rebased onto current `main` (`263e02f`); the new block
appends after them and the diff is still only the two test files.
