### PR TITLE
models: add decoded GPT-2 generation helper

### DIFF
--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -553,6 +553,10 @@ class GPT2:
       ids = np.concatenate([ids, [int(self(ids)[-1].argmax())]])
     return [int(t) for t in ids[len(base):]]
 
+  def generate_text(self, prompt: str, max_new_tokens: int = 16) -> str:
+    """Greedy-decode and return the newly generated tokens as text."""
+    return self.tok.decode(self.generate(prompt, max_new_tokens))
+
   def release(self) -> None:
     for net, head in self._cache.values():
       net.release(); head.release()

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -77,7 +77,9 @@ A strided `PxP` patch conv is walled on the ANE, so patch embedding runs as `spa
 
 ```python
 gpt2 = af.load_gpt2("gpt2-medium")
-ids  = gpt2.generate("The future of artificial intelligence is", max_new_tokens=16)  # greedy; returns token ids
+prompt = "The future of artificial intelligence is"
+ids  = gpt2.generate(prompt, max_new_tokens=16)       # greedy; returns newly generated token ids
+text = gpt2.generate_text(prompt, max_new_tokens=16)  # decoded newly generated text
 logits = gpt2(token_ids)                     # 1-D ids -> [S, vocab], for custom decoding
 ```
 

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -1,6 +1,8 @@
 """GPT-2 loader graph-level tests: the Conv1D->linear weight mapping, the tiled lm_head, and
 off-device MIL lowering (no ANE dispatch; CI-safe). Numerics are validated on-device by
 examples/gpt2.py."""
+from unittest.mock import Mock
+
 import numpy as np
 import pytest
 
@@ -77,6 +79,17 @@ def test_gpt2_embed_rejects_sequence_beyond_max_positions():
   g.wpe = np.zeros((10, 16), np.float32)
   with pytest.raises(ValueError, match="exceeds this model's 10 max positions"):
     g._embed(np.arange(11, dtype=np.int64))
+
+
+def test_gpt2_generate_text_decodes_generated_tokens():
+  g = GPT2.__new__(GPT2)
+  g.generate = Mock(return_value=[17, 42])
+  g.tok = Mock()
+  g.tok.decode.return_value = " generated text"
+
+  assert g.generate_text("prompt", max_new_tokens=2) == " generated text"
+  g.generate.assert_called_once_with("prompt", 2)
+  g.tok.decode.assert_called_once_with([17, 42])
 
 
 def test_gpt2_gelu_new_lowers():


### PR DESCRIPTION
## Summary
- add a backward-compatible `GPT2.generate_text()` helper that decodes the token IDs returned by `generate()`
- document both token-ID and decoded-text generation paths
- cover delegation and decoding with an off-device unit test

## Testing
- `pytest -o addopts="" -m "not requires_ane" -q` - 349 passed, 2 skipped, 697 deselected
- `ruff check`
- `python -m pylint --disable=all -e W0311 -e C0303 --indent-string='  ' --recursive=y aneforge tests`
- `pyright aneforge` in a CI/Linux-equivalent type-check environment - 0 errors
- `python -m compileall -q aneforge`
- `mkdocs build --strict`
- package build and `twine check` for both artifacts

Not run: the on-device ANE suite; this change only delegates existing generation output to the host-side tokenizer.

Closes #220
