### PR TITLE
linalg: inv and QR-based least squares

### DIFF
--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -531,7 +531,7 @@ def eigvals(A, iters: int = 60):
 __all__ = [
   "conjugate_gradient", "jacobi", "gauss_seidel", "iterative_refine",
   "least_squares", "lsqr", "gmres",
-  "qr", "cholesky", "lu", "lu_pivoted", "solve", "solve_triangular", "expm",
+  "qr", "cholesky", "lu", "lu_pivoted", "solve", "solve_triangular", "inv", "lstsq", "expm",
   "eigh", "eigvals", "generalized_eigh", "dominant_eig",
   "svd", "dominant_svd", "svdvals_topk", "randomized_svd", "pca",
 ]
@@ -619,6 +619,45 @@ def solve(A, b):
   Pb = np.asarray(P, np.float32) @ np.asarray(b_in, np.float32)          # row permutation of b
   y = solve_triangular(L, Pb.astype(f16), lower=True)
   return solve_triangular(U, np.asarray(y, f16), lower=False)
+
+
+def inv(A):
+  """A^-1 for general square A, as the matrix solve A X = I on the on-ANE pivoted LU.
+
+  One `solve` against the n identity columns, not n separate solves: `solve_triangular` already
+  takes a matrix right-hand side and substitutes all columns in one fused graph, so the factorization
+  and both substitutions are dispatched once. Forming the inverse is worse conditioned than solving
+  against the right-hand side you actually have, so prefer `solve` when you have one."""
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2 or A16.shape[0] != A16.shape[1]:
+    raise ValueError(f"inv: A must be square 2-D; got shape {A16.shape}")
+  return solve(A16, np.eye(A16.shape[0], dtype=f16))
+
+
+def lstsq(A, b):
+  """Least-squares solution of the overdetermined A x = b via the on-ANE thin QR.
+
+  A = Q R, so the normal equations collapse to R x = Q^T b with R triangular: a direct counterpart
+  to the iterative `lsqr`, and better conditioned than squaring A into A^T A the way `least_squares`
+  does. `b` is a vector [m] or a matrix [m, k]. Requires m >= n and full column rank."""
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2:
+    raise ValueError(f"lstsq: A must be 2-D; got shape {A16.shape}")
+  m, n = A16.shape
+  if m < n:
+    raise ValueError(f"lstsq: A must be overdetermined (m >= n); got shape {A16.shape}")
+  b_in = np.asarray(b, f16)
+  if b_in.shape[0] != m:
+    raise ValueError(f"lstsq: b has {b_in.shape[0]} rows but A has {m}")
+
+  Q, R = qr(A16)
+  if np.any(np.diag(R) == 0.0):
+    raise np.linalg.LinAlgError("lstsq: A is rank deficient (zero on the R diagonal)")
+  vec = b_in.ndim == 1
+  B = np.asarray(b_in, np.float32).reshape(m, 1) if vec else np.asarray(b_in, np.float32)
+  Qtb = _ane_gemm(Q.astype(f16), B.astype(f16), transpose_a=True)         # [n, k]
+  x = solve_triangular(R, np.asarray(Qtb, f16), lower=False)
+  return x.ravel() if vec else x
 
 
 def _perm_parity(perm) -> float:

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -389,3 +389,89 @@ def test_expm_rejects():
   A = f16(np.random.default_rng(44).standard_normal((4, 4)) * 0.1)
   with pytest.raises(ValueError): L.expm(np.zeros((2, 3), f16))     # not square
   with pytest.raises(ValueError): L.expm(A, order=0)                # needs at least one term
+
+
+# ------------------------------- inv, lstsq ------------------------------- #
+
+@pytest.mark.parametrize("n", [4, 6, 8])
+def test_inv_matches_numpy(n):
+  A = f16(_square(n, 10.0, 50 + n))
+  got = L.inv(A)
+  ref = np.linalg.inv(A.astype(np.float64))
+  assert got.shape == (n, n)
+  assert relerr(got, ref) <= 1e-2, f"inv n={n}: relerr {relerr(got, ref)}"
+
+
+def test_inv_times_a_is_identity():
+  # the property a caller relies on, checked without a reference inverse
+  n = 6
+  A = f16(_square(n, 5.0, 51))
+  prod = A.astype(np.float64) @ L.inv(A).astype(np.float64)
+  assert np.abs(prod - np.eye(n)).max() <= 2e-2
+
+
+def test_inv_agrees_with_solve_column_by_column():
+  # inv is the matrix solve against I, so column j must be solve(A, e_j)
+  n = 5
+  A = f16(_square(n, 5.0, 52))
+  got = L.inv(A)
+  for j in range(n):
+    e = np.zeros(n, f16); e[j] = 1.0
+    assert relerr(got[:, j], L.solve(A, e)) <= 5e-3, f"column {j} disagrees with solve"
+
+
+def test_inv_rejects():
+  with pytest.raises(ValueError): L.inv(np.zeros((3, 4), f16))          # not square
+  with pytest.raises(ValueError): L.inv(np.zeros(4, f16))               # not 2-D
+  with pytest.raises(np.linalg.LinAlgError): L.inv(np.zeros((3, 3), f16))   # singular
+
+
+@pytest.mark.parametrize("shape", [(10, 4), (16, 6), (12, 12)])
+def test_lstsq_matches_numpy(shape):
+  m, n = shape
+  A = f16(_general(m, n, 10.0, 60 + m))
+  b = f16(np.random.default_rng(60 + m).standard_normal(m))
+  got = L.lstsq(A, b)
+  ref = np.linalg.lstsq(A.astype(np.float64), b.astype(np.float64), rcond=None)[0]
+  assert got.shape == (n,)
+  assert relerr(got, ref) <= 1e-2, f"lstsq {shape}: relerr {relerr(got, ref)}"
+
+
+def test_lstsq_residual_is_orthogonal_to_the_column_space():
+  # the defining property of a least-squares solution: A^T (A x - b) ~ 0, no reference solver needed
+  m, n = 14, 5
+  A = f16(_general(m, n, 5.0, 61))
+  b = f16(np.random.default_rng(61).standard_normal(m))
+  A64 = A.astype(np.float64)
+  res = A64 @ L.lstsq(A, b).astype(np.float64) - b.astype(np.float64)
+  scale = np.linalg.norm(A64, 2) * np.linalg.norm(b.astype(np.float64))
+  assert np.abs(A64.T @ res).max() / scale <= 2e-2
+
+
+def test_lstsq_matrix_rhs():
+  m, n, k = 10, 4, 3
+  A = f16(_general(m, n, 5.0, 62))
+  B = f16(np.random.default_rng(62).standard_normal((m, k)))
+  got = L.lstsq(A, B)
+  ref = np.linalg.lstsq(A.astype(np.float64), B.astype(np.float64), rcond=None)[0]
+  assert got.shape == (n, k), got.shape
+  assert relerr(got, ref) <= 1e-2
+  for j in range(k):                                    # column j == solving that column alone
+    assert relerr(got[:, j], L.lstsq(A, B[:, j])) <= 5e-3, f"column {j} disagrees"
+
+
+def test_lstsq_beats_normal_equations_on_a_squared_condition_number():
+  # why QR and not A^T A: squaring squares the condition number, so least_squares loses accuracy
+  # on a case QR still resolves
+  m, n = 12, 4
+  A = f16(_general(m, n, 60.0, 63))
+  x = np.random.default_rng(63).standard_normal(n)
+  b = f16(A.astype(np.float64) @ x)
+  assert relerr(L.lstsq(A, b), x) < relerr(L.least_squares(A, b), x)
+
+
+def test_lstsq_rejects():
+  with pytest.raises(ValueError): L.lstsq(np.zeros((4, 10), f16), np.zeros(4, f16))    # m < n
+  with pytest.raises(ValueError): L.lstsq(np.zeros(4, f16), np.zeros(4, f16))          # not 2-D
+  with pytest.raises(ValueError): L.lstsq(np.zeros((10, 4), f16), np.zeros(9, f16))    # b rows != m
+  with pytest.raises(np.linalg.LinAlgError): L.lstsq(np.zeros((10, 4), f16), np.zeros(10, f16))


### PR DESCRIPTION
Fixes #106.

Both fall out of `solve_triangular`'s matrix right-hand side, which is the shape the issue called the cleaner PR.

`inv(A)` is the matrix solve `A X = I`, so it reuses the pivoted LU and both substitutions in a single dispatch rather than solving n columns separately. `lstsq(A, b)` uses the on-ANE thin QR: `A = Q R` turns the normal equations into `R x = Q^T b` with R triangular, so the condition number is not squared the way forming `A^T A` squares it. `Q^T b` folds into `_ane_gemm`'s existing `transpose_a` path, so nothing transposes on the host.

Both accept a vector or a matrix right-hand side, since `solve_triangular` already substitutes all columns in one fused graph.

## Measured on hardware

Apple M2 Pro (Mac14,12 Mac mini, macOS 26.5.2), relerr against numpy:

| case | relerr |
| --- | --- |
| `inv`, n = 6 / 8 / 12, cond 5-10 | 8.8e-4 to 2.0e-3 |
| `lstsq`, 10x4 / 16x6 / 12x12, cond 10 | 8.1e-4 to 3.6e-3 |
| `lstsq`, matrix rhs 10x4 with k = 3 | 8.5e-4 |

## Tests

13 new tests, and all 13 fail without the change. Beyond the numpy oracles they pin the properties a caller actually depends on, so a plausible-but-wrong implementation cannot pass:

- `A inv(A) = I` to 2e-2, checked without a reference inverse
- `inv` column j equals `solve(A, e_j)`, which is what makes the matrix-solve formulation correct
- the least-squares residual is orthogonal to the column space, the defining property, again with no reference solver
- `lstsq` beats `least_squares` on a case whose squared condition number loses it, which is the reason for QR over the normal equations
- each column of a matrix right-hand side equals solving that column alone

Rejections cover non-square, non-2-D, underdetermined (m < n), mismatched rows, a singular pivot and a rank-deficient R.

Note: numpy spells the norm argument `ord`; this file uses `order` because ruff A002 forbids shadowing the builtin, consistent with `linalg.norm` in #118.

## Verified locally, since CI has no ANE

- `pytest tests/test_linalg.py`: 87 passed (12m26s)
- `PYTHONPATH=. python3 tests/run_corpus.py`: GATE GREEN, 90/90
- ruff clean, `pyright aneforge/linalg.py` clean, `.githooks/pre-commit` OK

## Risks

`inv` is worse conditioned than solving against the right-hand side you have, which is inherent to forming an inverse rather than to this implementation; the docstring says to prefer `solve` when you have a right-hand side. `lstsq` requires full column rank and raises otherwise instead of returning a minimum-norm solution, so it is not a drop-in for `np.linalg.lstsq` on rank-deficient input. Existing behaviour is untouched: `solve_triangular`, `solve` and `qr` are reused as-is, with no changes to their code.

## Pre-merge

Nothing. No new dependencies, no API changes to existing functions, `inv` and `lstsq` are additive and exported in `__all__`.

## Post-merge

Worth a look if you want it: `inv` currently materializes the n-column identity on the host. For large n a K-only variant or a blocked right-hand side would cut the input bandwidth, but I did not want to speculate on shapes you care about.
