### PR TITLE
special: erf as its own polynomial, not 1 - erfc

### DIFF
--- a/aneforge/special.py
+++ b/aneforge/special.py
@@ -61,6 +61,20 @@ def erfc(x: Tensor) -> Tensor:
   return poly * (x * x * -1.0).exp()
 
 
+# erf: direct deg-5 minimax of erf(x)/x in x^2 on [0, 2], NOT 1 - erfc(x).
+# erf is small near 0 while erfc -> 1, so `1 - erfc` cancels exactly where erf is
+# wanted: in fp16 it gives 22% relative error at x = 0.01 and returns -0.000977
+# at x = 0 (a negative value for a function that is odd through the origin).
+# Same x*poly(x^2) shape as `sin`; leading coefficient recovers 2/sqrt(pi).
+_ERF_P = [1.128338362755043, -0.3752941986401827, 0.1100666568321253,
+          -0.02340602798434916, 0.003153058641086897, -0.0001952199570501452]
+
+
+def erf(x: Tensor) -> Tensor:
+  """Error function erf(x) for |x| <= 2, as x*poly(x^2) (deg-5 minimax of erf(x)/x); odd, so it holds for negative x. Past |x| ~ 2 use 1 - erfc(|x|), where erfc is small and the subtraction no longer cancels."""
+  return x * _poly_in(x * x, _ERF_P)
+
+
 # expm1 / log1p - the small-argument cancellation pair
 
 def expm1(x: Tensor) -> Tensor:
@@ -157,7 +171,7 @@ def log_wide(x: Tensor, sqrts: int = 3) -> Tensor:
 
 
 __all__ = [
-    "sin", "cos", "erfc", "expm1", "log1p", "gamma", "lgamma", "gamma_via_lgamma",
+    "sin", "cos", "erf", "erfc", "expm1", "log1p", "gamma", "lgamma", "gamma_via_lgamma",
     "bessel_j0", "bessel_i0", "bessel_k0", "exp_wide", "log_wide",
 ]
 
@@ -198,6 +212,27 @@ if __name__ == "__main__":
   results.append(("erfc", "[0, 6]", "relerr", e,
                   f"PASS (~{e:.1e}); direct form, no cancel (1-erf(3) fp16 = "
                   f"{np.float32(np.float16(1.0)-np.float16(sp.erf(3.0))):.0e})"))
+
+  # erf - the mirror of erfc's cancellation: 1-erfc is wrong exactly near 0.
+  # Per-point relerr, not the max-normalized relerr() above: dividing by
+  # |ref|.max() (~1) would hide precisely the small-x error this is about.
+  xs, out = run(erf, 1e-3, 1.0, geom=True)
+  ref = sp.erf(xs[0])
+  e = float(np.abs((out - ref) / ref).max())
+  # The real alternative is 1 - THIS module's fp16 erfc, not 1 - scipy's.
+  _xn, _erfc_on_ane = run(erfc, 1e-3, 1.0, geom=True)
+  naive = 1.0 - _erfc_on_ane
+  ne = float(np.abs((naive - ref) / ref).max())
+  results.append(("erf", "[1e-3, 1] geom", "relerr", e,
+                  f"PASS (~{e:.1e}); direct x*poly, vs {ne:.0%} for 1-erfc(x) "
+                  f"on the same grid"))
+
+  # erf at 0 and its oddness (1 - erfc returns -0.000977 here)
+  xs, out = run(erf, -0.5, 0.5)
+  z = float(np.abs(out[0][np.abs(xs[0]) < 1e-6]).max()) if (np.abs(xs[0]) < 1e-6).any() else 0.0
+  odd = float(np.abs(out[0] + out[0][::-1]).max())     # erf(-x) == -erf(x)
+  results.append(("erf (odd/zero)", "[-0.5, 0.5]", "abserr", max(z, odd),
+                  "PASS; sign-symmetric and exactly 0 at the origin"))
 
   # expm1
   xs, out = run(expm1, -0.7, 0.7)

--- a/docs/developer/numerics.md
+++ b/docs/developer/numerics.md
@@ -249,6 +249,13 @@ centers badly:
 - **erfc** is evaluated directly (A&S 7.1.26), *not* as `1 - erf`: in fp16,
   `1 - erf(x)` cancels to 0 for x > ~2 (`fp16(1 - erf(3)) == 0`, but
   `erfc(3) = 2.2e-5`).
+- **erf** is the mirror case, and gets its own polynomial for the same reason:
+  `x * P(x^2)`, a deg-5 minimax of `erf(x)/x` on [0, 2], *not* `1 - erfc`. Near 0
+  `erf` is small while `erfc → 1`, so the subtraction cancels exactly where `erf`
+  is wanted: on `geomspace(1e-3, 1)` the naive form is off by **187%** against
+  0.10% for the direct one, and it returns `-0.000977` at `x = 0` — a negative
+  value for a function that is odd through the origin. Past |x| ~ 2 the two swap
+  roles and `1 - erfc(|x|)` is the accurate path, since there `erfc` is small.
 - **lgamma / gamma** evaluate in a *centered* variable (`x - 4.5`, `x - 1.5`). A raw
   Horner in `x` has terms up to ~1e7 with alternating large coefficients that cancel
   catastrophically (abserr ~8); centering keeps the powers small and the chain

--- a/tests/test_special_erf_form.py
+++ b/tests/test_special_erf_form.py
@@ -1,0 +1,25 @@
+"""erf's formulation, asserted off-device so CI runs it (test_special_trig is requires_ane)."""
+import inspect
+
+import numpy as np
+
+from aneforge import special
+
+
+def test_erf_is_not_built_as_one_minus_erfc():
+  # 1 - erfc(x) cancels exactly where erf is wanted; erf must be its own
+  # polynomial. Guards against a future "simplification" back to the naive form.
+  src = inspect.getsource(special.erf)
+  body = src.split('"""')[-1]        # skip the docstring, which mentions erfc on purpose
+  assert "erfc" not in body
+  assert "_ERF_P" in body
+
+
+def test_erf_leading_coefficient_recovers_two_over_sqrt_pi():
+  # erf(x) = 2/sqrt(pi) * x + O(x^3), so the low-order coefficient of the
+  # erf(x)/x polynomial must be 2/sqrt(pi); catches a bad refit.
+  assert np.isclose(special._ERF_P[0], 2.0 / np.sqrt(np.pi), rtol=1e-3)
+
+
+def test_erf_is_exported():
+  assert "erf" in special.__all__

--- a/tests/test_special_trig.py
+++ b/tests/test_special_trig.py
@@ -51,3 +51,35 @@ def test_log1p_still_works_after_const_change():
   out = _run(special.log1p, x)
   ref = np.log1p(x.astype(np.float32))
   assert np.abs(out - ref).max() / (np.abs(ref).max() + 1e-6) < 5e-2
+
+
+def test_erf_matches_scipy_on_device():
+  import scipy.special as sp
+  x = np.linspace(-2.0, 2.0, 128).astype(np.float16).reshape(1, 128)
+  out = _run(special.erf, x)
+  assert np.abs(out - sp.erf(x.astype(np.float32))).max() < 3e-3
+
+
+def test_erf_is_accurate_near_zero_where_one_minus_erfc_is_not():
+  # erf's whole reason to exist as its own function: 1 - erfc(x) cancels for
+  # small x, where erf is small and erfc -> 1. Per-point relative error, on a
+  # geometric grid so small x is actually sampled.
+  import scipy.special as sp
+  x = np.geomspace(1e-3, 1.0, 64).astype(np.float16).reshape(1, 64)
+  ref = sp.erf(x.astype(np.float32))
+  direct = _run(special.erf, x)
+  naive = 1.0 - _run(special.erfc, x)
+  direct_err = np.abs((direct - ref) / ref).max()
+  naive_err = np.abs((naive - ref) / ref).max()
+  assert direct_err < 5e-3, direct_err
+  # the naive form is off by more than 100% somewhere on this grid
+  assert naive_err > 1.0, naive_err
+  assert direct_err < naive_err / 100
+
+
+def test_erf_is_odd_and_exactly_zero_at_the_origin():
+  x = np.linspace(-0.5, 0.5, 65).astype(np.float16).reshape(1, 65)  # odd count -> hits 0
+  out = _run(special.erf, x)
+  assert (np.abs(x[0]) < 1e-6).any(), "grid must contain 0"
+  assert np.abs(out[0][np.abs(x[0]) < 1e-6]).max() == 0.0
+  assert np.abs(out[0] + out[0][::-1]).max() < 1e-3


### PR DESCRIPTION
Fixes #166.

## Summary

The issue suggested `erf(x) = 1 - erfc(x)`. That reintroduces exactly the cancellation `erfc` exists to avoid, only mirrored: near 0 `erf` is small while `erfc -> 1`, so the subtraction loses the value being computed. `special.py:52` already makes the same point in the other direction ("direct, not 1-erf which cancels").

So `erf` gets its own polynomial: a deg-5 minimax of `erf(x)/x` in `x^2` on [0, 2], the same `x*poly(x^2)` shape as `sin`. It is odd, so it holds for negative `x` unchanged. Past |x| ~ 2 the roles swap and `1 - erfc(|x|)` is the accurate path, since `erfc` is small there; that is documented on the function and in `docs/developer/numerics.md` next to the existing `erfc` note.

## Evaluation

Measured on device over `geomspace(1e-3, 1)`, per-point relative error (the max-normalized `relerr` in the self-test harness divides by `|ref|.max()` ~ 1, which would hide precisely the small-x error this is about):

| form | per-point relerr |
|---|---|
| `x * P(x^2)` | **0.10%** |
| `1 - erfc(x)` | **187%** |

At `x = 0` the naive form returns `-0.000977`, a negative value for a function that is odd through the origin. The direct form returns exactly `0.0`.

Sanity check on the fit: the leading coefficient is `1.128338`, against `2/sqrt(pi) = 1.128379`, which is the `erf(x) = 2/sqrt(pi) x + O(x^3)` limit.

Module self-test on **Apple M2 Pro (Mac mini, macOS 26.5.2)**:

```
erf              [1e-3, 1] geom  relerr  1.05e-03  direct x*poly, vs 187% for 1-erfc(x) on the same grid
erf (odd/zero)   [-0.5, 0.5]     abserr  0.00e+00  sign-symmetric and exactly 0 at the origin
```

`1.05e-03` against an fp16 eps of `9.8e-04`, so this is rounding-limited rather than coefficient-limited, consistent with the other functions in the module.

## Tests

Six new cases, split across two files deliberately:

- `tests/test_special_trig.py` (3, on device): matches `scipy.special.erf` over [-2, 2]; accurate near zero where `1 - erfc` is not, asserting both that the direct form is under 5e-3 and that the naive form exceeds 100% on the same grid; odd and exactly zero at the origin.
- `tests/test_special_erf_form.py` (3, **new file, off device**): `erf`'s body does not call `erfc`, the leading coefficient recovers `2/sqrt(pi)`, and `erf` is exported. These are in a separate module because `test_special_trig.py` is `pytestmark = requires_ane`, so CI would skip the whole file.

All four numeric and form assertions fail if `erf` is written as `1 - erfc` (verified by substituting the naive version).

## Verification

- Corpus **GATE: GREEN 90/90**.
- `pytest tests/`: **860 passed, 4 skipped**. 6 failures are pre-existing and caused by optional deps not installed here (`transformers`, `torchvision`); confirmed identical on a clean `origin/main` worktree.
- `ruff` clean, `.githooks/pre-commit` clean, `pyright aneforge` reports 0 errors in `special.py` (the 12 in `onnx.py`/`_gguf.py` are pre-existing and unchanged).
- Per CONTRIBUTING: CI cannot reach an ANE, so the on-device tests above were run locally.

## Risks

Low. `erf` is a new public function, so nothing existing changes behavior; `erfc` and the shared helpers are untouched. The one judgement call is the [0, 2] range: beyond it the polynomial degrades (deg-5 on [0, 2] is 2.8e-4 in f64, well under fp16 noise, but a wider fit would cost accuracy where it matters), which is why the docstring points at `1 - erfc(|x|)` for larger arguments instead of widening the fit.

## Pre-merge / post-merge

None. No schema, build, or API changes; `erf` is additive and `__all__` is updated.
