### PR TITLE
docs: document ViT and CrossEncoder loaders (fixes #211)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ Pretrained models, each fused into one ANE program:
 | ResNet-18          | ImageNet classification    | cosine 1.0000           |
 | ViT-B/16           | vision transformer encoder | cosine 1.0000           |
 | all-MiniLM-L6-v2   | sentence embedding         | cosine 1.0000           |
+| ms-marco-MiniLM-L-6-v2 | reranker (CrossEncoder) | identical ranking, relerr 5e-4 |
 | ESPCN              | super-resolution           | runs end to end         |
 | Stable Diffusion 1.5 | U-Net + VAE (per component) | U-Net 1.5%, VAE 4.4% rel. |
 

--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -31,7 +31,8 @@ from ._rewrite import reduce_sum_to_matmul, paired_subtract
 from .autograd import (Adam, adam_step, backward, backward_from, conv2d, conv_param,
                        mse, parameter, SGD, softmax_cross_entropy, Trainer, UnrolledTrainer)
 from .streaming import CheckpointedStack
-from .models import Encoder, Vision, load, load_resnet18, conv_block, cifar_cnn, group_norm_train
+from .models import (Encoder, Vision, ViT, load, load_resnet18, load_vit,
+                    conv_block, cifar_cnn, group_norm_train)
 from .onnx import load_onnx, onnx_to_tensor, onnx_to_features
 from .llm import LlamaConfig, LlamaPrefill, from_pretrained as load_llm, rope, rope_tables, prefill_block
 from . import moe as moe   # registers the "moe" MLP + Qwen3-MoE adapter into the llm registries
@@ -52,7 +53,7 @@ __all__ = [
     "precision_risk", "project_peak",
     "CompileBackoffError", "reset_compile_breaker",
     "reduce_sum_to_matmul", "paired_subtract",
-    "load", "load_resnet18", "Encoder", "Vision", "conv_block", "cifar_cnn", "group_norm_train",
+    "load", "load_resnet18", "load_vit", "Encoder", "Vision", "ViT", "conv_block", "cifar_cnn", "group_norm_train",
     "Paired", "paired",
     "parameter", "backward", "backward_from", "mse", "SGD", "Adam",
     "softmax_cross_entropy", "Trainer", "UnrolledTrainer", "adam_step",

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -30,6 +30,18 @@ The transformer layers run on the ANE as fused programs (cached per sequence len
 
 A model's correct mode lives in its sentence-transformers config; `aneforge.sentence_transformers` reads it for you (see below).
 
+## CrossEncoder() — BERT-family reranker
+
+`aneforge.sentence_transformers.CrossEncoder` scores `(query, passage)` pairs, mirroring `sentence_transformers.CrossEncoder`:
+
+```python
+from aneforge.sentence_transformers import CrossEncoder
+ce = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
+scores = ce.predict([(query, passage) for passage in passages])   # higher = more relevant
+```
+
+It reuses the same BERT encoder graph as `load()`, then applies the sequence-classification head (pooler + classifier) host-side. The loader requires a BERT-family `AutoModelForSequenceClassification` — a token-type embedding, a pooler, and a classifier head — and raises a clear error otherwise; RoBERTa/XLM-R (e.g. bge-reranker) and DistilBERT-style heads aren't wired up yet.
+
 ## load_resnet18() — torchvision ImageNet classifier
 
 `af.load_resnet18()` loads torchvision ResNet-18 as a fused ANE classifier:
@@ -41,6 +53,18 @@ clf    = af.load_resnet18(compress="int4")   # 4-bit LUT weights
 ```
 
 **BatchNorm is folded into the preceding conv at load**, so the ANE graph is pure conv/relu/pool/add/fc — conv is the ANE's strongest workload. `compress` picks the weight encoding (see `af.compile`); `build_dir` keeps the packed program on disk (its `weights.bin` is the packed-model size).
+
+## load_vit() — Hugging Face ViT image classifier
+
+`af.load_vit()` loads any HF `ViTForImageClassification` (and compatible DeiT/BEiT-style models with a CLS token) as a fused ANE classifier:
+
+```python
+vit    = af.load_vit("google/vit-base-patch16-224")
+logits = vit(image)             # [1,3,H,W] -> [1,num_labels]
+top    = vit.classify(image)    # top-k (label, logit)
+```
+
+A strided `PxP` patch conv is walled on the ANE, so patch embedding runs as `space_to_depth(P)` followed by a 1x1 conv; the CLS token's row is picked out of the encoder output via a one-hot picker matmul (a bare row slice is also walled). The loader auto-detects two HF layer namings: the modern one (`vit.layers.{i}.attention.q_proj`, `mlp.fc1/fc2`) and the legacy one (`vit.encoder.layer.{i}.attention.attention.query`, `intermediate.dense`).
 
 ## Weight layout: He init is layout-dependent
 


### PR DESCRIPTION


## What

Follow-up to #211, noticed while reviewing #210 (GPT-2): every shipped model loader should have a README/docs entry.

- `docs/developer/models.md`: adds sections for `load_vit()`/`ViT` and `CrossEncoder`, mirroring the existing `load()`/`load_resnet18()` sections.
- README "What runs" table: adds a `CrossEncoder` (ms-marco-MiniLM-L-6-v2 reranker) row, using the #189 M5 Pro measurement (identical ranking, relerr 5e-4). ViT-B/16 was already listed there.
- `aneforge/__init__.py`: exports `ViT`/`load_vit` at the top level.

## Why the `__init__.py` change

While writing the `load_vit()` docs section I found `af.load_vit(...)` - the exact form #189's own PR description uses as the example - actually raises `AttributeError`, because `ViT`/`load_vit` were added to `aneforge/models.py` but never added to `aneforge/__init__.py`'s imports/`__all__`. Only `from aneforge.models import load_vit` worked. Exported both alongside `load()`/`load_resnet18()` so the documented usage is real. `CrossEncoder` is intentionally left out of the top-level namespace, unchanged - it's already exported from `aneforge.sentence_transformers`, consistent with how `SentenceTransformer` is scoped there too.

## Checks

- `pytest -m "not requires_ane"` (excluding the two pre-existing `onnx`-import test files this environment doesn't have the optional dep for): 308 passed, 3 skipped.
- Verified `af.load_vit`, `af.ViT`, and `from aneforge.sentence_transformers import CrossEncoder` all resolve.

Closes #211.