### PR TITLE
rag: keep model-download progress visible (+ first-run heads-up)

### DIFF
--- a/examples/rag_chat.py
+++ b/examples/rag_chat.py
@@ -10,7 +10,8 @@ import sys
 import time
 import warnings
 
-os.environ.setdefault("HF_HUB_DISABLE_PROGRESS_BARS", "1")            # quiet the model-load bars
+# Keep Hugging Face *download* progress bars (the first run pulls ~1.5 GB); only the per-load bars and
+# aneforge's per-call dispatch note are silenced below -- those are noise, a multi-minute download is not.
 warnings.filterwarnings("ignore", "aneforge.compile: dispatch-floor")  # per-call dispatch notes are noise in a REPL
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))  # repo root -> import aneforge / examples._rag; works as a script and when imported under pytest
@@ -113,7 +114,8 @@ def main(argv) -> int:
   args = [a for a in argv if not a.startswith("--")]
   path = args[0] if args else REPO_DOCS
   energy = "--energy" in argv
-  print(f"indexing {path} on the Apple Neural Engine ...", flush=True)
+  print(f"loading models and indexing {path} on the Apple Neural Engine ...\n"
+        f"(first run downloads ~1.5 GB of models from Hugging Face; cached for later runs)", flush=True)
   p = Pipeline.build(path)
   print(f"indexed {len(p.chunks)} chunks from {len({c.source for c in p.chunks})} files. "
         f"embeddings + reranker + Qwen3-0.6B all on the ANE.\nask a question (Ctrl-D to quit).\n")


### PR DESCRIPTION
Follow-up to #234. That PR quieted the REPL by disabling progress bars, but it also disabled the Hugging Face **download** bars -- so on a machine that doesn't have the models cached, `python3 examples/rag_chat.py` prints "indexing..." and then hangs silently for minutes while it pulls ~1.5 GB (Qwen3-0.6B ~1.2 GB + two MiniLM models). A silent multi-minute hang is worse than the noise it removed.

- Stop setting `HF_HUB_DISABLE_PROGRESS_BARS`, so the download bars show again on first run. The transformers per-load bars and aneforge's per-call dispatch note stay silenced (those are the actual REPL noise).
- Print a first-run heads-up: "loading models ... (first run downloads ~1.5 GB of models from Hugging Face; cached for later runs)".

No `[y/N]` prompt: this is an example script, and a blocking stdin prompt would break piping and non-interactive use. A visible download plus a clear line is the right amount of warning. Cached runs stay clean (verified: 0 load-bar lines); ruff + off-device tests pass.