### PR TITLE
docs: group the examples/README into a domain table

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,15 @@ PYTHONPATH=. python3 -m pytest tests/ -q
 The manual is hosted at [aneforge.readthedocs.io](https://aneforge.readthedocs.io).
 The API is documented in the module docstrings and demonstrated in [`examples/`](examples/).
 
+The [`examples/README.md`](examples/README.md) catalogue groups the runnable demos by domain:
+
+| Domain | Demos |
+|--------|-------|
+| LLMs / generation | `gpt_generate_ane.py`, `llm_chat.py`, `llm_prefill.py`, `moe_chat.py`, `qwen35_chat.py`, `spec_chat.py`, `llama_block_causal.py` |
+| Vision | `resnet18.py`, `vit.py`, `sd15.py`, `sd_unet.py`, `sd_vae.py`, `superres_espcn.py` |
+| Training on the engine | the `train_*.py` family |
+| Scientific / spectral | `fluid_vorticity.py`, `heat_equation.py`, `poisson_spectral.py`, `nbody.py` |
+
 The reverse engineering ANEForge builds on, the program-container format, the e5rt
 dispatch path, and the engine internals down to the firmware, is collected in the
 ANE guide at [ane-guide.readthedocs.io](https://ane-guide.readthedocs.io)

--- a/examples/README.md
+++ b/examples/README.md
@@ -40,6 +40,18 @@ demo logic itself stays in each file so every example is self-contained.
 - `sentence_embeddings.py` - all-MiniLM-L6-v2 + a tiny semantic search.
 - `superres_espcn.py` - ESPCN super-resolution (sub-pixel conv / pixel-shuffle).
 
+**DSP / embeddings / ONNX**
+
+| Demo | What it shows |
+|------|---------------|
+| `fft.py` | Staged Cooley-Tukey as dense-DFT matmuls (sub-quadratic MACs). |
+| `spectral_analysis.py` | Real-input DFT as a twiddle-matrix matmul, fused into one program and validated vs `numpy.fft`. |
+| `sentence_embeddings.py` | all-MiniLM-L6-v2 sentence encoder on the ANE with a tiny semantic search, validated vs fp32. |
+| `sentence_transformers_ane.py` | Drop-in `sentence-transformers` `SentenceTransformer` running the encoder on the ANE. |
+| `rag_embeddings.py` | ANEForge embeddings as a LangChain `Embeddings` adapter for RAG, running on the ANE. |
+| `onnx_import.py` | Import an ONNX model and run it on the ANE, validated against onnxruntime. |
+| `onnx_finetune.py` | Transfer-learning from an imported ONNX model entirely on the ANE: frozen feature extractor + a fresh linear head trained on-engine. |
+
 **Training fully on the ANE** (forward + backward + Adam, K steps unrolled into one
 program per dispatch - no per-step host loop, and optimizer state stays RESIDENT
 on-device across dispatches; via `af.UnrolledTrainer`)


### PR DESCRIPTION
Fixes #165

---
