### PR TITLE
models: generalize the ResNet loader to 18/34/50/101

### DIFF
--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -31,7 +31,7 @@ from ._rewrite import reduce_sum_to_matmul, paired_subtract
 from .autograd import (Adam, adam_step, backward, backward_from, conv2d, conv_param,
                        mse, parameter, SGD, softmax_cross_entropy, Trainer, UnrolledTrainer)
 from .streaming import CheckpointedStack
-from .models import Encoder, Vision, load, load_resnet18, conv_block, cifar_cnn, group_norm_train
+from .models import Encoder, Vision, load, load_resnet, load_resnet18, conv_block, cifar_cnn, group_norm_train
 from .onnx import load_onnx, onnx_to_tensor, onnx_to_features
 from .llm import LlamaConfig, LlamaPrefill, from_pretrained as load_llm, rope, rope_tables, prefill_block
 from . import moe as moe   # registers the "moe" MLP + Qwen3-MoE adapter into the llm registries
@@ -52,7 +52,7 @@ __all__ = [
     "precision_risk", "project_peak",
     "CompileBackoffError", "reset_compile_breaker",
     "reduce_sum_to_matmul", "paired_subtract",
-    "load", "load_resnet18", "Encoder", "Vision", "conv_block", "cifar_cnn", "group_norm_train",
+    "load", "load_resnet", "load_resnet18", "Encoder", "Vision", "conv_block", "cifar_cnn", "group_norm_train",
     "Paired", "paired",
     "parameter", "backward", "backward_from", "mse", "SGD", "Adam",
     "softmax_cross_entropy", "Trainer", "UnrolledTrainer", "adam_step",

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -23,17 +23,48 @@ def load(name: str, int8: bool = False, pooling: str = "mean") -> "Encoder":
   return Encoder(name, int8=int8, pooling=pooling)
 
 
+# ResNet stage layouts, straight from the torchvision factories: blocks per stage and the residual
+# block shape. Bottleneck expands its output 4x, which is what makes its stage-1 shortcut projected.
+_RESNETS: dict[int, tuple[str, tuple[int, int, int, int]]] = {
+  18: ("basic", (2, 2, 2, 2)),
+  34: ("basic", (3, 4, 6, 3)),
+  50: ("bottleneck", (3, 4, 6, 3)),
+  101: ("bottleneck", (3, 4, 23, 3)),
+}
+
+
+def load_resnet(name_or_depth: int | str = 18, int8: bool = False, compress: str | None = None,
+                compress_atol: float = 0.05, build_dir: str | None = None,
+                weights: str = "IMAGENET1K_V1") -> "Vision":
+  """Load a torchvision ResNet (18/34/50/101, ImageNet) as a fused ANE classifier; BatchNorm folded
+  into the preceding conv at load. `name_or_depth` takes 50, "50" or "resnet50"."""
+  return Vision(name_or_depth, int8=int8, compress=compress, compress_atol=compress_atol,
+                build_dir=build_dir, weights=weights)
+
+
 def load_resnet18(int8: bool = False, compress: str | None = None,
                   compress_atol: float = 0.05, build_dir: str | None = None) -> "Vision":
   """Load torchvision ResNet-18 (ImageNet) as a fused ANE classifier; BatchNorm folded into the preceding conv at load."""
   return Vision(int8=int8, compress=compress, compress_atol=compress_atol, build_dir=build_dir)
 
 
+def _resnet_depth(name_or_depth: int | str) -> int:
+  """Accept 50, "50" or "resnet50"."""
+  s = str(name_or_depth).lower().removeprefix("resnet")
+  if not s.isdigit() or int(s) not in _RESNETS:
+    raise ValueError(f"load_resnet: unsupported ResNet {name_or_depth!r}; "
+                     f"supported depths are {sorted(_RESNETS)}")
+  return int(s)
+
+
 class Vision:
-  def __init__(self, int8: bool = False, compress: str | None = None,
-               compress_atol: float = 0.05, build_dir: str | None = None) -> None:
+  def __init__(self, name_or_depth: int | str = 18, int8: bool = False, compress: str | None = None,
+               compress_atol: float = 0.05, build_dir: str | None = None,
+               weights: str = "IMAGENET1K_V1") -> None:
     import torchvision  # lazy
-    m = torchvision.models.resnet18(weights="IMAGENET1K_V1").eval()
+    self.depth = _resnet_depth(name_or_depth)
+    self.block, self.stages = _RESNETS[self.depth]
+    m = getattr(torchvision.models, f"resnet{self.depth}")(weights=weights).eval()
     self.sd = {k: v.detach().numpy().astype(np.float32) for k, v in m.state_dict().items()}
     self.int8 = int8
     self.compress = compress
@@ -49,26 +80,48 @@ class Vision:
     sc = g / np.sqrt(var + 1e-5)
     return (W * sc[:, None, None, None]).astype(np.float32), (b - mu * sc).astype(np.float32)
 
-  def _block(self, x: Tensor, prefix: str, stride: int, downsample: bool) -> Tensor:
+  def _shortcut(self, x: Tensor, prefix: str, stride: int) -> Tensor:
+    """The residual branch: a projection when the block carries one, otherwise the identity.
+
+    Presence is read from the weights rather than derived from a rule. torchvision projects when
+    `stride != 1 or inplanes != planes * expansion`, so with Bottleneck even stage 1 is projected
+    (64 -> 256 at stride 1) while with BasicBlock it is not. A "stage 1 never downsamples" rule holds
+    for BasicBlock only, and would silently drop layer1's projection on ResNet-50/101."""
+    if prefix + ".downsample.0.weight" not in self.sd:
+      return x
+    wd, bd = self._fold(prefix + ".downsample.0", prefix + ".downsample.1")
+    return conv(x, wd, stride=stride, pad=0, bias=bd)
+
+  def _block(self, x: Tensor, prefix: str, stride: int) -> Tensor:
+    """BasicBlock: 3x3 -> 3x3, stride on the first conv."""
     w1, b1 = self._fold(prefix + ".conv1", prefix + ".bn1")
     w2, b2 = self._fold(prefix + ".conv2", prefix + ".bn2")
     out = conv(x, w1, stride=stride, pad=1, bias=b1).relu()
     out = conv(out, w2, stride=1, pad=1, bias=b2)
-    idn = x
-    if downsample:
-      wd, bd = self._fold(prefix + ".downsample.0", prefix + ".downsample.1")
-      idn = conv(x, wd, stride=stride, pad=0, bias=bd)
-    return (out + idn).relu()
+    return (out + self._shortcut(x, prefix, stride)).relu()
+
+  def _bottleneck(self, x: Tensor, prefix: str, stride: int) -> Tensor:
+    """Bottleneck: 1x1 -> 3x3 -> 1x1 with a 4x expansion. The stride sits on the 3x3, not on the
+    first 1x1: that is torchvision's ResNet V1.5 variant, and putting it on conv1 instead changes
+    which pixels survive."""
+    w1, b1 = self._fold(prefix + ".conv1", prefix + ".bn1")
+    w2, b2 = self._fold(prefix + ".conv2", prefix + ".bn2")
+    w3, b3 = self._fold(prefix + ".conv3", prefix + ".bn3")
+    out = conv(x, w1, stride=1, pad=0, bias=b1).relu()
+    out = conv(out, w2, stride=stride, pad=1, bias=b2).relu()
+    out = conv(out, w3, stride=1, pad=0, bias=b3)
+    return (out + self._shortcut(x, prefix, stride)).relu()
 
   def _build(self) -> Model | SegmentedModel:
     x = input((1, 3, 224, 224))
     w, b = self._fold("conv1", "bn1")
     h = conv(x, w, stride=2, pad=3, bias=b).relu().max_pool(3, stride=2, pad=1)
-    for name, stride in [("layer1", 1), ("layer2", 2), ("layer3", 2), ("layer4", 2)]:
-      for i in range(2):
-        h = self._block(h, f"{name}.{i}", stride if i == 0 else 1,
-                        downsample=(i == 0 and name != "layer1"))
-    h = h.mean((2, 3)).reshape(1, 512)
+    block = self._bottleneck if self.block == "bottleneck" else self._block
+    for name, stride, n in zip(("layer1", "layer2", "layer3", "layer4"), (1, 2, 2, 2), self.stages):
+      for i in range(n):
+        h = block(h, f"{name}.{i}", stride if i == 0 else 1)
+    feat = self.sd["fc.weight"].shape[1]          # 512 for BasicBlock, 2048 once expanded 4x
+    h = h.mean((2, 3)).reshape(1, feat)
     out = h.linear(self.sd["fc.weight"], self.sd["fc.bias"])
     return compile(out, int8=self.int8, compress=self.compress,
                    compress_atol=self.compress_atol, build_dir=self.build_dir)

--- a/docs/aneforge-api.md
+++ b/docs/aneforge-api.md
@@ -165,9 +165,11 @@ logits = clf(image)                                        # [1,3,224,224] -> [1
 - `af.load(name, int8=False) -> Encoder` - a BERT-family sentence encoder. The
   transformer layers run on the ANE as fused programs (cached per sequence
   length); tokenisation, embedding lookup, and mean-pooling run on the host.
-- `af.load_resnet18(int8=False) -> Vision` - torchvision ResNet-18 (ImageNet).
-  BatchNorm is folded into the preceding conv at load, so the ANE graph is pure
-  conv/relu/pool/add/fc.
+- `af.load_resnet(depth=18, int8=False) -> Vision` - torchvision ResNet 18/34/50/101
+  (ImageNet); `depth` takes `50`, `"50"` or `"resnet50"`. BatchNorm is folded into
+  the preceding conv at load, so the ANE graph is pure conv/relu/pool/add/fc.
+- `af.load_resnet18(int8=False) -> Vision` - ResNet-18, kept as the original
+  shorthand for `af.load_resnet(18)`.
 
 `transformers` / `torchvision` are imported lazily, only when these loaders are
 used.
@@ -182,7 +184,7 @@ used.
 | `Model` | a compiled single fused ANE program. Call with input array(s); `.n_ops` = fused graph ops; `.release()`. |
 | `SegmentedModel` | a compiled plan of e5rt regions interleaved with native bridge sub-programs. `.n_ops`, `.n_netplist`, `.release()`. |
 | `Encoder` | sentence-embedding model from `af.load`. |
-| `Vision` | ResNet-18 classifier from `af.load_resnet18`. |
+| `Vision` | ResNet classifier from `af.load_resnet` (18/34/50/101). |
 
 `compile(out, int8=False, build_dir=None)` returns a `Model`, or a
 `SegmentedModel` if the graph contains any netplist-bridge op.

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -30,17 +30,22 @@ The transformer layers run on the ANE as fused programs (cached per sequence len
 
 A model's correct mode lives in its sentence-transformers config; `aneforge.sentence_transformers` reads it for you (see below).
 
-## load_resnet18() — torchvision ImageNet classifier
+## load_resnet() — torchvision ImageNet classifier
 
-`af.load_resnet18()` loads torchvision ResNet-18 as a fused ANE classifier:
+`af.load_resnet()` loads a torchvision ResNet as a fused ANE classifier. Depths 18, 34, 50 and 101 are supported; `af.load_resnet18()` stays as the shorthand for depth 18.
 
 ```python
-clf    = af.load_resnet18()
+clf    = af.load_resnet(50)                  # 50, "50" and "resnet50" all work
 logits = clf(image)                          # [1,3,224,224] -> [1,1000]
-clf    = af.load_resnet18(compress="int4")   # 4-bit LUT weights
+clf    = af.load_resnet(18, compress="int4") # 4-bit LUT weights
 ```
 
 **BatchNorm is folded into the preceding conv at load**, so the ANE graph is pure conv/relu/pool/add/fc — conv is the ANE's strongest workload. `compress` picks the weight encoding (see `af.compile`); `build_dir` keeps the packed program on disk (its `weights.bin` is the packed-model size).
+
+18 and 34 are BasicBlock (3x3 -> 3x3); 50 and 101 are Bottleneck (1x1 -> 3x3 -> 1x1, 4x expansion). Two details are worth knowing if you touch this code:
+
+- **The stride sits on the Bottleneck's 3x3, not on its first 1x1.** That is torchvision's ResNet V1.5 variant. Moving it keeps every tensor shape intact and still agrees on top-1, so shape checks will not catch the mistake.
+- **A block's shortcut is projected or not according to its weights**, never according to its stage index. Bottleneck projects stage 1 (64 -> 256 at stride 1) while BasicBlock does not.
 
 ## Weight layout: He init is layout-dependent
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,7 @@ minutes.
 
 The `aneforge` package imports only `numpy`. `torch` / `torchvision` /
 `transformers` are lazy imports used only by the pretrained loaders
-(`af.load`, `af.load_resnet18`) and the diffusion examples; install them with
+(`af.load`, `af.load_resnet`) and the diffusion examples; install them with
 the `models` extra when you need them.
 
 ## Install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ bench = [
     "mlx>=0.31",
     "torch",
 ]
-# Pretrained model loaders (aneforge.models.load / load_resnet18), the LLM/MoE GGUF
+# Pretrained model loaders (aneforge.models.load / load_resnet), the LLM/MoE GGUF
 # loader (aneforge.moe.load_gguf needs gguf), and the diffusion examples. Imported
 # lazily; only install if you use them.
 models = [

--- a/tests/test_resnet_depths.py
+++ b/tests/test_resnet_depths.py
@@ -1,0 +1,79 @@
+"""Stage layout and shortcut rules for the ResNet loader.
+
+The parts that generalize `load_resnet18` to 18/34/50/101 are host-side and hardware-free: which
+stage layout each depth uses, and whether a block's residual branch is projected. The end-to-end
+check against torchvision needs an ANE and pretrained weights, so it lives in the PR body.
+
+`[dev]` alone does not install torchvision (it sits in the `models` extra), so the tests that need it
+skip rather than fail. The ones that pin the constants run everywhere.
+"""
+import numpy as np
+import pytest
+
+from aneforge.models import _RESNETS, _resnet_depth, Vision
+
+EXPECTED = {                       # mirrors the torchvision factories
+  18: ("basic", (2, 2, 2, 2)),
+  34: ("basic", (3, 4, 6, 3)),
+  50: ("bottleneck", (3, 4, 6, 3)),
+  101: ("bottleneck", (3, 4, 23, 3)),
+}
+
+
+def test_layout_table():
+  assert _RESNETS == EXPECTED
+
+
+@pytest.mark.parametrize("given,depth", [(18, 18), ("18", 18), ("resnet50", 50), ("ResNet101", 101), (34, 34)])
+def test_depth_accepts_int_str_and_name(given, depth):
+  assert _resnet_depth(given) == depth
+
+
+@pytest.mark.parametrize("bad", [19, "resnet19", "152", "resnext50", "", "resnet"])
+def test_depth_rejects_unsupported(bad):
+  with pytest.raises(ValueError, match="unsupported ResNet"):
+    _resnet_depth(bad)
+
+
+def test_shortcut_is_the_identity_when_the_block_has_no_projection():
+  """No `downsample.0.weight` in the weights means the residual branch passes x through untouched."""
+  v = object.__new__(Vision)
+  v.sd = {}
+  x = object()                     # the identity path must not look at it
+  assert v._shortcut(x, "layer1.0", 1) is x
+
+
+def test_shortcut_reads_the_weights_rather_than_a_stage_rule():
+  """A block with a projection must take the conv branch even at stride 1, which is exactly the
+  Bottleneck stage-1 case (64 -> 256). Keyed off the weights, stride carries no meaning here."""
+  v = object.__new__(Vision)
+  v.sd = {
+    "layer1.0.downsample.0.weight": np.zeros((256, 64, 1, 1), np.float32),
+    "layer1.0.downsample.1.weight": np.ones(256, np.float32),
+    "layer1.0.downsample.1.bias": np.zeros(256, np.float32),
+    "layer1.0.downsample.1.running_mean": np.zeros(256, np.float32),
+    "layer1.0.downsample.1.running_var": np.ones(256, np.float32),
+  }
+  from aneforge.graph import input as _input
+  out = v._shortcut(_input((1, 64, 56, 56)), "layer1.0", 1)
+  assert out.shape == (1, 256, 56, 56), "stage-1 Bottleneck must project 64 -> 256 at stride 1"
+
+
+def test_layout_table_matches_torchvision():
+  tv = pytest.importorskip("torchvision")
+  from torchvision.models.resnet import BasicBlock, Bottleneck
+  for depth, (block, stages) in _RESNETS.items():
+    m = getattr(tv.models, f"resnet{depth}")(weights=None)     # no download: architecture only
+    got = tuple(len(getattr(m, f"layer{i}")) for i in (1, 2, 3, 4))
+    kind = Bottleneck if block == "bottleneck" else BasicBlock
+    assert got == stages, f"resnet{depth} stage layout"
+    assert isinstance(m.layer1[0], kind), f"resnet{depth} block type"
+
+
+def test_bottleneck_projects_stage_one_and_basicblock_does_not():
+  """The reason `_shortcut` reads the weights. A "stage 1 never downsamples" rule is true for
+  BasicBlock and false for Bottleneck, where layer1 changes 64 channels into 256 at stride 1."""
+  tv = pytest.importorskip("torchvision")
+  for depth, projected in [(18, False), (34, False), (50, True), (101, True)]:
+    sd = getattr(tv.models, f"resnet{depth}")(weights=None).state_dict()
+    assert ("layer1.0.downsample.0.weight" in sd) is projected, f"resnet{depth} layer1 projection"


### PR DESCRIPTION
Closes #191.

`Vision` hardcoded ResNet-18: two BasicBlocks per stage and a 512-wide head. `af.load_resnet(name_or_depth)` now covers 18/34/50/101 and takes `50`, `"50"` or `"resnet50"`. `af.load_resnet18()` stays as the shorthand and returns bit-identical output.

## What changed

**`_bottleneck`** adds the 1x1 -> 3x3 -> 1x1 block with its 4x expansion. The stride sits on the 3x3, which is torchvision's ResNet V1.5 variant rather than the placement in the original paper.

**`_shortcut`** decides the residual branch from the weights rather than from a stage rule. torchvision projects when `stride != 1 or inplanes != planes * expansion`.

**The head width** comes from `fc.weight` instead of a constant 512.

`_RESNETS` holds the stage layouts, and `_resnet_depth` does the parsing so an unsupported depth fails with a list of what is supported instead of a `KeyError` deep in the build.

## Two things worth flagging

**Stage 1 is projected for Bottleneck and not for BasicBlock.** The existing rule was `downsample=(i == 0 and name != "layer1")`, which is correct for ResNet-18 and wrong for 50/101: there `layer1.0` changes 64 channels into 256 at stride 1, so it does carry a projection. Reading `downsample.0.weight` from the state dict makes the rule unnecessary and covers both families. `test_bottleneck_projects_stage_one_and_basicblock_does_not` pins the underlying fact against torchvision.

**Top-1 agreement is too weak a check for this port.** Moving the Bottleneck stride from the 3x3 to the first 1x1, i.e. building V1 instead of V1.5, leaves every tensor shape intact and *still gives the same top-1* on my test image, while cosine against torchvision drops from 0.999999 to 0.9499. That is why the numbers below are cosine and full-logit deltas rather than a label match, and why the V1.5 placement is called out in a comment and in `docs/developer/models.md`.

## Verification

**On device (M2 Pro, macOS 26.5.2), against `torchvision.models.resnet*` with `IMAGENET1K_V1`, one fixed input for both sides:**

| depth | block | top-1 | top-5 | max abs logit delta | cosine |
|---|---|---|---|---|---|
| 18 | BasicBlock | match | match | 0.01356 | 0.999998 |
| 34 | BasicBlock | match | match | 0.01810 | 0.999998 |
| 50 | Bottleneck | match | match | 0.02213 | 0.999999 |
| 101 | Bottleneck | match | match | 0.03028 | 0.999994 |

**Back-compat:** `load_resnet18()` and `load_resnet(18)` return bit-identical logits (`np.array_equal`).

**Mutation:**

- shortcut keyed on the stage index instead of the weights: `test_shortcut_reads_the_weights_rather_than_a_stage_rule` fails.
- Bottleneck stride moved to conv1: no test fails, cosine on ResNet-50 drops to 0.9499 while top-1 still matches. Reported above rather than hidden.
- restored: 16/16.

`pytest -m "not requires_ane"`: 327 passed, 2 skipped (up from 311). ruff, pylint 2-space 10.00/10 and compileall clean; pyright reports the same 12 baseline errors in `onnx.py`/`_gguf.py`.

## Notes

- `[dev]` does not install torchvision, it lives in the `models` extra, so the tests that need it use `importorskip` and skip in CI rather than fail. The layout table itself is pinned by a test that runs everywhere, and a second test checks that table against the torchvision factories when it is present. Those torchvision tests construct with `weights=None`, so they need no download.
- Docs updated: `docs/aneforge-api.md`, `docs/developer/models.md`, `docs/getting-started.md`, and the `models` extra comment in `pyproject.toml`.
- ResNeXt and wide_resnet reuse Bottleneck with `groups`/`base_width`, so they are close but not free; left out since the issue scopes to plain ResNet. Happy to add if wanted.
