### PR TITLE
bench: let roofline_analysis handle a device a sweep could not measure

### DIFF
--- a/bench/roofline_analysis.py
+++ b/bench/roofline_analysis.py
@@ -32,9 +32,11 @@ def load_ceilings():
     bw = json.loads(BW_JSON.read_text())
 
     peaks = sat["peaks"]
-    # Compute roof (GFLOP/s): GEMM and conv kept separate.
+    # Compute roof (GFLOP/s): GEMM and conv kept separate. A device a sweep could not
+    # measure (an engine where a shape fails to compile) is absent, not zero -> skip it.
     compute = {}
     for dev in ("CPU", "GPU", "ANE"):
+        if dev not in peaks["gemm"] or dev not in peaks["conv"]: continue
         compute[dev] = {
             "gemm_peak_gflops": peaks["gemm"][dev]["peak_gflops"],
             "gemm_peak_at_N": peaks["gemm"][dev]["peak_gflops_size"],
@@ -44,13 +46,15 @@ def load_ceilings():
 
     # Bandwidth roof (GB/s): streaming archetype peak.
     stream = bw["results"]["roofline"]["streaming (relu / x*2)"]["peak"]
-    bandwidth = {dev.upper(): stream[dev.lower()]["gbps"] for dev in ("CPU", "GPU", "ANE")}
+    bandwidth = {dev.upper(): stream[dev.lower()]["gbps"] for dev in ("CPU", "GPU", "ANE")
+                 if dev.lower() in stream}
 
     # achieved GB/s per device per archetype -> achieved GFLOP/s for bw-bound ops.
     arche_bw = {}
     for name, blk in bw["results"]["roofline"].items():
-        arche_bw[name] = {dev.upper(): blk["peak"][dev.lower()]["gbps"]
-                          for dev in ("CPU", "GPU", "ANE")}
+        pk = blk.get("peak") or {}
+        arche_bw[name] = {dev.upper(): pk[dev.lower()]["gbps"]
+                          for dev in ("CPU", "GPU", "ANE") if dev.lower() in pk}
     return sat, bw, compute, bandwidth, arche_bw
 
 
@@ -345,8 +349,9 @@ def _sat_achieved(sat, dev, archetype):
 
 def build_placement(arche, compute, bandwidth, arche_bw, gaps, sat):
     """Per (op, device): AI, applicable roof, achieved, %roof."""
-    placement = {dev: [] for dev in ("CPU", "GPU", "ANE")}
-    for dev in ("CPU", "GPU", "ANE"):
+    devs = [d for d in ("CPU", "GPU", "ANE") if d in compute and d in bandwidth]
+    placement = {dev: [] for dev in devs}
+    for dev in devs:
         bpe = FP32 if dev == "CPU" else FP16
         bw_roof = bandwidth[dev]
         for row in arche:
@@ -366,7 +371,7 @@ def build_placement(arche, compute, bandwidth, arche_bw, gaps, sat):
             else:
                 # bandwidth-bound: achieved = AI * achieved_GB/s
                 bwname = row.get("bw_archetype")
-                if bwname and bwname in arche_bw:
+                if bwname and dev in arche_bw.get(bwname, {}):
                     gbps = arche_bw[bwname][dev]
                     achieved = ai * gbps  # GFLOP/s = FLOP/byte * GB/s
                     src = f"DERIVED: AI x achieved {gbps:.1f} GB/s ({bwname})"
@@ -473,7 +478,8 @@ def main():
 
     # ridge points
     ridges = {}
-    for dev in ("CPU", "GPU", "ANE"):
+    for dev in compute:
+        if dev not in bandwidth: continue
         # GEMM compute peak as the headline roof
         ridges[dev] = compute[dev]["gemm_peak_gflops"] / bandwidth[dev]
 
@@ -481,7 +487,7 @@ def main():
     print(" ROOFLINE ANALYSIS - per-device ridge points (recomputed from the two JSONs)")
     print("=" * 88)
     print(f" {'device':<5} {'dtype':<5} {'compute roof (GFLOP/s)':>26} {'bw roof (GB/s)':>15} {'ridge FLOP/byte':>17}")
-    for dev in ("CPU", "GPU", "ANE"):
+    for dev in ridges:
         dtype = "fp32" if dev == "CPU" else "fp16"
         cg = compute[dev]["gemm_peak_gflops"]; cc = compute[dev]["conv_peak_gflops"]
         print(f" {dev:<5} {dtype:<5} {f'gemm {cg:.0f} / conv {cc:.0f}':>26} "
@@ -520,7 +526,7 @@ def main():
     print("\n" + "=" * 88)
     print(" OP PLACEMENT per device - AI / applicable roof / achieved / %roof")
     print("=" * 88)
-    for dev in ("CPU", "GPU", "ANE"):
+    for dev in placement:
         print(f"\n--- {dev} ---")
         print(f" {'archetype':<36} {'AI':>9} {'roof@AI':>10} {'achieved':>10} {'%roof':>7}")
         for r in placement[dev]:
@@ -532,7 +538,7 @@ def main():
     print(" ASCII ROOFLINES")
     print("=" * 88)
     sketches = {}
-    for dev in ("CPU", "GPU", "ANE"):
+    for dev in placement:
         s = ascii_roofline(dev, compute, bandwidth, placement[dev], ridges[dev])
         sketches[dev] = s
         print("\n" + s)


### PR DESCRIPTION
Fixes #146.

## The bug

`load_ceilings` and its consumers iterated a hardcoded `("CPU", "GPU", "ANE")` and indexed each device directly, so one missing entry aborted the whole synthesis.

That is not hypothetical. `device_bandwidth_roofline.py` does the right thing when an archetype fails to compile on an engine: it records `ane_gbps: None` and carries on. On M2 Pro, `layer_norm` does not compile on the ANE at `[R, 4096]` (`ANECCompile() FAILED`, `err=11`), so that archetype's `peak` block has no `ane` key:

```
streaming (relu / x*2) -> ['ane', 'gpu', 'cpu']
gelu (light compute)   -> ['ane', 'gpu', 'cpu']
reduction (sum)        -> ['ane', 'gpu', 'cpu']
softmax                -> ['ane', 'gpu', 'cpu']
layer_norm             -> ['gpu', 'cpu']        <-- no 'ane'
```

`roofline_analysis.py:52` then raised `KeyError: 'ane'`, `--perf` lost its last step, and the table lost the GEMM, bandwidth and ridge columns even though every number had been measured and was sitting in the report.

This is not `--quick`-specific and not M2-specific. Any run where one archetype loses one engine loses the whole synthesis, and which key trips first depends on what that machine managed to measure.

## The fix

Skip absent devices instead of assuming three:

- `load_ceilings`: intersect with the keys actually present, in all three dicts (`compute`, `bandwidth`, `arche_bw`).
- `build_placement`: derive the device list from those with both a compute and a bandwidth roof, and guard the per-archetype lookup with `dev in arche_bw.get(bwname, {})` (the old `bwname in arche_bw` check passed while the inner `[dev]` still raised).
- ridge computation, the two print loops, and the sketch loop: drive off the resulting dicts rather than the literal triple.

Six call sites in total. Fixing only `load_ceilings` moves the `KeyError` downstream to lines 351/478/490/529/541, so all of them are needed.

## Verification

Driven against the exact two reference JSONs from an affected `--perf` run, so the input is the real failure, not a reconstruction:

| | result |
|---|---|
| Before | `KeyError: 'ane'` at `roofline_analysis.py:52` |
| After | `rc=0`, writes its JSON |

Recovered values, which are what `aggregate_rooflines` needs for the empty columns:

```
ANE gemm 3.26 TF/s | ANE bandwidth 0.96 GB/s | ANE ridge 3404.2
archetype layer_norm devs: ['CPU', 'GPU']      # degrades, does not raise
```

**Control, so this is not a behaviour change on healthy data:** with `layer_norm`'s ANE entry filled in, old and new produce a **byte-identical `ceilings`** block. `placement` differs slightly between any two runs, including the original against itself, because `achieved_gflops` comes from live benchmarks; the deterministic part is identical.

`ruff check` clean. `bench/` uses 4-space indent so pylint `W0311` fires there, but that is pre-existing (351 findings on `main`) and CI scopes that check to `aneforge tests`, so this diff keeps the surrounding style.

## Note

My original report on #146 misdiagnosed this as `--quick` dropping GPU from the sweeps. That was wrong, GPU is present throughout, and I corrected the issue. The `KeyError: 'GPU'` I first reproduced came from running the sweeps with `--quick` by hand, which is a different path from what the suite does.
