### PR TITLE
feat(llm): add a Gemma adapter - GeGLU MLP, scaled embeddings, (1+w) RMSNorm

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -150,6 +150,20 @@ def _swiglu(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
   return h + (hn.linear(w["wgate"]).silu() * hn.linear(w["wup"])).linear(w["wdown"])
 
 
+def _gelu_tanh(x: Tensor) -> Tensor:
+  """PyTorch 'tanh' GELU (Gemma's `gelu_pytorch_tanh`): 0.5*x*(1+tanh(sqrt(2/pi)*(x+0.044715*x^3)))."""
+  x3 = (x * x) * x
+  inner = (x3 * 0.044715) + x
+  t = inner.scaled_tanh(1.0, 0.7978845608028654)
+  return (x * t.adds(1.0)) * 0.5
+
+
+def _geglu(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
+  """GeGLU MLP with its residual: `h + down(gelu_tanh(gate(norm(h))) * up(norm(h)))`."""
+  hn = h.rms_norm(w["mlp_norm"], cfg.norm_eps)
+  return h + (_gelu_tanh(hn.linear(w["wgate"])) * hn.linear(w["wup"])).linear(w["wdown"])
+
+
 def prefill_block(x: Tensor, w: dict, cfg: LlamaConfig, cos, sin, ls: LayerSpec | None = None) -> Tensor:
   """One pre-norm decoder block (mixer + MLP). Back-compatible: with no `ls`, QK-norm is detected from `w`."""
   ls = ls or LayerSpec(qk_norm="q_norm" in w)
@@ -187,9 +201,9 @@ def _attn_decode(x: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec, ctx: dict,
 
 
 PREFILL_MIXERS = {"attention": _attn_prefill}
-PREFILL_MLPS = {"swiglu": _swiglu}
+PREFILL_MLPS = {"swiglu": _swiglu, "geglu": _geglu}
 DECODE_MIXERS = {"attention": _attn_decode}
-DECODE_MLPS = {"swiglu": _swiglu}
+DECODE_MLPS = {"swiglu": _swiglu, "geglu": _geglu}
 # Per-position decode inputs a mixer may read from `ctx` (created per chunk, shared across its layers).
 _DECODE_CTX = ("oh", "inv", "mask", "cosp", "sinp")
 
@@ -446,6 +460,40 @@ def _dense_adapter(c, sd) -> tuple[LlamaConfig, dict]:
   return cfg, _weights_from_state_dict(sd, cfg)
 
 
+def _rope_theta(c) -> float:
+  """HF RoPE base, reading the transformers-5.x `rope_parameters` dict with a legacy fallback."""
+  rp = getattr(c, "rope_parameters", None)
+  if isinstance(rp, dict) and "rope_theta" in rp:
+    return float(rp["rope_theta"])
+  return float(getattr(c, "rope_theta", 10000.0))
+
+
+def _rope_scaling(c):
+  """HF rope_scaling, but only when the runner implements the type (Llama-3.1 "llama3")."""
+  s = getattr(c, "rope_scaling", None)
+  return s if isinstance(s, dict) and s.get("rope_type") == "llama3" else None
+
+
+def _gemma_adapter(c, sd) -> tuple[LlamaConfig, dict]:
+  """Adapter for Gemma decoders. The runner's graph is Llama-shaped, so the differences are baked
+  into the weights: embeddings are scaled by sqrt(dim) at input, the FFN is GeGLU (gelu_pytorch_tanh,
+  via `LayerSpec(mlp="geglu")`), and the RMSNorm weights use the `(1 + weight)` convention."""
+  n = int(c.num_hidden_layers)
+  cfg = LlamaConfig(dim=c.hidden_size, n_layers=n, n_heads=c.num_attention_heads,
+                    n_kv_heads=int(getattr(c, "num_key_value_heads", c.num_attention_heads)),
+                    ffn_dim=c.intermediate_size, vocab=c.vocab_size,
+                    rope_base=_rope_theta(c), norm_eps=float(c.rms_norm_eps),
+                    head_dim=int(getattr(c, "head_dim", 0) or 0),
+                    layers=[LayerSpec(mixer="attention", mlp="geglu") for _ in range(n)])
+  w = _weights_from_state_dict(sd, cfg)
+  w["embed"] = w["embed"] * np.sqrt(c.hidden_size)        # HF: inputs_embeds * hidden_size**0.5
+  for lw in w["layers"]:                                   # HF GemmaRMSNorm: output * (1.0 + weight)
+    lw["attn_norm"] = lw["attn_norm"] + 1.0
+    lw["mlp_norm"] = lw["mlp_norm"] + 1.0
+  w["final_norm"] = w["final_norm"] + 1.0
+  return cfg, w
+
+
 def _cfg_from_hf(c) -> LlamaConfig:
   """Back-compat: a `LlamaConfig` (no per-layer plan) from a Hugging Face config."""
   return LlamaConfig(dim=c.hidden_size, n_layers=c.num_hidden_layers, n_heads=c.num_attention_heads,
@@ -457,7 +505,9 @@ def _cfg_from_hf(c) -> LlamaConfig:
 
 # Architecture adapters: (predicate(hf_config) -> bool, adapter(hf_config, sd) -> (cfg, weights)); first match
 # wins, dense Llama/Qwen is the fallback. New archs append here (e.g. aneforge.moe) so the loader stays generic.
-ADAPTERS: list = []
+ADAPTERS: list = [
+  (lambda c: c.model_type == "gemma", _gemma_adapter),
+]
 
 
 def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -152,7 +152,8 @@ before RoPE), and a large vocab - the layers run on the ANE; the lm_head project
 
 ## Scope
 
-Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), sparse **Mixture-of-Experts**
+Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), **Gemma**
+(scaled embeddings + GeGLU + `(1+w)` RMSNorm), sparse **Mixture-of-Experts**
 (Qwen3-MoE, Qwen2-MoE), and **hybrid** DeltaNet+attention (Qwen3.5). Runtime features: prefill + resident
 KV-cache decode, automatic segmentation past the ~2 GB program ceiling, int8/int4 weights, and exact
 speculative decoding. Static prompt length per compiled graph; the lm_head projection runs on host.

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,6 @@
 import numpy as np
 import aneforge as af
-from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf
+from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf, _gemma_adapter
 from _helpers import requires_ane, make_random_llama_model as _random_model
 
 pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
@@ -114,3 +114,21 @@ def test_prefill_matches_huggingface_llama():  # the definitive check: ANE prefi
   ane = np.asarray(LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg)).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"
+
+
+@requires_ane
+def test_prefill_matches_huggingface_gemma():  # the Gemma adapter: embed scale, (1+w) norms, GeGLU
+  import torch
+  from transformers import GemmaConfig as HF, GemmaForCausalLM
+  hf_cfg = HF(**{"hidden_size": 64, "num_hidden_layers": 2, "num_attention_heads": 4, "num_key_value_heads": 1,
+                 "head_dim": 16, "intermediate_size": 128, "vocab_size": 64, "rms_norm_eps": 1e-6,
+                 "max_position_embeddings": 64, "tie_word_embeddings": True,
+                 "rope_parameters": {"rope_theta": 10000.0, "rope_type": "default"}})
+  torch.manual_seed(0); m = GemmaForCausalLM(hf_cfg).eval()
+  toks = np.random.default_rng(0).integers(0, 64, 10)
+  with torch.no_grad(): ref = m(torch.tensor(toks)[None]).logits[0, -1].numpy()
+  sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
+  cfg, w = _gemma_adapter(m.config, sd)
+  ane = np.asarray(LlamaPrefill(cfg, w).prefill(toks)).ravel().astype(np.float32)
+  cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
+  assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE Gemma prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"


### PR DESCRIPTION
Closes #193

Gemma is Llama-shaped except for three weight-level differences, all baked into the adapter:

- **Embeddings scaled by sqrt(hidden_size)** at input (HF bakes this into `GemmaTextScaledWordEmbedding`).
- **GeGLU FFN** (`gelu_pytorch_tanh`), which the runner didn't have: new `_geglu` builder composed from fused ops (`muls`/`adds`/`scaled_tanh`), registered in `PREFILL_MLPS`/`DECODE_MLPS` and selected via `LayerSpec(mlp="geglu")`.
- **RMSNorm `(1 + weight)` convention** (checked against `modeling_gemma.py`: `output * (1.0 + weight)`), applied at adapter time so the runner's direct-gamma norm stays untouched.

GQA and the explicit `head_dim` (gemma-7b: 256 != dim // heads) were already handled by the runner. Registered `model_type == "gemma"` only: gemma2 additionally needs logit softcapping, which the runner does not support yet, so registering it would silently produce wrong logits. That is a follow-up.

### Validation

- **On-device (M2 Pro, macOS 26.5.2)**: `google/gemma-2b` int8. Prefill argmax matches HF fp16 (`"The capital of France is"` -> 476 `"a"`); 12-token greedy decode is token-identical to `transformers` fp16: *"a city of contrasts. It is a city of history,"*.
- **In-process test** (`test_prefill_matches_huggingface_gemma`): small random `GemmaForCausalLM` (GQA 4/1, head_dim 16, tied embeddings), cosine > 0.99 + argmax match vs HF. Runs on any ANE; `requires_ane` marked.
- `tests/test_llm.py`: 12 passed. Off-device suite: 303 passed, 2 skipped. ruff, pylint 2-space gate, pyright clean (12 pre-existing errors in `onnx.py`/`_gguf.py` untouched).
- Docs: `docs/llm.md` scope section lists Gemma.