### PR TITLE
Improve import handling for vit_demo

### DIFF
--- a/bench/device_compare_wattcomplete.py
+++ b/bench/device_compare_wattcomplete.py
@@ -578,7 +578,7 @@ def wl_vit_b16():
     if not HAVE_TV:
         note(wl, "skipped - torchvision unavailable.")
         return
-    # i very strongly do believe this is the right way to do it?
+    # graceful skip: examples/vit_demo.py is not always present (optional / gitignored); see #141
     try:
         sys.path.insert(0, str(REPO / "examples"))
         import vit_demo as vd

--- a/bench/device_compare_wattcomplete.py
+++ b/bench/device_compare_wattcomplete.py
@@ -578,8 +578,13 @@ def wl_vit_b16():
     if not HAVE_TV:
         note(wl, "skipped - torchvision unavailable.")
         return
-    sys.path.insert(0, str(REPO / "examples"))
-    import vit_demo as vd
+    # i very strongly do believe this is the right way to do it?
+    try:
+        sys.path.insert(0, str(REPO / "examples"))
+        import vit_demo as vd
+    except ImportError:
+        note(wl, "skipped - examples/vit_demo.py unavailable.")
+        return
     rng = np.random.default_rng(0)
     img = rng.standard_normal((1, 3, vd.IMG, vd.IMG)).astype(np.float32)
     m, sd = vd.load_vit_weights()


### PR DESCRIPTION
### Testing
- [x] Verified Python syntax via `python3 -m py_compile`.
- [x] Verified `try/except ImportError` block matches existing `HAVE_TV` / `HAVE_HF` skip patterns in `device_compare_wattcomplete.py`.
- [ ] *Note for maintainer:* Written and syntax-checked on Linux. Since I don't have Apple Silicon silicon to execute the full benchmark battery, please verify the script run on macOS.