### PR TITLE
opt=1: decline the int8 variant above its activation-encoding ceiling

### DIFF
--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1093,6 +1093,25 @@ class CrossChipFP16Warning(UserWarning):
   """Emitted by `cross_compile_check` when a graph compiles for a different-family target but an op's fp16 value can diverge."""
 
 
+def _act_max_abs(out: Tensor):
+  """Static bound on the largest activation magnitude feeding `out`, or None if any leaf is unbounded.
+
+  Only baked constants carry a bound; a runtime `input` does not, so a graph with one returns None and
+  callers must treat that as unsafe (see `_optimize._exceeds_act_ceiling`)."""
+  seen, stack, worst = set(), [out], 0.0
+  while stack:
+    t = stack.pop()
+    if id(t) in seen: continue
+    seen.add(id(t))
+    if not t.srcs:                                   # leaf: const (bounded) or input (unbounded)
+      b = _node_max_abs(t)
+      if b is None: return None
+      worst = max(worst, b)
+      continue
+    stack.extend(t.srcs)
+  return worst
+
+
 def _node_max_abs(t: Tensor):
   """Static bound on a node's value magnitude: a baked const's max, else None."""
   v = t.attrs.get("value")
@@ -1247,8 +1266,9 @@ def _compile_opt(out: Tensor, int8: bool, opt):
   """opt=1/2/'max' dispatch (lazy-imported so aneforge imports without the optimizer)."""
   from . import _optimize
   if opt in (1,):
-    # cost-model pick: cheaper-predicted variant, no measurement.
-    cfgs = _optimize._variants(out)
+    # cost-model pick: cheaper-predicted variant, no measurement. Since nothing here validates the
+    # result, drop lossy variants whose activation-encoding ceiling this graph can exceed (#153).
+    cfgs = _optimize._variants(out, drop_unsafe=True)
     best = min(cfgs, key=lambda c: _optimize._estimate_variant(out, c))
     return _optimize.build_variant(out, best)
   if opt in (2, "max", "2"): return _optimize.tune(out)

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -273,8 +273,34 @@ def _route_configs(routes) -> list:
   return configs
 
 
-def _variants(out):
-  """Legal variant configs: route flips (lossless) + global int8 / const-fold / scalar-fold (lossy)."""
+# Activation-encoding ceiling per lossy variant: above it the variant saturates to inf rather than
+# losing accuracy. Keyed by config flag so int4-LUT / sparse can declare their own encodings; only
+# the int8-weight matmul is characterized so far (Q.4 x16, see #153).
+def _variant_act_ceiling(cfg) -> "float | None":
+  """The activation magnitude this variant can encode, or None if it has no such limit."""
+  from ._targets import Q4_X16_SAT
+  return Q4_X16_SAT if cfg.get("int8") else None
+
+
+def _exceeds_act_ceiling(out, cfg) -> bool:
+  """True if `cfg` cannot safely encode this graph's activations.
+
+  Fail closed on an unknown bound, matching `_targets.py`'s slice-saturation rule: a runtime input
+  has no static bound, so it must be treated as unsafe rather than assumed small. Without this an
+  unbounded activation silently saturates to inf at opt=1, which never runs the accuracy gate."""
+  ceiling = _variant_act_ceiling(cfg)
+  if ceiling is None: return False
+  from ._compile import _act_max_abs
+  bound = _act_max_abs(out)
+  return bound is None or float(bound) > ceiling
+
+
+def _variants(out, drop_unsafe: bool = False):
+  """Legal variant configs: route flips (lossless) + global int8 / const-fold / scalar-fold (lossy).
+
+  `drop_unsafe` removes lossy variants whose activation-encoding ceiling this graph can exceed. The
+  cost-model-only path (opt=1) needs it because nothing downstream validates the variant; opt=2
+  leaves it off and rejects on measured error instead."""
   configs = _route_configs(_route_ids(out))
   if _has_weights(out):
     configs.append({"int8": True, "decomp": [], "lossy": True})   # PRIMARY: global int8
@@ -284,6 +310,8 @@ def _variants(out):
   sf = _scalarchain_candidates(out)
   if sf:
     configs.append({"int8": False, "decomp": [], "scalarfold": sf, "lossy": True})
+  if drop_unsafe:
+    configs = [c for c in configs if not _exceeds_act_ceiling(out, c)]
   return configs
 
 

--- a/aneforge/_targets.py
+++ b/aneforge/_targets.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 __all__ = ["Family", "MIN_FAMILY", "supports_mil", "family_of_arch", "arch_for_family",
            "op_status", "has_texture_engine", "limit", "OpReport", "Preflight",
            "preflight", "detect_family", "predict_fp16_divergence", "FP16_SLICE_SAT",
-           "native_streams"]
+           "Q4_X16_SAT", "native_streams"]
 
 
 class Family(IntEnum):
@@ -179,8 +179,14 @@ def limit(name: str, family: int) -> int:
 # Cross-chip fp16 VALUE divergence comes only from HAL-data-selected codegen routes that
 # reorder/saturate fp16 ops, predictable from a few per-family HAL fields.
 
-# fp16 max / 16 = 65504/16: the slice-x16 Q.4 crop-DMA saturation threshold (finite->inf).
-FP16_SLICE_SAT = 4094.0
+# fp16 max / 16 = 65504/16: the Q.4 x16 activation encoding's range (finite->inf past it). Measured
+# identical on M1 Max / M2 Pro / M5 Pro, and invariant to weight scale, K, N and seed, so it is the
+# encoding's fixed range rather than an accumulation cliff. Shared by the slice-x16 crop-DMA path and
+# the int8-weight matmul variant, which routes activations through the same encoding (see #153).
+# The flip is between the adjacent fp16 representables 4094 and 4096 (fp16 spacing is 2 there, so
+# 4095 rounds to 4096), which makes `|act| <= Q4_X16_SAT` an exact gate with no boundary gap.
+Q4_X16_SAT = 4094.0
+FP16_SLICE_SAT = Q4_X16_SAT        # back-compat alias: the slice path's name for the same encoding
 
 _HAL_FIELDS = {
   # 0x494 reduce->square fusion: silicon-measured no-op; kept uniform 0 so the predictor never flags it.

--- a/tests/test_opt1_act_ceiling.py
+++ b/tests/test_opt1_act_ceiling.py
@@ -1,0 +1,71 @@
+"""opt=1 must decline a lossy variant whose activation-encoding ceiling the graph can exceed (#153).
+
+Build-level: no dispatch, so these run in CI without an ANE. The on-device consequence (opt=1
+returning inf on a bounded matmul) is covered by bench/opt1_int8_saturation_repro.py.
+"""
+import numpy as np
+import pytest
+
+import aneforge as af
+from aneforge import _optimize
+from aneforge._compile import _act_max_abs
+from aneforge._targets import FP16_SLICE_SAT, Q4_X16_SAT
+from aneforge.graph import _const
+
+W = (np.random.default_rng(0).standard_normal((15, 16)) / 4).astype(np.float16)
+
+
+def _labels(cfgs):
+  return {"int8" if c.get("int8") else "other" for c in cfgs}
+
+
+def test_ceiling_is_pinned_at_4094():
+  """The Q.4 x16 encoding range, measured identical on M1 Max / M2 Pro / M5 Pro and invariant to
+  weight scale, K, N and seed. 4095 is not representable in fp16 (spacing is 2 there), so the gate
+  sits exactly between the adjacent representables 4094 and 4096."""
+  assert Q4_X16_SAT == 4094.0
+  assert FP16_SLICE_SAT == Q4_X16_SAT, "the slice path and the int8 variant share one encoding"
+  assert np.float16(4095) == np.float16(4096), "no fp16 activation lies between 4094 and 4096"
+
+
+def test_ceiling_is_per_variant_not_global():
+  """int4-LUT / sparse may encode differently, so the ceiling is keyed by variant, and a variant
+  with no encoding limit reports None rather than inheriting int8's."""
+  assert _optimize._variant_act_ceiling({"int8": True}) == Q4_X16_SAT
+  assert _optimize._variant_act_ceiling({"int8": False}) is None
+  assert _optimize._variant_act_ceiling({"int8": False, "constfold": [0]}) is None
+
+
+def test_runtime_input_has_no_static_bound():
+  assert _act_max_abs(af.input((31, 15)) @ W) is None
+
+def test_const_fed_graph_is_bounded():
+  assert _act_max_abs(_const((np.ones((31, 15)) * 10.0).astype(np.float16)) @ W) == pytest.approx(10.0)
+
+
+def test_opt1_declines_int8_for_runtime_input():
+  """Fail closed on an unknown bound, matching the slice-saturation rule in _targets.py."""
+  out = af.input((31, 15)) @ W
+  assert "int8" in _labels(_optimize._variants(out)), "int8 is offered without the gate"
+  assert "int8" not in _labels(_optimize._variants(out, drop_unsafe=True))
+
+def test_opt1_declines_int8_above_the_ceiling():
+  out = _const((np.ones((31, 15)) * 5000.0).astype(np.float16)) @ W
+  assert "int8" not in _labels(_optimize._variants(out, drop_unsafe=True))
+
+def test_opt1_keeps_int8_below_the_ceiling():
+  """The gate must not be a blanket ban: a bounded const-fed graph still gets the cheap variant."""
+  out = _const((np.ones((31, 15)) * 10.0).astype(np.float16)) @ W
+  assert "int8" in _labels(_optimize._variants(out, drop_unsafe=True))
+
+@pytest.mark.parametrize("scale,expect_int8", [(4094.0, True), (4096.0, False)])
+def test_gate_boundary_is_exact(scale, expect_int8):
+  """At the encoding boundary: 4094 encodes, the next representable does not."""
+  out = _const((np.ones((31, 15)) * scale).astype(np.float16)) @ W
+  assert ("int8" in _labels(_optimize._variants(out, drop_unsafe=True))) is expect_int8
+
+
+def test_opt2_still_offers_lossy_variants():
+  """opt=2 measures and rejects on error, so it must keep int8 available (no drop_unsafe there)."""
+  out = af.input((31, 15)) @ W
+  assert "int8" in _labels(_optimize._variants(out))


### PR DESCRIPTION
Fixes #153. Implements option 1 with the fail-closed rule on an unknown bound, per your design call, plus the three asks that came with it.

## The bug

`opt=1` selects on predicted cost and never measures (`_compile._compile_opt`), so nothing validated the lossy int8 variant. A matmul whose true sums sit inside fp16 range came back with `inf`:

```
[31,15] @ [15,16], true |x|@|W| max = 30133   (fp16 cliff is ~32760)
  opt=0: 0/496 non-finite
  opt=1: 179/496 non-finite       <- int8 variant won on cost, unvalidated
```

## The three asks

**Share the constant, don't add a second 4094.** `_targets.FP16_SLICE_SAT` becomes `Q4_X16_SAT`, naming the encoding rather than the slice op, with the old name kept as an alias so nothing outside breaks. Your invariance result is what justifies this: the ceiling not moving with weight scale, K, N or seed means the int8-weight matmul is routing activations through the same Q.4 x16 encoding, so one constant is correct rather than a coincidence.

**Per-variant, not global.** `_variant_act_ceiling(cfg)` is keyed by config flag and returns `None` for variants with no encoding limit, so int4-LUT and sparse can declare their own ceilings without inheriting int8's. A test pins that `{"int8": False}` and const-fold report `None`.

**Pin 4094 in a regression test.** Done, including the exactness argument: `np.float16(4095) == np.float16(4096)`, so no fp16 activation lies between 4094 and 4096 and `|act| <= 4094` is a gate with no boundary gap. Parametrized either side of it.

## How the bound is computed

`_node_max_abs` only ever bounded a single node, so it could not answer "what is the largest activation in this graph". Added `_act_max_abs`, which walks to the leaves and returns `None` if any leaf is a runtime `input`. `_exceeds_act_ceiling` then treats `None` as unsafe, mirroring the precedent you pointed at (`_targets.py:215`):

```python
if max_abs is None or float(max_abs) > FP16_SLICE_SAT: return "saturation"
```

`_variants(out, drop_unsafe=True)` filters on that, and only the `opt=1` path passes the flag. `opt=2` is untouched, since it validates by measurement and was already safe.

## Verification

Apple M2 Pro (Mac14,12 Mac mini), macOS 26.5.2.

The repro is fixed, and `opt=1` now matches `opt=0` exactly:

```
  opt=0: 0/496 non-finite, max 29280.0
  opt=1: 0/496 non-finite, max 29280.0      (was 179/496)
```

**It is a gate, not a ban.** int8 still survives at `opt=1` where it is safe:

| graph | static bound | int8 offered |
|---|---|---|
| runtime `input` | `None` | no (fail closed) |
| const-fed, 10.0 | 10.0 | **yes** |
| const-fed, 5000.0 | 5000.0 | no |
| const-fed, 4094.0 | 4094.0 | **yes** |
| const-fed, 4096.0 | 4096.0 | no |

| Check | Result |
|---|---|
| `tests/test_opt1_act_ceiling.py` | 10 passed, all build-level so they run in CI without an ANE |
| `test_routes`, `test_tune_guards`, `test_compile_targets` | 36 passed |
| `tests/run_corpus.py` | **GATE: GREEN, 90/90** |
| `ruff` / `pyright aneforge` / pre-commit | clean (pyright's 9 findings are the pre-existing optional-import ones) |

Behaviour gap confirmed on `main` through the public API rather than by a stashed-file run, which only produces a collection error: `_variants` has no `drop_unsafe` parameter there and offers int8 unconditionally.

## On the cost, honestly

You flagged that on any graph with runtime inputs the bound is `None`, so this declines int8 at `opt=1` nearly always, landing close to option 3 in practice. That matches what I see, and I have not measured the throughput given up on real `opt=1` workloads either, so I would not claim the cost is negligible. Two things make me still prefer this shape: it keeps int8 available for const-fed subgraphs today, and it is the right structure once input ranges can be declared, which is the change that makes this meaningfully different from option 3. Happy to switch to option 2 (single probe dispatch, reject on non-finite) if you would rather trade a dispatch for the throughput.

Declaring an input range looks worth its own issue, as you said. Say the word and I will file it with this PR as context.

## Not in this PR

The fail-closed `not (relerr <= tol)` change on the `opt=2` path, which you asked for as a separate small PR since it is independently merge-worthy rather than a fix for this. Sending that next.
