### PR TITLE
bench: breaker-controlled probe for the layer_norm ANE compile failure

### DIFF
--- a/bench/layer_norm_compile_probe.py
+++ b/bench/layer_norm_compile_probe.py
@@ -3,13 +3,20 @@
 The naive sweep is confounded: after one compile failure the circuit breaker paces the next compile
 (`ANEFORGE_COMPILE_BACKOFF`), so a single early failure makes later shapes look like they fail too.
 This runs **one compile per fresh process** with the breaker disabled, which is the only way to get a
-per-shape answer.
+per-shape answer, and reports the chip so cells are comparable across generations (per the scoping
+note on #115).
 
-  python bench/layer_norm_compile_probe.py --one R D      # single attempt, prints OK / FAIL
-  python bench/layer_norm_compile_probe.py                # the R x D matrix, one subprocess per cell
-  python bench/layer_norm_compile_probe.py --repeat 5 --one 256 3994   # determinism check
+  python bench/layer_norm_compile_probe.py                      # the R x D matrix
+  python bench/layer_norm_compile_probe.py --scan-d 512         # D-scan at fixed R: finds the
+                                                                # scattered cells a matrix misses
+  python bench/layer_norm_compile_probe.py --op rms_norm --scan-d 512   # is it layer_norm-specific?
+  python bench/layer_norm_compile_probe.py --one 256 3994 --repeat 5    # determinism check
 
-Reports the chip so results are comparable across generations, per the scoping note on #115.
+Findings so far, every cell deterministic across repeats: M1 Max and M2 Pro are indistinguishable and
+fail a *scattered* set of D at fixed R, non-monotonic in both axes ([512,1024] fails while [512,8192]
+passes with 16x the elements). M5 Pro passes all of those and fails only past a clean threshold
+between 8192 and 10240. rms_norm and softmax compile where layer_norm does not, so the trigger is
+layer_norm's own decomposition rather than reduce-over-last-axis in general.
 """
 from __future__ import annotations
 
@@ -20,10 +27,12 @@ import sys
 
 RS = (64, 128, 256, 512)
 DS = (1024, 2048, 3072, 4096)
+SCAN_DS = (512, 768, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 5120, 6144, 8192, 10240, 12288, 16384)
+OPS = ("layer_norm", "rms_norm", "softmax")
 
 
-def _attempt(R: int, D: int, seed: int = 13) -> str:
-  """One compile+dispatch of layer_norm at [R, D]; returns 'OK' or 'FAIL <ExcType>'."""
+def _attempt(R: int, D: int, op: str, seed: int = 13) -> str:
+  """One compile+dispatch of `op` at [R, D]; returns 'OK' or 'FAIL <ExcType>'."""
   os.environ["ANEFORGE_DISABLE_COMPILE_BREAKER"] = "1"   # one compile per process: nothing to pace
   os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
   import warnings
@@ -33,20 +42,28 @@ def _attempt(R: int, D: int, seed: int = 13) -> str:
   import aneforge as af
 
   rng = np.random.default_rng(seed)
-  g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
-  b = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
+  x = af.input((R, D))
+  if op == "layer_norm":
+    g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+    b = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
+    graph = x.layer_norm(g, b)
+  elif op == "rms_norm":
+    g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+    graph = x.rms_norm(g)
+  else:
+    graph = x.softmax(-1)
   try:
-    net = af.compile(af.input((R, D)).layer_norm(g, b))
+    net = af.compile(graph)
     out = np.asarray(net(rng.standard_normal((R, D)).astype(np.float16)), np.float32)
     return "OK" if np.isfinite(out).all() else "FAIL nonfinite"
   except Exception as e:                                # noqa: BLE001 - any failure is the datum
     return f"FAIL {type(e).__name__}"
 
 
-def _subprocess_attempt(R: int, D: int) -> str:
+def _isolated(R: int, D: int, op: str) -> str:
   """Run _attempt in a fresh interpreter so no compiler or breaker state carries over."""
   env = dict(os.environ, PYTHONPATH=os.environ.get("PYTHONPATH", "."))
-  p = subprocess.run([sys.executable, __file__, "--one", str(R), str(D)],
+  p = subprocess.run([sys.executable, __file__, "--op", op, "--one", str(R), str(D)],
                      capture_output=True, text=True, env=env)
   for line in reversed(p.stdout.splitlines()):          # stderr carries E5RT noise; parse stdout
     if line.startswith(("OK", "FAIL")):
@@ -54,40 +71,61 @@ def _subprocess_attempt(R: int, D: int) -> str:
   return "FAIL nolines"
 
 
+def _chip() -> str:
+  try:
+    from bench import _machine
+    return _machine.fingerprint()["hardware"]["chip"]
+  except Exception:                                     # noqa: BLE001 - the probe works without it
+    return "unknown chip"
+
+
 def main() -> int:
   ap = argparse.ArgumentParser()
   ap.add_argument("--one", nargs=2, type=int, metavar=("R", "D"))
+  ap.add_argument("--scan-d", type=int, metavar="R", help="sweep D at this fixed R")
+  ap.add_argument("--op", choices=OPS, default="layer_norm")
   ap.add_argument("--repeat", type=int, default=1)
   args = ap.parse_args()
 
-  if args.one and args.repeat == 1:
-    print(_attempt(*args.one))
+  if args.one and args.repeat == 1:                     # the subprocess worker
+    print(_attempt(args.one[0], args.one[1], args.op))
     return 0
 
-  try:
-    from bench import _machine
-    chip = _machine.fingerprint()["hardware"]["chip"]
-  except Exception:                                     # noqa: BLE001 - probe still works without it
-    chip = "unknown chip"
+  chip = _chip()
 
   if args.one:
     R, D = args.one
-    res = [_subprocess_attempt(R, D) for _ in range(args.repeat)]
-    print(f"{chip}  [{R},{D}] x{args.repeat}: " + "  ".join(res))
+    res = [_isolated(R, D, args.op) for _ in range(args.repeat)]
+    print(f"{chip}  {args.op} [{R},{D}] x{args.repeat}: " + "  ".join(res))
     return 0
 
-  print(f"{chip}: layer_norm compile, one fresh process per cell, breaker disabled\n")
+  if args.scan_d:
+    R = args.scan_d
+    print(f"{chip}: {args.op} at R={R}, one fresh process per cell, breaker disabled\n")
+    fails = []
+    for D in SCAN_DS:
+      res = _isolated(R, D, args.op)
+      print(f"  [{R:5d},{D:6d}]  {res}")
+      if res.startswith("FAIL"):
+        fails.append(D)
+    print(f"\n{len(SCAN_DS) - len(fails)}/{len(SCAN_DS)} compile."
+          + (f" Failing D: {fails}" if fails else " No failures."))
+    if len(fails) > 1 and fails != list(SCAN_DS[-len(fails):]):
+      print("Failing D is a scattered set rather than a tail, so no threshold in D explains it.")
+    return 0
+
+  print(f"{chip}: {args.op} compile, one fresh process per cell, breaker disabled\n")
   print("        " + "".join(f"D={d:<7}" for d in DS))
   grid = {}
   for R in RS:
     cells = []
     for D in DS:
-      grid[(R, D)] = res = _subprocess_attempt(R, D)
+      grid[(R, D)] = res = _isolated(R, D, args.op)
       cells.append(res.split()[0])
     print(f"  R={R:<5}" + "".join(f"{c:<9}" for c in cells))
   ok = sum(1 for v in grid.values() if v == "OK")
-  print(f"\n{ok}/{len(grid)} shapes compile. Non-monotonic in both axes means this is not a "
-        f"size cap: see issue #149.")
+  print(f"\n{ok}/{len(grid)} shapes compile. Non-monotonic in both axes means this is not a size "
+        f"cap; --scan-d finds the scattered cells a fixed matrix misses. See issue #149.")
   return 0
 
 

--- a/bench/layer_norm_compile_probe.py
+++ b/bench/layer_norm_compile_probe.py
@@ -1,0 +1,95 @@
+"""Breaker-controlled probe for the layer_norm ANE compile failure (issue #149).
+
+The naive sweep is confounded: after one compile failure the circuit breaker paces the next compile
+(`ANEFORGE_COMPILE_BACKOFF`), so a single early failure makes later shapes look like they fail too.
+This runs **one compile per fresh process** with the breaker disabled, which is the only way to get a
+per-shape answer.
+
+  python bench/layer_norm_compile_probe.py --one R D      # single attempt, prints OK / FAIL
+  python bench/layer_norm_compile_probe.py                # the R x D matrix, one subprocess per cell
+  python bench/layer_norm_compile_probe.py --repeat 5 --one 256 3994   # determinism check
+
+Reports the chip so results are comparable across generations, per the scoping note on #115.
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import sys
+
+RS = (64, 128, 256, 512)
+DS = (1024, 2048, 3072, 4096)
+
+
+def _attempt(R: int, D: int, seed: int = 13) -> str:
+  """One compile+dispatch of layer_norm at [R, D]; returns 'OK' or 'FAIL <ExcType>'."""
+  os.environ["ANEFORGE_DISABLE_COMPILE_BREAKER"] = "1"   # one compile per process: nothing to pace
+  os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+  import warnings
+
+  import numpy as np
+  warnings.filterwarnings("ignore")
+  import aneforge as af
+
+  rng = np.random.default_rng(seed)
+  g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+  b = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
+  try:
+    net = af.compile(af.input((R, D)).layer_norm(g, b))
+    out = np.asarray(net(rng.standard_normal((R, D)).astype(np.float16)), np.float32)
+    return "OK" if np.isfinite(out).all() else "FAIL nonfinite"
+  except Exception as e:                                # noqa: BLE001 - any failure is the datum
+    return f"FAIL {type(e).__name__}"
+
+
+def _subprocess_attempt(R: int, D: int) -> str:
+  """Run _attempt in a fresh interpreter so no compiler or breaker state carries over."""
+  env = dict(os.environ, PYTHONPATH=os.environ.get("PYTHONPATH", "."))
+  p = subprocess.run([sys.executable, __file__, "--one", str(R), str(D)],
+                     capture_output=True, text=True, env=env)
+  for line in reversed(p.stdout.splitlines()):          # stderr carries E5RT noise; parse stdout
+    if line.startswith(("OK", "FAIL")):
+      return line.strip()
+  return "FAIL nolines"
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser()
+  ap.add_argument("--one", nargs=2, type=int, metavar=("R", "D"))
+  ap.add_argument("--repeat", type=int, default=1)
+  args = ap.parse_args()
+
+  if args.one and args.repeat == 1:
+    print(_attempt(*args.one))
+    return 0
+
+  try:
+    from bench import _machine
+    chip = _machine.fingerprint()["hardware"]["chip"]
+  except Exception:                                     # noqa: BLE001 - probe still works without it
+    chip = "unknown chip"
+
+  if args.one:
+    R, D = args.one
+    res = [_subprocess_attempt(R, D) for _ in range(args.repeat)]
+    print(f"{chip}  [{R},{D}] x{args.repeat}: " + "  ".join(res))
+    return 0
+
+  print(f"{chip}: layer_norm compile, one fresh process per cell, breaker disabled\n")
+  print("        " + "".join(f"D={d:<7}" for d in DS))
+  grid = {}
+  for R in RS:
+    cells = []
+    for D in DS:
+      grid[(R, D)] = res = _subprocess_attempt(R, D)
+      cells.append(res.split()[0])
+    print(f"  R={R:<5}" + "".join(f"{c:<9}" for c in cells))
+  ok = sum(1 for v in grid.values() if v == "OK")
+  print(f"\n{ok}/{len(grid)} shapes compile. Non-monotonic in both axes means this is not a "
+        f"size cap: see issue #149.")
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
For #149, with the `--scan-d` and `--op` modes you and @diegobauavi both asked for.

`bench/layer_norm_compile_probe.py` runs **one compile per fresh subprocess** with `ANEFORGE_DISABLE_COMPILE_BREAKER=1`, which is what makes per-shape answers trustworthy: in a single long-lived process the breaker paces every compile after the first failure, so a naive sweep reports failures that are really just pacing.

```
python bench/layer_norm_compile_probe.py                    # R x D matrix
python bench/layer_norm_compile_probe.py --scan-d 512       # D-scan at fixed R
python bench/layer_norm_compile_probe.py --op rms_norm --scan-d 512
python bench/layer_norm_compile_probe.py --one 256 3994 --repeat 5
```

The scan also prints whether the failing set is a tail or scattered, since that distinction is the whole argument against a size cap.

## New M2 Pro data this run produced

**The M1 Max pattern reproduces exactly on M2 Pro.** R=512 D-scan, 8/15 compile:

```
  D:  512  768  1024  1536  2048  2560  3072  3584  4096  5120  6144  8192  10240  12288  16384
      OK   OK   FAIL  FAIL  OK    FAIL  OK    OK    FAIL  OK    OK    OK    FAIL   FAIL   FAIL
```

Failing D is `[1024, 1536, 2560, 4096, 10240, 12288, 16384]`, scattered rather than a tail, and `[512,8192]` compiles with **16x** the elements of `[512,1024]` which fails. That is the same set @diegobauavi measured on M1 Max, so M1 ≡ M2 holds cell for cell on the scan too, not just on the 4x4 matrix.

**The layer_norm-specificity extends to M2.** You asked whether `rms_norm`/`softmax` pass on M1/M2 where `layer_norm` fails. On M2 Pro they do, at all four cells:

```
                [512,1024]  [512,1536]  [512,2560]  [512,4096]
  layer_norm    FAIL        FAIL        FAIL        FAIL
  rms_norm      OK          OK          OK          OK
  softmax       OK          OK          OK          OK
```

So it is `layer_norm`'s decomposition across all three generations, not reduce-over-last-axis in general, and the fix surface really is that one lowering.

## What the probe corrected

Both caveats in the issue text were mine from #146 and both were wrong, which is worth stating since the issue still carries them:

- **Not intermittent.** Deterministic 5/5 per shape. `[2048,4096]` passing once and failing later was breaker contamination inside one process.
- **Not a shape threshold.** Non-monotonic in both axes, and single-element steps flip it (D=3993 ok, 3994 fail, 3995 ok, 3996 fail at R=256).

## Scope

Tooling only: nothing under `aneforge/` is touched, so there is no library behaviour change and nothing to regress. `ruff` and the pre-commit hook are clean. It is a `bench/` script rather than a test because the interesting output is a table to read, not an assertion, and because the failing cells are per-generation, so pinning them would encode M2's set as if it were universal.

Not done, and I did not want to guess at it: `ANEFORGE_COMPILE_BREAKER_STRICT` may change behaviour here, and I have not looked at whether the bad factorizations are visible in the emitted MIL, which is probably where the actual root cause lives.
