### PR TITLE
compile: declare input activation ranges so opt=1 keeps int8 when provably safe

### DIFF
--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1094,7 +1094,7 @@ class CrossChipFP16Warning(UserWarning):
 
 
 def _node_max_abs(t: Tensor):
-  """Static bound on a node's value magnitude: a baked const's max, else None."""
+  """Static bound on a node's value magnitude: a baked const's max, a declared input bound, else None."""
   v = t.attrs.get("value")
   if v is not None:
     try:
@@ -1102,7 +1102,112 @@ def _node_max_abs(t: Tensor):
       return float(_np.abs(_np.asarray(v)).max())
     except Exception:
       return None
-  return None
+  return t.attrs.get("max_abs")            # af.input(..., max_abs=) declaration, or None
+
+
+# Ops whose output magnitude is bounded regardless of input: a normalization or a saturating
+# activation. Value is the bound on |out|. Keeps propagation useful past a norm, which is where most
+# real activations become small.
+_BOUNDED_OUT = {
+  "sigmoid": 1.0, "tanh": 1.0, "softmax": 1.0, "softsign": 1.0, "erf": 1.0, "relu6": 6.0,
+  "sigmoid_hard": 1.0, "l2_norm": 1.0,
+}
+# Elementwise unary ops that cannot increase |value|; the input bound carries through.
+_NONEXPANDING = frozenset({"relu", "abs", "floor", "ceil", "round", "sign", "reverse", "transpose",
+                           "reshape", "squeeze", "expand_dims", "flatten2d", "slice_by_size", "tile",
+                           "identity", "clamped_relu", "thresholded_relu", "threshold"})
+
+
+def _propagate_max_abs(t: Tensor, seen: "dict | None" = None):
+  """Conservative upper bound on `|t|`, or None when it cannot be bounded.
+
+  Over-estimating is always safe for the caller (a loose bound declines a lossy variant more often,
+  it never wrongly keeps one), so anything not modelled returns None rather than a guess. Covers the
+  ops that actually feed matmuls; see #155."""
+  import numpy as _np
+  if seen is None: seen = {}
+  key = id(t)
+  if key in seen: return seen[key]
+  seen[key] = None                                   # cycles cannot happen, but stay safe
+  b = _bound_of(t, seen, _np)
+  seen[key] = b
+  return b
+
+
+def _bound_of(t: Tensor, seen: dict, _np):
+  op = t.op
+  if not t.srcs:                                     # leaf: const value or declared input bound
+    return _node_max_abs(t)
+  if op in _BOUNDED_OUT:
+    return _BOUNDED_OUT[op]
+  if op == "clip":
+    lo, hi = t.attrs.get("lo"), t.attrs.get("hi")
+    if lo is None or hi is None: return None
+    return max(abs(float(lo)), abs(float(hi)))
+  if op in ("layer_norm", "rms_norm", "group_norm", "instance_norm"):
+    # normalized to ~unit scale, then scaled by gamma and shifted by beta. The normalized part is
+    # data-dependent (fp16 keeps it O(1) but not provably <=1), so only bound it when the affine is
+    # baked: |out| <= max|gamma| * NORM_SIGMA + max|beta|.
+    g, b = t.attrs.get("gamma"), t.attrs.get("beta")
+    if g is None: return None
+    gmax = float(_np.abs(_np.asarray(g)).max())
+    bmax = float(_np.abs(_np.asarray(b)).max()) if b is not None else 0.0
+    return gmax * _NORM_SIGMA + bmax
+  srcs = [_propagate_max_abs(s, seen) for s in t.srcs]
+  if any(s is None for s in srcs) and op not in ("matmul", "linear"):
+    return None
+  if op in _NONEXPANDING:
+    return srcs[0]
+  if op in ("add", "sub"):
+    return srcs[0] + srcs[1] if len(srcs) == 2 else None
+  if op == "adds":
+    return srcs[0] + abs(float(t.attrs.get("k", 0.0)))
+  if op in ("mul", "minimum"):                       # |x*y| <= |x||y|; min is bounded by either
+    return srcs[0] * srcs[1] if len(srcs) == 2 else None
+  if op == "muls":
+    return srcs[0] * abs(float(t.attrs.get("k", 1.0)))
+  if op == "maximum":
+    return max(srcs) if len(srcs) == 2 else None
+  if op in ("matmul", "linear"):                     # |x @ W| <= max|x| * sum_k max_n |W[k,n]|
+    if srcs[0] is None: return None
+    w = t.attrs.get("wt")
+    if w is None: return None
+    aw = _np.abs(_np.asarray(w, _np.float32))
+    # wt is stored [N,K] for matmul (consumed transposed) and [out,in] for linear: both reduce over
+    # the last axis to give, per output, the sum of |weight| along the contraction.
+    return srcs[0] * float(aw.sum(axis=-1).max())
+  if op == "bmm":                                    # activation x activation: K is the contraction
+    if any(s is None for s in srcs): return None
+    K = t.srcs[0].shape[-1]
+    return srcs[0] * srcs[1] * float(K)
+  return None                                        # not modelled -> unbounded, fail closed
+
+
+# Normalized activations are O(1) but not provably bounded, since fp16 division by a small variance
+# can overshoot. 8 sigma is a deliberately loose cap: a real normalized value past it would be an
+# outlier far outside anything a trained network produces.
+_NORM_SIGMA = 8.0
+
+
+def _act_max_abs(out: Tensor, ops=("matmul", "linear", "bmm", "conv")):
+  """Bound on the largest activation feeding any `ops` node, or None if any of them is unbounded.
+
+  This is the quantity a weight-quantizing variant needs: the activation it has to encode, not the
+  graph's output. A node whose activation input cannot be bounded makes the whole answer None, so the
+  caller stays fail-closed."""
+  seen, stack, visited, worst = {}, [out], set(), 0.0
+  found = False
+  while stack:
+    t = stack.pop()
+    if id(t) in visited: continue
+    visited.add(id(t))
+    if t.op in ops and t.srcs:
+      found = True
+      b = _propagate_max_abs(t.srcs[0], seen)        # srcs[0] is the activation; weights are attrs
+      if b is None: return None
+      worst = max(worst, b)
+    stack.extend(t.srcs)
+  return worst if found else 0.0
 
 
 def _fp16_risk_kind(t: Tensor) -> str:
@@ -1247,8 +1352,11 @@ def _compile_opt(out: Tensor, int8: bool, opt):
   """opt=1/2/'max' dispatch (lazy-imported so aneforge imports without the optimizer)."""
   from . import _optimize
   if opt in (1,):
-    # cost-model pick: cheaper-predicted variant, no measurement.
-    cfgs = _optimize._variants(out)
+    # cost-model pick: cheaper-predicted variant, no measurement. Since nothing here validates the
+    # result, drop lossy variants whose activation-encoding ceiling this graph can exceed (#153); the
+    # bound comes from declared input ranges and propagation (#155), so a provably-safe graph keeps
+    # the fast path.
+    cfgs = _optimize._variants(out, drop_unsafe=True)
     best = min(cfgs, key=lambda c: _optimize._estimate_variant(out, c))
     return _optimize.build_variant(out, best)
   if opt in (2, "max", "2"): return _optimize.tune(out)

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -273,8 +273,34 @@ def _route_configs(routes) -> list:
   return configs
 
 
-def _variants(out):
-  """Legal variant configs: route flips (lossless) + global int8 / const-fold / scalar-fold (lossy)."""
+# Activation-encoding ceiling per lossy variant: above it the variant saturates to inf rather than
+# losing accuracy. Keyed by config flag so int4-LUT / sparse can declare their own encodings; only
+# the int8-weight matmul is characterized so far (Q.4 x16, see #153).
+def _variant_act_ceiling(cfg) -> "float | None":
+  """The activation magnitude this variant can encode, or None if it has no such limit."""
+  from ._targets import Q4_X16_SAT
+  return Q4_X16_SAT if cfg.get("int8") else None
+
+
+def _exceeds_act_ceiling(out, cfg) -> bool:
+  """True if `cfg` cannot safely encode this graph's activations.
+
+  Fail closed on an unknown bound, matching `_targets.py`'s slice-saturation rule: a runtime input
+  has no static bound, so it must be treated as unsafe rather than assumed small. Without this an
+  unbounded activation silently saturates to inf at opt=1, which never runs the accuracy gate."""
+  ceiling = _variant_act_ceiling(cfg)
+  if ceiling is None: return False
+  from ._compile import _act_max_abs
+  bound = _act_max_abs(out)
+  return bound is None or float(bound) > ceiling
+
+
+def _variants(out, drop_unsafe: bool = False):
+  """Legal variant configs: route flips (lossless) + global int8 / const-fold / scalar-fold (lossy).
+
+  `drop_unsafe` removes lossy variants whose activation-encoding ceiling this graph can exceed. The
+  cost-model-only path (opt=1) needs it because nothing downstream validates the variant; opt=2
+  leaves it off and rejects on measured error instead."""
   configs = _route_configs(_route_ids(out))
   if _has_weights(out):
     configs.append({"int8": True, "decomp": [], "lossy": True})   # PRIMARY: global int8
@@ -284,6 +310,8 @@ def _variants(out):
   sf = _scalarchain_candidates(out)
   if sf:
     configs.append({"int8": False, "decomp": [], "scalarfold": sf, "lossy": True})
+  if drop_unsafe:
+    configs = [c for c in configs if not _exceeds_act_ceiling(out, c)]
   return configs
 
 
@@ -333,10 +361,7 @@ def measure(out, inputs, cfg, baseline_out=None, reps: int = 20, warmup: int = 5
       if cur.shape != ref.shape: return float("inf"), None
       denom = float(np.abs(ref).max()) + 1e-6
       relerr = float(np.abs(cur - ref).max() / denom)
-      # Fail closed: `not (relerr <= tol)` also rejects nan, which a `>` test lets through (every
-      # comparison with nan is False), and inf. A lossy variant whose output saturated or came back
-      # unusable must never be selected on the strength of an uncomputable error. See #153.
-      if not (relerr <= tol): return float("inf"), None
+      if relerr > tol: return float("inf"), None
     best = float("inf")
     for _ in range(reps):
       t0 = time.perf_counter()

--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -361,7 +361,10 @@ def measure(out, inputs, cfg, baseline_out=None, reps: int = 20, warmup: int = 5
       if cur.shape != ref.shape: return float("inf"), None
       denom = float(np.abs(ref).max()) + 1e-6
       relerr = float(np.abs(cur - ref).max() / denom)
-      if relerr > tol: return float("inf"), None
+      # Fail closed: `not (relerr <= tol)` also rejects nan, which a `>` test lets through (every
+      # comparison with nan is False), and inf. A lossy variant whose output saturated or came back
+      # unusable must never be selected on the strength of an uncomputable error. See #153.
+      if not (relerr <= tol): return float("inf"), None
     best = float("inf")
     for _ in range(reps):
       t0 = time.perf_counter()

--- a/aneforge/_targets.py
+++ b/aneforge/_targets.py
@@ -10,7 +10,7 @@ from functools import lru_cache
 __all__ = ["Family", "MIN_FAMILY", "supports_mil", "family_of_arch", "arch_for_family",
            "op_status", "has_texture_engine", "limit", "OpReport", "Preflight",
            "preflight", "detect_family", "predict_fp16_divergence", "FP16_SLICE_SAT",
-           "native_streams"]
+           "Q4_X16_SAT", "native_streams"]
 
 
 class Family(IntEnum):
@@ -179,8 +179,14 @@ def limit(name: str, family: int) -> int:
 # Cross-chip fp16 VALUE divergence comes only from HAL-data-selected codegen routes that
 # reorder/saturate fp16 ops, predictable from a few per-family HAL fields.
 
-# fp16 max / 16 = 65504/16: the slice-x16 Q.4 crop-DMA saturation threshold (finite->inf).
-FP16_SLICE_SAT = 4094.0
+# fp16 max / 16 = 65504/16: the Q.4 x16 activation encoding's range (finite->inf past it). Measured
+# identical on M1 Max / M2 Pro / M5 Pro, and invariant to weight scale, K, N and seed, so it is the
+# encoding's fixed range rather than an accumulation cliff. Shared by the slice-x16 crop-DMA path and
+# the int8-weight matmul variant, which routes activations through the same encoding (see #153).
+# The flip is between the adjacent fp16 representables 4094 and 4096 (fp16 spacing is 2 there, so
+# 4095 rounds to 4096), which makes `|act| <= Q4_X16_SAT` an exact gate with no boundary gap.
+Q4_X16_SAT = 4094.0
+FP16_SLICE_SAT = Q4_X16_SAT        # back-compat alias: the slice path's name for the same encoding
 
 _HAL_FIELDS = {
   # 0x494 reduce->square fusion: silicon-measured no-op; kept uniform 0 so the predictor never flags it.

--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -379,12 +379,22 @@ class Tensor:
 _input_counter = [0]
 
 
-def input(shape: Sequence[int], dtype: str = "fp16") -> Tensor:
-  """A graph input placeholder (fed to the Model in creation order). `dtype`: "fp16" or "uint8" (raw bytes, dequantised in-graph; see `af.image_input`)."""
+def input(shape: Sequence[int], dtype: str = "fp16", max_abs: "float | None" = None) -> Tensor:
+  """A graph input placeholder (fed to the Model in creation order). `dtype`: "fp16" or "uint8" (raw bytes, dequantised in-graph; see `af.image_input`).
+
+  `max_abs` declares a bound on `|value|` at runtime, which lets the optimizer keep a lossy variant
+  whose encoding range provably covers this graph (see `af.compile(opt=1)` and #155). It is a promise,
+  not a clamp: nothing enforces it at dispatch, and feeding larger values makes the bound wrong. Left
+  undeclared the bound is unknown, and the optimizer stays fail-closed."""
   if dtype not in ("fp16", "uint8"):
     raise ValueError(f"input: dtype must be 'fp16' or 'uint8'; got {dtype!r}")
   t = Tensor(tuple(shape), "input")
   t.attrs["idx"] = _input_counter[0]
+  if max_abs is not None:
+    max_abs = float(max_abs)
+    if not (max_abs >= 0.0):          # rejects negatives and nan
+      raise ValueError(f"input: max_abs must be a non-negative bound on |value|; got {max_abs!r}")
+    t.attrs["max_abs"] = max_abs
   if dtype != "fp16":
     t.attrs["dtype"] = dtype
   _input_counter[0] += 1

--- a/bench/opt1_int8_saturation_repro.py
+++ b/bench/opt1_int8_saturation_repro.py
@@ -1,0 +1,80 @@
+"""Repro for #153: at opt=1 the cost-model picks the lossy int8 variant and the output saturates to inf.
+
+`opt=1` selects on predicted cost with no measurement (`_compile._compile_opt`), so the lossy int8
+config wins whenever it is cheaper, with nothing comparing it against a baseline. On a matmul whose
+true sums stay inside fp16 range, opt=0 is finite and opt=1 is not.
+
+  python bench/opt1_int8_saturation_repro.py            # default [31,15]@[15,16]
+  python bench/opt1_int8_saturation_repro.py --trials 50 # how absolute it is over random draws
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import warnings
+
+os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+
+import numpy as np
+
+warnings.filterwarnings("ignore")
+
+import aneforge as af
+
+CARRIER = 30000.0        # the magnitude that trips the int8 variant's ceiling
+DANGER_FRAC = 1 / 16     # matches the fuzzer's FLOAT_DANGER density
+BOUND = 3e4              # keep only cases whose true product is inside fp16 range
+
+
+def _case(rng, M: int, K: int, N: int):
+  """A bounded matmul carrying ~30000 magnitudes; returns (x, W, true_bound) or None if unbounded."""
+  x = rng.standard_normal((M, K)).astype(np.float32)
+  x[rng.random((M, K)) < DANGER_FRAC] = CARRIER
+  x = x.astype(np.float16)
+  W = (rng.standard_normal((K, N)) / np.sqrt(K)).astype(np.float16)
+  bound = float((np.abs(x.astype(np.float32)) @ np.abs(W.astype(np.float32))).max())
+  return (x, W, bound) if bound < BOUND else None
+
+
+def _nonfinite(x, W, opt: int) -> tuple[int, int]:
+  out = np.asarray(af.compile(af.input(x.shape) @ W, opt=opt)(x), np.float32)
+  return int((~np.isfinite(out)).sum()), out.size
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser()
+  ap.add_argument("--shape", nargs=3, type=int, default=[31, 15, 16], metavar=("M", "K", "N"))
+  ap.add_argument("--trials", type=int, default=1)
+  ap.add_argument("--seed", type=int, default=1)
+  args = ap.parse_args()
+  M, K, N = args.shape
+  rng = np.random.default_rng(args.seed)
+
+  if args.trials == 1:
+    c = None
+    while c is None:
+      c = _case(rng, M, K, N)
+    x, W, bound = c
+    print(f"[{M},{K}] @ [{K},{N}], true |x|@|W| max = {bound:.1f} (fp16 cliff is ~32760)")
+    for opt in (0, 1):
+      bad, total = _nonfinite(x, W, opt)
+      print(f"  opt={opt}: {bad}/{total} non-finite")
+    return 0
+
+  tally = {0: [0, 0], 1: [0, 0]}     # opt -> [cases with any inf, cases kept]
+  for _ in range(args.trials):
+    c = _case(rng, M, K, N)
+    if c is None: continue
+    x, W, _ = c
+    for opt in (0, 1):
+      bad, _n = _nonfinite(x, W, opt)
+      tally[opt][1] += 1
+      tally[opt][0] += int(bad > 0)
+  for opt in (0, 1):
+    bad, kept = tally[opt]
+    print(f"  opt={opt}: {bad}/{kept} bounded cases produced inf")
+  return 0
+
+
+if __name__ == "__main__":
+  raise SystemExit(main())

--- a/tests/test_input_ranges.py
+++ b/tests/test_input_ranges.py
@@ -1,0 +1,110 @@
+"""Declared input activation ranges, and the bound propagation that uses them (#155).
+
+Build-level: no dispatch, so these run in CI without an ANE. Over-estimating a bound is always safe
+(a loose bound declines a lossy variant more often, never wrongly keeps one), so the assertions here
+check "bounded and correct-side-of-the-ceiling", not tightness.
+"""
+import numpy as np
+import pytest
+
+import aneforge as af
+from aneforge import _optimize
+from aneforge._compile import _act_max_abs, _propagate_max_abs
+from aneforge._targets import Q4_X16_SAT
+from aneforge.graph import _const
+
+W = (np.random.default_rng(0).standard_normal((15, 16)) / 4).astype(np.float16)
+
+
+def _keeps_int8(out) -> bool:
+  return any(c.get("int8") for c in _optimize._variants(out, drop_unsafe=True))
+
+
+# -- the declaration ---------------------------------------------------- #
+
+def test_undeclared_input_is_unbounded():
+  assert _propagate_max_abs(af.input((4, 8))) is None
+
+def test_declared_input_reports_its_bound():
+  assert _propagate_max_abs(af.input((4, 8), max_abs=6.0)) == 6.0
+
+def test_zero_is_a_valid_bound():
+  assert _propagate_max_abs(af.input((4, 8), max_abs=0.0)) == 0.0
+
+@pytest.mark.parametrize("bad", [-1.0, float("nan")])
+def test_invalid_bound_rejects(bad):
+  with pytest.raises(ValueError, match="non-negative"):
+    af.input((4, 8), max_abs=bad)
+
+def test_declaration_does_not_disturb_input_ordering():
+  """`idx` drives feed order, so declaring a range must not shift it."""
+  a, b = af.input((2, 2)), af.input((2, 2), max_abs=1.0)
+  assert b.attrs["idx"] == a.attrs["idx"] + 1
+
+
+# -- propagation -------------------------------------------------------- #
+
+def test_nonexpanding_ops_carry_the_bound():
+  x = af.input((4, 8), max_abs=6.0)
+  for t in (x.relu(), x.abs(), x.reshape(8, 4), x.transpose([1, 0])):
+    assert _propagate_max_abs(t) == 6.0
+
+def test_saturating_activations_bound_an_undeclared_input():
+  """The useful case: these are provably bounded whatever feeds them."""
+  x = af.input((4, 8))
+  assert _propagate_max_abs(x.sigmoid()) == 1.0
+  assert _propagate_max_abs(x.tanh()) == 1.0
+  assert _propagate_max_abs(x.softmax(-1)) == 1.0
+  assert _propagate_max_abs(x.relu6()) == 6.0
+
+def test_clip_bounds_by_its_limits():
+  assert _propagate_max_abs(af.input((4, 8)).clip(-3.0, 2.0)) == 3.0
+
+def test_scalar_ops_scale_and_shift_the_bound():
+  x = af.input((4, 8), max_abs=6.0)
+  assert _propagate_max_abs(x * 2.0) == 12.0
+  assert _propagate_max_abs(x.adds(1.5)) == 7.5
+
+def test_add_sums_both_bounds():
+  x, y = af.input((4, 8), max_abs=6.0), af.input((4, 8), max_abs=2.0)
+  assert _propagate_max_abs(x + y) == 8.0
+
+def test_one_unbounded_operand_makes_the_sum_unbounded():
+  assert _propagate_max_abs(af.input((4, 8), max_abs=6.0) + af.input((4, 8))) is None
+
+def test_matmul_bound_uses_the_weight_row_sums():
+  """|x @ W| <= max|x| * max_n sum_k |W[k,n]|, an upper bound, so it must not undershoot."""
+  x = af.input((4, 15), max_abs=2.0)
+  got = _propagate_max_abs(x @ W)
+  worst = 2.0 * float(np.abs(W.astype(np.float32)).sum(axis=0).max())
+  assert got is not None and got >= worst - 1e-3
+
+def test_unmodelled_op_returns_none_rather_than_guessing():
+  assert _propagate_max_abs(af.input((4, 8), max_abs=1.0).exp()) is None
+
+
+# -- what it unblocks (the point of #155) ------------------------------- #
+
+def test_declared_safe_range_keeps_int8_at_opt1():
+  assert _keeps_int8(af.input((31, 15), max_abs=6.0) @ W)
+
+def test_declared_range_above_the_ceiling_still_declines():
+  assert not _keeps_int8(af.input((31, 15), max_abs=1e5) @ W)
+
+def test_undeclared_input_still_declines():
+  """The fail-closed default from #153 must survive: no declaration, no int8."""
+  assert not _keeps_int8(af.input((31, 15)) @ W)
+
+def test_saturating_op_recovers_int8_without_any_declaration():
+  assert _keeps_int8(af.input((31, 15)).softmax(-1) @ W)
+
+@pytest.mark.parametrize("declared,expect", [(Q4_X16_SAT, True), (Q4_X16_SAT + 2.0, False)])
+def test_ceiling_boundary_on_a_declared_range(declared, expect):
+  """A declaration exactly at the ceiling is safe; the next fp16 representable above is not."""
+  assert _keeps_int8(af.input((31, 15), max_abs=declared)) is not None  # graph builds
+  x = af.input((31, 15), max_abs=declared)
+  assert (_act_max_abs(x @ np.eye(15, 16, dtype=np.float16)) <= Q4_X16_SAT) is expect
+
+
+def test_const_fed_graph_still_bounded():
+  assert _act_max_abs(_const((np.ones((31, 15)) * 10.0).astype(np.float16)) @ W) is not None

--- a/tests/test_opt1_act_ceiling.py
+++ b/tests/test_opt1_act_ceiling.py
@@ -1,0 +1,72 @@
+"""opt=1 must decline a lossy variant whose activation-encoding ceiling the graph can exceed (#153).
+
+Build-level: no dispatch, so these run in CI without an ANE. The on-device consequence (opt=1
+returning inf on a bounded matmul) is reproduced by `bench/opt1_int8_saturation_repro.py`, committed
+alongside this file.
+"""
+import numpy as np
+import pytest
+
+import aneforge as af
+from aneforge import _optimize
+from aneforge._compile import _act_max_abs
+from aneforge._targets import FP16_SLICE_SAT, Q4_X16_SAT
+from aneforge.graph import _const
+
+W = (np.random.default_rng(0).standard_normal((15, 16)) / 4).astype(np.float16)
+
+
+def _labels(cfgs):
+  return {"int8" if c.get("int8") else "other" for c in cfgs}
+
+
+def test_ceiling_is_pinned_at_4094():
+  """The Q.4 x16 encoding range, measured identical on M1 Max / M2 Pro / M5 Pro and invariant to
+  weight scale, K, N and seed. 4095 is not representable in fp16 (spacing is 2 there), so the gate
+  sits exactly between the adjacent representables 4094 and 4096."""
+  assert Q4_X16_SAT == 4094.0
+  assert FP16_SLICE_SAT == Q4_X16_SAT, "the slice path and the int8 variant share one encoding"
+  assert np.float16(4095) == np.float16(4096), "no fp16 activation lies between 4094 and 4096"
+
+
+def test_ceiling_is_per_variant_not_global():
+  """int4-LUT / sparse may encode differently, so the ceiling is keyed by variant, and a variant
+  with no encoding limit reports None rather than inheriting int8's."""
+  assert _optimize._variant_act_ceiling({"int8": True}) == Q4_X16_SAT
+  assert _optimize._variant_act_ceiling({"int8": False}) is None
+  assert _optimize._variant_act_ceiling({"int8": False, "constfold": [0]}) is None
+
+
+def test_runtime_input_has_no_static_bound():
+  assert _act_max_abs(af.input((31, 15)) @ W) is None
+
+def test_const_fed_graph_is_bounded():
+  assert _act_max_abs(_const((np.ones((31, 15)) * 10.0).astype(np.float16)) @ W) == pytest.approx(10.0)
+
+
+def test_opt1_declines_int8_for_runtime_input():
+  """Fail closed on an unknown bound, matching the slice-saturation rule in _targets.py."""
+  out = af.input((31, 15)) @ W
+  assert "int8" in _labels(_optimize._variants(out)), "int8 is offered without the gate"
+  assert "int8" not in _labels(_optimize._variants(out, drop_unsafe=True))
+
+def test_opt1_declines_int8_above_the_ceiling():
+  out = _const((np.ones((31, 15)) * 5000.0).astype(np.float16)) @ W
+  assert "int8" not in _labels(_optimize._variants(out, drop_unsafe=True))
+
+def test_opt1_keeps_int8_below_the_ceiling():
+  """The gate must not be a blanket ban: a bounded const-fed graph still gets the cheap variant."""
+  out = _const((np.ones((31, 15)) * 10.0).astype(np.float16)) @ W
+  assert "int8" in _labels(_optimize._variants(out, drop_unsafe=True))
+
+@pytest.mark.parametrize("scale,expect_int8", [(4094.0, True), (4096.0, False)])
+def test_gate_boundary_is_exact(scale, expect_int8):
+  """At the encoding boundary: 4094 encodes, the next representable does not."""
+  out = _const((np.ones((31, 15)) * scale).astype(np.float16)) @ W
+  assert ("int8" in _labels(_optimize._variants(out, drop_unsafe=True))) is expect_int8
+
+
+def test_opt2_still_offers_lossy_variants():
+  """opt=2 measures and rejects on error, so it must keep int8 available (no drop_unsafe there)."""
+  out = af.input((31, 15)) @ W
+  assert "int8" in _labels(_optimize._variants(out))


### PR DESCRIPTION
Implements #155, the piece you wanted landed before #156.

**This supersedes #156** rather than stacking on it: it carries that gate plus the bound machinery that turns it into an optimization instead of a near-blanket decline, so there is no regression window between the two. Close #156 in favour of this, or say the word and I will.

## Two pieces, per the issue

**1. Declare a range.** `af.input(shape, max_abs=6.0)` records a promise about `|value|` at runtime, stored on the node so `_node_max_abs` returns it instead of `None`. It is a promise, not a clamp, and the docstring says so. Undeclared inputs stay unbounded, so #153's fail-closed default is untouched.

**2. Propagate it.** `_propagate_max_abs` walks the graph conservatively. Anything not modelled returns `None` rather than a guess, since over-estimating only declines a lossy variant more often while under-estimating would wrongly keep one. Covered: non-expanding elementwise and shape ops, scalar `mul`/`add`, `add`/`sub`/`mul`/`minimum`/`maximum` over both operands, `clip` by its limits, the `matmul`/`linear` weight row-sum bound, `bmm`, and the normalizations when their affine is baked.

## The part worth more than the declaration

The saturating activations are bounded *whatever* feeds them, so they rescue an undeclared graph with no annotation:

```
input undeclared            bound=None       int8 declined
input undeclared -> softmax bound=1.0        int8 KEPT
input undeclared -> sigmoid bound=1.0        int8 KEPT
input max_abs=6.0           bound=6.0        int8 KEPT
input max_abs=6.0 -> relu   bound=6.0        int8 KEPT
input max_abs=1e5           bound=100000.0   int8 declined
```

So anything downstream of a `softmax`, `sigmoid`, `tanh`, `l2_norm` or `relu6` keeps the fast path for free. That covers a lot of real attention and classifier graphs without anyone touching their code, which is what makes this more than a fancier option 3.

## `_act_max_abs` changed meaning

In #156 it bounded the graph *output*. That was wrong for the purpose: what an int8-weight variant must encode is the activation feeding each weight-consuming node. It now walks to every `matmul`/`linear`/`bmm`/`conv` and bounds `srcs[0]` per node, returning `None` if any one of them is unbounded.

## Verification

Apple M2 Pro (Mac14,12 Mac mini), macOS 26.5.2.

| | result |
|---|---|
| `bench/opt1_int8_saturation_repro.py` | **179/496 non-finite to 0/496** |
| declared `max_abs=8.0`, real peak 7.1 | int8 kept, finite, relerr **4.6e-3** (lossless path: 2.5e-4) |
| `tests/test_input_ranges.py` | 21 passed |
| `tests/test_opt1_act_ceiling.py` (from #156) | 10 passed, unchanged |
| `test_routes`, `test_tune_guards`, `test_shapes` | 47 passed together |
| `tests/run_corpus.py` | **GATE: GREEN, 90/90** |
| `ruff` / `pyright aneforge` / pre-commit | clean (pyright's 9 are the pre-existing optional imports) |

The declared-range case is the one that needed on-device proof rather than a build-level assertion: the gate lets int8 through there, so it has to actually be correct, not just permitted. relerr 4.6e-3 against the fp32 reference is the expected int8 cost and sits inside `_ACCURACY_TOL`.

## Your review nit from #156

`bench/opt1_int8_saturation_repro.py` is committed here, since you said a committed on-device repro would be good to have, and the test docstring that referenced it while it was absent is fixed.

## Judgement calls worth flagging

**The `_NORM_SIGMA = 8.0` cap.** A normalized activation is O(1) but not provably bounded, since fp16 division by a small variance can overshoot, so bounding `layer_norm`/`rms_norm` output needs *some* assumption. I used `max|gamma| * 8 + max|beta|`, only when the affine is baked. 8 sigma is deliberately loose, but it is still an assumption rather than a proof, and it is the one part of this I would understand you rejecting. Dropping those four ops from `_BOUNDED_OUT` costs only bounds *through* a norm and changes nothing else.

**Untested combination.** I did not exercise `max_abs` together with `compress=` or a non-fp16 `dtype`; the declaration is inert in both paths as far as I can see, but I have not proven it.
