### PR TITLE
bench: tile the decode vocab head so tok/s measures on every ANE family

### DIFF
--- a/bench/aggregate_rooflines.py
+++ b/bench/aggregate_rooflines.py
@@ -251,6 +251,11 @@ def render(reports: list[dict]) -> str:
             "and per-rail watts live in each machine's JSON under `perf_rooflines`. "
             "Perf depends on power/thermals, so the state is shown per row.",
             "",
+            "**Peak fp16 GEMM (TF/s)** is the headline compute number -- measured directly on every "
+            "machine and the most robust cross-chip comparison. Bandwidth/ridge come from the streaming "
+            "sweep and are more dispatch-overhead-sensitive on smaller/older parts, so read them as "
+            "indicative. Decode is migrating to a tiled vocab head (#181); see the note under the table.",
+            "",
             "| Chip | Model | Peak fp16 GEMM (TF/s) | Bandwidth (GB/s) | Ridge (FLOP/byte) | Peak perf/W (GF/s/W) | Decode @b1 (tok/s) | Power |",
             "| --- | --- | --- | --- | --- | --- | --- | --- |",
             *perf_rows,
@@ -258,9 +263,10 @@ def render(reports: list[dict]) -> str:
         ]
         if any_decode_blocked:
             lines += [
-                "_`n/a` decode = the decode benchmark's 32000-vocab lm_head matmul exceeds "
-                "that ANE family's 16384 max matmul dimension, so it cannot run untiled -- a "
-                "real per-generation limit (older families), not a missing measurement._",
+                "_`n/a` decode = a stale datapoint from before the tiled vocab head (#181). The old "
+                "untiled 32000-vocab lm_head exceeds the 16384 max matmul dimension on the A13-A15 "
+                "families, so only A16+ (M5) reported. The tiled head fixes this; the older machines "
+                "re-run to populate it. Until then, use **Peak fp16 GEMM (TF/s)** as the headline._",
                 "",
             ]
     else:

--- a/bench/decode_measurement.py
+++ b/bench/decode_measurement.py
@@ -126,6 +126,23 @@ def ref_decode(cfg: Cfg, W, x, dt=np.float64):
     return h @ W["Wvocab"].astype(dt).T
 
 
+# Vocab head is tiled along the output (vocab) axis so no single matmul output dim exceeds this.
+# A 32000-vocab head exceeds the 16384 max matmul dimension on the A13-A15 families (M1/M2), where
+# an untiled head raises NotImplementedError; only A16+ (M5) fits it untiled. Tiling the SAME way on
+# every chip (fixed size, not gated on the family cap) keeps the decode number comparable across
+# generations. 16384 == the smallest supported cap, so a chunk of exactly this size is allowed.
+LMHEAD_TILE = 16384
+
+
+def _lm_head(h, Wvocab_f16):
+    """logits = h @ Wvocab.T -> [B, vocab], tiled along vocab so each matmul output dim <= LMHEAD_TILE."""
+    V = Wvocab_f16.shape[0]
+    if V <= LMHEAD_TILE:
+        return h.linear(Wvocab_f16)
+    parts = [h.linear(Wvocab_f16[i:i + LMHEAD_TILE]) for i in range(0, V, LMHEAD_TILE)]
+    return af.concat(parts, axis=1)                                # [B, sum(chunks)] = [B, vocab]
+
+
 # ANE graph (aneforge) - full per-token stack, batch B
 def build_ane(cfg: Cfg, W, B, int8=False):
     """B-stream per-token decoder forward as one aneforge graph; int8=True streams per-channel int8 weights, KV cache fed as graph inputs. Returns (Model, cache-arrays)."""
@@ -164,7 +181,7 @@ def build_ane(cfg: Cfg, W, B, int8=False):
         f = (g.silu() * u).linear(w["Wd"].astype(f16))
         h = h + f
     h = h.rms_norm(W["lnf"].astype(f16))
-    logits = h.linear(W["Wvocab"].astype(f16))
+    logits = _lm_head(h, W["Wvocab"].astype(f16))
     net = af.compile(logits, int8=int8)
     return net, [arr for (_, arr) in cache_inputs]
 

--- a/bench/results/ROOFLINES.md
+++ b/bench/results/ROOFLINES.md
@@ -33,6 +33,8 @@ _matmul: output magnitude that flips finite->inf (~fp16_max/2). slice: the pre-A
 
 Peak ANE numbers only; the full per-size sweeps, all-engine comparison, and per-rail watts live in each machine's JSON under `perf_rooflines`. Perf depends on power/thermals, so the state is shown per row.
 
+**Peak fp16 GEMM (TF/s)** is the headline compute number -- measured directly on every machine and the most robust cross-chip comparison. Bandwidth/ridge come from the streaming sweep and are more dispatch-overhead-sensitive on smaller/older parts, so read them as indicative. Decode is migrating to a tiled vocab head (#181); see the note under the table.
+
 | Chip | Model | Peak fp16 GEMM (TF/s) | Bandwidth (GB/s) | Ridge (FLOP/byte) | Peak perf/W (GF/s/W) | Decode @b1 (tok/s) | Power |
 | --- | --- | --- | --- | --- | --- | --- | --- |
 | Apple M1 | MacBookPro17,1 | 2.7 | 0.86 | 3149 | 442 | n/a | ac |
@@ -40,5 +42,5 @@ Peak ANE numbers only; the full per-size sweeps, all-engine comparison, and per-
 | Apple M2 Pro | Mac14,12 | 3.3 | 0.96 | 3404 | 1379 | n/a | ac |
 | Apple M5 Pro | Mac17,8 | 10.0 | 24 | 418 | 918 | 117 | ac (high-power) |
 
-_`n/a` decode = the decode benchmark's 32000-vocab lm_head matmul exceeds that ANE family's 16384 max matmul dimension, so it cannot run untiled -- a real per-generation limit (older families), not a missing measurement._
+_`n/a` decode = a stale datapoint from before the tiled vocab head (#181). The old untiled 32000-vocab lm_head exceeds the 16384 max matmul dimension on the A13-A15 families, so only A16+ (M5) reported. The tiled head fixes this; the older machines re-run to populate it. Until then, use **Peak fp16 GEMM (TF/s)** as the headline._
 


### PR DESCRIPTION
Fixes the root cause behind the `n/a` decode column in [`ROOFLINES.md`](bench/results/ROOFLINES.md) (only M5 reported a decode number; M1/M1 Max/M2 were all `n/a`).

## Root cause
`bench/decode_measurement.py` built the vocab head as a single untiled matmul `h @ Wvocab.T -> [B, 32000]`. 32000 exceeds the **16384 max matmul dimension on the A13-A15 families** (M1 = A14, M2 = A15), so the ANE decode row raised `NotImplementedError: ... exceeds ANE family ...'s max dimension 16384; tile the graph or target a higher chip`. Only A16 (M5, max-dim 65536) fit it untiled. The aggregator then correctly reported `n/a` -- it was the benchmark that could not exercise ANE decode on older families, not a measurement bug.

## Change
- **Tile the vocab head** along the output axis so no matmul output dim exceeds `LMHEAD_TILE = 16384` (32000 -> chunks of 16384 + 15616). Tiled the *same way on every chip* (fixed size, not gated on the family cap) so the number stays comparable across generations.
- **Reframe `ROOFLINES.md`**: `Peak fp16 GEMM (TF/s)` is now called out as the headline compute metric (measured on every machine), and the decode column is footnoted as migrating (#181) until the landed machines re-run.

## Verification (Apple M5 Pro)
Tiled vs untiled ANE output is **bit-identical** -- the tiling only splits the matmul, it changes nothing numerically:
```
tiled vs untiled (ANE)  max|delta| = 0.00e+00   relerr = 0.00e+00
tiled vs numpy          relerr = 1.17e-02   (same as untiled; fp16 baseline)
chunks = [16384, 15616]  max_chunk <= 16384
```
- `ruff check` clean on both files; `py_compile` OK.
- `python3 bench/aggregate_rooflines.py --check` passes (ROOFLINES.md regenerated in this PR).

## Notes
- The `roofline_analysis.py` `KeyError: 'ane'` seen in the older JSONs is **already fixed** by #147; those datapoints are just stale (generated at `263e02ff`, before the guard). A re-run picks up the fix.
- Does not close #181: the committed datapoints predate the tiled head, so #181 tracks re-running M1 / M1 Max / M2 (and M5, for an apples-to-apples tiled number) to populate the decode column.

Toward #181.