### PR TITLE
feat(llm): add a Mistral adapter (GQA + sliding window) and fix RoPE base under transformers 5.x

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -494,6 +494,22 @@ def _gemma_adapter(c, sd) -> tuple[LlamaConfig, dict]:
   return cfg, w
 
 
+def _mistral_adapter(c, sd) -> tuple[LlamaConfig, dict]:
+  """Adapter for Mistral decoders: Llama-shaped (same state_dict names) with grouped-query attention
+  and a sliding window. With a resident KV cache the window is the cache length, so decode stays
+  exact while `max_len` does not exceed `sliding_window`; the limit is surfaced in `cfg.extra`."""
+  n = int(c.num_hidden_layers)
+  cfg = LlamaConfig(dim=c.hidden_size, n_layers=n, n_heads=c.num_attention_heads,
+                    n_kv_heads=int(getattr(c, "num_key_value_heads", c.num_attention_heads)),
+                    ffn_dim=c.intermediate_size, vocab=c.vocab_size,
+                    rope_base=_rope_theta(c), norm_eps=float(c.rms_norm_eps),
+                    head_dim=int(getattr(c, "head_dim", 0) or 0),
+                    layers=[LayerSpec(mixer="attention", mlp="swiglu") for _ in range(n)])
+  if getattr(c, "sliding_window", None):
+    cfg.extra["sliding_window"] = int(c.sliding_window)
+  return cfg, _weights_from_state_dict(sd, cfg)
+
+
 def _cfg_from_hf(c) -> LlamaConfig:
   """Back-compat: a `LlamaConfig` (no per-layer plan) from a Hugging Face config."""
   return LlamaConfig(dim=c.hidden_size, n_layers=c.num_hidden_layers, n_heads=c.num_attention_heads,
@@ -507,6 +523,7 @@ def _cfg_from_hf(c) -> LlamaConfig:
 # wins, dense Llama/Qwen is the fallback. New archs append here (e.g. aneforge.moe) so the loader stays generic.
 ADAPTERS: list = [
   (lambda c: c.model_type == "gemma", _gemma_adapter),
+  (lambda c: c.model_type == "mistral", _mistral_adapter),
 ]
 
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,6 +1,6 @@
 import numpy as np
 import aneforge as af
-from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf, _gemma_adapter
+from aneforge.llm import LlamaConfig, LlamaPrefill, prefill_block, rope, rope_tables, _weights_from_state_dict, _cfg_from_hf, _gemma_adapter, _mistral_adapter
 from _helpers import requires_ane, make_random_llama_model as _random_model
 
 pytestmark = requires_ane  # every test in this module compiles/dispatches to the ANE
@@ -132,3 +132,21 @@ def test_prefill_matches_huggingface_gemma():  # the Gemma adapter: embed scale,
   ane = np.asarray(LlamaPrefill(cfg, w).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE Gemma prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"
+
+
+@requires_ane
+def test_prefill_matches_huggingface_mistral():  # the Mistral adapter: GQA + sliding window surfaced in extra
+  import torch
+  from transformers import MistralConfig as HF, MistralForCausalLM
+  hf_cfg = HF(**{"hidden_size": 64, "num_hidden_layers": 2, "num_attention_heads": 4, "num_key_value_heads": 2,
+                 "intermediate_size": 128, "vocab_size": 64, "rms_norm_eps": 1e-5, "sliding_window": 32,
+                 "max_position_embeddings": 64, "rope_parameters": {"rope_theta": 10000.0, "rope_type": "default"}})
+  torch.manual_seed(0); m = MistralForCausalLM(hf_cfg).eval()
+  toks = np.random.default_rng(0).integers(0, 64, 10)
+  with torch.no_grad(): ref = m(torch.tensor(toks)[None]).logits[0, -1].numpy()
+  sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
+  cfg, w = _mistral_adapter(m.config, sd)
+  assert cfg.extra["sliding_window"] == 32, "sliding window must be surfaced in cfg.extra"
+  ane = np.asarray(LlamaPrefill(cfg, w).prefill(toks)).ravel().astype(np.float32)
+  cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
+  assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE Mistral prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"


### PR DESCRIPTION
Closes #192 (draft - more validation runs pending)

Mistral is Llama-shaped with the same state_dict names, so the adapter reuses the dense plan with grouped-query attention (already handled by the runner) and surfaces the sliding window in `cfg.extra`: with a resident KV cache the window is the cache length, so decode stays exact while `max_len` does not exceed `sliding_window`.

Two fixes along the way, required for 7B models:

- **transformers 5.x RoPE base**: `rope_theta` moved into `config.rope_parameters`; the old `getattr(c, "rope_theta", ...)` silently returned the 10000.0 fallback for every Llama/Qwen/Mistral config, so Qwen3 was being loaded with base 1e4 instead of 1e6. New `_rope_theta()` helper reads the dict with a legacy fallback (also applied to `_dense_adapter` and `_cfg_from_hf`).
- **fp16 state dict in `from_pretrained`**: extracting fp32 cost ~28 GB on top of the loaded model for a 7B - enough to OOM a 32 GB Mac. The weights are baked to fp16 (or quantized) for the ANE anyway, so extract fp16 directly.

### Validation so far (M2 Pro, macOS 26.5.2)

- Small in-process `MistralForCausalLM` test (GQA 4/2, sliding_window 32): cosine > 0.99 + argmax match vs HF. Green and reproducible.
- Real `mistralai/Mistral-7B-Instruct-v0.3` int8: **prefill argmax matches HF exactly** ("The capital of France is" -> 6233 "Paris").
- The decode-program compile is **flaky on this machine** for 7B-sized graphs (`ANECCompile() FAILED`, err=11 - the same instability class as #149). It compiled once (greedy agreed for the first 4 tokens before a near-tie drift) and failed ~6 consecutive retries after that.

**Draft**: running the decode validation on a fresh machine to close the greedy check and quantify the near-tie drift. The adapter mapping itself is verified by the prefill argmax match and the in-process test.