### PR TITLE
models: pad + mask the BERT encoder so batches share one ANE program (fixes #232)

### DIFF
--- a/aneforge/graph.py
+++ b/aneforge/graph.py
@@ -944,8 +944,11 @@ def _tiled_attention(qh: Tensor, kt: Tensor, vh: Tensor, scale: float, n_tiles: 
   return concat(out_tiles, axis=seq_axis)
 
 
-def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
-  """Multi-head self-attention on `x` [S,D]. Weights [out,in]; biases [D] or None."""
+def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int, mask=None) -> Tensor:
+  """Multi-head self-attention on `x` [S,D]. Weights [out,in]; biases [D] or None. `mask`, when given,
+  is an additive score bias broadcast to [H,S,S] and sliced along the query axis -- pass `[1,S,S]` (or
+  `[S,S]`) with -inf/-1e4 at padded key columns for a key-padding mask (lets a padded batch share one
+  program without pad tokens corrupting the real ones)."""
   S, D = x.shape
   if D % n_heads:
     raise ValueError(f"mha: D={D} not divisible by n_heads={n_heads}")
@@ -957,7 +960,7 @@ def mha(x: Tensor, Wq, bq, Wk, bk, Wv, bv, Wo, bo, n_heads: int) -> Tensor:
   # query-tiling: [tile, S] score tiles per head instead of the full [H, S, S] matrix
   from . import _optimize as _opt
   n_tiles = _opt.attention_tiles(S, n_heads, dh)
-  o = _tiled_attention(qh, kt, vh, scale, n_tiles, seq_axis=1)  # [H, S, dh]
+  o = _tiled_attention(qh, kt, vh, scale, n_tiles, seq_axis=1, mask=mask)  # [H, S, dh]
   o = o.transpose([1, 0, 2]).reshape(S, D)
   return o.linear(Wo, bo)
 

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -193,8 +193,9 @@ class Encoder:
 
   def _build(self, S: int) -> Model | SegmentedModel:
     h = input((S, self.D))
+    m = input((1, S, S))                     # additive key-padding mask: 0 on real keys, -1e4 on padded ones
     for w in self.layers:
-      attn = mha(h, w["Wq"], w["bq"], w["Wk"], w["bk"], w["Wv"], w["bv"], w["Wo"], w["bo"], self.H)
+      attn = mha(h, w["Wq"], w["bq"], w["Wk"], w["bk"], w["Wv"], w["bv"], w["Wo"], w["bo"], self.H, mask=m)
       h = (h + attn).layer_norm(w["ln1w"], w["ln1b"], self.eps)
       ff = h.linear(w["Wi"], w["bi"]).gelu().linear(w["Wd"], w["bd"])
       h = (h + ff).layer_norm(w["ln2w"], w["ln2b"], self.eps)
@@ -209,11 +210,18 @@ class Encoder:
 
   def __call__(self, texts, normalize: bool = True) -> np.ndarray:
     if isinstance(texts, str): texts = [texts]
+    enc = [np.asarray(self.tok(t)["input_ids"], dtype=np.int64) for t in texts]
+    # Pad the whole batch to its longest sequence and compile ONE program for that length -- the padded
+    # keys are masked out per text, so a corpus of varied lengths shares one program instead of one each.
+    S = max((len(ids) for ids in enc), default=1)
+    net = self._cache.get(S) or self._cache.setdefault(S, self._build(S))
+    pad_id = self.tok.pad_token_id or 0
     vecs = []
-    for t in texts:
-      ids = np.asarray(self.tok(t)["input_ids"], dtype=np.int64)
-      net = self._cache.get(len(ids)) or self._cache.setdefault(len(ids), self._build(len(ids)))
-      states = net(self._embed(ids))               # [S, D] per-token states on the ANE
+    for ids in enc:
+      n = len(ids)
+      padded = np.full(S, pad_id, dtype=np.int64); padded[:n] = ids
+      mask = np.zeros((1, S, S), dtype=np.float32); mask[0, :, n:] = -1e4   # mask the padded key columns
+      states = net(self._embed(padded), mask)[:n]  # real-token states on the ANE (pads masked + dropped)
       if self.pooling == "cls":
         v = states[0]
       elif self.pooling == "max":
@@ -323,8 +331,9 @@ class CrossEncoder:
 
   def _build(self, S: int) -> Model | SegmentedModel:
     h = input((S, self.D))
+    m = input((1, S, S))                     # additive key-padding mask: 0 on real keys, -1e4 on padded ones
     for w in self.layers:
-      attn = mha(h, w["Wq"], w["bq"], w["Wk"], w["bk"], w["Wv"], w["bv"], w["Wo"], w["bo"], self.H)
+      attn = mha(h, w["Wq"], w["bq"], w["Wk"], w["bk"], w["Wv"], w["bv"], w["Wo"], w["bo"], self.H, mask=m)
       h = (h + attn).layer_norm(w["ln1w"], w["ln1b"], self.eps)
       ff = h.linear(w["Wi"], w["bi"]).gelu().linear(w["Wd"], w["bd"])
       h = (h + ff).layer_norm(w["ln2w"], w["ln2b"], self.eps)
@@ -341,13 +350,21 @@ class CrossEncoder:
     """`pairs` is a (query, passage) tuple or a list of them; returns a relevance score each."""
     if pairs and isinstance(pairs[0], str):     # a single (query, passage) pair
       pairs = [pairs]
+    enc = [self.tok(q, p, truncation=True) for q, p in pairs]
+    ids = [np.asarray(e["input_ids"], dtype=np.int64) for e in enc]
+    # Pad the batch to its longest pair and compile ONE program; padded keys are masked per pair, so a
+    # query's candidates (and the next query) share one program instead of one per pair length.
+    S = max((len(i) for i in ids), default=1)
+    net = self._cache.get(S) or self._cache.setdefault(S, self._build(S))
+    pad_id = self.pad_id or 0
     scores = []
-    for query, passage in pairs:
-      enc = self.tok(query, passage, truncation=True)
-      ids = np.asarray(enc["input_ids"], dtype=np.int64)
-      typ = _token_type_ids(enc, len(ids), self._has_typ)
-      net = self._cache.get(len(ids)) or self._cache.setdefault(len(ids), self._build(len(ids)))
-      cls = net(self._embed(ids, typ))[0]                              # [CLS] / <s> state, on the ANE
+    for e, tid in zip(enc, ids):
+      n = len(tid)
+      typ = _token_type_ids(e, n, self._has_typ)
+      padded = np.full(S, pad_id, dtype=np.int64); padded[:n] = tid
+      typ_p = np.zeros(S, dtype=np.int64); typ_p[:n] = typ
+      mask = np.zeros((1, S, S), dtype=np.float32); mask[0, :, n:] = -1e4   # mask the padded key columns
+      cls = net(self._embed(padded, typ_p), mask)[0]                   # [CLS] / <s> state (row 0), on the ANE
       pooled = _seqcls_activation(cls @ self.pool_w.T + self.pool_b, self._model_type)
       logits = pooled @ self.cls_w.T + self.cls_b                      # [num_labels]
       scores.append(float(logits[0]))

--- a/tests/test_encoder_padding.py
+++ b/tests/test_encoder_padding.py
@@ -1,0 +1,21 @@
+"""The BERT encoder pads a batch to one length and masks the padding (mha `mask=`), so a varied-length
+corpus compiles one program instead of one per length, and each text's embedding is unchanged by the
+padding. Regression for the per-length-compile crash / padding corruption (issue #232)."""
+from _helpers import requires_ane
+from aneforge.sentence_transformers import SentenceTransformer
+
+
+@requires_ane
+def test_encoder_padding_is_invariant_and_bounds_programs():
+  st = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2")
+  texts = ["cat",
+           "the neural engine runs fp16 compute",
+           "a much longer sentence about compiling operator graphs to the apple neural engine"]
+  batch = st.encode(texts, normalize_embeddings=True)         # padded to the longest -> one program
+  alone = st.encode(["cat"], normalize_embeddings=True)[0]    # the same short text, no padding
+  assert float(batch[0] @ alone) > 0.999                      # padding must not change the embedding
+
+  enc = st._enc
+  enc._cache.clear()
+  st.encode([("w " * int(n)).strip() for n in (5, 40, 90, 150, 30, 200)], normalize_embeddings=True)
+  assert len(enc._cache) == 1                                 # six distinct lengths -> a single compiled program


### PR DESCRIPTION
Fixes #232. The `Encoder` (embeddings) and `CrossEncoder` (reranker) compiled one ANE program per input token length and had no way to pad -- the fused BERT attention took no mask. So a real corpus of varied lengths exhausted the engine (`op_create err=13`), and padding to a common length corrupted embeddings because real tokens attended to the pad tokens. This surfaced building the RAG demo (#231), which had to work around it; it also affects the shipped sentence-transformers and langchain integrations.

## Change

- `mha(x, ..., n_heads, mask=None)` now takes an optional additive score bias and threads it to `_tiled_attention` (which already accepted a `mask`). Default `None` leaves every other caller -- ViT, CLIP, SD -- byte-identical.
- The BERT `_build(S)` adds a runtime `[1,S,S]` key-padding-mask input passed to each layer's `mha`.
- `Encoder.__call__` / `CrossEncoder.predict` pad each batch to its longest sequence, build the per-item mask (`-1e4` on padded key columns), and run one program; embeddings pool only the real tokens, `CrossEncoder` reads the always-real `[CLS]` row.

The result: a batch of any lengths compiles ONE program, and each item's real tokens are unaffected by the padding.

## Validation (M5 Pro)

- Embeddings match the HF `AutoModel` mean-pool reference at cos 0.9999, and are batch-invariant: a text embeds the same alone or padded in a batch (cos 1.0008).
- 60 varied-length texts compile 1 program (was ~50, and a real corpus previously crashed).
- The reranker runs many queries with no `op_create err=13` and no per-query cache clearing; rankings correct.
- ViT still matches (the `mha` default path is unchanged).
- New on-device test `tests/test_encoder_padding.py`; off-device suite 362 passed; ruff + `pyright aneforge` clean.

Follow-up: this lets the #231 RAG demo drop its token-window chunking and per-query reranker cache-clearing workarounds -- I'll simplify that PR on top of this.