### PR TITLE
docs: list Mistral in the LLM scope and document load_gpt2()

### DIFF
--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -71,6 +71,20 @@ top    = vit.classify(image)    # top-k (label, logit)
 
 A strided `PxP` patch conv is walled on the ANE, so patch embedding runs as `space_to_depth(P)` followed by a 1x1 conv; the CLS token's row is picked out of the encoder output via a one-hot picker matmul (a bare row slice is also walled). The loader auto-detects two HF layer namings: the modern one (`vit.layers.{i}.attention.q_proj`, `mlp.fc1/fc2`) and the legacy one (`vit.encoder.layer.{i}.attention.attention.query`, `intermediate.dense`).
 
+## load_gpt2() — GPT-2 text generation
+
+`af.load_gpt2()` loads a GPT-2-family checkpoint — the pre-norm, pure-LayerNorm decoder — as a fused ANE program:
+
+```python
+gpt2 = af.load_gpt2("gpt2-medium")
+ids  = gpt2.generate("The future of artificial intelligence is", max_new_tokens=16)  # greedy; returns token ids
+logits = gpt2(token_ids)                     # 1-D ids -> [S, vocab], for custom decoding
+```
+
+GPT-2 is the family that the LayerNorm-at-`D>=1024` fix unlocks (Llama/Qwen use RMSNorm, so `load_llm` never hit that wall). Each sequence length compiles as **two fused programs**: the pre-norm transformer (`ln_1 -> native causal SDPA -> residual; ln_2 -> Linear -> gelu_new -> Linear -> residual`, then `ln_f`) and the **tied lm_head tiled along the 50257 vocab** — a single matmul that wide exceeds the ANE's per-op dimension cap on the A13-A15 families, so it is emitted as vocab-sized output-port tiles (e.g. `[16384, 16384, 16384, 1105]`) and stitched host-side. Token + positional embedding lookup runs on the host (`gather` is not an ANE op).
+
+Two limits worth knowing: decode has **no KV cache yet** — it recomputes the forward on the growing sequence (cached per length), so it validates correctness rather than throughput; and native causal SDPA is reliable only for `S < 512`, so use short prompts and small `max_new_tokens`. `examples/gpt2.py` compiles the full 24-layer `gpt2-medium` as one program and checks the greedy decode is token-identical to Hugging Face.
+
 ## Weight layout: He init is layout-dependent
 
 `_he` (He/Kaiming-normal init) computes `fan_in` from the weight layout, which differs between conv and fc weights:

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -152,8 +152,8 @@ before RoPE), and a large vocab - the layers run on the ANE; the lm_head project
 
 ## Scope
 
-Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), **Gemma**
-(scaled embeddings + GeGLU + `(1+w)` RMSNorm), sparse **Mixture-of-Experts**
+Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), **Mistral**
+(GQA + sliding window), **Gemma** (scaled embeddings + GeGLU + `(1+w)` RMSNorm), sparse **Mixture-of-Experts**
 (Qwen3-MoE, Qwen2-MoE), and **hybrid** DeltaNet+attention (Qwen3.5). Runtime features: prefill + resident
 KV-cache decode, automatic segmentation past the ~2 GB program ceiling, int8/int4 weights, and exact
 speculative decoding. Static prompt length per compiled graph; the lm_head projection runs on host.


### PR DESCRIPTION
Two loaders shipped without a docs entry (follow-up to #212).

Mistral (#206) landed in the llm.py adapters, but docs/llm.md's Scope section still listed only Llama/Qwen, Gemma, MoE, and hybrid. Adds Mistral (GQA + sliding window).

GPT-2 (#210, af.load_gpt2 / af.GPT2) had no section in docs/developer/models.md, which documents every other shipped loader. Adds a load_gpt2() section: the two-program split, the vocab-tiled tied lm_head, and the two limits (no KV cache yet; native SDPA needs S < 512). API documented against the real surface (generate(prompt, max_new_tokens=16) returns token ids; GPT2(name)(ids) returns [S, vocab]).

Docs-only; mkdocs build clean.