### PR TITLE
llm: reject archs the dense loader would silently mis-load (+ use _rope_scaling)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -455,7 +455,7 @@ def _dense_adapter(c, sd) -> tuple[LlamaConfig, dict]:
                     n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                     ffn_dim=c.intermediate_size, vocab=c.vocab_size,
                     rope_base=_rope_theta(c), norm_eps=float(c.rms_norm_eps),
-                    head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=getattr(c, "rope_scaling", None),
+                    head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=_rope_scaling(c),
                     layers=[LayerSpec(mixer="attention", mlp="swiglu", qk_norm=qk) for _ in range(n)])
   return cfg, _weights_from_state_dict(sd, cfg)
 
@@ -516,7 +516,7 @@ def _cfg_from_hf(c) -> LlamaConfig:
                      n_kv_heads=getattr(c, "num_key_value_heads", c.num_attention_heads),
                      ffn_dim=c.intermediate_size, vocab=c.vocab_size,
                      rope_base=_rope_theta(c), norm_eps=float(c.rms_norm_eps),
-                     head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=getattr(c, "rope_scaling", None))
+                     head_dim=int(getattr(c, "head_dim", 0) or 0), rope_scaling=_rope_scaling(c))
 
 
 # Architecture adapters: (predicate(hf_config) -> bool, adapter(hf_config, sd) -> (cfg, weights)); first match
@@ -526,6 +526,26 @@ ADAPTERS: list = [
   (lambda c: c.model_type == "mistral", _mistral_adapter),
 ]
 
+# model_types that are Llama-shaped enough to reach the _dense_adapter fallback but need semantics it
+# does not implement (logit softcapping; Gemma-2/3's GeGLU / (1+w)-norm / embed-scale). Loading one
+# through the dense path does not error -- it silently produces wrong logits (measured cosine ~0 vs HF).
+_DENSE_INCOMPATIBLE = {"gemma2", "gemma3", "gemma3_text"}
+
+
+def _assert_dense_compatible(c) -> None:
+  """Raise if a config reaches the dense fallback but carries semantics the dense path silently drops.
+
+  Feature-based first (`*_logit_softcapping`, which real Gemma-2/3 checkpoints set), so genuine
+  Llama-shaped finetunes with an unusual `model_type` are not rejected; the name set is a backstop."""
+  mt = getattr(c, "model_type", "?")
+  cap = getattr(c, "attn_logit_softcapping", None) or getattr(c, "final_logit_softcapping", None)
+  if cap or mt in _DENSE_INCOMPATIBLE:
+    why = "logit softcapping" if cap else "architecture-specific semantics"
+    raise ValueError(
+      f"load_llm: {mt!r} needs {why} that aneforge's dense loader does not implement, so the dense "
+      f"path would silently produce wrong logits. Supported: dense Llama/Qwen/Mistral, Gemma "
+      f"(model_type 'gemma'), and MoE. See docs/llm.md.")
+
 
 def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
   """Load a Llama/Qwen-class model from Hugging Face for ANE inference. `compress` ("int8"/"int4"/"blockwise")
@@ -533,10 +553,12 @@ def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
   import torch
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)
+  adapt = next((fn for pred, fn in ADAPTERS if pred(hf.config)), _dense_adapter)
+  if adapt is _dense_adapter:            # fail fast, before the state-dict copy, on an unsupported arch
+    _assert_dense_compatible(hf.config)
   # fp16 state dict: the weights are baked to fp16 (or quantized) for the ANE anyway, so an fp32 copy
   # only wastes memory -- for a 7B that fp32 copy is ~28 GB on top of the loaded model, enough to OOM a
   # 32 GB Mac. Rounding to fp16 here is the same rounding the bake would do, so outputs are unchanged.
   sd = {k: v.detach().to(torch.float16).numpy() for k, v in hf.state_dict().items()}
-  adapt = next((fn for pred, fn in ADAPTERS if pred(hf.config)), _dense_adapter)
   cfg, weights = adapt(hf.config, sd)
   return LlamaPrefill(cfg, weights, compress=compress)

--- a/tests/test_dense_loader_guard.py
+++ b/tests/test_dense_loader_guard.py
@@ -1,0 +1,36 @@
+"""`from_pretrained` must reject an arch the dense fallback would silently mis-load.
+
+The ADAPTERS registry matches by exact model_type and anything unmatched falls through to the dense
+Llama path. A Gemma-2/3 checkpoint is Llama-shaped enough to load without error there, but the dense
+graph drops its logit softcapping / GeGLU / (1+w)-norm / embed-scale -- measured cosine ~0 vs HF. The
+guard turns that silent garbage into a clear error. Off-device: pure config inspection, no ANE.
+"""
+from types import SimpleNamespace
+
+import pytest
+
+from aneforge.llm import _assert_dense_compatible
+
+
+def test_softcapping_config_is_rejected():
+  # real Gemma-2 sets attn_logit_softcapping=50.0, final_logit_softcapping=30.0
+  c = SimpleNamespace(model_type="gemma2", attn_logit_softcapping=50.0, final_logit_softcapping=30.0)
+  with pytest.raises(ValueError, match="softcapping"):
+    _assert_dense_compatible(c)
+
+
+def test_incompatible_model_type_is_rejected_even_without_softcapping():
+  # gemma3 dropped softcapping but is still not the dense arch; the name backstop catches it
+  c = SimpleNamespace(model_type="gemma3")
+  with pytest.raises(ValueError):
+    _assert_dense_compatible(c)
+
+
+def test_plain_llama_config_passes():
+  c = SimpleNamespace(model_type="llama", attn_logit_softcapping=None, final_logit_softcapping=None)
+  _assert_dense_compatible(c)   # must not raise
+
+
+def test_llama_shaped_finetune_with_unusual_model_type_passes():
+  # a genuine Llama-shaped finetune must not be rejected just for a nonstandard model_type
+  _assert_dense_compatible(SimpleNamespace(model_type="my_custom_llama"))   # must not raise


### PR DESCRIPTION
from_pretrained matches adapters by exact model_type and falls through to the dense Llama path for anything unmatched. A Gemma-2/3 checkpoint is Llama-shaped enough to load there without error, but the dense graph drops its logit softcapping, GeGLU, (1+w)-norm, and embed-scale. On a real Gemma2ForCausalLM the dense path returned cosine 0.0 vs HF with the wrong argmax and no exception, so af.load_llm("google/gemma-2-2b") returned garbage silently.

_assert_dense_compatible() runs when the dense fallback is selected and raises a ValueError if the config has attn_logit_softcapping / final_logit_softcapping set (real Gemma-2/3 do) or its model_type is in a known-incompatible set (gemma2, gemma3, gemma3_text). The softcapping check is the primary signal, so a Llama-shaped finetune with an unusual model_type is not rejected. It runs before the fp16 state-dict copy, so an unsupported model fails fast.

Also wires in the previously-unused _rope_scaling() helper: on transformers 5.x rope_scaling aliases the rope_parameters dict and is non-None even for default models, so _dense_adapter/_cfg_from_hf were passing a spurious {"rope_type":"default"} dict. Behavior-neutral -- rope_tables already guards on rope_type == "llama3", and test_llama3_rope_scaling still passes.

Testing (M5 Pro): tests/test_dense_loader_guard.py 4/4 off-device; tests/test_llm.py 13/13 on the ANE; off-device suite 349 passed; ruff clean. GPT-2 decode gap filed separately as #215.