### PR TITLE
models: support RoBERTa/XLM-R rerankers in CrossEncoder

### DIFF
--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -153,11 +153,48 @@ class Encoder:
     return np.asarray(vecs, dtype=np.float32)
 
 
+def _position_ids(ids: np.ndarray, pad_id: int | None) -> np.ndarray:
+  """Position ids as the reference implementations build them.
+
+  BERT counts from 0. RoBERTa counts from `padding_idx + 1` and skips pads, i.e. HF's
+  `create_position_ids_from_input_ids`: `cumsum(ids != pad) * mask + pad`. That offset is why a
+  RoBERTa position table has `max_position_embeddings + 2` rows; counting from 0 reads the wrong row
+  for every token and silently shifts the whole sequence."""
+  if pad_id is None:
+    return np.arange(len(ids))
+  mask = (ids != pad_id).astype(np.int64)
+  return np.cumsum(mask) * mask + pad_id
+
+
+def _seqcls_head(sd: dict, pref: str | None) -> tuple[str, str, str, str] | None:
+  """The two-layer tanh classification head, as (dense_w, dense_b, out_w, out_b) state-dict keys.
+
+  BERT is `pooler.dense -> tanh -> classifier`; RoBERTa is `RobertaClassificationHead`, i.e.
+  `classifier.dense -> tanh -> classifier.out_proj`, with no pooler at all. Same arithmetic on token 0,
+  different names. Returns None when neither shape is present.
+
+  RoBERTa is identified by its head, *not* by a missing token-type table: XLM-R does ship
+  `token_type_embeddings` (a single row, always index 0), so absence identifies nothing."""
+  if "classifier.dense.weight" in sd and "classifier.out_proj.weight" in sd:
+    return ("classifier.dense.weight", "classifier.dense.bias",
+            "classifier.out_proj.weight", "classifier.out_proj.bias")
+  if pref is not None and f"{pref}.pooler.dense.weight" in sd and "classifier.weight" in sd:
+    return (f"{pref}.pooler.dense.weight", f"{pref}.pooler.dense.bias",
+            "classifier.weight", "classifier.bias")
+  return None
+
+
 class CrossEncoder:
-  """Reranker: scores (query, passage) pairs with a BERT-family sequence-classification
+  """Reranker: scores (query, passage) pairs with a BERT- or RoBERTa-family sequence-classification
   model, the transformer running on the ANE. Mirrors `sentence_transformers.CrossEncoder`:
   `CrossEncoder(name).predict([(query, passage), ...])` returns one relevance score per pair
-  (raw logits -- order is what a reranker needs). Higher is more relevant."""
+  (raw logits -- order is what a reranker needs). Higher is more relevant.
+
+  Both families share the encoder graph and the `_BERT_KEYS` layer names; they differ only in host-side
+  plumbing, so the two are handled by weight selection rather than by a second code path:
+
+  - **Head.** See `_seqcls_head`: same two-layer tanh head on token 0, different key names.
+  - **Position ids.** See `_position_ids`: RoBERTa counts from `padding_idx + 1`, BERT from 0."""
 
   def __init__(self, name: str, int8: bool = False) -> None:
     from transformers import AutoConfig, AutoModelForSequenceClassification, AutoTokenizer  # lazy
@@ -168,21 +205,24 @@ class CrossEncoder:
     # The base transformer sits under a model-specific prefix (bert / roberta / ...).
     marker = ".embeddings.word_embeddings.weight"
     pref = next((k[: -len(marker)] for k in sd if k.endswith(marker)), None)
-    if pref is None or f"{pref}.pooler.dense.weight" not in sd or "classifier.weight" not in sd:
+    head = _seqcls_head(sd, pref)
+    if pref is None or head is None:
       raise ValueError(
-        f"CrossEncoder: {name!r} is not a supported reranker -- it needs a BERT-family "
-        "sequence-classification head (token-type embeddings, a pooler, and a classifier). "
-        "RoBERTa/DistilBERT-style heads are not handled yet.")
+        f"CrossEncoder: {name!r} is not a supported reranker -- it needs either a BERT-family head "
+        "(a pooler plus `classifier`) or a RoBERTa-family one (`classifier.dense` plus "
+        "`classifier.out_proj`). DistilBERT-style heads are not handled yet.")
+    roberta = head[0].startswith("classifier.")
     self.D, self.H = cfg.hidden_size, cfg.num_attention_heads
     self.L, self.eps, self.int8 = cfg.num_hidden_layers, cfg.layer_norm_eps, int8
+    self.pad_id = int(cfg.pad_token_id) if roberta else None   # None -> positions count from 0
     self.word = g(f"{pref}.embeddings.word_embeddings.weight")
     self.pos = g(f"{pref}.embeddings.position_embeddings.weight")
-    self.typ = g(f"{pref}.embeddings.token_type_embeddings.weight")
+    typ_key = f"{pref}.embeddings.token_type_embeddings.weight"
+    self.typ = g(typ_key) if typ_key in sd else np.zeros((1, self.D), np.float32)
     self.eln_w, self.eln_b = g(f"{pref}.embeddings.LayerNorm.weight"), g(f"{pref}.embeddings.LayerNorm.bias")
     self.layers = [{k: g(f"{pref}.encoder.layer.{i}." + v) for k, v in _BERT_KEYS.items()}
                    for i in range(self.L)]
-    self.pool_w, self.pool_b = g(f"{pref}.pooler.dense.weight"), g(f"{pref}.pooler.dense.bias")
-    self.cls_w, self.cls_b = g("classifier.weight"), g("classifier.bias")
+    self.pool_w, self.pool_b, self.cls_w, self.cls_b = (g(k) for k in head)
     self._cache: dict[int, Model | SegmentedModel] = {}
 
   def _build(self, S: int) -> Model | SegmentedModel:
@@ -196,7 +236,7 @@ class CrossEncoder:
 
   def _embed(self, ids: np.ndarray, typ_ids: np.ndarray) -> np.ndarray:
     """Host-side token + position + segment embedding lookup, then LayerNorm."""
-    e = self.word[ids] + self.pos[np.arange(len(ids))] + self.typ[typ_ids]
+    e = self.word[ids] + self.pos[_position_ids(ids, self.pad_id)] + self.typ[typ_ids]
     m = e.mean(-1, keepdims=True)
     v = ((e - m) ** 2).mean(-1, keepdims=True)
     return ((e - m) / np.sqrt(v + self.eps) * self.eln_w + self.eln_b).astype(np.float32)
@@ -211,8 +251,8 @@ class CrossEncoder:
       ids = np.asarray(enc["input_ids"], dtype=np.int64)
       typ = np.asarray(enc.get("token_type_ids") or [0] * len(ids), dtype=np.int64)
       net = self._cache.get(len(ids)) or self._cache.setdefault(len(ids), self._build(len(ids)))
-      cls = net(self._embed(ids, typ))[0]                              # [CLS] state, on the ANE
-      pooled = np.tanh(cls @ self.pool_w.T + self.pool_b)              # BERT pooler
+      cls = net(self._embed(ids, typ))[0]                              # [CLS] / <s> state, on the ANE
+      pooled = np.tanh(cls @ self.pool_w.T + self.pool_b)              # BERT pooler / Roberta head dense
       logits = pooled @ self.cls_w.T + self.cls_b                      # [num_labels]
       scores.append(float(logits[0]))
     return np.asarray(scores, dtype=np.float32)

--- a/tests/test_cross_encoder.py
+++ b/tests/test_cross_encoder.py
@@ -1,0 +1,72 @@
+"""Host-side plumbing that makes a RoBERTa/XLM-R reranker differ from a BERT one.
+
+Off-device on purpose: the encoder graph is identical for both families, so what a regression would
+break is the weight selection and the position indexing, and both are pure numpy. The end-to-end
+check against `transformers` on real weights needs an ANE and a download; it lives in the PR body.
+"""
+import numpy as np
+import pytest
+
+from aneforge.models import _position_ids, _seqcls_head
+
+BERT_SD = {
+  "bert.embeddings.word_embeddings.weight": None,
+  "bert.pooler.dense.weight": None, "bert.pooler.dense.bias": None,
+  "classifier.weight": None, "classifier.bias": None,
+}
+# As shipped by BAAI/bge-reranker-base: no pooler, a two-layer classifier, and a token-type table
+# that exists with exactly one row.
+ROBERTA_SD = {
+  "roberta.embeddings.word_embeddings.weight": None,
+  "roberta.embeddings.token_type_embeddings.weight": None,
+  "classifier.dense.weight": None, "classifier.dense.bias": None,
+  "classifier.out_proj.weight": None, "classifier.out_proj.bias": None,
+}
+
+
+def test_bert_head_keys():
+  assert _seqcls_head(BERT_SD, "bert") == (
+    "bert.pooler.dense.weight", "bert.pooler.dense.bias", "classifier.weight", "classifier.bias")
+
+
+def test_roberta_head_keys():  # RobertaClassificationHead: dense -> tanh -> out_proj, no pooler
+  assert _seqcls_head(ROBERTA_SD, "roberta") == (
+    "classifier.dense.weight", "classifier.dense.bias",
+    "classifier.out_proj.weight", "classifier.out_proj.bias")
+
+
+def test_roberta_is_not_detected_by_a_missing_token_type_table():
+  """The obvious discriminator does not work: XLM-R *has* token_type_embeddings, so keying on its
+  absence would classify bge-reranker-base as BERT and then look for a pooler that is not there."""
+  assert "roberta.embeddings.token_type_embeddings.weight" in ROBERTA_SD
+  assert _seqcls_head(ROBERTA_SD, "roberta")[0] == "classifier.dense.weight"
+
+
+def test_head_is_none_for_an_unsupported_model():
+  assert _seqcls_head({"distilbert.embeddings.word_embeddings.weight": None}, "distilbert") is None
+  assert _seqcls_head(BERT_SD, None) is None          # no prefix -> no pooler key to look for
+
+
+def test_bert_positions_count_from_zero():
+  ids = np.array([101, 2054, 2003, 102], dtype=np.int64)
+  assert _position_ids(ids, None).tolist() == [0, 1, 2, 3]
+
+
+def test_roberta_positions_are_offset_by_padding_idx_plus_one():
+  """HF create_position_ids_from_input_ids. With pad_token_id=1 the first real token is position 2,
+  which is why the table carries max_position_embeddings + 2 rows."""
+  ids = np.array([0, 2367, 83, 2], dtype=np.int64)     # <s> ... </s>, no pads
+  assert _position_ids(ids, 1).tolist() == [2, 3, 4, 5]
+
+
+def test_roberta_positions_skip_pads():
+  ids = np.array([0, 2367, 2, 1, 1], dtype=np.int64)   # two trailing <pad>
+  assert _position_ids(ids, 1).tolist() == [2, 3, 4, 1, 1]
+
+
+@pytest.mark.parametrize("pad_id", [0, 1, 3])
+def test_roberta_positions_stay_inside_the_table(pad_id):
+  """Every index must be addressable in a table of max_position + 2 rows, for any padding_idx."""
+  ids = np.arange(100, 140, dtype=np.int64)
+  pos = _position_ids(ids, pad_id)
+  assert pos.min() >= 0 and pos.max() < len(ids) + pad_id + 1


### PR DESCRIPTION
Closes #190.

`CrossEncoder` handled BERT-family sequence-classification models and raised on RoBERTa/XLM-R, which left out the most widely used reranker family. `BAAI/bge-reranker-base` now runs on the engine.

The encoder graph and the `_BERT_KEYS` layer names are already shared between the two families, so the whole difference is host-side plumbing and it lands as weight selection rather than a second code path. `predict()` and `_build()` are unchanged.

## What changed

**`_seqcls_head(sd, pref)`** picks the classification head by state-dict shape. BERT is `pooler.dense -> tanh -> classifier`. RoBERTa is `RobertaClassificationHead`, i.e. `classifier.dense -> tanh -> classifier.out_proj`, with no pooler at all. Both are the same two-layer tanh head on token 0, so once the four keys are chosen the arithmetic is identical.

**`_position_ids(ids, pad_id)`** implements HF `create_position_ids_from_input_ids`: `cumsum(ids != pad) * mask + pad`. RoBERTa counts from `padding_idx + 1` and skips pads, which is why its position table carries `max_position_embeddings + 2` rows (514 here). Counting from 0 reads the wrong row for every token.

The token-type lookup now falls back to zeros for a checkpoint that genuinely omits the table.

Both helpers are module-level so CI can cover them off-device.

## One correction to the issue

The issue suggests detecting the family by `{pref}.embeddings.token_type_embeddings` being absent. That does not work: `bge-reranker-base` **does** ship `token_type_embeddings`, shape `(1, 768)`, a single row that is always index 0. Absence identifies nothing, and keying on it also misclassifies BERT. Detecting by head shape covers both families, and `test_roberta_is_not_detected_by_a_missing_token_type_table` pins that down so the shortcut is not reintroduced.

Everything else was read off the model rather than assumed: `model_type=xlm-roberta`, `num_labels=1`, `pad_token_id=1`, `type_vocab_size=1`, no `roberta.pooler.*`, and the tokenizer returns no `token_type_ids` (the existing fallback already covers that).

## Verification

**On device (M2 Pro, macOS 26.5.2), `BAAI/bge-reranker-base` against `AutoModelForSequenceClassification`:**

| query | passage | HF | ANE | abs err |
|---|---|---|---|---|
| what is a panda? | The giant panda is a bear species endemic to China. | 0.9140 | 0.9113 | 0.00273 |
| what is a panda? | Paris is the capital and most populous city of France. | -10.1960 | -10.1959 | 0.00008 |
| how do I boil an egg? | Place eggs in a pot, cover with water, bring to a boil. | 6.3916 | 6.3929 | 0.00131 |
| how do I boil an egg? | The Apple Neural Engine accelerates matrix multiplication. | -10.1930 | -10.1928 | 0.00021 |

Max abs err 0.00273 on raw logits, ranking identical, relevant above irrelevant on both sides.

**BERT path unchanged** (`cross-encoder/ms-marco-MiniLM-L-6-v2`, the path added in #189): max abs err 0.00236, same order, and `pad_id` is `None` so it takes the BERT branch.

**Mutation, behavioural rather than by import:**

- `_position_ids` ignoring `pad_id`: the 2 position tests fail.
- detecting RoBERTa by a missing token-type table: 4 tests fail, including the BERT one.
- restored: 10/10.

`pytest -m "not requires_ane"`: 321 passed, 2 skipped. ruff, pylint 2-space 10.00/10 and compileall clean; pyright reports the same 12 baseline errors in `onnx.py`/`_gguf.py`.

## Risks and scope

- The end-to-end check needs an ANE and a model download, so it cannot live in CI. What CI does cover is the head selection and the position indexing, which is where a regression would land.
- DistilBERT-style heads are still rejected, with the error message updated to say what is supported.
- `#189` added `CrossEncoder` and `ViT` with no tests. This PR opens `tests/test_cross_encoder.py`; `ViT` is still uncovered, happy to follow up if useful.
