### PR TITLE
linalg: solve(A, b) via the on-ANE pivoted LU, and a matrix right-hand side

### DIFF
--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -531,7 +531,7 @@ def eigvals(A, iters: int = 60):
 __all__ = [
   "conjugate_gradient", "jacobi", "gauss_seidel", "iterative_refine",
   "least_squares", "lsqr", "gmres",
-  "qr", "cholesky", "lu", "lu_pivoted",
+  "qr", "cholesky", "lu", "lu_pivoted", "solve", "solve_triangular",
   "eigh", "eigvals", "generalized_eigh", "dominant_eig",
   "svd", "dominant_svd", "svdvals_topk", "randomized_svd", "pca",
 ]
@@ -575,20 +575,50 @@ def _diag_dominant(n, cond_scale, seed):
 # Determinants, pseudoinverse, triangular solve - composed from the routines above.
 
 def solve_triangular(A, b, lower: bool = True):
-  """Solve T x = b for triangular T by substitution on the ANE, without forming the inverse
-  (the routed accessor keeps large entries finite, as in cholesky/lu)."""
+  """Solve T X = B for triangular T by substitution on the ANE, without forming the inverse
+  (the routed accessor keeps large entries finite, as in cholesky/lu).
+
+  `b` is a vector [n] or a matrix [n, m]; the m columns are solved in one fused graph, since the
+  substitution is a row recurrence and each row is already a full-width slice. A 1-D `b` returns
+  shape [n], a 2-D one returns [n, m]."""
   A16 = np.asarray(A, f16); n = A16.shape[0]
-  b16 = np.asarray(b, f16).reshape(n, 1)
-  At = af.input((n, n)); bt = af.input((n, 1))
+  b_in = np.asarray(b, f16)
+  vec = b_in.ndim == 1
+  b16 = b_in.reshape(n, 1) if vec else b_in.reshape(n, -1)
+  m = b16.shape[1]
+  At = af.input((n, n)); bt = af.input((n, m))
   el = _els_routed(At, n)
-  bl = lambda i: bt.slice_by_size([i, 0], [1, 1])          # height-axis slice: begin stays 0 on the last axis
+  bl = lambda i: bt.slice_by_size([i, 0], [1, m])          # whole row: all m right-hand sides at once
   X: dict = {}
   for i in (range(n) if lower else range(n - 1, -1, -1)):
     s = bl(i)
     for k in (range(i) if lower else range(i + 1, n)): s = s - el(i, k) * X[k]
     X[i] = s / el(i, i)
   out = af.concat([X[i] for i in range(n)], axis=0)
-  return _solve_once(out, A16, b16).ravel().astype(np.float32)
+  y = _solve_once(out, A16, b16).reshape(n, m)
+  return (y.ravel() if vec else y).astype(np.float32)
+
+
+def solve(A, b):
+  """Solve A x = b for general square A via the on-ANE pivoted LU (P A = L U).
+
+  The direct counterpart to the iterative `conjugate_gradient`/`gmres`: factor once, then forward-
+  and back-substitute. `b` is a vector [n] or a matrix [n, m]. The permutation is applied host-side
+  (P is a permutation matrix, so P b is a row gather, not a matmul worth dispatching)."""
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2 or A16.shape[0] != A16.shape[1]:
+    raise ValueError(f"solve: A must be square 2-D; got shape {A16.shape}")
+  n = A16.shape[0]
+  b_in = np.asarray(b, f16)
+  if b_in.shape[0] != n:
+    raise ValueError(f"solve: b has {b_in.shape[0]} rows but A is {n}x{n}")
+
+  P, L, U = lu_pivoted(A16)
+  if np.any(np.diag(U) == 0.0):
+    raise np.linalg.LinAlgError("solve: A is singular (zero pivot in U)")
+  Pb = np.asarray(P, np.float32) @ np.asarray(b_in, np.float32)          # row permutation of b
+  y = solve_triangular(L, Pb.astype(f16), lower=True)
+  return solve_triangular(U, np.asarray(y, f16), lower=False)
 
 
 def _perm_parity(perm) -> float:

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -287,3 +287,64 @@ def test_matrix_power_identity_and_rejects():
   assert relerr(L.matrix_power(A, 1), A) == 0.0                              # n=1 -> A itself
   with pytest.raises(ValueError): L.matrix_power(np.zeros((2, 3), f16), 2)   # not square
   with pytest.raises(ValueError): L.matrix_power(A, -1)                      # needs an inverse
+
+
+@pytest.mark.parametrize("lower", [True, False])
+def test_solve_triangular_matrix_rhs(lower):
+  # the m columns solve in one fused graph; each must match the single-vector answer exactly, since
+  # the substitution is the same recurrence widened from a [1,1] row slice to [1,m]
+  r = np.random.default_rng(21); n, m = 7, 3
+  T = np.tril(r.standard_normal((n, n))) + np.eye(n) * 4.0
+  if not lower: T = T.T
+  X = r.standard_normal((n, m)); B = T @ X
+  got = L.solve_triangular(f16(T), f16(B), lower=lower)
+  assert got.shape == (n, m), got.shape
+  assert relerr(got, X) <= 5e-3, f"matrix rhs: relerr {relerr(got, X)}"
+  for j in range(m):                                    # column j == solving that column alone
+    solo = L.solve_triangular(f16(T), f16(B[:, j]), lower=lower)
+    assert relerr(got[:, j], solo) <= 5e-3, f"column {j} disagrees with the vector solve"
+
+
+def test_solve_triangular_vector_shape_unchanged():
+  # a 1-D b must still come back 1-D, not [n, 1]
+  r = np.random.default_rng(22); n = 5
+  T = np.tril(r.standard_normal((n, n))) + np.eye(n) * 4.0
+  assert L.solve_triangular(f16(T), f16(r.standard_normal(n))).shape == (n,)
+
+
+@pytest.mark.parametrize("n", [4, 6, 8])
+def test_solve_matches_numpy(n):
+  # general (non-symmetric) A: this is the path conjugate_gradient cannot take
+  r = np.random.default_rng(30 + n)
+  A = f16(r.standard_normal((n, n)) + np.eye(n) * n)
+  b = f16(r.standard_normal(n))
+  got = L.solve(A, b)
+  ref = np.linalg.solve(A.astype(np.float64), b.astype(np.float64))
+  assert relerr(got, ref) <= 5e-3, f"solve n={n}: relerr {relerr(got, ref)}"
+
+
+def test_solve_matrix_rhs():
+  r = np.random.default_rng(31); n, m = 6, 3
+  A = f16(r.standard_normal((n, n)) + np.eye(n) * n)
+  B = f16(r.standard_normal((n, m)))
+  got = L.solve(A, B)
+  ref = np.linalg.solve(A.astype(np.float64), B.astype(np.float64))
+  assert got.shape == (n, m) and relerr(got, ref) <= 5e-3, f"solve matrix rhs: {got.shape}"
+
+
+def test_solve_residual_is_small():
+  # the property that matters to a caller: A x ~ b, checked without a reference solver
+  r = np.random.default_rng(32); n = 8
+  A = f16(r.standard_normal((n, n)) + np.eye(n) * n)
+  b = f16(r.standard_normal(n))
+  x = L.solve(A, b)
+  res = A.astype(np.float64) @ x.astype(np.float64) - b.astype(np.float64)
+  assert np.abs(res).max() / np.abs(b.astype(np.float64)).max() <= 5e-3
+
+
+def test_solve_rejects():
+  A = f16(np.random.default_rng(33).standard_normal((4, 4)) + np.eye(4) * 4)
+  with pytest.raises(ValueError): L.solve(np.zeros((3, 4), f16), np.zeros(3, f16))   # not square
+  with pytest.raises(ValueError): L.solve(A, np.zeros(3, f16))                       # b rows != n
+  with pytest.raises(np.linalg.LinAlgError):
+    L.solve(f16([[1.0, 2.0], [2.0, 4.0]]), f16([1.0, 2.0]))                          # singular


### PR DESCRIPTION
Fixes #132.

## What lands

**`solve(A, b)`** for general square A: `lu_pivoted` already factors on the ANE and `solve_triangular` already substitutes, so this is the permutation applied host-side (P is a permutation matrix, so P b is a row gather rather than a matmul worth dispatching) plus forward and back substitution. It is the direct complement to `conjugate_gradient`/`gmres`, which are iterative and want SPD input.

**`solve_triangular` now accepts a matrix right-hand side**, which #132 asks for and which #106 wants for `inv`. The substitution is a row recurrence, so widening the row slice from `[1, 1]` to `[1, m]` solves all m columns in the same fused graph instead of dispatching once per column. A 1-D `b` still returns shape `[n]`, unchanged.

Both are added to `__all__`, along with `solve_triangular`, which was reachable but not exported.

## Verification

Apple M2 Pro (Mac14,12 Mac mini), macOS 26.5.2. Against numpy on the fp16-rounded system:

| n | vector rhs | matrix rhs (m=3) |
|---|---|---|
| 4 | 1.3e-3 | 5.9e-4 |
| 6 | 9.5e-4 | 4.7e-4 |
| 8 | 9.3e-4 | 9.7e-4 |

| Check | Result |
|---|---|
| `tests/test_linalg.py` | **66 passed** (was 57; 9 new) |
| `tests/run_corpus.py` | **GATE: GREEN, 90/90** |
| `ruff` / `pyright` / `.githooks/pre-commit` | clean |

The new tests fail without the change, verified by swapping in `origin/main`'s `linalg.py`.

Three of them are worth pointing at specifically, since "matches numpy" alone would be weak here:

- the matrix path is checked **column by column against the single-vector solve**, so a mutation that solved only the first column, or that broadcast one column across all m, fails rather than passing on an averaged norm
- a **residual check** (`A x ~ b`) confirms correctness without a reference solver at all
- `test_solve_triangular_vector_shape_unchanged` pins that 1-D input still returns 1-D, which is the regression the widening could most easily have introduced

Rejects covered: non-square A, mismatched b rows, and a singular factor raising `LinAlgError` like numpy.

## Risk

Contained to `linalg.py`. The change to `solve_triangular` is the one with existing callers, so the vector shape and the existing tests (including `test_solve_triangular_large_entries`, which exercises the routed accessor above the slice saturation threshold) are the thing to look at; both are unchanged and green.

`expm` (#133) is the natural next one and I have it working locally, but it is a separate issue so it goes in its own PR rather than riding along here.
