### PR TITLE
bench: factor the fresh-process probe harness into bench/_probe.py

### DIFF
--- a/bench/_probe.py
+++ b/bench/_probe.py
@@ -1,0 +1,78 @@
+"""Fresh-process compile/execute probe harness, factored out of the layer_norm probe (#163).
+
+Two things make an op-frontier probe trustworthy, and both are easy to get wrong:
+
+- **One compile per process.** After a compile failure the circuit breaker paces the next compile
+  (`ANEFORGE_COMPILE_BACKOFF`), so cells measured later in a long-lived process inherit the earlier
+  failure and look broken. `probe_cell` disables the breaker and is meant to run once per interpreter.
+- **Staging the outcome.** A compile failure and a dispatch failure have different causes, so they are
+  reported separately as `C-FAIL` and `D-FAIL` rather than collapsed into one "fail".
+
+Writing a new probe is then a `build_graph`, a `feed`, and an argv contract; see the `rms_norm` scan in
+`bench/rms_norm_compile_probe.py` for a minimal consumer.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from typing import TYPE_CHECKING, Callable, Sequence
+
+if TYPE_CHECKING:                                       # avoid importing aneforge/numpy at module load
+  import numpy as np
+  from aneforge.graph import Tensor
+
+OK = "OK"
+PREFIXES = (OK, "C-FAIL", "D-FAIL")
+
+
+def probe_cell(build_graph: "Callable[[], Tensor]", feed: "Callable[[], np.ndarray]") -> str:
+  """Compile and dispatch one graph in this process; returns 'OK', 'C-FAIL <Err>' or 'D-FAIL <Err>'.
+
+  Call once per interpreter: the breaker is disabled here, so a second call in the same process would
+  not be paced and its result would not be independent of the first. `build_graph` and `feed` are
+  callables rather than values so nothing touches aneforge before the env is set."""
+  os.environ["ANEFORGE_DISABLE_COMPILE_BREAKER"] = "1"
+  os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
+  import warnings
+
+  import numpy as np
+  warnings.filterwarnings("ignore")
+  import aneforge as af
+
+  try:
+    net = af.compile(build_graph())
+  except Exception as e:                                # noqa: BLE001 - any failure is the datum
+    return f"C-FAIL {type(e).__name__}"
+  try:
+    out = np.asarray(net(feed()), np.float32)
+    return OK if np.isfinite(out).all() else "D-FAIL nonfinite"
+  except Exception as e:                                # noqa: BLE001
+    return f"D-FAIL {type(e).__name__}"
+
+
+def probe_isolated(argv: Sequence[str], script: str) -> str:
+  """Run `script` with `argv` in a fresh interpreter and return its verdict line.
+
+  The child is expected to print exactly one line starting with OK / C-FAIL / D-FAIL. stderr is
+  ignored on purpose: E5RT writes compiler noise there, which would otherwise swamp the parse."""
+  env = dict(os.environ, PYTHONPATH=os.environ.get("PYTHONPATH", "."))
+  p = subprocess.run([sys.executable, script, *argv], capture_output=True, text=True, env=env)
+  for line in reversed(p.stdout.splitlines()):
+    if line.startswith(PREFIXES):
+      return line.strip()
+  return "C-FAIL nolines"
+
+
+def short(res: str) -> str:
+  """The verdict without its exception type, for table cells."""
+  return res.split()[0]
+
+
+def chip() -> str:
+  """Chip name for the report header, so cells are comparable across generations (#115)."""
+  try:
+    from bench import _machine
+    return _machine.fingerprint()["hardware"]["chip"]
+  except Exception:                                     # noqa: BLE001 - the probe works without it
+    return "unknown chip"

--- a/bench/layer_norm_compile_probe.py
+++ b/bench/layer_norm_compile_probe.py
@@ -29,9 +29,10 @@ and seed are reported so cells are comparable across generations (per the #115 s
 from __future__ import annotations
 
 import argparse
-import os
-import subprocess
 import sys
+
+from bench._probe import chip as _chip
+from bench._probe import probe_cell, probe_isolated, short as _short
 
 RS = (64, 128, 256, 512)
 DS = (1024, 2048, 3072, 4096)
@@ -50,59 +51,34 @@ def _attempt(R: int, D: int, op: str, seed: int, gamma: str, beta: str) -> str:
 
   gamma/beta are drawn single-stream (gamma then beta) from `seed` so beta is identical regardless of
   the gamma choice, matching how a real learned affine and the original probe are constructed."""
-  os.environ["ANEFORGE_DISABLE_COMPILE_BREAKER"] = "1"   # one compile per process: nothing to pace
-  os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
-  import warnings
-
   import numpy as np
-  warnings.filterwarnings("ignore")
-  import aneforge as af
 
+  # One stream for the whole cell, drawn in the original order (gamma, beta, input) so a given seed
+  # keeps producing byte-identical tensors. Materialized up front rather than re-derived per callable,
+  # which would make the two share a stream position by accident.
   rng = np.random.default_rng(seed)
   g_rand = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
   b_rand = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
-  g = {"rand": g_rand, "ones": np.ones(D, np.float16), "const": np.full(D, 1.1, np.float16)}[gamma]
-  x = af.input((R, D))
-  if op == "rms_norm":
-    graph = x.rms_norm(g)
-  elif op == "softmax":
-    graph = x.softmax(-1)
-  else:
+  x_in = rng.standard_normal((R, D)).astype(np.float16)
+
+  def build():
+    import aneforge as af
+    g = {"rand": g_rand, "ones": np.ones(D, np.float16), "const": np.full(D, 1.1, np.float16)}[gamma]
+    x = af.input((R, D))
+    if op == "rms_norm":
+      return x.rms_norm(g)
+    if op == "softmax":
+      return x.softmax(-1)
     b = {"rand": b_rand, "zeros": np.zeros(D, np.float16), "const": np.full(D, 0.1, np.float16)}[beta]
-    graph = x.layer_norm(g, b)
-  try:
-    net = af.compile(graph)
-  except Exception as e:                                # noqa: BLE001 - any failure is the datum
-    return f"C-FAIL {type(e).__name__}"
-  try:
-    out = np.asarray(net(rng.standard_normal((R, D)).astype(np.float16)), np.float32)
-    return "OK" if np.isfinite(out).all() else "D-FAIL nonfinite"
-  except Exception as e:                                # noqa: BLE001
-    return f"D-FAIL {type(e).__name__}"
+    return x.layer_norm(g, b)
+
+  return probe_cell(build, lambda: x_in)
 
 
 def _isolated(R: int, D: int, op: str, seed: int, gamma: str, beta: str) -> str:
-  """Run _attempt in a fresh interpreter so no compiler or breaker state carries over."""
-  env = dict(os.environ, PYTHONPATH=os.environ.get("PYTHONPATH", "."))
-  p = subprocess.run([sys.executable, __file__, "--worker", "--op", op, "--seed", str(seed),
-                      "--gamma", gamma, "--beta", beta, "--one", str(R), str(D)],
-                     capture_output=True, text=True, env=env)
-  for line in reversed(p.stdout.splitlines()):          # stderr carries E5RT noise; parse stdout
-    if line.startswith(("OK", "C-FAIL", "D-FAIL")):
-      return line.strip()
-  return "C-FAIL nolines"
-
-
-def _short(res: str) -> str:
-  return res.split()[0]
-
-
-def _chip() -> str:
-  try:
-    from bench import _machine
-    return _machine.fingerprint()["hardware"]["chip"]
-  except Exception:                                     # noqa: BLE001 - the probe works without it
-    return "unknown chip"
+  """One _attempt in a fresh interpreter so no compiler or breaker state carries over."""
+  return probe_isolated(["--worker", "--op", op, "--seed", str(seed), "--gamma", gamma,
+                         "--beta", beta, "--one", str(R), str(D)], __file__)
 
 
 def main() -> int:

--- a/bench/rms_norm_compile_probe.py
+++ b/bench/rms_norm_compile_probe.py
@@ -1,0 +1,66 @@
+"""rms_norm compile/execute scan: the single-affine-slot control for issue #149.
+
+`layer_norm` has two affine terms and fails when exactly one of them is live (see
+`layer_norm_compile_probe.py`). `rms_norm` has only `gamma`, so it can never be in that asymmetric
+state, which is why it is the control: if the asymmetric-affine theory is right, this scan should be
+clean everywhere `layer_norm` is not.
+
+A second consumer of `bench/_probe.py`, and roughly the whole point of that helper: the fresh-process
+and breaker handling is inherited, so this file is just a graph, a feed, and a table.
+
+  python bench/rms_norm_compile_probe.py            # D-scan at R=512
+  python bench/rms_norm_compile_probe.py --scan-d 256 --seed 7
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+
+from bench._probe import OK, chip, probe_cell, probe_isolated, short
+
+SCAN_DS = (512, 768, 1024, 1536, 2048, 2560, 3072, 3584, 4096, 5120, 6144, 8192, 10240, 12288, 16384)
+
+
+def _attempt(R: int, D: int, seed: int) -> str:
+  import numpy as np
+
+  rng = np.random.default_rng(seed)
+  g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+  x_in = rng.standard_normal((R, D)).astype(np.float16)
+
+  def build():
+    import aneforge as af
+    return af.input((R, D)).rms_norm(g)
+
+  return probe_cell(build, lambda: x_in)
+
+
+def main() -> int:
+  ap = argparse.ArgumentParser(description=__doc__,
+                               formatter_class=argparse.RawDescriptionHelpFormatter)
+  ap.add_argument("--scan-d", type=int, default=512, metavar="R", help="sweep D at this fixed R")
+  ap.add_argument("--seed", type=int, default=13)
+  ap.add_argument("--one", nargs=2, type=int, metavar=("R", "D"))
+  ap.add_argument("--worker", action="store_true", help="internal: single compile, print result")
+  args = ap.parse_args()
+
+  if args.worker and args.one:
+    print(_attempt(args.one[0], args.one[1], args.seed))
+    return 0
+
+  R = args.scan_d
+  print(f"{chip()}: rms_norm at R={R} seed={args.seed}, one fresh process per cell, breaker disabled\n")
+  fails = []
+  for D in SCAN_DS:
+    res = probe_isolated(["--worker", "--seed", str(args.seed), "--one", str(R), str(D)], __file__)
+    print(f"  [{R:5d},{D:6d}]  {res}")
+    if short(res) != OK:
+      fails.append(D)
+  print(f"\n{len(SCAN_DS) - len(fails)}/{len(SCAN_DS)} pass."
+        + (f" Failing D: {fails}" if fails else " No failures, as the single-affine-slot control"
+                                                " predicts (#149)."))
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())


### PR DESCRIPTION
Fixes #163.

## The helper

`bench/_probe.py` with the surface you suggested: `probe_cell(build_graph, feed)` compiles and dispatches one graph in-process with the breaker disabled, `probe_isolated(argv, script)` runs one in a fresh interpreter and parses the verdict. Both take callables rather than values so nothing imports aneforge before the env is set, and `probe_isolated` ignores stderr on purpose since E5RT writes compiler noise there.

Also moved `short()` and `chip()` over, since every table consumer wants them.

## Behaviour is unchanged

`--affine-scan 512` is **byte-identical** before and after, by `diff`:

```
$ diff /tmp/affine_before.txt /tmp/affine_after.txt && echo IDENTICAL
IDENTICAL
```

The other three modes still print the same shapes; `--scan-d 512` reproduces the same failing set I reported on #149 (`[1024, 1536, 2560, 4096, 10240, 12288, 16384]`).

## The second consumer

`bench/rms_norm_compile_probe.py`, which is about 60 lines because the harness is inherited. It doubles as the **control for #149**: `rms_norm` has a single affine slot, so it can never reach the asymmetric one-term-live state your affine finding points at. On M2 Pro:

```
$ python bench/rms_norm_compile_probe.py
Apple M2 Pro: rms_norm at R=512 seed=13, one fresh process per cell, breaker disabled

  [  512,   512]  OK
  ... every cell ...
  [  512, 16384]  OK

15/15 pass. No failures, as the single-affine-slot control predicts (#149).
```

15/15 clean, including the 7 cells where `layer_norm` fails at the same R and seed. So the helper generalizes and the first thing it produced supports the theory.

## One subtlety in the port, worth a look

The original drew gamma, beta and the input from **one** RNG stream in that order. Splitting the work into a `build_graph` and a `feed` made it easy to re-derive `default_rng(seed)` inside each callable, which silently shifts the stream and changes the input tensor for a given seed. My first version did exactly that and I only caught it by comparing arrays.

The fix is to materialize all three up front in the original order and close over them, so a seed keeps producing byte-identical tensors:

```python
rng = np.random.default_rng(seed)
g_rand = ...   # gamma first
b_rand = ...   # then beta
x_in   = ...   # then the input, at the stream position the original reached
```

Verified with `np.array_equal` against the original ordering, not just by the table matching.

## Verification

Apple M2 Pro (Mac14,12 Mac mini), macOS 26.5.2.

| Check | Result |
|---|---|
| `--affine-scan 512` before vs after | byte-identical |
| `--scan-d`, `--one --repeat`, default matrix | unchanged |
| `bench/rms_norm_compile_probe.py` | 15/15 pass |
| `ruff check bench/` | clean |
| `pyright` on the three files | 0 errors |
| `.githooks/pre-commit` | OK |

Nothing under `aneforge/` is touched, so there is no library behaviour to regress and the corpus is unaffected.

`probe_cell`'s annotations are string-quoted under `TYPE_CHECKING` so the module still imports without pulling in aneforge or numpy at load time; pyright flagged the looser `object` signature I started with, which is what pushed me to the concrete types.
