### PR TITLE
compile: apply layer_norm's affine on the last axis, not in the rank-4 body

### DIFF
--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -726,9 +726,16 @@ def _e_rms_norm(em, t, n, s):
 
 @op("layer_norm")
 def _e_layer_norm(em, t, n, s):
+  # The affine consts stay on the LAST axis at rank 2, applied AFTER the reshape back, not inside the
+  # rank-4 body. A non-uniform const multiplied between the reshape-in and reshape-out fails
+  # ANECCompile from D=1024 up (#162), and it is non-uniformity that trips it, not being runtime:
+  # a gamma differing in one element out of 1024 fails exactly like a random one, while an all-equal
+  # vector compiles. Not the channel axis per se -- channel_layer_norm applies the same [1,C,1,1]
+  # const at [512,1024,1,1] with no reshape pair and compiles. The reduce still needs the rank-4
+  # form, so only the affine moves.
   M, D = t.shape[0], t.shape[-1]
-  g4 = em.weight(f"{n}_g", t.attrs["gamma"].reshape(1, D, 1, 1), allow_int8=False)
-  b4 = em.weight(f"{n}_b", t.attrs["beta"].reshape(1, D, 1, 1), allow_int8=False)
+  g2 = em.weight(f"{n}_g", t.attrs["gamma"].reshape(1, D), allow_int8=False)
+  b2 = em.weight(f"{n}_b", t.attrs["beta"].reshape(1, D), allow_int8=False)
   eps = float(np.float16(t.attrs["eps"])).hex()
   em.line(f'tensor<int32,[4]> {n}_rs = const()[name=string("{n}_rs"), val=tensor<int32,[4]>([{M},{D},1,1])];')
   em.line(f'tensor<int32,[{len(t.shape)}]> {n}_ro = const()[name=string("{n}_ro"), val=tensor<int32,[{len(t.shape)}]>({list(t.shape)})];')
@@ -743,9 +750,9 @@ def _e_layer_norm(em, t, n, s):
   em.line(f'tensor<fp16,[{M},1,1,1]> {n}_ve = add(x={n}_var, y={n}_ep)[name=string("{n}_ve")];')
   em.line(f'tensor<fp16,[{M},1,1,1]> {n}_rr = rsqrt(epsilon=fp16(0.0), x={n}_ve)[name=string("{n}_rr")];')
   em.line(f'tensor<fp16,[{M},{D},1,1]> {n}_xn = mul(x={n}_xc, y={n}_rr)[name=string("{n}_xn")];')
-  em.line(f'tensor<fp16,[{M},{D},1,1]> {n}_gg = mul(x={n}_xn, y={g4})[name=string("{n}_gg")];')
-  em.line(f'tensor<fp16,[{M},{D},1,1]> {n}_bb = add(x={n}_gg, y={b4})[name=string("{n}_bb")];')
-  em.line(f'{em.ty(t.shape)} {n} = reshape(shape={n}_ro, x={n}_bb)[name=string("{n}")];')
+  em.line(f'{em.ty(t.shape)} {n}_rb = reshape(shape={n}_ro, x={n}_xn)[name=string("{n}_rb")];')
+  em.line(f'{em.ty(t.shape)} {n}_gg = mul(x={n}_rb, y={g2})[name=string("{n}_gg")];')
+  em.line(f'{em.ty(t.shape)} {n} = add(x={n}_gg, y={b2})[name=string("{n}")];')
 
 
 @op("channel_layer_norm")

--- a/tests/test_layer_norm_affine_form.py
+++ b/tests/test_layer_norm_affine_form.py
@@ -1,0 +1,65 @@
+"""layer_norm's affine layout, asserted off-device so CI runs it (#162).
+
+A non-uniform affine const on the CHANNEL axis fails ANECCompile from D=1024 up, so the affine must
+be applied after the reshape back, at rank 2 on the last axis. That is a property of the emitted MIL,
+and `_lower_fused_to_dir` produces it without compiling or dispatching, so CI can check it even
+though CI cannot reach an ANE.
+"""
+import re
+
+import numpy as np
+
+import aneforge as af
+from aneforge._compile import _lower_fused_to_dir
+
+R, D = 8, 1024
+
+
+def _mil(tmp_path, gamma, beta):
+  x = af.input((R, D))
+  d = _lower_fused_to_dir(x.layer_norm(gamma, beta), build_dir=str(tmp_path / "prog"))
+  return (d / "model.mil").read_text()
+
+
+def _affine(tmp_path):
+  """MIL for a non-uniform affine, the case that regressed."""
+  rng = np.random.default_rng(13)
+  g = (rng.standard_normal(D).astype(np.float32) * 0.1 + 1.0).astype(np.float16)
+  b = (rng.standard_normal(D).astype(np.float32) * 0.1).astype(np.float16)
+  return _mil(tmp_path, g, b)
+
+
+def test_affine_consts_are_rank2_on_the_last_axis(tmp_path):
+  # [1,D,1,1] puts D on the channel axis, which is what ANECCompile rejects above D=1024.
+  mil = _affine(tmp_path)
+  for slot in ("_g", "_b"):
+    decl = re.search(rf"tensor<fp16, \[([^\]]+)\]> \w+{slot} = const\(\)", mil)
+    assert decl, f"no const declaration for the {slot} affine slot"
+    assert [s.strip() for s in decl.group(1).split(",")] == ["1", str(D)], \
+        f"{slot} affine const is [{decl.group(1)}], expected [1, {D}]"
+
+
+def test_affine_is_applied_after_the_reshape_back(tmp_path):
+  # Order matters as much as shape: a [1,D] const multiplied while still rank-4 would broadcast
+  # differently and lose the property this guards.
+  mil = _affine(tmp_path)
+  assert mil.index("_rb = reshape(") < mil.index("_gg = mul("), \
+      "gamma is applied before the reshape back to [M,D]"
+  assert mil.index("_gg = mul(") < mil.rindex("= add("), "beta is applied before gamma"
+
+
+def test_normalized_body_stays_rank4(tmp_path):
+  # The reduce still needs the [M,D,1,1] form; only the affine moved. Guards an over-correction
+  # that would also move the reduce and change what is measured.
+  mil = _affine(tmp_path)
+  assert f"tensor<fp16,[{R},{D},1,1]> " in mil, "the normalization body is no longer rank-4"
+  assert "reduce_mean(" in mil
+
+
+def test_layout_does_not_depend_on_the_affine_values(tmp_path):
+  # The emitted MIL is value-independent: consts are BLOBFILE references. A uniform affine must not
+  # take a different path from a non-uniform one, or the fix would only cover the case it was
+  # written against.
+  uniform = _mil(tmp_path / "u", np.full(D, 1.1, np.float16), np.full(D, 0.1, np.float16))
+  varied = _affine(tmp_path / "v")
+  assert uniform == varied


### PR DESCRIPTION
Fixes #162.

`layer_norm` applies its affine while still inside the rank-4 body, multiplying a `[1,D,1,1]` const between the reshape-in and the reshape-out. That is what ANECCompile rejects from D=1024 up. This applies the affine after the reshape back instead, as a `[1,D]` const on the last axis. The reduce still needs the rank-4 form, so only the affine moves.

Full measurements and the elimination are in [my comment on #162](https://github.com/sbryngelson/ANEForge/issues/162#issuecomment-5258288390). The short version:

**It is not fold asymmetry.** The emitted MIL is byte-identical across `cc`/`rz`/`or`/`rr` (md5 `813ac48a0bf77a85a8352b33f9c5c772`); only `weights.bin` differs. `_e_layer_norm` never omitted a slot, so there was no asymmetry in what we emit.

**It is not constant-vs-live.** A fully compile-time-constant gamma differing in **one element out of 1024** C-FAILs exactly like a random one, while an all-equal vector compiles. The trigger is non-uniformity.

**It is not the channel axis on its own.** `channel_layer_norm` multiplies the same `[1,C,1,1]` non-uniform const at `[512,1024,1,1]`, the exact shape `layer_norm` builds internally, and compiles. What fails is that const applied *between a reshape pair*. I do not know the mechanism inside ANECCompile; that is the empirical boundary, and it is the one this moves across.

## Result on hardware

Apple M2 Pro (Mac14,12), macOS 26.5.2. Every cell 5 runs, fresh process per compile, breaker disabled. All previously failing configs now compile:

| gamma/beta | D=1024 | D=2048 | D=4096 |
|---|---|---|---|
| `rand`/`zeros` | C-FAIL → **OK** 5/5 | C-FAIL → **OK** 5/5 | C-FAIL → **OK** 5/5 |
| `ones`/`rand` | C-FAIL → **OK** 5/5 | C-FAIL → **OK** 5/5 | |
| `rand`/`rand` | C-FAIL → **OK** 5/5 | OK → **OK** 5/5 | |
| `const`/`const` | OK → **OK** 5/5 | | |

Numerically it is a small improvement, not a regression. Against an fp64 numpy reference on the same fp16-rounded input, at D=512 where both forms compile:

| form | mean relerr | max abs err |
|---|---|---|
| before | 6.504e-04 | 9.707e-03 |
| after | 6.442e-04 | 7.391e-03 |

Max absolute error stays flat as D grows (7.39e-03 / 7.91e-03 / 6.81e-03 at D=512/1024/2048).

## Checks

- **Corpus gate: GREEN 90/90**, 0 red. Median relerr 6.27e-04.
- Off-device suite (what CI runs): 264 passed, 2 skipped.
- Full on-device suite: **954 passed, 7 failed** in 15m55s. The 7 are pre-existing and unrelated: I ran exactly those on a clean worktree at `origin/main` (`a2506ba`) and **the same 7 fail there**, all from optional deps I do not have installed (`transformers` for test_llm / test_moe / test_qwen35, `torchvision` for test_onnx resnet18 / test_train_cifar).
- `ruff check` clean, `.githooks/pre-commit` clean, `pyright` 0 errors on the touched files.
- The emitted program is still **one fused e5rt program** with a single input, checked through `_lower_fused_to_dir` rather than inferred from a successful compile; gamma and beta remain `const()` `BLOBFILE` entries and nothing became a runtime input.

## Tests

`tests/test_layer_norm_affine_form.py` is a new module with no `requires_ane` marker, so **CI runs it** even though CI cannot reach an ANE: the property is a shape and an ordering in the emitted MIL, and `_lower_fused_to_dir` produces that without compiling or dispatching. Same split as #144 and #196.

Being precise about what they prove: **2 of the 4 fail without this change** (`test_affine_consts_are_rank2_on_the_last_axis` and `test_affine_is_applied_after_the_reshape_back`). The other two are deliberate invariant guards rather than regression tests, one that the normalization body stays rank-4 so a future change does not also move the reduce, one that the emitted MIL stays value-independent.

## Risk

The affine now runs on `[M,D]` instead of `[M,D,1,1]`. Same elementwise ops, same broadcast semantics, one extra `reshape` node moved rather than added. The main thing worth a reviewer's eye is whether any consumer depends on the old node names (`_bb` is gone; the output is now the `add` itself).

Not addressed here: the value-dependence you filed as bug B. At `[512,2048]` before this change, `rz` C-FAILed 5/5 while `rr` passed 5/5, which uniformity alone does not explain. Both compile after, but I would not claim this closes that thread.

Happy to close this if you would rather pick a different shape for the fix, or land it alongside a probe change that adds a uniformity axis to `layer_norm_compile_probe.py` (today `const` happens to mean uniform and `rand` non-uniform, which is what hid this for so long).
