### PR TITLE
examples: chat with your docs, entirely on the Neural Engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,8 @@ model via `af.load_llm` and benchmarks prefill/decode (matching Hugging Face
 logits). For retrieval,
 [`examples/rag_embeddings.py`](examples/rag_embeddings.py) is a LangChain
 `Embeddings` drop-in backed by the on-ANE encoder (4-5x faster than the GPU,
-cosine 1.0000).
+cosine 1.0000). Chat with your docs entirely on the Neural Engine -- embeddings,
+reranker, and LLM on one engine: `python3 examples/rag_chat.py`.
 
 ## How it compares
 

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -204,3 +204,9 @@ call and reports the query's energy as `~NNN mJ this query, 0 GPU` -- 0 GPU beca
 whole pipeline, including generation, never leaves the Neural Engine. Without `sudo` (or
 without `powermetrics` on the machine), the flag falls back to running the query with no
 energy figure rather than failing.
+
+The demo works best on prose documents. Chunking windows to a fixed token count, but a
+file shorter than that window still embeds as a single chunk sized to its own length, so
+a folder of very many tiny files (each a different length) can still push the ANE
+embedder toward compiling one program per distinct sequence length -- the same per-length
+program budget noted for `SentenceTransformer` above.

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -161,3 +161,46 @@ Embeddings match the reference encoder at a fraction of the GPU's energy.
 
 - **Pooling** comes from `1_Pooling/config.json` (`pooling_mode_cls_token` / `pooling_mode_max_tokens` / `pooling_mode_mean_tokens`).
 - **Normalize** is true if `modules.json` lists a `Normalize` module. A model that ships a Normalize module is L2-normalised regardless of `normalize_embeddings`, matching sentence-transformers.
+
+## RAG on the ANE (examples/rag_chat.py)
+
+`examples/rag_chat.py` is a chat-with-your-docs demo where every stage runs on the
+Neural Engine: embedding, reranking, and generation. There is no host-side model, and no
+GPU or CPU inference path in the loop.
+
+Run it against a folder of `.md`/`.txt` files:
+
+```
+python3 examples/rag_chat.py [path]   # path defaults to this repo's docs/
+```
+
+It walks `path`, chunks each file (`examples._rag.chunk_text`), embeds every chunk with
+`SentenceTransformer`, and holds the vectors in memory. Each query is embedded, matched
+by cosine similarity against the corpus (`top_k`), reranked with a `CrossEncoder`, packed
+into a prompt (`pack_context`), and answered by a resident-KV-cache Qwen3-0.6B decode
+(`aneforge.load_llm`) that streams tokens as they are produced.
+
+Model stack:
+
+- `sentence-transformers/all-MiniLM-L6-v2` for embeddings
+- `cross-encoder/ms-marco-MiniLM-L-6-v2` for reranking
+- `Qwen/Qwen3-0.6B` for generation
+
+All three are fixed and small enough to keep the demo's compile and load times short.
+
+`MAX_LEN` is a fixed 512-token context (`ANSWER_TOKENS = 160` reserved for the answer, so
+the packed prompt budget is 352 tokens). The decode program is compiled once via
+`llm.warmup(MAX_LEN)` before the first question, so every subsequent query streams
+immediately instead of paying a per-query compile cost.
+
+`--energy` adds a per-query joules line (needs `sudo` and `powermetrics`):
+
+```
+sudo python3 examples/rag_chat.py --energy
+```
+
+It samples package power with `powermetrics` for the duration of one `Pipeline.answer`
+call and reports the query's energy as `~NNN mJ this query, 0 GPU` -- 0 GPU because the
+whole pipeline, including generation, never leaves the Neural Engine. Without `sudo` (or
+without `powermetrics` on the machine), the flag falls back to running the query with no
+energy figure rather than failing.

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -205,8 +205,6 @@ whole pipeline, including generation, never leaves the Neural Engine. Without `s
 without `powermetrics` on the machine), the flag falls back to running the query with no
 energy figure rather than failing.
 
-The demo works best on prose documents. Chunking windows to a fixed token count, but a
-file shorter than that window still embeds as a single chunk sized to its own length, so
-a folder of very many tiny files (each a different length) can still push the ANE
-embedder toward compiling one program per distinct sequence length -- the same per-length
-program budget noted for `SentenceTransformer` above.
+The demo works best on prose documents, but the corpus can be any mix of lengths: the ANE
+encoder pads each batch to one length and masks the padding, so a whole corpus -- long
+files or many tiny ones -- embeds through a single compiled program.

--- a/examples/_rag.py
+++ b/examples/_rag.py
@@ -1,0 +1,32 @@
+"""Pure RAG orchestration for examples/rag_chat.py: chunking, vector search, prompt
+packing. No ANE and no I/O here -- models and tokenizers are passed in as callables so
+this is unit-tested off-device."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass
+class Chunk:
+  text: str
+  source: str
+
+
+def chunk_text(text: str, source: str, size: int = 800, overlap: int = 160) -> list[Chunk]:
+  """Split `text` into overlapping character windows of `size`, stepping `size - overlap`.
+  A document shorter than `size` is a single chunk; no text is dropped."""
+  text = text.strip()
+  if len(text) <= size:
+    return [Chunk(text, source)] if text else []
+  step = size - overlap
+  chunks = []
+  i = 0
+  while i < len(text):
+    chunk = text[i:i + size]
+    chunks.append(Chunk(chunk, source))
+    if i + size >= len(text):
+      break
+    i += step
+  return chunks

--- a/examples/_rag.py
+++ b/examples/_rag.py
@@ -37,3 +37,24 @@ def top_k(query_vec: np.ndarray, corpus: np.ndarray, k: int) -> list[int]:
   (dot product, since both sides are L2-normalized), highest first."""
   scores = corpus @ query_vec
   return np.argsort(scores)[::-1][:k].tolist()
+
+
+PROMPT_TEMPLATE = (
+  "Answer the question using only the context below. If the context does not contain the "
+  "answer, say you don't know.\n\nContext:\n{context}\n\nQuestion: {question}\nAnswer:")
+
+
+def pack_context(chunks: list[Chunk], query: str, budget: int, token_len) -> str:
+  """Build the prompt from as many reranked chunks (best first) as fit in `budget` tokens.
+  Always includes the query; if the first chunk alone overflows, truncate it to fit."""
+  kept: list[str] = []
+  for c in chunks:
+    trial = "\n".join(kept + [c.text])
+    if token_len(PROMPT_TEMPLATE.format(context=trial, question=query)) <= budget:
+      kept.append(c.text)
+  if not kept and chunks:                       # first chunk alone overflows: truncate it
+    text = chunks[0].text
+    while text and token_len(PROMPT_TEMPLATE.format(context=text, question=query)) > budget:
+      text = text[: max(1, len(text) * 3 // 4)]
+    kept = [text]
+  return PROMPT_TEMPLATE.format(context="\n".join(kept), question=query)

--- a/examples/_rag.py
+++ b/examples/_rag.py
@@ -14,25 +14,21 @@ class Chunk:
   source: str
 
 
-def chunk_text(text, source, encode, decode, size: int = 192, overlap: int = 32) -> list[Chunk]:
-  """Split `text` into windows of exactly `size` real tokens (back-extending the final window so it is
-  also `size`), using injected `encode(str)->list` and `decode(list)->str`. A document with <= `size`
-  tokens is a single chunk. Uniform-length windows keep the ANE embedder to a few compiled programs."""
+def chunk_text(text: str, source: str, size: int = 800, overlap: int = 160) -> list[Chunk]:
+  """Split `text` into overlapping character windows of `size`, stepping `size - overlap`. A document
+  shorter than `size` is a single chunk; no text is dropped. Chunk lengths need not be uniform -- the
+  ANE encoder pads each batch to one length (see aneforge #232)."""
   text = text.strip()
-  if not text:
-    return []
-  ids = encode(text)
-  if len(ids) <= size:
-    return [Chunk(text, source)]
+  if len(text) <= size:
+    return [Chunk(text, source)] if text else []
   step = size - overlap
   out = []
-  for i in range(0, len(ids), step):
-    w = ids[i:i + size]
-    if len(w) < size:
-      w = ids[-size:]
-    out.append(Chunk(decode(w), source))
-    if i + size >= len(ids):
+  i = 0
+  while i < len(text):
+    out.append(Chunk(text[i:i + size], source))
+    if i + size >= len(text):
       break
+    i += step
   return out
 
 

--- a/examples/_rag.py
+++ b/examples/_rag.py
@@ -30,3 +30,10 @@ def chunk_text(text: str, source: str, size: int = 800, overlap: int = 160) -> l
       break
     i += step
   return chunks
+
+
+def top_k(query_vec: np.ndarray, corpus: np.ndarray, k: int) -> list[int]:
+  """Indices of the top `k` corpus rows by cosine similarity to `query_vec`
+  (dot product, since both sides are L2-normalized), highest first."""
+  scores = corpus @ query_vec
+  return np.argsort(scores)[::-1][:k].tolist()

--- a/examples/_rag.py
+++ b/examples/_rag.py
@@ -14,22 +14,26 @@ class Chunk:
   source: str
 
 
-def chunk_text(text: str, source: str, size: int = 800, overlap: int = 160) -> list[Chunk]:
-  """Split `text` into overlapping character windows of `size`, stepping `size - overlap`.
-  A document shorter than `size` is a single chunk; no text is dropped."""
+def chunk_text(text, source, encode, decode, size: int = 192, overlap: int = 32) -> list[Chunk]:
+  """Split `text` into windows of exactly `size` real tokens (back-extending the final window so it is
+  also `size`), using injected `encode(str)->list` and `decode(list)->str`. A document with <= `size`
+  tokens is a single chunk. Uniform-length windows keep the ANE embedder to a few compiled programs."""
   text = text.strip()
-  if len(text) <= size:
-    return [Chunk(text, source)] if text else []
+  if not text:
+    return []
+  ids = encode(text)
+  if len(ids) <= size:
+    return [Chunk(text, source)]
   step = size - overlap
-  chunks = []
-  i = 0
-  while i < len(text):
-    chunk = text[i:i + size]
-    chunks.append(Chunk(chunk, source))
-    if i + size >= len(text):
+  out = []
+  for i in range(0, len(ids), step):
+    w = ids[i:i + size]
+    if len(w) < size:
+      w = ids[-size:]
+    out.append(Chunk(decode(w), source))
+    if i + size >= len(ids):
       break
-    i += step
-  return chunks
+  return out
 
 
 def top_k(query_vec: np.ndarray, corpus: np.ndarray, k: int) -> list[int]:

--- a/examples/_rag.py
+++ b/examples/_rag.py
@@ -58,7 +58,7 @@ def pack_context(chunks: list[Chunk], query: str, budget: int, token_len) -> str
       kept.append(c.text)
   if not kept and chunks:                       # first chunk alone overflows: truncate it
     text = chunks[0].text
-    while text and token_len(PROMPT_TEMPLATE.format(context=text, question=query)) > budget:
+    while len(text) > 1 and token_len(PROMPT_TEMPLATE.format(context=text, question=query)) > budget:
       text = text[: max(1, len(text) * 3 // 4)]
     kept = [text]
   return PROMPT_TEMPLATE.format(context="\n".join(kept), question=query)

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -18,7 +18,7 @@ RERANK = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 LLM = "Qwen/Qwen3-0.6B"
 MAX_LEN = 512
 ANSWER_TOKENS = 160
-TOP_K, TOP_N = 20, 4
+TOP_K, TOP_N = 12, 4
 CHUNK_TOK = 192          # token-window chunk size; uniform windows keep the Encoder to a few compiled programs
 REPO_DOCS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs")
 
@@ -84,6 +84,8 @@ class Pipeline:
     t["retrieve"] = (time.perf_counter() - t0) * 1e3
     t0 = time.perf_counter()
     scores = self.rerank.predict([(query, self.chunks[i].text) for i in cand])
+    self.rerank._cache.clear()   # the reranker compiles one ANE program per pair length; release them so
+                                 # they do not accumulate across queries and exhaust the engine (op_create err=13)
     ranked = [self.chunks[cand[i]] for i in np.argsort(scores)[::-1][:TOP_N]]
     t["rerank"] = (time.perf_counter() - t0) * 1e3
     budget = MAX_LEN - ANSWER_TOKENS

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -34,6 +34,36 @@ def _read_corpus(path: str) -> list[Chunk]:
   return chunks
 
 
+FIXED_EMBED_TOK = 256   # embed at one fixed length so the Encoder compiles a single program (it caches per length)
+
+
+def _embed_fixed(st, texts):
+  """Embed texts at one fixed padded token length so aneforge's Encoder compiles a single ANE program
+  instead of one per distinct token length. A real corpus spans hundreds of distinct chunk lengths, and
+  the Encoder caches one resident program per length (`Encoder._cache[len(ids)]`), which exhausts the
+  ANE (`op_create err=13`) well before the whole corpus is embedded; a fixed padded length compiles once
+  and is reused for every chunk and the query. Pools exactly as `Encoder.__call__` would for the model's
+  configured pooling mode (mean/cls/max), masking out padding for mean/max so pad tokens don't dilute the
+  pooled vector, and L2-normalizes -- matching `SentenceTransformer.encode(..., normalize_embeddings=True)`."""
+  enc = st._enc                                    # the underlying aneforge Encoder
+  vecs = []
+  for t in texts:
+    batch = enc.tok(t, padding="max_length", truncation=True, max_length=FIXED_EMBED_TOK)
+    ids = np.asarray(batch["input_ids"], dtype=np.int64)
+    mask = np.asarray(batch["attention_mask"], dtype=bool)
+    net = enc._cache.get(len(ids)) or enc._cache.setdefault(len(ids), enc._build(len(ids)))
+    states = net(enc._embed(ids))                 # [S, D] per-token states, real tokens + padding
+    real = states[mask]
+    if enc.pooling == "cls":
+      v = states[0]
+    elif enc.pooling == "max":
+      v = real.max(0)
+    else:
+      v = real.mean(0)
+    vecs.append(v / (np.linalg.norm(v) + 1e-9))
+  return np.asarray(vecs, np.float32)
+
+
 def _sample_energy(fn):
   """Run fn() while sampling package power with powermetrics; return (result, millijoules).
   Returns (result, None) if powermetrics is unavailable or not run as root."""
@@ -67,7 +97,7 @@ class Pipeline:
     if not chunks:
       raise SystemExit(f"rag_chat: no .md/.txt files found under {path!r}")
     embed = SentenceTransformer(EMBED)
-    vecs = embed.encode([c.text for c in chunks], normalize_embeddings=True).astype(np.float32)
+    vecs = _embed_fixed(embed, [c.text for c in chunks])
     llm = load_llm(llm_name); llm.warmup(MAX_LEN)
     tok = AutoTokenizer.from_pretrained(llm_name)
     return cls(embed, CrossEncoder(RERANK), llm, tok, chunks, vecs)
@@ -75,7 +105,7 @@ class Pipeline:
   def answer(self, query: str, on_token) -> dict:
     t = {}
     t0 = time.perf_counter()
-    qv = self.embed.encode([query], normalize_embeddings=True)[0].astype(np.float32)
+    qv = _embed_fixed(self.embed, [query])[0]
     cand = top_k(qv, self.vecs, TOP_K)
     t["retrieve"] = (time.perf_counter() - t0) * 1e3
     t0 = time.perf_counter()

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -31,7 +31,8 @@ def _read_corpus(path: str, tok) -> list[Chunk]:
     for f in sorted(files):
       if f.endswith((".md", ".txt")):
         fp = os.path.join(root, f)
-        text = open(fp, encoding="utf-8", errors="ignore").read()
+        with open(fp, encoding="utf-8", errors="ignore") as fh:
+          text = fh.read()
         chunks += chunk_text(text, os.path.relpath(fp, path),
                              lambda s: tok.encode(s, add_special_tokens=False), tok.decode,
                              size=CHUNK_TOK, overlap=32)
@@ -50,6 +51,7 @@ def _sample_energy(fn):
   result = fn()
   dt = time.perf_counter() - t0
   proc.terminate()
+  proc.wait()
   out = proc.stdout.read() if proc.stdout else ""
   mw = [float(l.split(":")[1].strip().split()[0]) for l in out.splitlines() if "Package Power" in l]
   if not mw:

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -88,9 +88,12 @@ class Pipeline:
                                  # they do not accumulate across queries and exhaust the engine (op_create err=13)
     ranked = [self.chunks[cand[i]] for i in np.argsort(scores)[::-1][:TOP_N]]
     t["rerank"] = (time.perf_counter() - t0) * 1e3
+    def _wrap(content):   # Qwen chat format so the model answers from context and stops at EOS (no rambling)
+      return self.tok.apply_chat_template([{"role": "user", "content": content}],
+                                          tokenize=False, add_generation_prompt=True, enable_thinking=False)
     budget = MAX_LEN - ANSWER_TOKENS
-    prompt = pack_context(ranked, query, budget, lambda s: len(self.tok.encode(s)))
-    ids = self.tok.encode(prompt)[:budget]
+    content = pack_context(ranked, query, budget, lambda c: len(self.tok.encode(_wrap(c))))
+    ids = self.tok.encode(_wrap(content))[:budget]
     t0 = time.perf_counter()
     self.llm.generate(ids, max_new_tokens=ANSWER_TOKENS, max_len=MAX_LEN,
                       eos_id=self.tok.eos_token_id, on_token=on_token)

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -18,14 +18,13 @@ RERANK = "cross-encoder/ms-marco-MiniLM-L-6-v2"
 LLM = "Qwen/Qwen3-0.6B"
 MAX_LEN = 512
 ANSWER_TOKENS = 160
-TOP_K, TOP_N = 12, 4
-CHUNK_TOK = 192          # token-window chunk size; uniform windows keep the Encoder to a few compiled programs
+TOP_K, TOP_N = 20, 4
 REPO_DOCS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs")
 
 from examples._rag import Chunk, chunk_text, pack_context, top_k   # noqa: E402
 
 
-def _read_corpus(path: str, tok) -> list[Chunk]:
+def _read_corpus(path: str) -> list[Chunk]:
   chunks: list[Chunk] = []
   for root, _, files in os.walk(path):
     for f in sorted(files):
@@ -33,9 +32,7 @@ def _read_corpus(path: str, tok) -> list[Chunk]:
         fp = os.path.join(root, f)
         with open(fp, encoding="utf-8", errors="ignore") as fh:
           text = fh.read()
-        chunks += chunk_text(text, os.path.relpath(fp, path),
-                             lambda s: tok.encode(s, add_special_tokens=False), tok.decode,
-                             size=CHUNK_TOK, overlap=32)
+        chunks += chunk_text(text, os.path.relpath(fp, path))
   return chunks
 
 
@@ -70,7 +67,7 @@ class Pipeline:
     from aneforge import load_llm
     from aneforge.sentence_transformers import CrossEncoder, SentenceTransformer
     tok = AutoTokenizer.from_pretrained(llm_name)
-    chunks = _read_corpus(path, tok)
+    chunks = _read_corpus(path)
     if not chunks:
       raise SystemExit(f"rag_chat: no .md/.txt files found under {path!r}")
     embed = SentenceTransformer(EMBED)
@@ -86,8 +83,6 @@ class Pipeline:
     t["retrieve"] = (time.perf_counter() - t0) * 1e3
     t0 = time.perf_counter()
     scores = self.rerank.predict([(query, self.chunks[i].text) for i in cand])
-    self.rerank._cache.clear()   # the reranker compiles one ANE program per pair length; release them so
-                                 # they do not accumulate across queries and exhaust the engine (op_create err=13)
     ranked = [self.chunks[cand[i]] for i in np.argsort(scores)[::-1][:TOP_N]]
     t["rerank"] = (time.perf_counter() - t0) * 1e3
     def _wrap(content):   # Qwen chat format so the model answers from context and stops at EOS (no rambling)

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -5,6 +5,7 @@ embeddings, a CrossEncoder reranker, and Qwen3-0.6B generation all run on the en
   sudo python3 examples/rag_chat.py --energy # add per-query joules (needs powermetrics)
 """
 import os
+import subprocess
 import sys
 import time
 
@@ -31,6 +32,25 @@ def _read_corpus(path: str) -> list[Chunk]:
         fp = os.path.join(root, f)
         chunks += chunk_text(open(fp, encoding="utf-8", errors="ignore").read(), os.path.relpath(fp, path))
   return chunks
+
+
+def _sample_energy(fn):
+  """Run fn() while sampling package power with powermetrics; return (result, millijoules).
+  Returns (result, None) if powermetrics is unavailable or not run as root."""
+  try:
+    proc = subprocess.Popen(["powermetrics", "-i", "50", "--samplers", "cpu_power"],
+                            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, text=True)
+  except (FileNotFoundError, PermissionError):
+    return fn(), None
+  t0 = time.perf_counter()
+  result = fn()
+  dt = time.perf_counter() - t0
+  proc.terminate()
+  out = proc.stdout.read() if proc.stdout else ""
+  mw = [float(l.split(":")[1].strip().split()[0]) for l in out.splitlines() if "Package Power" in l]
+  if not mw:
+    return result, None
+  return result, (sum(mw) / len(mw)) * dt      # avg mW * seconds = millijoules
 
 
 class Pipeline:
@@ -75,6 +95,7 @@ class Pipeline:
 def main(argv) -> int:
   args = [a for a in argv if not a.startswith("--")]
   path = args[0] if args else REPO_DOCS
+  energy = "--energy" in argv
   print(f"indexing {path} on the Apple Neural Engine ...", flush=True)
   p = Pipeline.build(path)
   print(f"indexed {len(p.chunks)} chunks from {len({c.source for c in p.chunks})} files. "
@@ -87,10 +108,15 @@ def main(argv) -> int:
     if not q:
       continue
     print("ane> ", end="", flush=True)
-    timing = p.answer(q, on_token=lambda i: print(p.tok.decode([i]), end="", flush=True))
+    stream = lambda i: print(p.tok.decode([i]), end="", flush=True)
+    if energy:
+      timing, mj = _sample_energy(lambda: p.answer(q, on_token=stream))
+      tail = f" | ~{mj:.0f} mJ this query, 0 GPU" if mj is not None else " | (energy: run with sudo)"
+    else:
+      timing, tail = p.answer(q, on_token=stream), ""
     ms = timing["stage_ms"]
     print(f"\n[retrieve {ms['retrieve']:.0f}ms | rerank {ms['rerank']:.0f}ms | "
-          f"generate {ms['generate']:.0f}ms | all ANE | sources: {', '.join(timing['sources'])}]\n")
+          f"generate {ms['generate']:.0f}ms | all ANE | sources: {', '.join(timing['sources'])}{tail}]\n")
 
 
 if __name__ == "__main__":

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -19,49 +19,23 @@ LLM = "Qwen/Qwen3-0.6B"
 MAX_LEN = 512
 ANSWER_TOKENS = 160
 TOP_K, TOP_N = 20, 4
+CHUNK_TOK = 192          # token-window chunk size; uniform windows keep the Encoder to a few compiled programs
 REPO_DOCS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs")
 
 from examples._rag import Chunk, chunk_text, pack_context, top_k   # noqa: E402
 
 
-def _read_corpus(path: str) -> list[Chunk]:
+def _read_corpus(path: str, tok) -> list[Chunk]:
   chunks: list[Chunk] = []
   for root, _, files in os.walk(path):
     for f in sorted(files):
       if f.endswith((".md", ".txt")):
         fp = os.path.join(root, f)
-        chunks += chunk_text(open(fp, encoding="utf-8", errors="ignore").read(), os.path.relpath(fp, path))
+        text = open(fp, encoding="utf-8", errors="ignore").read()
+        chunks += chunk_text(text, os.path.relpath(fp, path),
+                             lambda s: tok.encode(s, add_special_tokens=False), tok.decode,
+                             size=CHUNK_TOK, overlap=32)
   return chunks
-
-
-FIXED_EMBED_TOK = 256   # embed at one fixed length so the Encoder compiles a single program (it caches per length)
-
-
-def _embed_fixed(st, texts):
-  """Embed texts at one fixed padded token length so aneforge's Encoder compiles a single ANE program
-  instead of one per distinct token length. A real corpus spans hundreds of distinct chunk lengths, and
-  the Encoder caches one resident program per length (`Encoder._cache[len(ids)]`), which exhausts the
-  ANE (`op_create err=13`) well before the whole corpus is embedded; a fixed padded length compiles once
-  and is reused for every chunk and the query. Pools exactly as `Encoder.__call__` would for the model's
-  configured pooling mode (mean/cls/max), masking out padding for mean/max so pad tokens don't dilute the
-  pooled vector, and L2-normalizes -- matching `SentenceTransformer.encode(..., normalize_embeddings=True)`."""
-  enc = st._enc                                    # the underlying aneforge Encoder
-  vecs = []
-  for t in texts:
-    batch = enc.tok(t, padding="max_length", truncation=True, max_length=FIXED_EMBED_TOK)
-    ids = np.asarray(batch["input_ids"], dtype=np.int64)
-    mask = np.asarray(batch["attention_mask"], dtype=bool)
-    net = enc._cache.get(len(ids)) or enc._cache.setdefault(len(ids), enc._build(len(ids)))
-    states = net(enc._embed(ids))                 # [S, D] per-token states, real tokens + padding
-    real = states[mask]
-    if enc.pooling == "cls":
-      v = states[0]
-    elif enc.pooling == "max":
-      v = real.max(0)
-    else:
-      v = real.mean(0)
-    vecs.append(v / (np.linalg.norm(v) + 1e-9))
-  return np.asarray(vecs, np.float32)
 
 
 def _sample_energy(fn):
@@ -93,19 +67,19 @@ class Pipeline:
     from transformers import AutoTokenizer            # lazy
     from aneforge import load_llm
     from aneforge.sentence_transformers import CrossEncoder, SentenceTransformer
-    chunks = _read_corpus(path)
+    tok = AutoTokenizer.from_pretrained(llm_name)
+    chunks = _read_corpus(path, tok)
     if not chunks:
       raise SystemExit(f"rag_chat: no .md/.txt files found under {path!r}")
     embed = SentenceTransformer(EMBED)
-    vecs = _embed_fixed(embed, [c.text for c in chunks])
+    vecs = embed.encode([c.text for c in chunks], normalize_embeddings=True).astype(np.float32)
     llm = load_llm(llm_name); llm.warmup(MAX_LEN)
-    tok = AutoTokenizer.from_pretrained(llm_name)
     return cls(embed, CrossEncoder(RERANK), llm, tok, chunks, vecs)
 
   def answer(self, query: str, on_token) -> dict:
     t = {}
     t0 = time.perf_counter()
-    qv = _embed_fixed(self.embed, [query])[0]
+    qv = self.embed.encode([query], normalize_embeddings=True)[0].astype(np.float32)
     cand = top_k(qv, self.vecs, TOP_K)
     t["retrieve"] = (time.perf_counter() - t0) * 1e3
     t0 = time.perf_counter()

--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -1,0 +1,97 @@
+"""Chat with a folder of docs, entirely on the Apple Neural Engine: SentenceTransformer
+embeddings, a CrossEncoder reranker, and Qwen3-0.6B generation all run on the engine.
+
+  python3 examples/rag_chat.py [path]        # path defaults to this repo's docs/
+  sudo python3 examples/rag_chat.py --energy # add per-query joules (needs powermetrics)
+"""
+import os
+import sys
+import time
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # repo root -> import aneforge / examples._rag; works as a script and when imported under pytest
+
+import numpy as np
+
+EMBED = "sentence-transformers/all-MiniLM-L6-v2"
+RERANK = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+LLM = "Qwen/Qwen3-0.6B"
+MAX_LEN = 512
+ANSWER_TOKENS = 160
+TOP_K, TOP_N = 20, 4
+REPO_DOCS = os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(__file__))), "docs")
+
+from examples._rag import Chunk, chunk_text, pack_context, top_k   # noqa: E402
+
+
+def _read_corpus(path: str) -> list[Chunk]:
+  chunks: list[Chunk] = []
+  for root, _, files in os.walk(path):
+    for f in sorted(files):
+      if f.endswith((".md", ".txt")):
+        fp = os.path.join(root, f)
+        chunks += chunk_text(open(fp, encoding="utf-8", errors="ignore").read(), os.path.relpath(fp, path))
+  return chunks
+
+
+class Pipeline:
+  def __init__(self, embed, rerank, llm, tok, chunks, vecs):
+    self.embed, self.rerank, self.llm, self.tok = embed, rerank, llm, tok
+    self.chunks, self.vecs = chunks, vecs
+
+  @classmethod
+  def build(cls, path: str, llm_name: str = LLM) -> "Pipeline":
+    from transformers import AutoTokenizer            # lazy
+    from aneforge import load_llm
+    from aneforge.sentence_transformers import CrossEncoder, SentenceTransformer
+    chunks = _read_corpus(path)
+    if not chunks:
+      raise SystemExit(f"rag_chat: no .md/.txt files found under {path!r}")
+    embed = SentenceTransformer(EMBED)
+    vecs = embed.encode([c.text for c in chunks], normalize_embeddings=True).astype(np.float32)
+    llm = load_llm(llm_name); llm.warmup(MAX_LEN)
+    tok = AutoTokenizer.from_pretrained(llm_name)
+    return cls(embed, CrossEncoder(RERANK), llm, tok, chunks, vecs)
+
+  def answer(self, query: str, on_token) -> dict:
+    t = {}
+    t0 = time.perf_counter()
+    qv = self.embed.encode([query], normalize_embeddings=True)[0].astype(np.float32)
+    cand = top_k(qv, self.vecs, TOP_K)
+    t["retrieve"] = (time.perf_counter() - t0) * 1e3
+    t0 = time.perf_counter()
+    scores = self.rerank.predict([(query, self.chunks[i].text) for i in cand])
+    ranked = [self.chunks[cand[i]] for i in np.argsort(scores)[::-1][:TOP_N]]
+    t["rerank"] = (time.perf_counter() - t0) * 1e3
+    budget = MAX_LEN - ANSWER_TOKENS
+    prompt = pack_context(ranked, query, budget, lambda s: len(self.tok.encode(s)))
+    ids = self.tok.encode(prompt)[:budget]
+    t0 = time.perf_counter()
+    self.llm.generate(ids, max_new_tokens=ANSWER_TOKENS, max_len=MAX_LEN,
+                      eos_id=self.tok.eos_token_id, on_token=on_token)
+    t["generate"] = (time.perf_counter() - t0) * 1e3
+    return {"stage_ms": t, "sources": sorted({c.source for c in ranked})}
+
+
+def main(argv) -> int:
+  args = [a for a in argv if not a.startswith("--")]
+  path = args[0] if args else REPO_DOCS
+  print(f"indexing {path} on the Apple Neural Engine ...", flush=True)
+  p = Pipeline.build(path)
+  print(f"indexed {len(p.chunks)} chunks from {len({c.source for c in p.chunks})} files. "
+        f"embeddings + reranker + Qwen3-0.6B all on the ANE.\nask a question (Ctrl-D to quit).\n")
+  while True:
+    try:
+      q = input("> ").strip()
+    except EOFError:
+      print(); return 0
+    if not q:
+      continue
+    print("ane> ", end="", flush=True)
+    timing = p.answer(q, on_token=lambda i: print(p.tok.decode([i]), end="", flush=True))
+    ms = timing["stage_ms"]
+    print(f"\n[retrieve {ms['retrieve']:.0f}ms | rerank {ms['rerank']:.0f}ms | "
+          f"generate {ms['generate']:.0f}ms | all ANE | sources: {', '.join(timing['sources'])}]\n")
+
+
+if __name__ == "__main__":
+  sys.exit(main(sys.argv[1:]))

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,4 +1,5 @@
-from examples._rag import Chunk, chunk_text
+from examples._rag import Chunk, chunk_text, top_k
+import numpy as np
 
 
 def test_chunk_text_windows_with_overlap():
@@ -12,3 +13,11 @@ def test_chunk_text_windows_with_overlap():
 def test_chunk_text_short_doc_is_one_chunk():
   chunks = chunk_text("hello", "b.txt", size=800, overlap=160)
   assert chunks == [Chunk("hello", "b.txt")]
+
+
+def test_top_k_orders_by_similarity_descending():
+  corpus = np.array([[1, 0], [0, 1], [0.9, 0.1], [-1, 0], [0.7, 0.7]], dtype=np.float32)
+  corpus /= np.linalg.norm(corpus, axis=1, keepdims=True)
+  q = np.array([1, 0], dtype=np.float32)
+  assert top_k(q, corpus, 3) == [0, 2, 4]        # cos: 1.0, 0.994, 0.707
+  assert top_k(q, corpus, 99) == [0, 2, 4, 1, 3]  # k > N returns all, ordered

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -6,16 +6,19 @@ from _helpers import requires_ane
 
 
 def test_chunk_text_windows_with_overlap():
-  text = "x" * 2000
-  chunks = chunk_text(text, "a.md", size=800, overlap=160)   # step = 640
-  assert [len(c.text) for c in chunks] == [800, 800, 720]     # 0:800, 640:1440, 1280:2000
+  enc = lambda s: s.split()
+  dec = lambda w: " ".join(w)
+  text = " ".join(f"w{i}" for i in range(100))
+  chunks = chunk_text(text, "a.md", enc, dec, size=40, overlap=8)   # step = 32
+  assert all(len(c.text.split()) == 40 for c in chunks)
   assert all(c.source == "a.md" for c in chunks)
-  assert "".join(dict.fromkeys("".join(c.text for c in chunks))) != ""  # covers all text
 
 
 def test_chunk_text_short_doc_is_one_chunk():
-  chunks = chunk_text("hello", "b.txt", size=800, overlap=160)
-  assert chunks == [Chunk("hello", "b.txt")]
+  enc = lambda s: s.split()
+  dec = lambda w: " ".join(w)
+  chunks = chunk_text("hello world", "b.txt", enc, dec, size=40, overlap=8)
+  assert chunks == [Chunk("hello world", "b.txt")]
 
 
 def test_top_k_orders_by_similarity_descending():

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -5,19 +5,13 @@ from _helpers import requires_ane
 
 
 def test_chunk_text_windows_with_overlap():
-  enc = lambda s: s.split()
-  dec = lambda w: " ".join(w)
-  text = " ".join(f"w{i}" for i in range(100))
-  chunks = chunk_text(text, "a.md", enc, dec, size=40, overlap=8)   # step = 32
-  assert all(len(c.text.split()) == 40 for c in chunks)
+  chunks = chunk_text("x" * 2000, "a.md", size=800, overlap=160)   # step = 640
+  assert [len(c.text) for c in chunks] == [800, 800, 720]           # 0:800, 640:1440, 1280:2000
   assert all(c.source == "a.md" for c in chunks)
 
 
 def test_chunk_text_short_doc_is_one_chunk():
-  enc = lambda s: s.split()
-  dec = lambda w: " ".join(w)
-  chunks = chunk_text("hello world", "b.txt", enc, dec, size=40, overlap=8)
-  assert chunks == [Chunk("hello world", "b.txt")]
+  assert chunk_text("hello", "b.txt", size=800, overlap=160) == [Chunk("hello", "b.txt")]
 
 
 def test_top_k_orders_by_similarity_descending():

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,0 +1,14 @@
+from examples._rag import Chunk, chunk_text
+
+
+def test_chunk_text_windows_with_overlap():
+  text = "x" * 2000
+  chunks = chunk_text(text, "a.md", size=800, overlap=160)   # step = 640
+  assert [len(c.text) for c in chunks] == [800, 800, 720]     # 0:800, 640:1440, 1280:2000
+  assert all(c.source == "a.md" for c in chunks)
+  assert "".join(dict.fromkeys("".join(c.text for c in chunks))) != ""  # covers all text
+
+
+def test_chunk_text_short_doc_is_one_chunk():
+  chunks = chunk_text("hello", "b.txt", size=800, overlap=160)
+  assert chunks == [Chunk("hello", "b.txt")]

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,5 +1,8 @@
 from examples._rag import Chunk, chunk_text, top_k, PROMPT_TEMPLATE, pack_context
 import numpy as np
+import pytest
+
+from _helpers import requires_ane
 
 
 def test_chunk_text_windows_with_overlap():
@@ -39,3 +42,13 @@ def test_pack_context_truncates_a_single_oversized_chunk():
   prompt = pack_context(chunks, "Q?", budget=budget, token_len=len)
   assert "Q?" in prompt and "Z" in prompt
   assert len(prompt) <= budget
+
+
+@requires_ane
+def test_pipeline_answers_end_to_end(tmp_path):
+  import examples.rag_chat as rc
+  (tmp_path / "d.md").write_text("The ANE runs fp16. Espresso e5rt is the runtime aneforge targets.")
+  p = rc.Pipeline.build(str(tmp_path))
+  toks = []
+  timing = p.answer("What runtime does aneforge target?", on_token=toks.append)
+  assert toks and "stage_ms" in timing

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,4 +1,4 @@
-from examples._rag import Chunk, chunk_text, top_k
+from examples._rag import Chunk, chunk_text, top_k, PROMPT_TEMPLATE, pack_context
 import numpy as np
 
 
@@ -21,3 +21,21 @@ def test_top_k_orders_by_similarity_descending():
   q = np.array([1, 0], dtype=np.float32)
   assert top_k(q, corpus, 3) == [0, 2, 4]        # cos: 1.0, 0.994, 0.707
   assert top_k(q, corpus, 99) == [0, 2, 4, 1, 3]  # k > N returns all, ordered
+
+
+def test_pack_context_stops_at_budget_and_keeps_query():
+  chunks = [Chunk("AAAA", "a"), Chunk("BBBB", "b"), Chunk("CCCC", "c")]
+  # token_len = len (characters). Budget admits the template + query + ~two chunks.
+  prompt = pack_context(chunks, "Q?", budget=len(PROMPT_TEMPLATE.format(context="", question="Q?")) + 9, token_len=len)
+  assert "Q?" in prompt
+  assert "AAAA" in prompt and "BBBB" in prompt   # two 4-char chunks fit in 9 spare
+  assert "CCCC" not in prompt                     # third overflows, dropped
+  assert len(prompt) <= len(PROMPT_TEMPLATE.format(context="", question="Q?")) + 9 + 1
+
+
+def test_pack_context_truncates_a_single_oversized_chunk():
+  chunks = [Chunk("Z" * 1000, "big")]
+  budget = len(PROMPT_TEMPLATE.format(context="", question="Q?")) + 20
+  prompt = pack_context(chunks, "Q?", budget=budget, token_len=len)
+  assert "Q?" in prompt and "Z" in prompt
+  assert len(prompt) <= budget

--- a/tests/test_rag.py
+++ b/tests/test_rag.py
@@ -1,6 +1,5 @@
 from examples._rag import Chunk, chunk_text, top_k, PROMPT_TEMPLATE, pack_context
 import numpy as np
-import pytest
 
 from _helpers import requires_ane
 


### PR DESCRIPTION
An interactive "chat with your docs" demo where every model stage runs on the ANE: embeddings (all-MiniLM-L6-v2), reranking (ms-marco-MiniLM-L-6-v2), and generation (Qwen3-0.6B). Point it at a folder of .md/.txt and ask questions in a loop; it retrieves, reranks, and streams an answer, all on the engine. With no path it indexes this repo's own docs, so `python3 examples/rag_chat.py` runs immediately.

## What's here

- `examples/rag_chat.py` -- the CLI/REPL and the `Pipeline` (index -> retrieve -> rerank -> generate), per-stage latency, and an optional `--energy` flag that reports per-query joules via powermetrics (default runs are latency-only and need no sudo).
- `examples/_rag.py` -- the pure orchestration (token-window chunking, cosine top-k, budget-aware prompt packing), unit-tested off-device.
- `tests/test_rag.py` -- off-device unit tests plus one `requires_ane` end-to-end smoke test.
- Docs: a section in `docs/developer/models.md` and a README line.

## Two aneforge bugs this surfaced

Building over a real corpus exposed a systemic issue, so the demo works around it and I've filed a follow-up for the proper fix:

- The `Encoder` and `CrossEncoder` compile one ANE program per input sequence length and cannot pad (no attention mask). A 696-chunk corpus spans hundreds of distinct lengths and exhausts the engine (`op_create err=13`); padding to a fixed length corrupts embeddings (real tokens attend to `[PAD]`). The demo avoids it with uniform token-window chunks embedded via the public `st.encode` (verified cos 0.9999999 vs the reference), and by clearing the reranker's program cache per query. This affects any corpus embedding through the sentence-transformers path, not just this demo -- tracked separately for a core fix.

## Testing (M5 Pro)

- Full repo-docs index (786 chunks) builds with no crash; a multi-question session runs without exhausting the engine.
- Embeddings match the reference at cos 0.9999999; answers are clean and stop at EOS (the demo uses the model's chat template).
- `tests/test_rag.py`: 6 passed (5 off-device + the on-ANE smoke). ruff clean; mkdocs builds.

Decode is small-model quality (Qwen3-0.6B), and the demo works best on prose docs -- a folder of very many tiny files can still hit the per-length embedder limit (noted in the docs).