### PR TITLE
llm: read RoPE base from transformers-5.x rope_parameters (+ fp16 state dict)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -454,7 +454,7 @@ def _dense_adapter(c, sd) -> tuple[LlamaConfig, dict]:
   cfg = LlamaConfig(dim=c.hidden_size, n_layers=n, n_heads=c.num_attention_heads,
                     n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                     ffn_dim=c.intermediate_size, vocab=c.vocab_size,
-                    rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps),
+                    rope_base=_rope_theta(c), norm_eps=float(c.rms_norm_eps),
                     head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=getattr(c, "rope_scaling", None),
                     layers=[LayerSpec(mixer="attention", mlp="swiglu", qk_norm=qk) for _ in range(n)])
   return cfg, _weights_from_state_dict(sd, cfg)
@@ -499,7 +499,7 @@ def _cfg_from_hf(c) -> LlamaConfig:
   return LlamaConfig(dim=c.hidden_size, n_layers=c.num_hidden_layers, n_heads=c.num_attention_heads,
                      n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                      ffn_dim=c.intermediate_size, vocab=c.vocab_size,
-                     rope_base=float(getattr(c, "rope_theta", 10000.0)), norm_eps=float(c.rms_norm_eps),
+                     rope_base=_rope_theta(c), norm_eps=float(c.rms_norm_eps),
                      head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=getattr(c, "rope_scaling", None))
 
 
@@ -513,9 +513,13 @@ ADAPTERS: list = [
 def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
   """Load a Llama/Qwen-class model from Hugging Face for ANE inference. `compress` ("int8"/"int4"/"blockwise")
   quantizes the ANE weights."""
+  import torch
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)
-  sd = {k: v.detach().float().numpy() for k, v in hf.state_dict().items()}
+  # fp16 state dict: the weights are baked to fp16 (or quantized) for the ANE anyway, so an fp32 copy
+  # only wastes memory -- for a 7B that fp32 copy is ~28 GB on top of the loaded model, enough to OOM a
+  # 32 GB Mac. Rounding to fp16 here is the same rounding the bake would do, so outputs are unchanged.
+  sd = {k: v.detach().to(torch.float16).numpy() for k, v in hf.state_dict().items()}
   adapt = next((fn for pred, fn in ADAPTERS if pred(hf.config)), _dense_adapter)
   cfg, weights = adapt(hf.config, sd)
   return LlamaPrefill(cfg, weights, compress=compress)

--- a/tests/test_rope_theta.py
+++ b/tests/test_rope_theta.py
@@ -1,0 +1,33 @@
+"""_rope_theta reads the RoPE base from transformers-5.x's rope_parameters dict.
+
+transformers 5.x moved rope_theta out of a top-level config attribute into the `rope_parameters`
+dict, so the old `getattr(c, "rope_theta", 10000.0)` silently returned the 10000.0 fallback for every
+model with a non-default base (Qwen3 uses 1e6, Llama-3 uses 5e5) -- wrong RoPE, silent wrong logits.
+This asserts the base is read from either layout. Off-device: pure config parsing, no ANE.
+"""
+from types import SimpleNamespace
+
+from aneforge.llm import _rope_theta
+
+
+def test_reads_base_from_rope_parameters_dict():
+  # transformers 5.x layout: base lives in rope_parameters, with no top-level rope_theta attribute.
+  c = SimpleNamespace(rope_parameters={"rope_theta": 1000000.0, "rope_type": "default"})
+  assert _rope_theta(c) == 1000000.0
+  # guard the regression directly: the pre-fix code path returns the wrong value on this layout.
+  assert float(getattr(c, "rope_theta", 10000.0)) == 10000.0
+
+
+def test_reads_legacy_top_level_attribute():
+  c = SimpleNamespace(rope_theta=500000.0)
+  assert _rope_theta(c) == 500000.0
+
+
+def test_falls_back_to_default_when_absent():
+  assert _rope_theta(SimpleNamespace()) == 10000.0
+
+
+def test_rope_parameters_without_theta_falls_back_to_attr():
+  # a rope_parameters dict that lacks rope_theta must not shadow a legacy top-level attribute.
+  c = SimpleNamespace(rope_parameters={"rope_type": "default"}, rope_theta=800000.0)
+  assert _rope_theta(c) == 800000.0


### PR DESCRIPTION
Splits the two infrastructure fixes out of #206 (axiom-of-choice's diagnosis) so they land independently of that draft's pending 7B decode validation.

RoPE base: transformers 5.x moved rope_theta into the rope_parameters dict, and the config no longer exposes a .rope_theta attribute. _dense_adapter and _cfg_from_hf read it with getattr(c, "rope_theta", 10000.0), which now returns the 10000.0 fallback, so every Qwen3 (base 1e6) and Llama-3 (base 5e5) load on transformers 5.x got the wrong base. _rope_theta() (added in #205 for Gemma, but the two general paths still used the old getattr) reads the dict with a legacy fallback. New off-device test covers all four layouts.

fp16 state dict: from_pretrained extracted at fp32. The weights are baked to fp16 (or quantized) for the ANE anyway, so the fp32 copy only wastes memory -- about 28 GB for a 7B, enough to OOM a 32 GB Mac. Extract fp16 directly; same rounding the bake would do, outputs unchanged.

Testing (M5 Pro): new tests/test_rope_theta.py 4/4 off-device; off-device suite 312 passed; on-device tests/test_llm.py 12/12; ruff clean.