### PR TITLE
trim redundant comments added in #199 / #207 / #214

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -526,9 +526,8 @@ ADAPTERS: list = [
   (lambda c: c.model_type == "mistral", _mistral_adapter),
 ]
 
-# model_types that are Llama-shaped enough to reach the _dense_adapter fallback but need semantics it
-# does not implement (logit softcapping; Gemma-2/3's GeGLU / (1+w)-norm / embed-scale). Loading one
-# through the dense path does not error -- it silently produces wrong logits (measured cosine ~0 vs HF).
+# Gemma-2/3 reach the dense fallback (Llama-shaped) but need softcapping / GeGLU / (1+w)-norm it lacks;
+# a name backstop for the softcapping feature check in _assert_dense_compatible.
 _DENSE_INCOMPATIBLE = {"gemma2", "gemma3", "gemma3_text"}
 
 
@@ -557,9 +556,8 @@ def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
   adapt = next((fn for pred, fn in ADAPTERS if pred(hf.config)), _dense_adapter)
   if adapt is _dense_adapter:            # fail fast, before the state-dict copy, on an unsupported arch
     _assert_dense_compatible(hf.config)
-  # fp16 state dict: the weights are baked to fp16 (or quantized) for the ANE anyway, so an fp32 copy
-  # only wastes memory -- for a 7B that fp32 copy is ~28 GB on top of the loaded model, enough to OOM a
-  # 32 GB Mac. Rounding to fp16 here is the same rounding the bake would do, so outputs are unchanged.
+  # fp16 state dict: the weights bake to fp16 (or quantized) for the ANE anyway, so an fp32 copy only
+  # wastes memory (~28 GB for a 7B, enough to OOM a 32 GB Mac). Same rounding the bake does, so unchanged.
   sd = {k: v.detach().to(torch.float16).numpy() for k, v in hf.state_dict().items()}
   cfg, weights = adapt(hf.config, sd)
   return LlamaPrefill(cfg, weights, compress=compress)

--- a/bench/aggregate_rooflines.py
+++ b/bench/aggregate_rooflines.py
@@ -142,9 +142,7 @@ def _perf_headline(report: dict) -> dict:
             # older family's matmul-dim limit. Distinguish that from "not measured".
             if h["decode_tok_s"] is None and b1.get("status") not in (None, "ok"):
                 h["decode_blocked"] = True
-            # decode ran a different (heavier) model than the canonical one -- a --perf-full
-            # submission. Its tok/s is real but not comparable to the canonical-config rows,
-            # so drop it from the shared column rather than rank a heavier model against them.
+            # off-config (a --perf-full submission ran a heavier model): a real but incomparable tok/s
             if h["decode_tok_s"] is not None and dm.get("config") != CANONICAL_DECODE_CONFIG:
                 h["decode_tok_s"] = None
                 h["decode_offconfig"] = True


### PR DESCRIPTION
Three comments I added this week restated rationale that an adjacent constant, docstring, or error message already carried. This says each thing once. Comment-only, no behavior change; ruff clean, rooflines --check passes.

- aggregate_rooflines.py: the inline decode-guard comment repeated the CANONICAL_DECODE_CONFIG block right above it. Cut to one line.
- llm.py _DENSE_INCOMPATIBLE: dropped the "silently produces wrong logits" restatement, which the _assert_dense_compatible docstring and the raised error already say. Two lines.
- llm.py fp16 state-dict comment: three lines to two, same facts.