### PR TITLE
bench: fix layer_norm probe -- affine/seed axes + corrected docstring (#149)

### DIFF
--- a/bench/layer_norm_compile_probe.py
+++ b/bench/layer_norm_compile_probe.py
@@ -39,9 +39,10 @@ SCAN_DS = (512, 768, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 5120, 6144, 8192,
 OPS = ("layer_norm", "rms_norm", "softmax")
 GAMMAS = ("rand", "ones", "const")     # const = 1.1 (folds); ones = identity scale
 BETAS = ("rand", "zeros", "const")     # const = 0.1 (folds); zeros = no shift
-# the affine 2x2 (+ rms control) that separates the two bugs; each is (label, gamma, beta)
+# the affine 2x2 (+ rms control) that separates the two bugs; each is (label, gamma, beta).
+# rms_norm ignores beta, so its beta is a valid-but-unused placeholder ("zeros").
 AFFINE_CONFIGS = (("cc", "const", "const"), ("rz", "rand", "zeros"),
-                  ("or", "ones", "rand"), ("rr", "rand", "rand"), ("rms", "rand", "-"))
+                  ("or", "ones", "rand"), ("rr", "rand", "rand"), ("rms", "rand", "zeros"))
 
 
 def _attempt(R: int, D: int, op: str, seed: int, gamma: str, beta: str) -> str:

--- a/bench/layer_norm_compile_probe.py
+++ b/bench/layer_norm_compile_probe.py
@@ -1,22 +1,30 @@
-"""Breaker-controlled probe for the layer_norm ANE compile failure (issue #149).
+"""Probe for the layer_norm ANE compile/execute failure (issue #149).
 
-The naive sweep is confounded: after one compile failure the circuit breaker paces the next compile
-(`ANEFORGE_COMPILE_BACKOFF`), so a single early failure makes later shapes look like they fail too.
-This runs **one compile per fresh process** with the breaker disabled, which is the only way to get a
-per-shape answer, and reports the chip so cells are comparable across generations (per the scoping
-note on #115).
+IMPORTANT (corrects earlier readings in #149): the failure is NOT a shape frontier. It depends on the
+gamma/beta AFFINE values, and the "scattered non-monotonic frontier" first reported was the signature
+of one specific affine -- `numpy.default_rng(13)` with both gamma and beta non-constant, the config an
+earlier version of this probe hardcoded. Verified across three families (M1 Max, M2 Pro, M5 Pro), the
+2x2 over affine constant-ness (`--affine-scan`) separates two distinct, family-specific bugs:
 
-  python bench/layer_norm_compile_probe.py                      # the R x D matrix
-  python bench/layer_norm_compile_probe.py --scan-d 512         # D-scan at fixed R: finds the
-                                                                # scattered cells a matrix misses
-  python bench/layer_norm_compile_probe.py --op rms_norm --scan-d 512   # is it layer_norm-specific?
-  python bench/layer_norm_compile_probe.py --one 256 3994 --repeat 5    # determinism check
+  - M1 / M2 (compile stage): layer_norm compile-fails whenever EXACTLY ONE affine term is
+    non-constant (one folded, one live). Uniform -- no shape or seed dependence. A constant term
+    folds out, so this is a bug in the affine-emission/fold interaction of the lowering.
+  - M5 (execute stage): with BOTH terms live and large D (>=~10240) the compiled program fails to
+    execute (rc=-1). Seed-dependent at the edge, not a clean threshold.
 
-Findings so far, every cell deterministic across repeats: M1 Max and M2 Pro are indistinguishable and
-fail a *scattered* set of D at fixed R, non-monotonic in both axes ([512,1024] fails while [512,8192]
-passes with 16x the elements). M5 Pro passes all of those and fails only past a clean threshold
-between 8192 and 10240. rms_norm and softmax compile where layer_norm does not, so the trigger is
-layer_norm's own decomposition rather than reduce-over-last-axis in general.
+M1/M2 and M5 are exact opposites on the asymmetric configs (M1/M2 fail, M5 passes). rms_norm and
+softmax never fail here: rms_norm has a single affine slot (it can never be asymmetric) and softmax
+has none -- so "layer_norm-specific" is really "needs layer_norm's two-term affine".
+
+Method: one compile per FRESH process with the circuit breaker disabled (a compile failure otherwise
+paces the next compile via `ANEFORGE_COMPILE_BACKOFF`, making later shapes look failed too). The chip
+and seed are reported so cells are comparable across generations (per the #115 scoping note).
+
+  python bench/layer_norm_compile_probe.py --affine-scan 512      # the 2x2 x D table (the useful one)
+  python bench/layer_norm_compile_probe.py --scan-d 512           # D-scan, current --gamma/--beta
+  python bench/layer_norm_compile_probe.py --one 512 10240 --repeat 5   # determinism at one cell
+  python bench/layer_norm_compile_probe.py --scan-d 512 --seed 7  # vary the affine seed
+  python bench/layer_norm_compile_probe.py --op rms_norm --scan-d 512   # a single-slot control
 """
 from __future__ import annotations
 
@@ -29,10 +37,18 @@ RS = (64, 128, 256, 512)
 DS = (1024, 2048, 3072, 4096)
 SCAN_DS = (512, 768, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 5120, 6144, 8192, 10240, 12288, 16384)
 OPS = ("layer_norm", "rms_norm", "softmax")
+GAMMAS = ("rand", "ones", "const")     # const = 1.1 (folds); ones = identity scale
+BETAS = ("rand", "zeros", "const")     # const = 0.1 (folds); zeros = no shift
+# the affine 2x2 (+ rms control) that separates the two bugs; each is (label, gamma, beta)
+AFFINE_CONFIGS = (("cc", "const", "const"), ("rz", "rand", "zeros"),
+                  ("or", "ones", "rand"), ("rr", "rand", "rand"), ("rms", "rand", "-"))
 
 
-def _attempt(R: int, D: int, op: str, seed: int = 13) -> str:
-  """One compile+dispatch of `op` at [R, D]; returns 'OK' or 'FAIL <ExcType>'."""
+def _attempt(R: int, D: int, op: str, seed: int, gamma: str, beta: str) -> str:
+  """One compile+dispatch at [R,D]; returns 'OK', 'C-FAIL ...' (compile) or 'D-FAIL ...' (dispatch).
+
+  gamma/beta are drawn single-stream (gamma then beta) from `seed` so beta is identical regardless of
+  the gamma choice, matching how a real learned affine and the original probe are constructed."""
   os.environ["ANEFORGE_DISABLE_COMPILE_BREAKER"] = "1"   # one compile per process: nothing to pace
   os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
   import warnings
@@ -42,33 +58,42 @@ def _attempt(R: int, D: int, op: str, seed: int = 13) -> str:
   import aneforge as af
 
   rng = np.random.default_rng(seed)
+  g_rand = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+  b_rand = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
+  g = {"rand": g_rand, "ones": np.ones(D, np.float16), "const": np.full(D, 1.1, np.float16)}[gamma]
   x = af.input((R, D))
-  if op == "layer_norm":
-    g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
-    b = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
-    graph = x.layer_norm(g, b)
-  elif op == "rms_norm":
-    g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+  if op == "rms_norm":
     graph = x.rms_norm(g)
-  else:
+  elif op == "softmax":
     graph = x.softmax(-1)
+  else:
+    b = {"rand": b_rand, "zeros": np.zeros(D, np.float16), "const": np.full(D, 0.1, np.float16)}[beta]
+    graph = x.layer_norm(g, b)
   try:
     net = af.compile(graph)
-    out = np.asarray(net(rng.standard_normal((R, D)).astype(np.float16)), np.float32)
-    return "OK" if np.isfinite(out).all() else "FAIL nonfinite"
   except Exception as e:                                # noqa: BLE001 - any failure is the datum
-    return f"FAIL {type(e).__name__}"
+    return f"C-FAIL {type(e).__name__}"
+  try:
+    out = np.asarray(net(rng.standard_normal((R, D)).astype(np.float16)), np.float32)
+    return "OK" if np.isfinite(out).all() else "D-FAIL nonfinite"
+  except Exception as e:                                # noqa: BLE001
+    return f"D-FAIL {type(e).__name__}"
 
 
-def _isolated(R: int, D: int, op: str) -> str:
+def _isolated(R: int, D: int, op: str, seed: int, gamma: str, beta: str) -> str:
   """Run _attempt in a fresh interpreter so no compiler or breaker state carries over."""
   env = dict(os.environ, PYTHONPATH=os.environ.get("PYTHONPATH", "."))
-  p = subprocess.run([sys.executable, __file__, "--op", op, "--one", str(R), str(D)],
+  p = subprocess.run([sys.executable, __file__, "--worker", "--op", op, "--seed", str(seed),
+                      "--gamma", gamma, "--beta", beta, "--one", str(R), str(D)],
                      capture_output=True, text=True, env=env)
   for line in reversed(p.stdout.splitlines()):          # stderr carries E5RT noise; parse stdout
-    if line.startswith(("OK", "FAIL")):
+    if line.startswith(("OK", "C-FAIL", "D-FAIL")):
       return line.strip()
-  return "FAIL nolines"
+  return "C-FAIL nolines"
+
+
+def _short(res: str) -> str:
+  return res.split()[0]
 
 
 def _chip() -> str:
@@ -80,52 +105,70 @@ def _chip() -> str:
 
 
 def main() -> int:
-  ap = argparse.ArgumentParser()
+  ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
   ap.add_argument("--one", nargs=2, type=int, metavar=("R", "D"))
   ap.add_argument("--scan-d", type=int, metavar="R", help="sweep D at this fixed R")
+  ap.add_argument("--affine-scan", type=int, metavar="R", help="2x2 affine (+ rms) x D table at fixed R")
   ap.add_argument("--op", choices=OPS, default="layer_norm")
+  ap.add_argument("--seed", type=int, default=13, help="affine (and input) RNG seed")
+  ap.add_argument("--gamma", choices=GAMMAS, default="rand")
+  ap.add_argument("--beta", choices=BETAS, default="rand")
   ap.add_argument("--repeat", type=int, default=1)
+  ap.add_argument("--worker", action="store_true", help="internal: single compile, print result")
   args = ap.parse_args()
 
-  if args.one and args.repeat == 1:                     # the subprocess worker
-    print(_attempt(args.one[0], args.one[1], args.op))
+  if args.worker and args.one:                          # the subprocess worker
+    print(_attempt(args.one[0], args.one[1], args.op, args.seed, args.gamma, args.beta))
     return 0
 
   chip = _chip()
+  tag = f"{args.op} gamma={args.gamma} beta={args.beta} seed={args.seed}"
 
   if args.one:
     R, D = args.one
-    res = [_isolated(R, D, args.op) for _ in range(args.repeat)]
-    print(f"{chip}  {args.op} [{R},{D}] x{args.repeat}: " + "  ".join(res))
+    res = [_isolated(R, D, args.op, args.seed, args.gamma, args.beta) for _ in range(args.repeat)]
+    print(f"{chip}  {tag} [{R},{D}] x{args.repeat}: " + "  ".join(res))
+    return 0
+
+  if args.affine_scan:
+    R = args.affine_scan
+    print(f"{chip}  R={R}  seed={args.seed}   (C-FAIL=compile, D-FAIL=dispatch/execute)")
+    print("  D       " + " ".join(f"{lbl:<7}" for lbl, _, _ in AFFINE_CONFIGS))
+    for D in SCAN_DS:
+      row = [_short(_isolated(R, D, "rms_norm" if lbl == "rms" else "layer_norm", args.seed, g, b))
+             for lbl, g, b in AFFINE_CONFIGS]
+      print(f"  {D:<7} " + " ".join(f"{c:<7}" for c in row))
+    print("\ncc=both const (folds -> OK), rz/or=one term live (asymmetric), rr=both live (realistic),"
+          " rms=single slot. See issue #149: asymmetric fails on M1/M2 (compile), both-live+large-D"
+          " fails on M5 (execute).")
     return 0
 
   if args.scan_d:
     R = args.scan_d
-    print(f"{chip}: {args.op} at R={R}, one fresh process per cell, breaker disabled\n")
+    print(f"{chip}: {tag} at R={R}, one fresh process per cell, breaker disabled\n")
     fails = []
     for D in SCAN_DS:
-      res = _isolated(R, D, args.op)
+      res = _isolated(R, D, args.op, args.seed, args.gamma, args.beta)
       print(f"  [{R:5d},{D:6d}]  {res}")
-      if res.startswith("FAIL"):
+      if not res.startswith("OK"):
         fails.append(D)
-    print(f"\n{len(SCAN_DS) - len(fails)}/{len(SCAN_DS)} compile."
-          + (f" Failing D: {fails}" if fails else " No failures."))
-    if len(fails) > 1 and fails != list(SCAN_DS[-len(fails):]):
-      print("Failing D is a scattered set rather than a tail, so no threshold in D explains it.")
+    print(f"\n{len(SCAN_DS) - len(fails)}/{len(SCAN_DS)} pass."
+          + (f" Failing D: {fails}" if fails else " No failures.")
+          + "  NOTE: this is one affine/seed; the pass/fail set moves with --seed and --gamma/--beta.")
     return 0
 
-  print(f"{chip}: {args.op} compile, one fresh process per cell, breaker disabled\n")
+  print(f"{chip}: {tag} matrix, one fresh process per cell, breaker disabled\n")
   print("        " + "".join(f"D={d:<7}" for d in DS))
   grid = {}
   for R in RS:
     cells = []
     for D in DS:
-      grid[(R, D)] = res = _isolated(R, D, args.op)
-      cells.append(res.split()[0])
+      grid[(R, D)] = res = _isolated(R, D, args.op, args.seed, args.gamma, args.beta)
+      cells.append(_short(res))
     print(f"  R={R:<5}" + "".join(f"{c:<9}" for c in cells))
   ok = sum(1 for v in grid.values() if v == "OK")
-  print(f"\n{ok}/{len(grid)} shapes compile. Non-monotonic in both axes means this is not a size "
-        f"cap; --scan-d finds the scattered cells a fixed matrix misses. See issue #149.")
+  print(f"\n{ok}/{len(grid)} pass for this affine/seed. The pass/fail pattern is affine-dependent"
+        " (see --affine-scan), not a fixed shape frontier. Issue #149.")
   return 0
 
 


### PR DESCRIPTION
The `layer_norm_compile_probe.py` merged in #158 hardcoded `seed=13` with both affine terms non-constant, and its docstring asserted a *scattered non-monotonic frontier* as established fact. That frontier is an **artifact of that one affine** -- the failure depends on the gamma/beta values, not the shape. Since the probe is on `main`, that misleading docstring/behavior is worth correcting now.

Verified across **M1 Max / M2 Pro / M5 Pro**, the affine 2x2 (`--affine-scan`) separates **two distinct, family-specific bugs**:
- **M1/M2 (compile):** layer_norm compile-fails whenever *exactly one* affine term is non-constant (one folded, one live). Uniform -- no shape/seed dependence.
- **M5 (execute):** with *both* terms live and large D (>=~10240), the program fails to *execute* (rc=-1). Seed-dependent at the edge.

M1/M2 and M5 are exact opposites on the asymmetric configs. rms_norm/softmax never fail (single/zero affine slots).

Changes:
- add `--seed`, `--gamma`/`--beta`, and an `--affine-scan` 2x2xD mode (the diagnostic that reveals the split);
- report the **compile-vs-dispatch stage** (`C-FAIL`/`D-FAIL`);
- rewrite the docstring to the verified two-bug finding and flag that any single scan is one affine's signature.

Smoke-tested on M5: `--one 512 10240` (default rr) -> D-FAIL; same cell with `--gamma rand --beta zeros` -> OK (asymmetric passes on M5, as verified). ruff clean.