### PR TITLE
bench: mark decode 'n/a' when the ANE cannot run it

### DIFF
--- a/bench/aggregate_rooflines.py
+++ b/bench/aggregate_rooflines.py
@@ -99,7 +99,7 @@ def _perf_headline(report: dict) -> dict:
     device a sweep could not measure. The raw sweeps carry the same ANE peaks, so
     the headline still fills instead of showing three blanks."""
     h: dict = {"gemm_tflops": None, "bw_gbps": None, "ridge": None,
-               "perf_per_w": None, "decode_tok_s": None}
+               "perf_per_w": None, "decode_tok_s": None, "decode_blocked": False}
     ra = _perf_summary(report, "roofline_analysis.py")
     if ra:
         ceil = ra.get("ceilings") or {}
@@ -125,6 +125,10 @@ def _perf_headline(report: dict) -> dict:
                    if r.get("device") == "ANE" and r.get("batch") == 1), None)
         if b1:
             h["decode_tok_s"] = b1.get("tokens_per_s")
+            # decode ran but the ANE could not: e.g. the 32000-vocab lm_head exceeds an
+            # older family's matmul-dim limit. Distinguish that from "not measured".
+            if h["decode_tok_s"] is None and b1.get("status") not in (None, "ok"):
+                h["decode_blocked"] = True
     return h
 
 
@@ -213,6 +217,7 @@ def render(reports: list[dict]) -> str:
 
     # --- Performance rooflines (headline) ---
     perf_rows = []
+    any_decode_blocked = False
     for _, g in sorted(groups.items(), key=lambda kv: str(kv[1]["latest"]["machine"]["hardware"].get("chip"))):
         # use the most recent submission that carries perf data
         sub = next((r for r in reversed(g["submissions"]) if r.get("perf_rooflines")), None)
@@ -226,11 +231,17 @@ def render(reports: list[dict]) -> str:
 
         def _c(v, fmt):
             return format(v, fmt) if isinstance(v, (int, float)) else "-"
+        # decode: a number if it ran, "n/a" if the ANE could not run it (dim limit),
+        # "-" if simply not measured.
+        decode = _c(h["decode_tok_s"], ".0f")
+        if h["decode_tok_s"] is None and h.get("decode_blocked"):
+            decode = "n/a"
+            any_decode_blocked = True
         perf_rows.append(
             f"| {hw.get('chip','?')} | {hw.get('model_identifier','?')} "
             f"| {_c(h['gemm_tflops'], '.1f')} | {_c(h['bw_gbps'], '.2g')} "
             f"| {_c(h['ridge'], '.0f')} | {_c(h['perf_per_w'], '.0f')} "
-            f"| {_c(h['decode_tok_s'], '.0f')} | {power} |"
+            f"| {decode} | {power} |"
         )
 
     lines += ["## Performance rooflines (headline)", ""]
@@ -245,6 +256,13 @@ def render(reports: list[dict]) -> str:
             *perf_rows,
             "",
         ]
+        if any_decode_blocked:
+            lines += [
+                "_`n/a` decode = the decode benchmark's 32000-vocab lm_head matmul exceeds "
+                "that ANE family's 16384 max matmul dimension, so it cannot run untiled -- a "
+                "real per-generation limit (older families), not a missing measurement._",
+                "",
+            ]
     else:
         lines += ["_No `--perf` submissions yet. Run on AC power with "
                   "`python3 bench/roofline_suite.py --perf` (needs sudo for watts)._", ""]

--- a/bench/results/ROOFLINES.md
+++ b/bench/results/ROOFLINES.md
@@ -33,7 +33,9 @@ Peak ANE numbers only; the full per-size sweeps, all-engine comparison, and per-
 
 | Chip | Model | Peak fp16 GEMM (TF/s) | Bandwidth (GB/s) | Ridge (FLOP/byte) | Peak perf/W (GF/s/W) | Decode @b1 (tok/s) | Power |
 | --- | --- | --- | --- | --- | --- | --- | --- |
-| Apple M1 | MacBookPro17,1 | 2.7 | 0.86 | 3149 | 442 | - | ac |
-| Apple M2 Pro | Mac14,12 | 3.3 | 0.96 | 3404 | 1379 | - | ac |
+| Apple M1 | MacBookPro17,1 | 2.7 | 0.86 | 3149 | 442 | n/a | ac |
+| Apple M2 Pro | Mac14,12 | 3.3 | 0.96 | 3404 | 1379 | n/a | ac |
 | Apple M5 Pro | Mac17,8 | 10.0 | 24 | 418 | 918 | 117 | ac (high-power) |
+
+_`n/a` decode = the decode benchmark's 32000-vocab lm_head matmul exceeds that ANE family's 16384 max matmul dimension, so it cannot run untiled -- a real per-generation limit (older families), not a missing measurement._
 


### PR DESCRIPTION
The decode column in ROOFLINES.md showed a bare `-` on M1 and M2 Pro, which reads as 'not measured'. It is actually a **real per-generation ANE limit**: the decode benchmark's 32000-vocab lm_head matmul `(1, 32000)` exceeds those families' 16384 max matmul dimension, so it can't run untiled (`NotImplementedError`, already recorded in the decode row's `status`). M5 (family 5) runs it -> 117 tok/s.

Now the table shows `n/a` for the dim-limited case with a footnote, distinct from `-` (simply not submitted). Aggregator-only; ruff clean, `--check` green.

Getting an actual number on those chips would need tiling the lm_head into <=16384-wide chunks in `decode_measurement.py` -- doable, but that's a paper-repro script and a tiled lm_head isn't strictly comparable to M5's untiled one, so it's a separate, careful change (best done as a fallback that only triggers when the untiled compile fails, leaving M5 unchanged).