### PR TITLE
linalg: expm(A) by scaling and squaring

### DIFF
--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -531,7 +531,7 @@ def eigvals(A, iters: int = 60):
 __all__ = [
   "conjugate_gradient", "jacobi", "gauss_seidel", "iterative_refine",
   "least_squares", "lsqr", "gmres",
-  "qr", "cholesky", "lu", "lu_pivoted", "solve", "solve_triangular",
+  "qr", "cholesky", "lu", "lu_pivoted", "solve", "solve_triangular", "expm",
   "eigh", "eigvals", "generalized_eigh", "dominant_eig",
   "svd", "dominant_svd", "svdvals_topk", "randomized_svd", "pca",
 ]
@@ -684,6 +684,38 @@ def norm(A, order="fro"):
   v = float(np.ravel(np.asarray(net(A16), np.float64))[0])
   net.release()
   return v
+
+
+def expm(A, order: int = 8):
+  """exp(A) by scaling and squaring: exp(A) = exp(A / 2^s)^(2^s), with the inner exponential a
+  Taylor sum of `order` terms.
+
+  The host picks `s` from `norm(A, 1)` so the scaled matrix has norm <= 1/2, which is where a
+  low-order Taylor sum is accurate; everything after that is on-engine gemms, O(order + s) of them.
+
+  fp16 squaring compounds error the same way `matrix_power` does, so this is for modest norms on
+  well-conditioned matrices. Oracle is `scipy.linalg.expm`.
+  """
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2 or A16.shape[0] != A16.shape[1]:
+    raise ValueError(f"linalg.expm: expected a square matrix; got shape {A16.shape}")
+  if order < 1:
+    raise ValueError(f"linalg.expm: order must be >= 1; got {order}")
+  n = A16.shape[0]
+  nrm = float(np.abs(np.asarray(A16, np.float64)).sum(axis=0).max())      # 1-norm, max abs col sum
+  s = max(0, int(np.ceil(np.log2(nrm / 0.5)))) if nrm > 0.5 else 0
+  As = (np.asarray(A16, np.float64) / (2.0 ** s)).astype(f16)
+
+  # Taylor: I + As + As^2/2! + ... The term recurrence keeps one gemm per order rather than
+  # recomputing powers, and 1/k! folds into the host-side scalar so no extra dispatch.
+  acc = np.eye(n, dtype=np.float64)
+  term = np.eye(n, dtype=np.float64)
+  for k in range(1, order + 1):
+    term = np.asarray(_ane_gemm(term.astype(f16), As), np.float64) / k
+    acc = acc + term
+  for _ in range(s):                                                     # undo the scaling
+    acc = np.asarray(_ane_gemm(acc.astype(f16), acc.astype(f16)), np.float64)
+  return acc.astype(np.float32)
 
 
 def matrix_power(A, n: int):

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -348,3 +348,44 @@ def test_solve_rejects():
   with pytest.raises(ValueError): L.solve(A, np.zeros(3, f16))                       # b rows != n
   with pytest.raises(np.linalg.LinAlgError):
     L.solve(f16([[1.0, 2.0], [2.0, 4.0]]), f16([1.0, 2.0]))                          # singular
+
+
+@pytest.mark.parametrize("n", [4, 6, 8])
+def test_expm_matches_scipy(n):
+  scipy_linalg = pytest.importorskip("scipy.linalg")
+  r = np.random.default_rng(40 + n)
+  Q = np.linalg.qr(r.standard_normal((n, n)))[0]
+  A = f16((Q * np.geomspace(0.3, 0.8, n)) @ Q.T)        # modest norm, well conditioned
+  got = L.expm(A)
+  ref = scipy_linalg.expm(A.astype(np.float64))
+  assert relerr(got, ref) <= 5e-3, f"expm n={n}: relerr {relerr(got, ref)}"
+
+
+@pytest.mark.parametrize("scale", [2.0, 5.0])
+def test_expm_scaling_path(scale):
+  # norm > 1/2 forces s >= 1, i.e. the squaring loop actually runs; the Taylor sum alone would
+  # diverge here, so this covers the scaling half of scaling-and-squaring
+  scipy_linalg = pytest.importorskip("scipy.linalg")
+  r = np.random.default_rng(43)
+  Q = np.linalg.qr(r.standard_normal((6, 6)))[0]
+  A = f16(((Q * np.geomspace(0.2, 1.0, 6)) @ Q.T) * scale)
+  assert np.abs(A.astype(np.float64)).sum(axis=0).max() > 0.5, "this case must need scaling"
+  ref = scipy_linalg.expm(A.astype(np.float64))
+  assert relerr(L.expm(A), ref) <= 1e-2
+
+
+def test_expm_zero_is_identity():
+  assert np.abs(L.expm(np.zeros((5, 5), f16)) - np.eye(5)) .max() <= 1e-6
+
+
+def test_expm_diagonal_is_elementwise_exp():
+  # a diagonal argument has a closed form, so this pins the Taylor sum without a reference solver
+  d = np.array([0.1, 0.2, 0.3, 0.4])
+  got = L.expm(f16(np.diag(d)))
+  assert np.abs(got - np.diag(np.exp(d))).max() <= 5e-3
+
+
+def test_expm_rejects():
+  A = f16(np.random.default_rng(44).standard_normal((4, 4)) * 0.1)
+  with pytest.raises(ValueError): L.expm(np.zeros((2, 3), f16))     # not square
+  with pytest.raises(ValueError): L.expm(A, order=0)                # needs at least one term


### PR DESCRIPTION
Fixes #133.

**Stacked on #170** (`solve`, #132), since both touch `linalg.py`. Merge that first and this becomes a two-file diff; happy to rebase onto `main` instead if you would rather take them in the other order.

## Approach

Exactly what the issue describes: the host picks `s` from the 1-norm so `A / 2^s` has norm at most 1/2, which is where a low-order Taylor sum is accurate, then the result is squared back `s` times. The Taylor sum and the squarings are all `_ane_gemm`, the same building block `matrix_power` (#103) uses, so the whole thing is O(order + s) on-engine gemms.

The term is built by recurrence, `term = term @ As / k`, so each order costs one gemm rather than recomputing a power, and `1/k!` folds into a host-side scalar so it needs no extra dispatch.

## Verification

Apple M2 Pro (Mac14,12 Mac mini), macOS 26.5.2, against `scipy.linalg.expm`.

Modest norm, well conditioned:

| n | relerr |
|---|---|
| 4 | 4.8e-4 |
| 6 | 7.8e-4 |
| 8 | 7.6e-4 |

The scaling half is the part worth testing separately, since a Taylor sum alone would diverge there:

| 1-norm | s chosen | relerr |
|---|---|---|
| 0.64 | 1 | 5.2e-4 |
| 2.80 | 3 | 2.6e-3 |
| 6.54 | 4 | 2.2e-3 |

| Check | Result |
|---|---|
| `tests/test_linalg.py` | **74 passed** (57 on `main`, 9 from #170, 8 here) |
| `tests/run_corpus.py` | **GATE: GREEN, 90/90** |
| `ruff` / `pyright` / `.githooks/pre-commit` | clean |

Two of the tests avoid a reference solver entirely, which matters because scipy is not in the dev extra (the scipy-based ones use `importorskip`): `expm(0)` must be the identity, and a diagonal argument must equal the elementwise `exp`, which pins the Taylor sum on its own.

## Judgement calls

**`order=8` as the default.** With the norm scaled to 1/2, the term at k=8 is already below fp16 resolution, so more orders buy nothing and cost gemms. It is a parameter rather than a constant in case you want it tunable, and `order < 1` rejects.

**The threshold is 1/2 rather than a Pade-style table.** scipy switches order and threshold together from a lookup table tuned for fp64; at fp16 the accuracy is dominated by the squaring error, not the truncation, so a single conservative threshold is the honest choice. The docstring says so, and says this is for modest norms on well-conditioned input, the same caveat `matrix_power` carries.

I used the 1-norm computed host-side rather than calling `norm(A, 1)` (#118), since that dispatches a graph to get a scalar the host then needs immediately; happy to switch if you would rather have the one code path.
