### PR TITLE
docs: correct docstrings that understated supported models/features

### DIFF
--- a/aneforge/einsum.py
+++ b/aneforge/einsum.py
@@ -12,7 +12,8 @@ from aneforge.graph import Tensor, _const
 
 
 class EinsumUnsupported(NotImplementedError):
-  """Raised for equations not lowerable to ANE matmul/reduce ops (diagonal-write, triple repeats, ellipsis)."""
+  """Raised for equations not lowerable to ANE matmul/reduce ops (diagonal-write outputs, triple-repeat
+  indices, and ellipsis broadcast between mismatched size-1 dims). Plain ellipsis batch dims are supported."""
 
 
 # equation parsing

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -1,5 +1,5 @@
 """LLMs on the Apple Neural Engine. A config-driven decoder (RMSNorm + RoPE + grouped-query causal
-attention + SwiGLU) that loads Hugging Face weights and runs prefill and KV-cache decode as fused ANE
+attention + SwiGLU/GeGLU MLP) that loads Hugging Face weights and runs prefill and KV-cache decode as fused ANE
 programs. Matches HF logits; see `docs/llm.md`.
 
 The runner is model-agnostic: a `LlamaConfig` carries a per-layer plan (`LayerSpec`) naming a token-mixer
@@ -548,7 +548,8 @@ def _assert_dense_compatible(c) -> None:
 
 
 def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
-  """Load a Llama/Qwen-class model from Hugging Face for ANE inference. `compress` ("int8"/"int4"/"blockwise")
+  """Load a decoder LM from Hugging Face for ANE inference: dense Llama/Qwen/Mistral, Gemma, and MoE
+  (an unsupported arch is rejected, not silently mis-loaded). `compress` ("int8"/"int4"/"blockwise")
   quantizes the ANE weights."""
   import torch
   from transformers import AutoModelForCausalLM

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -1,4 +1,5 @@
-"""Pretrained-model loaders (`load`, `load_resnet18`) and trainable-graph
+"""Pretrained-model loaders (`load` and `CrossEncoder` for BERT/RoBERTa encoders and rerankers,
+`load_resnet`/`load_vit` image classifiers, `load_gpt2` text generation) and trainable-graph
 builders (`group_norm_train`, `conv_block`, `cifar_cnn`). See docs/developer/models.md."""
 from __future__ import annotations
 


### PR DESCRIPTION
A docstring audit after the Gemma/Mistral/GPT-2/ResNet/RoBERTa work found four stale claims. Docstring-only, no behavior change; ruff clean, imports verified.

- llm.py from_pretrained: said "Llama/Qwen-class" only; it now dispatches to the Gemma and Mistral adapters and rejects unsupported archs. Changed to match the guard's "dense Llama/Qwen/Mistral, Gemma, and MoE".
- llm.py module docstring: "SwiGLU" only, changed to "SwiGLU/GeGLU MLP" (the GeGLU builder and Gemma's LayerSpec(mlp="geglu") exist).
- models.py module docstring: listed only load and load_resnet18; adds load_resnet, load_vit, load_gpt2, CrossEncoder.
- einsum.py EinsumUnsupported: listed ellipsis as unsupported, but plain ellipsis batch dims are supported (einsum() documents it, the self-test battery includes an ellipsis case, _expand_ellipsis rewrites it); only diagonal-write, triple-repeat, and size-1 ellipsis broadcast raise.

Checked and left unchanged: _e_layer_norm, aggregate_rooflines CANONICAL_DECODE_CONFIG, and the CrossEncoder / ResNet / ViT / GPT-2 loader docstrings.