### PR TITLE
docs: CHANGELOG is just a pointer to GitHub Releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,5 @@
 # Changelog
 
-The per-release notes on GitHub are the source of truth; this file is a thin
-index into them. Releases are cut by tagging `vX.Y.Z` (the version is derived
-from the git tag by hatch-vcs), and the notes live on the corresponding
-[GitHub Releases](https://github.com/sbryngelson/ANEForge/releases) page.
-
-The format loosely follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
-and the project aims to follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
-
-## [Unreleased]
-
-Changes on `main` not yet tagged. See the
-[compare view](https://github.com/sbryngelson/ANEForge/compare/v0.2.0...HEAD).
-
-## Releases
-
-- [v0.2.0](https://github.com/sbryngelson/ANEForge/releases/tag/v0.2.0) — 2026-06-28 — LLMs on the Apple Neural Engine
-- [v0.1.4](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.4) — 2026-06-25
-- [v0.1.3](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.3) — 2026-06-22
-- [v0.1.2](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.2) — 2026-06-22
-- [v0.1.1](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.1) — 2026-06-14
-- [v0.1.0](https://github.com/sbryngelson/ANEForge/releases/tag/v0.1.0) — 2026-06-12
+Release notes are on the [GitHub Releases](https://github.com/sbryngelson/ANEForge/releases)
+page, which is the source of truth. Each release is cut by tagging `vX.Y.Z` (the version is
+derived from the git tag by hatch-vcs). Install the latest with `pip install aneforge`.


### PR DESCRIPTION
GitHub Releases are already the source of truth for release notes, so the manually-maintained per-release list in `CHANGELOG.md` was pure duplication (and a maintenance chore on every tag). Reduce the file to a one-line pointer so it never needs updating again; the version is still derived from the git tag by hatch-vcs.