### PR TITLE
perf: GPT-2 decode throughput (profile + wpe fold + host lm_head fp32 cache)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -8,6 +8,7 @@ the plan + canonical weights - not new branches in the hot path."""
 from __future__ import annotations
 from dataclasses import dataclass, field
 from enum import Enum
+import time
 import numpy as np
 
 from .graph import Tensor, input as _input, concat as _concat, _const
@@ -352,6 +353,10 @@ class LlamaPrefill:
       ctx = {"oh": _input((1, M, 1)), "inv": _input((1, M, 1)), "mask": _input((1, 1, M)),
              "cosp": _input((1, dh)), "sinp": _input((1, dh))}
       h = x; pairs = []
+      wpe_pos = None
+      if gi == 0 and "wpe" in self.w:
+        wpe_pos = _input((1, M))
+        h = h + wpe_pos @ _const(self.w["wpe"][:M].astype(np.float16))
       for li in grp:
         ls = self._spec(li); lw = self.w["layers"][li]
         h, sp = DECODE_MIXERS[ls.mixer](h, lw, cfg, ls, ctx, M)
@@ -365,6 +370,7 @@ class LlamaPrefill:
       for o, i in pairs:                                        # alias each state output -> its input (resident)
         net.prog.share_buffer(0, om[o], 0, inm[id(i)])
       p = {"x": inm[id(x)], "h": om[h], "states": {inm[id(i)]: i.shape for _, i in pairs}}
+      if wpe_pos is not None: p["wpe_pos"] = inm[id(wpe_pos)]
       for k, t in ctx.items():
         if id(t) in inm: p[k] = inm[id(t)]                      # only ports the chunk's mixers actually use
       chunks.append({"net": net, "p": p})
@@ -452,12 +458,15 @@ class LlamaPrefill:
         c["net"].prog.set_input(port, buf)
 
   def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None,
-               temperature=0.0, top_p=1.0, top_k=0, batched_prefill=True, prefill_pad=None):
+               temperature=0.0, top_p=1.0, top_k=0, batched_prefill=True, prefill_pad=None, on_stage=None):
     """Autoregressive generation with a resident KV-cache. The decode program (compiled once and cached) runs
     all layers for one token attending to caches that stay on the ANE across steps, so each step feeds only the
     token embedding + a position one-hot. `on_token(id)` is called per token (streaming). Greedy by default
     (`temperature=0`); pass temperature/top_p/top_k to sample. Returns the generated token ids."""
     cfg = self.cfg; f16 = np.float16
+    profiling = on_stage is not None
+    def stage(name, elapsed):
+      if on_stage is not None: on_stage(name, elapsed)
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
     self._check_positions(M)
     eos = {int(eos_id)} if isinstance(eos_id, int) else {int(e) for e in (eos_id or ())}   # any-of stop set
@@ -472,16 +481,21 @@ class LlamaPrefill:
       vals = {"oh": ohv, "inv": invv, "mask": mv}
       if d["cos"] is not None:
         vals["cosp"] = d["cos"][pos][None]; vals["sinp"] = d["sin"][pos][None]
+      t0 = time.perf_counter() if profiling else 0.0
       emb = self.w["embed"][tok]
-      if "wpe" in self.w:
-        emb = emb + self.w["wpe"][pos]
       h = np.asarray(emb)[None].astype(f16)
+      wpe_pos = np.zeros((1, M), f16) if "wpe" in self.w else None
+      if wpe_pos is not None: wpe_pos[0, pos] = 1.0
+      if profiling: stage("embedding", time.perf_counter() - t0)
+      t0 = time.perf_counter() if profiling else 0.0
       for c in chunks:                                         # hidden flows chunk -> chunk (cheap [1,dim] round-trip)
         p = c["p"]; pr = c["net"].prog
         pr.set_input(p["x"], h)
         for k in _DECODE_CTX:
           if k in p: pr.set_input(p[k], vals[k])
+        if "wpe_pos" in p: pr.set_input(p["wpe_pos"], wpe_pos)
         pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
+      if profiling: stage("layers", time.perf_counter() - t0)
       return h.reshape(cfg.dim).astype(np.float32)
     use_batched = (batched_prefill and len(prompt) > 1
                    and not hasattr(self.w["layers"], "free")     # streamed weights are freed by _decoder; can't re-bake
@@ -499,7 +513,13 @@ class LlamaPrefill:
       cur, pos = prompt[-1], len(prompt) - 1
     while len(out) < max_new_tokens:                           # decode
       if pos >= M - 1: break                                   # cache full
-      nxt = self._sample(self._logits(step(cur, pos)), temperature, top_p, top_k); out.append(nxt)
+      t0 = time.perf_counter() if profiling else 0.0; hidden = step(cur, pos)
+      if profiling: stage("step", time.perf_counter() - t0)
+      t0 = time.perf_counter() if profiling else 0.0; logits = self._logits(hidden)
+      if profiling: stage("lm_head", time.perf_counter() - t0)
+      t0 = time.perf_counter() if profiling else 0.0; nxt = self._sample(logits, temperature, top_p, top_k)
+      if profiling: stage("sample", time.perf_counter() - t0)
+      out.append(nxt)
       if nxt in eos: break
       if on_token is not None: on_token(nxt)                   # stream the token
       cur, pos = nxt, pos + 1

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -249,7 +249,9 @@ _DECODE_CTX = ("oh", "inv", "mask", "cosp", "sinp")
 class LlamaPrefill:
   """A decoder compiled for the ANE. `compile(seq)` builds the prefill graph for a fixed prompt length;
   `prefill(token_ids)` returns next-token logits; `generate(...)` does resident-KV-cache decode. Weights are
-  a dict of numpy arrays (see `from_pretrained`)."""
+  a dict of numpy arrays (see `from_pretrained`). The host `lm_head` keeps a cached fp32 transpose
+  (`_lmT`): for large vocabularies this is the runner's biggest host allocation (GPT-2 ~206 MB, a
+  151936x4096 head ~2.5 GB), freed by `release()`."""
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
@@ -257,15 +259,16 @@ class LlamaPrefill:
     self._lmT = None               # cached contiguous fp32 lm_head^T (host matmul); built on first use
 
   def release(self) -> None:
-    """Release every compiled program (prefill, decode chunks, batched-prefill chunks) and clear the cached
-    state, so a subsequent call transparently recompiles instead of replaying a freed program."""
+    """Release every compiled program (prefill, decode chunks, batched-prefill chunks), the cached host
+    `_lmT` transpose, and the cached state, so a subsequent call transparently recompiles instead of
+    replaying a freed program or stale buffers."""
     if self._net is not None:
       self._net.release()
     if self._dec is not None:
       for c in self._dec["chunks"]: c["net"].release()
     if self._pre is not None:
       for c in self._pre["chunks"]: c["net"].release()
-    self._net, self._seq, self._dec, self._pre = None, 0, None, None
+    self._net, self._seq, self._dec, self._pre, self._lmT = None, 0, None, None, None
 
   def _check_positions(self, n: int) -> None:
     """Raise a clear error instead of an out-of-bounds `wpe` index/broadcast failure when `n` exceeds a
@@ -349,6 +352,7 @@ class LlamaPrefill:
     are split into chunks under the ANE single-program weight ceiling (`_layer_chunks`); each mixer keeps its
     resident state (KV cache, ...) on the ANE across `execute` via `share_buffer`, and the hidden state chains
     chunk->chunk. Mixers own their state, so the runner is agnostic to the mixer type."""
+    self._check_positions(int(M))
     if self._dec is not None and self._dec["M"] == M: return self._dec
     if self._dec is not None:
       for c in self._dec["chunks"]: c["net"].release()
@@ -469,13 +473,14 @@ class LlamaPrefill:
     """Autoregressive generation with a resident KV-cache. The decode program (compiled once and cached) runs
     all layers for one token attending to caches that stay on the ANE across steps, so each step feeds only the
     token embedding + a position one-hot. `on_token(id)` is called per token (streaming). Greedy by default
-    (`temperature=0`); pass temperature/top_p/top_k to sample. Returns the generated token ids."""
+    (`temperature=0`); pass temperature/top_p/top_k to sample. Returns the generated token ids.
+
+    `on_stage(name, elapsed)` receives per-token timing (seconds) when profiling: `embedding` and `layers`
+    are the two halves of one decode step (the `step` stage times the whole call, so summing all stages
+    double-counts `step`), then `lm_head` and `sample`. Only emitted while profiling is on."""
     cfg = self.cfg; f16 = np.float16
     profiling = on_stage is not None
-    def stage(name, elapsed):
-      if on_stage is not None: on_stage(name, elapsed)
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
-    self._check_positions(M)
     eos = {int(eos_id)} if isinstance(eos_id, int) else {int(e) for e in (eos_id or ())}   # any-of stop set
     d = self._decoder(M); chunks = d["chunks"]
     for c in chunks:                                           # reset every mixer's resident state for this generation
@@ -493,7 +498,7 @@ class LlamaPrefill:
       h = np.asarray(emb)[None].astype(f16)
       wpe_pos = np.zeros((1, M), f16) if "wpe" in self.w else None
       if wpe_pos is not None: wpe_pos[0, pos] = 1.0
-      if profiling: stage("embedding", time.perf_counter() - t0)
+      if profiling: on_stage("embedding", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0
       for c in chunks:                                         # hidden flows chunk -> chunk (cheap [1,dim] round-trip)
         p = c["p"]; pr = c["net"].prog
@@ -502,7 +507,7 @@ class LlamaPrefill:
           if k in p: pr.set_input(p[k], vals[k])
         if "wpe_pos" in p: pr.set_input(p["wpe_pos"], wpe_pos)
         pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
-      if profiling: stage("layers", time.perf_counter() - t0)
+      if profiling: on_stage("layers", time.perf_counter() - t0)
       return h.reshape(cfg.dim).astype(np.float32)
     use_batched = (batched_prefill and len(prompt) > 1
                    and not hasattr(self.w["layers"], "free")     # streamed weights are freed by _decoder; can't re-bake
@@ -521,11 +526,11 @@ class LlamaPrefill:
     while len(out) < max_new_tokens:                           # decode
       if pos >= M - 1: break                                   # cache full
       t0 = time.perf_counter() if profiling else 0.0; hidden = step(cur, pos)
-      if profiling: stage("step", time.perf_counter() - t0)
+      if profiling: on_stage("step", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0; logits = self._logits(hidden)
-      if profiling: stage("lm_head", time.perf_counter() - t0)
+      if profiling: on_stage("lm_head", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0; nxt = self._sample(logits, temperature, top_p, top_k)
-      if profiling: stage("sample", time.perf_counter() - t0)
+      if profiling: on_stage("sample", time.perf_counter() - t0)
       out.append(nxt)
       if nxt in eos: break
       if on_token is not None: on_token(nxt)                   # stream the token

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -498,7 +498,7 @@ class LlamaPrefill:
       h = np.asarray(emb)[None].astype(f16)
       wpe_pos = np.zeros((1, M), f16) if "wpe" in self.w else None
       if wpe_pos is not None: wpe_pos[0, pos] = 1.0
-      if profiling: on_stage("embedding", time.perf_counter() - t0)
+      if on_stage is not None: on_stage("embedding", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0
       for c in chunks:                                         # hidden flows chunk -> chunk (cheap [1,dim] round-trip)
         p = c["p"]; pr = c["net"].prog
@@ -507,7 +507,7 @@ class LlamaPrefill:
           if k in p: pr.set_input(p[k], vals[k])
         if "wpe_pos" in p: pr.set_input(p["wpe_pos"], wpe_pos)
         pr.execute(); h = np.asarray(pr.read_output(p["h"])).astype(f16)
-      if profiling: on_stage("layers", time.perf_counter() - t0)
+      if on_stage is not None: on_stage("layers", time.perf_counter() - t0)
       return h.reshape(cfg.dim).astype(np.float32)
     use_batched = (batched_prefill and len(prompt) > 1
                    and not hasattr(self.w["layers"], "free")     # streamed weights are freed by _decoder; can't re-bake
@@ -526,11 +526,11 @@ class LlamaPrefill:
     while len(out) < max_new_tokens:                           # decode
       if pos >= M - 1: break                                   # cache full
       t0 = time.perf_counter() if profiling else 0.0; hidden = step(cur, pos)
-      if profiling: on_stage("step", time.perf_counter() - t0)
+      if on_stage is not None: on_stage("step", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0; logits = self._logits(hidden)
-      if profiling: on_stage("lm_head", time.perf_counter() - t0)
+      if on_stage is not None: on_stage("lm_head", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0; nxt = self._sample(logits, temperature, top_p, top_k)
-      if profiling: on_stage("sample", time.perf_counter() - t0)
+      if on_stage is not None: on_stage("sample", time.perf_counter() - t0)
       out.append(nxt)
       if nxt in eos: break
       if on_token is not None: on_token(nxt)                   # stream the token

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -254,6 +254,7 @@ class LlamaPrefill:
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
     self._chunk_bytes = 1.6e9      # max fp16 weight bytes per decode program (under the ~2GB ANE ceiling)
+    self._lmT = None               # cached contiguous fp32 lm_head^T (host matmul); built on first use
 
   def release(self) -> None:
     """Release every compiled program (prefill, decode chunks, batched-prefill chunks) and clear the cached
@@ -307,7 +308,13 @@ class LlamaPrefill:
     return np.asarray(net(emb.astype(np.float16))).astype(np.float32)
 
   def _logits(self, hidden_row):
-    return hidden_row @ np.asarray(self.w["lm_head"]).T    # host lm_head (vocab can exceed the ANE per-op dim limit)
+    lm = self._lmT
+    if lm is None:
+      # Build once: NumPy has no fp16 BLAS, and a live `.T` view is strided, so a per-call
+      # `hidden @ lm_head.T` re-converts the (fp16) weight to fp32 every token (~124ms on a
+      # 50k vocab). A contiguous fp32 copy of the transpose is converted once and is ~10x faster.
+      lm = self._lmT = np.ascontiguousarray(np.asarray(self.w["lm_head"]).T, np.float32)
+    return hidden_row @ lm
 
   @staticmethod
   def _sample(logits, temperature, top_p, top_k):

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -451,9 +451,9 @@ def _gelu_new(x: Tensor) -> Tensor:
 
 
 def _lm_head_tiles(h: Tensor, wte: np.ndarray) -> list[Tensor]:
-  """Tied lm_head logits = h @ wte.T, tiled along vocab so no matmul output dim exceeds
-  the target family's max tensor dimension. Returns a LIST of tiles, never a concatenated [S, vocab] tensor: the
-  concat itself exceeds the family-3 cap (the #183 lesson). The tiles are the head's
+  """Tied lm_head logits = h @ wte.T, tiled along vocab so no matmul output dim exceeds the
+  target family's max tensor dimension. Returns a LIST of tiles, never a concatenated [S, vocab]
+  tensor: the concat itself exceeds the family-3 cap (the #183 lesson). The tiles are the head's
   output ports; stitching is host-side via `_logits_from`."""
   V = wte.shape[0]
   tile = _targets.limit("max_tensor_dim", _targets.detect_family())

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -9,13 +9,9 @@ import numpy as np
 from .graph import Tensor, concat, conv, input, mha, space_to_depth
 from .autograd import conv2d, conv_param, parameter
 from ._compile import Model, SegmentedModel, MultiModel, compile
+from . import _targets
 
 _NORM_CACHE: dict[int, Model | SegmentedModel] = {}
-
-# Safe matmul output dim cap for all families. Family 3 (A13-A15, M1/M2) caps at 16384;
-# Family 4+ caps at 65536. Tiling at 16384 is conservative and safe everywhere.
-_LMHEAD_TILE = 16384
-
 
 def _l2_normalizer(D: int) -> Model | SegmentedModel:
   """Cached fused-ANE program L2-normalizing a [1, D] vector over its last axis."""
@@ -456,13 +452,14 @@ def _gelu_new(x: Tensor) -> Tensor:
 
 def _lm_head_tiles(h: Tensor, wte: np.ndarray) -> list[Tensor]:
   """Tied lm_head logits = h @ wte.T, tiled along vocab so no matmul output dim exceeds
-  `_LMHEAD_TILE`. Returns a LIST of tiles, never a concatenated [S, vocab] tensor: the
+  the target family's max tensor dimension. Returns a LIST of tiles, never a concatenated [S, vocab] tensor: the
   concat itself exceeds the family-3 cap (the #183 lesson). The tiles are the head's
   output ports; stitching is host-side via `_logits_from`."""
   V = wte.shape[0]
-  if V <= _LMHEAD_TILE:
+  tile = _targets.limit("max_tensor_dim", _targets.detect_family())
+  if V <= tile:
     return [h.linear(wte)]
-  return [h.linear(wte[i:i + _LMHEAD_TILE]) for i in range(0, V, _LMHEAD_TILE)]
+  return [h.linear(wte[i:i + tile]) for i in range(0, V, tile)]
 
 
 def _logits_from(net: MultiModel | Model, out) -> np.ndarray:

--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -75,6 +75,15 @@ def main():
         stage_total = sum(sum(profile.get(name, [])) for name in ("embedding", "layers", "lm_head", "sample")) / decode_steps
         print(f"  Profile decode stages: {stage_total * 1e3:.1f} ms/token ({decode_steps} steps; host dispatch overhead excluded)")
 
+    # Steady-state: a second call with prefill + decoder already compiled isolates decode throughput
+    t0 = time.perf_counter()
+    model.generate(ids, max_new_tokens=K, max_len=128, batched_prefill=True)
+    dt_ss = time.perf_counter() - t0
+    print(f"  Steady-state: {dt_ss / K * 1e3:.1f} ms/token ({K / dt_ss:.2f} tok/s, compile excluded)")
+    if decode_steps:
+        decode_ms = stage_total * 1e3
+        print(f"  Decode-only:  {decode_ms:.1f} ms/token ({1e3 / decode_ms:.2f} tok/s, from stage timing)")
+
     match_count = sum(int(a) == int(b) for a, b in zip(ane_toks, ref_toks))
     greedy_ok = list(ane_toks) == list(ref_toks) and match_count == K
     print(f"  Token match: {match_count}/{K} ({'PERFECT' if greedy_ok else 'MISMATCH'})")

--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -50,8 +50,12 @@ def main():
     print(f" done ({t_warm:.2f}s)")
 
     # Decode on ANE with resident KV cache
+    profile = {}
+    def on_stage(name, elapsed):
+        profile.setdefault(name, []).append(elapsed)
+
     t0 = time.perf_counter()
-    ane_toks = model.generate(ids, max_new_tokens=K, max_len=128, batched_prefill=True)
+    ane_toks = model.generate(ids, max_new_tokens=K, max_len=128, batched_prefill=True, on_stage=on_stage)
     dt = time.perf_counter() - t0
     tok_s = K / dt if dt > 0 else 0
 
@@ -61,7 +65,15 @@ def main():
 
     print(f"\n  ANE greedy: {tok.decode(ane_toks)!r}")
     print(f"  Ref greedy: {tok.decode(ref_toks)!r}")
-    print(f"  Speed:      {dt / K * 1e3:.1f} ms/token ({tok_s:.2f} tok/s, compile excluded)")
+    print(f"  Generation: {dt / K * 1e3:.1f} ms/token ({tok_s:.2f} tok/s, prefill included, compile excluded)")
+    for name in ("embedding", "layers", "step", "lm_head", "sample"):
+        values = profile.get(name, [])
+        if values:
+            print(f"  Profile {name:>9}: {np.mean(values) * 1e3:.1f} ms/token")
+    decode_steps = len(profile.get("step", []))
+    if decode_steps:
+        stage_total = sum(sum(profile.get(name, [])) for name in ("embedding", "layers", "lm_head", "sample")) / decode_steps
+        print(f"  Profile decode stages: {stage_total * 1e3:.1f} ms/token ({decode_steps} steps; host dispatch overhead excluded)")
 
     match_count = sum(int(a) == int(b) for a, b in zip(ane_toks, ref_toks))
     greedy_ok = list(ane_toks) == list(ref_toks) and match_count == K

--- a/examples/gpt2.py
+++ b/examples/gpt2.py
@@ -75,11 +75,12 @@ def main():
         stage_total = sum(sum(profile.get(name, [])) for name in ("embedding", "layers", "lm_head", "sample")) / decode_steps
         print(f"  Profile decode stages: {stage_total * 1e3:.1f} ms/token ({decode_steps} steps; host dispatch overhead excluded)")
 
-    # Steady-state: a second call with prefill + decoder already compiled isolates decode throughput
+    # Steady-state: a second call with prefill + decoder already compiled isolates decode throughput.
+    # The prompt prefill still runs inside this call; only compile is excluded.
     t0 = time.perf_counter()
     model.generate(ids, max_new_tokens=K, max_len=128, batched_prefill=True)
     dt_ss = time.perf_counter() - t0
-    print(f"  Steady-state: {dt_ss / K * 1e3:.1f} ms/token ({K / dt_ss:.2f} tok/s, compile excluded)")
+    print(f"  Steady-state: {dt_ss / K * 1e3:.1f} ms/token ({K / dt_ss:.2f} tok/s, prefill included, compile excluded)")
     if decode_steps:
         decode_ms = stage_total * 1e3
         print(f"  Decode-only:  {decode_ms:.1f} ms/token ({1e3 / decode_ms:.2f} tok/s, from stage timing)")

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -10,7 +10,7 @@ import aneforge as af
 import aneforge.models as models
 from aneforge._compile import _lower_fused_to_dir
 from aneforge.models import _gpt2_layers, _gelu_new, _lm_head_tiles, GPT2
-from aneforge.llm import _gpt2_adapter, LlamaPrefill, ModelType
+from aneforge.llm import _gpt2_adapter, LlamaConfig, LlamaPrefill, ModelType
 from _helpers import requires_ane
 
 
@@ -82,6 +82,23 @@ def test_gpt2_lm_head_tiles_follow_target_family(monkeypatch):
   assert [t.shape for t in models._lm_head_tiles(h, wte)] == [(1, 50257)]
   monkeypatch.setattr(models._targets, "detect_family", lambda: 3)
   assert [t.shape for t in models._lm_head_tiles(h, wte)] == [(1, 16384), (1, 16384), (1, 16384), (1, 1105)]
+
+
+def test_logits_caches_contiguous_fp32():
+  """`_logits` builds a contiguous fp32 lm_head transpose once (skipping the per-call fp16->fp32
+  conversion of a strided view); the result matches the naive fp16-weight matmul and the cache
+  is reused across calls."""
+  rng = np.random.default_rng(0)
+  cfg = LlamaConfig(dim=16, n_layers=2, n_heads=4, n_kv_heads=4, ffn_dim=64, vocab=100)
+  w = {"lm_head": rng.standard_normal((100, 16)).astype(np.float16), "layers": []}
+  model = LlamaPrefill(cfg, w)
+  h = rng.standard_normal(16).astype(np.float32)
+  expected = h @ np.asarray(w["lm_head"]).astype(np.float32).T
+  assert np.allclose(model._logits(h), expected)
+  assert model._lmT is not None and model._lmT.dtype == np.float32
+  assert model._lmT.flags["C_CONTIGUOUS"]
+  model._logits(h)          # second call reuses the cached transpose
+  assert model._lmT is not None
 
 
 def test_gpt2_generate_text_decodes_generated_tokens():

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -7,6 +7,7 @@ import numpy as np
 import pytest
 
 import aneforge as af
+import aneforge.models as models
 from aneforge._compile import _lower_fused_to_dir
 from aneforge.models import _gpt2_layers, _gelu_new, _lm_head_tiles, GPT2
 from aneforge.llm import _gpt2_adapter, LlamaPrefill, ModelType
@@ -71,6 +72,16 @@ def test_gpt2_lm_head_tiles_shapes():
   assert all(t.op == "matmul" for t in tiles)
   small = _lm_head_tiles(h, np.zeros((1000, 1024), np.float16))
   assert len(small) == 1 and small[0].shape == (1, 1000)
+
+
+def test_gpt2_lm_head_tiles_follow_target_family(monkeypatch):
+  """A16+ can keep GPT-2's vocabulary in one output tile; earlier families retain four."""
+  h = af.input((1, 1024))
+  wte = np.zeros((50257, 1024), np.float16)
+  monkeypatch.setattr(models._targets, "detect_family", lambda: 5)
+  assert [t.shape for t in models._lm_head_tiles(h, wte)] == [(1, 50257)]
+  monkeypatch.setattr(models._targets, "detect_family", lambda: 3)
+  assert [t.shape for t in models._lm_head_tiles(h, wte)] == [(1, 16384), (1, 16384), (1, 16384), (1, 1105)]
 
 
 def test_gpt2_generate_text_decodes_generated_tokens():

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -62,14 +62,22 @@ def test_gpt2_conv1d_mapping_orientation():
   assert np.array_equal(w["bv"], c[p + "attn.c_attn.bias"][2 * D:3 * D])
 
 
-def test_gpt2_lm_head_tiles_shapes():
-  """A 50257-vocab tied head tiles into ceil(50257/16384) = 4 output-port matmuls, the last
-  tile short; a small vocab stays a single tile."""
+def test_gpt2_lm_head_tiles_shapes(monkeypatch):
+  """A 50257-vocab tied head tiles to fit the target family's max tensor dim: four output-port
+  matmuls at the A13-A15 cap (16384, last tile short), one tile at the A16+ cap (65536). Mock the
+  cap so the result does not depend on which chip runs the test; a small vocab is always one tile."""
+  from aneforge import _targets
   h = af.input((1, 1024))
-  wte = np.zeros((50257, 1024), np.float32)
-  tiles = _lm_head_tiles(h, wte.astype(np.float16))
+  wte = np.zeros((50257, 1024), np.float16)
+
+  monkeypatch.setattr(_targets, "limit", lambda *_a, **_k: 16384)   # A13-A15
+  tiles = _lm_head_tiles(h, wte)
   assert [t.shape for t in tiles] == [(1, 16384), (1, 16384), (1, 16384), (1, 1105)]
   assert all(t.op == "matmul" for t in tiles)
+
+  monkeypatch.setattr(_targets, "limit", lambda *_a, **_k: 65536)   # A16+: 50257 fits one tile
+  assert [t.shape for t in _lm_head_tiles(h, wte)] == [(1, 50257)]
+
   small = _lm_head_tiles(h, np.zeros((1000, 1024), np.float16))
   assert len(small) == 1 and small[0].shape == (1, 1000)
 

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -86,19 +86,19 @@ def test_gpt2_lm_head_tiles_follow_target_family(monkeypatch):
 
 def test_logits_caches_contiguous_fp32():
   """`_logits` builds a contiguous fp32 lm_head transpose once (skipping the per-call fp16->fp32
-  conversion of a strided view); the result matches the naive fp16-weight matmul and the cache
-  is reused across calls."""
+  conversion of a strided view). The result is bit-identical to the previous per-call matmul
+  (`h @ np.asarray(lm_head).T`), and the cache is reused, not rebuilt, across calls."""
   rng = np.random.default_rng(0)
   cfg = LlamaConfig(dim=16, n_layers=2, n_heads=4, n_kv_heads=4, ffn_dim=64, vocab=100)
   w = {"lm_head": rng.standard_normal((100, 16)).astype(np.float16), "layers": []}
   model = LlamaPrefill(cfg, w)
   h = rng.standard_normal(16).astype(np.float32)
-  expected = h @ np.asarray(w["lm_head"]).astype(np.float32).T
-  assert np.allclose(model._logits(h), expected)
-  assert model._lmT is not None and model._lmT.dtype == np.float32
-  assert model._lmT.flags["C_CONTIGUOUS"]
+  expected = h @ np.asarray(w["lm_head"]).T          # the pre-cache matmul, unchanged numerics
+  assert np.array_equal(model._logits(h), expected)
+  first = model._lmT
+  assert first is not None and first.dtype == np.float32 and first.flags["C_CONTIGUOUS"]
   model._logits(h)          # second call reuses the cached transpose
-  assert model._lmT is not None
+  assert model._lmT is first
 
 
 def test_gpt2_generate_text_decodes_generated_tokens():
@@ -153,6 +153,8 @@ def test_llama_prefill_check_positions_rejects_beyond_wpe():
     model._hidden(np.arange(11, dtype=np.int64))
   with pytest.raises(ValueError, match="exceeds this model's 10 max positions"):
     model.generate([1, 2, 3], max_new_tokens=4, max_len=20)
+  with pytest.raises(ValueError, match="exceeds this model's 10 max positions"):
+    model.warmup(20)   # warmup goes straight to _decoder; must hit the same guard
 
 
 def test_llama_prefill_release_clears_state():
@@ -175,9 +177,11 @@ def test_llama_prefill_release_clears_state():
   model._seq = 5
   model._dec = {"M": 20, "chunks": [{"net": chunk_net}]}
   model._pre = {"seq": 5, "chunks": [{"net": chunk_net}]}
+  model._lmT = object()          # the cached host lm_head transpose must be dropped too
   model.release()
   assert net.released and chunk_net.released
   assert model._net is None and model._seq == 0 and model._dec is None and model._pre is None
+  assert model._lmT is None
 
 
 def test_gpt2_adapter_mapping():


### PR DESCRIPTION
READY:
Resolves #226 (throughput levers), plus a host-side `lm_head` fix surfaced by the profiling step the issue asked for.

## What's in this PR

1. **Per-stage decode profiling** (`examples/gpt2.py` + `on_stage` in `LlamaPrefill.generate`): splits per-token time into embedding / layers (ANE) / lm_head (host) / sample, so the cost is measured, not assumed (issue step 3).
2. **Family-aware `_lm_head_tiles`**: tile size comes from `_targets.limit("max_tensor_dim", detect_family())` instead of a hardcoded 16384. A16+ gets 65536 (GPT-2's 50257 vocab fits one tile); A13-A15 keep 4 tiles.
3. **Fold `wpe` into the resident decode graph**: the first decode chunk adds the learned positional embedding in-graph via a position one-hot + a baked `wpe` constant, removing the per-token host-side add.
4. **Host `lm_head` fp32-contiguous cache** (`LlamaPrefill._logits`): the weight is fp16 and NumPy has no fp16 BLAS, so every token re-converted a strided transpose (~124 ms). A contiguous fp32 transpose is now built once and reused (~10 ms), bit-identical to the previous per-call matmul.

## Measurements (M2 Pro, macOS 26.5.2, fp16)

GPT-2 medium, resident KV-cache decode (compile excluded):

| Stage | Before | After |
|---|---|---|
| host lm_head | 124.4 ms/token | 10.0 ms/token |
| ANE layers | 13.4 ms/token | 13.6 ms/token |
| decode (from stage timing) | ~136 ms/token (7.3 tok/s) | 23.8 ms/token (42 tok/s) |

Qwen3-0.6B, same fix, same machine: 2.1 → 16.6 tok/s (TPOT 480 → 62 ms). The host lm_head conversion dominated both, not the tiling.

## Honest accounting

- **Only lever 4 moved the needle.** The wpe fold is neutral for throughput (the host add it removed was microseconds) and cost ~0.2 ms/token in the ANE layers (13.4 → 13.6 ms; within run-to-run noise). The family-aware tile is correct but latent: `_lm_head_tiles` has no production call site today — its only caller (`GPT2.__call__`) was removed by #224 when GPT-2 folded onto `LlamaPrefill`, and `models.py` reaches it from tests only. It becomes live when #227 wires an ANE head back into decode.
- **The wpe fold is a numerics change, not just a move.** Decode now adds `wpe` in fp16 inside the graph, while prefill (`_hidden`/`_prefill_seed`) still adds it in fp32 on the host, so the same position is computed slightly differently per path. Greedy stays 16/16 identical to HF, but this is not "numerically identical" the way the lm_head cache is (that one is bit-exact).
- **`detect_family()` reads the host chip**, so a cross-compile for another family would tile for the host unless `ANEFORGE_TARGET` is set. Kept as the issue specified.

## Validation

- GPT-2: prefill cosine 1.00000, greedy 16/16 vs HF, long context >512 PASS.
- On-device `tests/test_gpt2.py` + `tests/test_llm.py`: 26 passed.
- Off-device suite: 330 passed; new `test_logits_caches_contiguous_fp32` (bit-identity + cache reuse), `test_gpt2_lm_head_tiles_follow_target_family`, and `warmup` position-guard coverage.
- Corpus gate: 90/90 GREEN.
- ruff, pylint 2-space gate, compileall clean.

## Review feedback applied

- `release()` now drops `_lmT` (the runner's largest host allocation, ~206 MB on gpt2-medium, ~2.5 GB on a 151936×4096 head), and the class docstring documents it.
- `warmup()` now hits the `_check_positions` guard via `_decoder` (previously a `warmup(2048)` on GPT-2 would silently truncate `wpe` and fail with a graph shape error instead of the clear ValueError).
- `on_stage` documented in `generate`'s docstring, including that `step` nests `embedding` + `layers` (summing all stages double-counts).

## Follow-ups

- #227: lm_head on the ANE for all LlamaPrefill models (tiled, speculative-style). This host fix is cheap and generic; #227 is the deeper optimization and should build on the `_lmT` cache.
- Want a stable repeated run and an A16 cross-check before leaving draft.