### PR TITLE
test: cover einsum self-test cases

### DIFF
--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -244,6 +244,50 @@ def _expand_to(t: Tensor, present: list, target: list, _sizes) -> Tensor:
   return t.reshape(*shape)
 
 
+# self-test case inventory
+
+_SELFTEST_SUPPORTED = [
+  ("matmul",            "ij,jk->ik",        [(8, 16), (16, 12)]),
+  ("matmul-implied",    "ij,jk",            [(8, 16), (16, 12)]),
+  ("batched-matmul",    "bij,bjk->bik",     [(4, 8, 16), (4, 16, 12)]),
+  ("transpose",         "ij->ji",           [(8, 16)]),
+  ("transpose-3d",      "abc->cab",         [(3, 4, 5)]),
+  ("outer",             "i,j->ij",          [(8,), (16,)]),
+  ("matvec",            "ij,j->i",          [(8, 16), (16,)]),
+  ("vecmat",            "i,ij->j",          [(8,), (8, 16)]),
+  ("elem-reduce",       "ij,ij->i",         [(8, 16), (8, 16)]),
+  ("dot",               "i,i->",            [(32,), (32,)]),
+  ("full-reduce",       "ij->",             [(8, 16)]),
+  ("row-reduce",        "ij->i",            [(8, 16)]),
+  ("col-reduce",        "ij->j",            [(8, 16)]),
+  ("bilinear",          "bi,ij,bj->b",      [(4, 8), (8, 8), (4, 8)]),
+  ("attn-scores",       "bhqd,bhkd->bhqk",  [(2, 3, 5, 7), (2, 3, 6, 7)]),
+  ("attn-context",      "bhqk,bhkd->bhqd",  [(2, 3, 5, 6), (2, 3, 6, 7)]),
+  ("weighted-combo",    "bn,bnd->bd",       [(4, 6), (4, 6, 5)]),
+  ("three-chain",       "ij,jk,kl->il",     [(6, 8), (8, 5), (5, 7)]),
+  ("batch-elem-mul",    "bij,bij->bij",     [(2, 4, 5), (2, 4, 5)]),
+  ("tensordot",         "ijk,kl->ijl",      [(3, 4, 5), (5, 6)]),
+  ("contract-mid",      "ijk,jl->ikl",      [(3, 4, 5), (4, 6)]),
+  ("partial-reduce",    "ijk,ik->i",        [(3, 4, 5), (3, 5)]),
+  ("rand-A",            "abc,cd->abd",      [(2, 3, 4), (4, 5)]),
+  ("rand-B",            "ij,ik->jk",        [(7, 4), (7, 5)]),
+  ("rand-C",            "abcd,abce->abde",  [(2, 2, 3, 4), (2, 2, 3, 5)]),
+  ("diag",              "ii->i",            [(5, 5)]),
+  ("trace",             "ii->",             [(5, 5)]),
+  ("diag-batch",        "bii->bi",          [(3, 5, 5)]),
+  ("diag-then-contract", "ii,ij->j",        [(5, 5), (5, 6)]),
+  ("diag-both-operands", "ii,jj->ij",       [(4, 4), (5, 5)]),
+  ("diag-middle",       "ibi->bi",          [(4, 3, 4)]),
+  ("two-diag-pairs",    "iijj->ij",         [(3, 3, 4, 4)]),
+  ("ellipsis",          "...ij->...ji",     [(2, 3, 4)]),
+]
+
+_SELFTEST_REJECTED = [
+  ("diag-write", "ij->ii", [(5, 5)]),
+  ("triple-repeat", "iii->i", [(4, 4, 4)]),
+]
+
+
 # public API
 
 def einsum(equation: str, *operands: Tensor) -> Tensor:
@@ -304,47 +348,8 @@ def _selftest() -> int:
   def R(*shape):
     return rng.standard_normal(shape).astype(f16)
 
-  # (name, equation, [shapes...], tol)
-  battery = [
-    ("matmul",            "ij,jk->ik",        [(8, 16), (16, 12)]),
-    ("matmul-implied",    "ij,jk",            [(8, 16), (16, 12)]),
-    ("batched-matmul",    "bij,bjk->bik",     [(4, 8, 16), (4, 16, 12)]),
-    ("transpose",         "ij->ji",           [(8, 16)]),
-    ("transpose-3d",      "abc->cab",         [(3, 4, 5)]),
-    ("outer",             "i,j->ij",          [(8,), (16,)]),
-    ("matvec",            "ij,j->i",          [(8, 16), (16,)]),
-    ("vecmat",            "i,ij->j",          [(8,), (8, 16)]),
-    ("elem-reduce",       "ij,ij->i",         [(8, 16), (8, 16)]),
-    ("dot",               "i,i->",            [(32,), (32,)]),
-    ("full-reduce",       "ij->",             [(8, 16)]),
-    ("row-reduce",        "ij->i",            [(8, 16)]),
-    ("col-reduce",        "ij->j",            [(8, 16)]),
-    ("bilinear",          "bi,ij,bj->b",      [(4, 8), (8, 8), (4, 8)]),
-    ("attn-scores",       "bhqd,bhkd->bhqk",  [(2, 3, 5, 7), (2, 3, 6, 7)]),
-    ("attn-context",      "bhqk,bhkd->bhqd",  [(2, 3, 5, 6), (2, 3, 6, 7)]),
-    ("weighted-combo",    "bn,bnd->bd",       [(4, 6), (4, 6, 5)]),
-    ("three-chain",       "ij,jk,kl->il",     [(6, 8), (8, 5), (5, 7)]),
-    ("batch-elem-mul",    "bij,bij->bij",     [(2, 4, 5), (2, 4, 5)]),
-    ("tensordot",         "ijk,kl->ijl",      [(3, 4, 5), (5, 6)]),
-    ("contract-mid",      "ijk,jl->ikl",      [(3, 4, 5), (4, 6)]),
-    ("partial-reduce",    "ijk,ik->i",        [(3, 4, 5), (3, 5)]),
-    ("rand-A",            "abc,cd->abd",      [(2, 3, 4), (4, 5)]),
-    ("rand-B",            "ij,ik->jk",        [(7, 4), (7, 5)]),
-    ("rand-C",            "abcd,abce->abde",  [(2, 2, 3, 4), (2, 2, 3, 5)]),
-    ("diag",              "ii->i",            [(5, 5)]),
-    ("trace",             "ii->",             [(5, 5)]),
-    ("diag-batch",        "bii->bi",          [(3, 5, 5)]),
-    ("diag-then-contract", "ii,ij->j",        [(5, 5), (5, 6)]),
-    ("diag-both-operands", "ii,jj->ij",       [(4, 4), (5, 5)]),
-    ("diag-middle",       "ibi->bi",          [(4, 3, 4)]),
-    ("two-diag-pairs",    "iijj->ij",         [(3, 3, 4, 4)]),
-    ("ellipsis",          "...ij->...ji",     [(2, 3, 4)]),   # supported since _expand_ellipsis landed
-  ]
-
-  rejected = [
-    ("diag-write", "ij->ii", [(5, 5)]),
-    ("triple-repeat", "iii->i", [(4, 4, 4)]),
-  ]
+  battery = _SELFTEST_SUPPORTED
+  rejected = _SELFTEST_REJECTED
 
   print("SUPPORTED battery (relerr vs numpy.einsum on the ANE):")
   passes = 0

--- a/tests/test_einsum_selftest.py
+++ b/tests/test_einsum_selftest.py
@@ -1,0 +1,34 @@
+"""Pytest coverage for the einsum self-test case inventory."""
+import numpy as np
+import pytest
+
+import importlib
+
+import aneforge as af
+
+einsum_mod = importlib.import_module("aneforge.einsum")
+
+
+def _inputs(shapes):
+  return [af.input(shape) for shape in shapes]
+
+
+@pytest.mark.parametrize("name,equation,shapes", einsum_mod._SELFTEST_SUPPORTED)
+def test_einsum_selftest_supported_cases_lower_without_dispatch(name, equation, shapes):
+  """Every supported self-test equation should build a graph with numpy's shape."""
+  tensors = _inputs(shapes)
+
+  out = einsum_mod.einsum(equation, *tensors)
+  ref = np.einsum(equation, *[np.zeros(shape, np.float32) for shape in shapes])
+
+  expected_shape = tuple(np.shape(ref)) or (1,)
+  assert tuple(out.shape) == expected_shape, name
+
+
+@pytest.mark.parametrize("name,equation,shapes", einsum_mod._SELFTEST_REJECTED)
+def test_einsum_selftest_rejected_cases_still_raise(name, equation, shapes):
+  """Unsupported self-test equations should keep failing before dispatch."""
+  tensors = _inputs(shapes)
+
+  with pytest.raises((einsum_mod.EinsumUnsupported, ValueError, NotImplementedError)):
+    einsum_mod.einsum(equation, *tensors)


### PR DESCRIPTION
## Summary

- move the einsum self-test case inventory to module-level constants
- add pytest coverage that imports those cases and checks supported equations lower off-device with numpy-compatible shapes
- add pytest coverage that the rejected self-test equations still raise before dispatch

## Related issue

Related to #127. This is the off-device slice for the `aneforge/einsum.py` self-test battery; it does not claim on-device numeric coverage.

## Verification

- `pytest -m 'not requires_ane' tests/test_einsum_selftest.py -q`
- `ruff check`
- `python -m pylint --disable=all -e W0311 -e C0303 --indent-string='  ' --recursive=y aneforge tests`
- `pyright aneforge` after installing `.[dev,models] scipy`
- `python -m compileall -q aneforge/einsum.py tests/test_einsum_selftest.py`
- `pytest -m 'not requires_ane' -q`

On-device ANE numeric self-test was not run in this Linux environment.
