### PR TITLE
docs: sync docs with the model-loader wave (GPT-2 KV cache, Whisper, loaders)

### DIFF
--- a/docs/aneforge-api.md
+++ b/docs/aneforge-api.md
@@ -170,9 +170,24 @@ logits = clf(image)                                        # [1,3,224,224] -> [1
   the preceding conv at load, so the ANE graph is pure conv/relu/pool/add/fc.
 - `af.load_resnet18(int8=False) -> Vision` - ResNet-18, kept as the original
   shorthand for `af.load_resnet(18)`.
+- `af.load_vit(name, int8=False) -> ViT` - HF ViT-family image classifier (CLS
+  token, pre-norm encoder); `.classify(image)` returns top-k labels.
+- `af.load_clip(name) -> CLIP` - CLIP dual-encoder; both the vision and text
+  towers run on the ANE for zero-shot classification.
+- `af.load_gpt2(name) -> GPT2` / `af.load_llm(name) -> ...` - decoder LLMs on the
+  ANE with prefill + resident-KV-cache decode. `load_llm` covers
+  Llama/Qwen/Mistral/Gemma/GPT-2/MoE (see the [LLM guide](llm.md)); `load_gpt2`
+  is the GPT-2 shorthand.
+- `af.load_whisper(name="openai/whisper-base.en") -> Whisper` - speech-to-text;
+  the audio encoder and the autoregressive text decoder both run on the ANE.
+  `.transcribe(audio) -> str`, `.encode(audio) -> [1500, 512]`.
+- `CrossEncoder(name) -> CrossEncoder` - BERT/RoBERTa/DistilBERT reranker;
+  `.predict([(query, passage), ...])` returns relevance scores.
+- `af.load_onnx(path, ...)` - import an ONNX model as an ANE program (see
+  [ONNX import](onnx.md)).
 
-`transformers` / `torchvision` are imported lazily, only when these loaders are
-used.
+`transformers` / `torchvision` (and `soundfile` for Whisper) are imported lazily,
+only when these loaders are used.
 
 ---
 
@@ -184,7 +199,12 @@ used.
 | `Model` | a compiled single fused ANE program. Call with input array(s); `.n_ops` = fused graph ops; `.release()`. |
 | `SegmentedModel` | a compiled plan of e5rt regions interleaved with native bridge sub-programs. `.n_ops`, `.n_netplist`, `.release()`. |
 | `Encoder` | sentence-embedding model from `af.load`. |
+| `CrossEncoder` | reranker (BERT/RoBERTa/DistilBERT) from `CrossEncoder(name)`. |
 | `Vision` | ResNet classifier from `af.load_resnet` (18/34/50/101). |
+| `ViT` | ViT image classifier from `af.load_vit`. |
+| `CLIP` | CLIP dual-encoder from `af.load_clip`. |
+| `GPT2` | GPT-2 text generation from `af.load_gpt2`. |
+| `Whisper` | speech-to-text (encoder + decoder) from `af.load_whisper`. |
 
 `compile(out, int8=False, build_dir=None)` returns a `Model`, or a
 `SegmentedModel` if the graph contains any netplist-bridge op.

--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -1,5 +1,8 @@
 # Pretrained models
 
 Loaders that import pretrained weights and fuse the model into one ANE program.
+This covers the vision, encoder, reranker, CLIP, GPT-2, and Whisper loaders in
+`aneforge.models`. Decoder LLMs load via `af.load_llm` (see the [LLM guide](../llm.md))
+and ONNX models via `af.load_onnx` (see [ONNX import](../onnx.md)).
 
 ::: aneforge.models

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -5,7 +5,7 @@ table see [op-catalog.md](op-catalog.md).
 
 ## Coverage summary
 
-ANEForge classifies the full **187-op MIL vocabulary** against a machine-checkable
+ANEForge classifies the full **166-op MIL vocabulary** against a machine-checkable
 registry (`aneforge/_capabilities.py`, serialized to `capabilities.json` and
 CI-gated). Each op falls into one of a few practical buckets:
 

--- a/docs/developer/models.md
+++ b/docs/developer/models.md
@@ -40,7 +40,7 @@ ce = CrossEncoder("cross-encoder/ms-marco-MiniLM-L-6-v2")
 scores = ce.predict([(query, passage) for passage in passages])   # higher = more relevant
 ```
 
-It reuses the same encoder graph as `load()`, then applies the sequence-classification head host-side. It supports BERT-family and RoBERTa/XLM-R (e.g. bge-reranker) `AutoModelForSequenceClassification` heads, detected by head shape; DistilBERT-style heads aren't wired up yet.
+It reuses the same encoder graph as `load()`, then applies the sequence-classification head host-side. It supports BERT-family, RoBERTa/XLM-R (e.g. bge-reranker), and DistilBERT (`pre_classifier -> ReLU -> classifier`) `AutoModelForSequenceClassification` heads, detected by head shape.
 
 ## load_resnet() — torchvision ImageNet classifier
 
@@ -81,9 +81,9 @@ ids  = gpt2.generate("The future of artificial intelligence is", max_new_tokens=
 logits = gpt2(token_ids)                     # 1-D ids -> [S, vocab], for custom decoding
 ```
 
-GPT-2 is the family that the LayerNorm-at-`D>=1024` fix unlocks (Llama/Qwen use RMSNorm, so `load_llm` never hit that wall). Each sequence length compiles as **two fused programs**: the pre-norm transformer (`ln_1 -> native causal SDPA -> residual; ln_2 -> Linear -> gelu_new -> Linear -> residual`, then `ln_f`) and the **tied lm_head tiled along the 50257 vocab** — a single matmul that wide exceeds the ANE's per-op dimension cap on the A13-A15 families, so it is emitted as vocab-sized output-port tiles (e.g. `[16384, 16384, 16384, 1105]`) and stitched host-side. Token + positional embedding lookup runs on the host (`gather` is not an ANE op).
+GPT-2 loads through the unified LLM runner (`LlamaPrefill`): the same prefill + resident-KV-cache decode path as Llama/Qwen, adapted for GPT-2's pre-norm LayerNorm blocks and `gelu_new` MLP. It is the family that the LayerNorm-at-`D>=1024` fix unlocks (Llama/Qwen use RMSNorm, so `load_llm` never hit that wall). The **tied lm_head is tiled along the 50257 vocab** — a matmul that wide exceeds the ANE's per-op dimension cap on the A13-A15 families, so it is emitted as vocab-sized output-port tiles and stitched host-side (a single tile fits on A16/M-series). Token + positional embedding lookup runs on the host (`gather` is not an ANE op).
 
-Two limits worth knowing: decode has **no KV cache yet** — it recomputes the forward on the growing sequence (cached per length), so it validates correctness rather than throughput; and native causal SDPA is reliable only for `S < 512`, so use short prompts and small `max_new_tokens`. `examples/gpt2.py` compiles the full 24-layer `gpt2-medium` as one program and checks the greedy decode is token-identical to Hugging Face.
+Decode keeps a **resident KV cache** on the engine (via the shared runner), streaming tokens instead of recomputing the growing sequence — ~140 tok/s on `gpt2-medium` on an M5 Pro. `examples/gpt2.py` loads via `af.load_llm`, checks the prefill logits against Hugging Face fp32, runs resident-KV-cache greedy decode that is token-identical to HF, and includes a >512-token long-context test.
 
 ## load_clip() — CLIP zero-shot image/text classification
 

--- a/docs/developer/overview.md
+++ b/docs/developer/overview.md
@@ -61,8 +61,11 @@ Some ops have no ANE hardware layer and are built from primitives, made exact by
 
 ## Pretrained loaders
 
-- `af.load(".../all-MiniLM-L6-v2")` — sentence encoder.
-- `af.load_resnet18()` — ImageNet classifier.
+- `af.load(".../all-MiniLM-L6-v2")` — sentence encoder (`CrossEncoder` for rerankers).
+- `af.load_resnet18()` / `af.load_vit(...)` / `af.load_clip(...)` — vision classifiers and CLIP.
+- `af.load_gpt2(...)` / `af.load_llm(...)` — decoder LLMs (prefill + resident-KV-cache decode).
+- `af.load_whisper(...)` — Whisper speech-to-text, both towers on the ANE.
+- `af.load_onnx(...)` — import an ONNX model.
 
 ## Numerics
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -11,9 +11,10 @@ minutes.
 - Python 3.10+ with `numpy`.
 
 The `aneforge` package imports only `numpy`. `torch` / `torchvision` /
-`transformers` are lazy imports used only by the pretrained loaders
-(`af.load`, `af.load_resnet`) and the diffusion examples; install them with
-the `models` extra when you need them.
+`transformers` (and `soundfile` for Whisper) are lazy imports used only by the
+pretrained loaders (`af.load`, `af.load_resnet`, `af.load_vit`, `af.load_clip`,
+`af.load_gpt2`, `af.load_llm`, `af.load_whisper`, `af.load_onnx`) and the
+diffusion examples; install them with the `models` extra when you need them.
 
 ## Install
 
@@ -78,7 +79,14 @@ Pretrained loaders ship too:
 ```python
 embed = af.load("sentence-transformers/all-MiniLM-L6-v2")  # sentence encoder
 clf   = af.load_resnet18()                                 # ImageNet classifier
+vit   = af.load_vit("google/vit-base-patch16-224")         # vision transformer
+llm   = af.load_llm("Qwen/Qwen3-0.6B")                     # decoder LLM (prefill + KV-cache decode)
+asr   = af.load_whisper("openai/whisper-base.en")          # speech-to-text, both towers on the ANE
 ```
+
+Vision (`load_resnet`/`load_vit`/`load_clip`), encoders and rerankers (`load`/`CrossEncoder`),
+decoder LLMs (`load_llm`/`load_gpt2`), Whisper (`load_whisper`), and ONNX (`load_onnx`) all load
+the same way.
 
 A few more things reachable from the same API:
 
@@ -100,7 +108,8 @@ pk  = af.project_peak("h17s")                # M5 fp16 peak {tflops, ...}
 Worked demos live in [`examples/`](https://github.com/sbryngelson/ANEForge/tree/main/examples) - start with
 `examples/quickstart.py` (a CNN and a transformer encoder block), then
 `resnet18.py`, `sentence_embeddings.py`, `sdpa.py`, `native_ranking.py`, and
-`pointcloud.py`. The chapter-aligned mechanism demos are in `examples/demos/`.
+`pointcloud.py`. For pretrained models see `vit.py`, `clip_zero_shot.py`, `gpt2.py`,
+`llm_chat.py`, `whisper.py`, and `rag_chat.py`. The chapter-aligned mechanism demos are in `examples/demos/`.
 
 ## MIL input format
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,14 @@ train, target, and extend the frontend.
 - **[FAQ](faq.md)** - common questions, gotchas, what to expect.
 - **[MIL primer](mil-primer.md)** - writing MIL programs by hand.
 
+### Run pretrained models
+
+- **[LLMs on the ANE](llm.md)** - `af.load_llm` prefill + resident-KV-cache decode for
+  Llama/Qwen/Mistral/Gemma/GPT-2/MoE, speculative decoding, and MoE from GGUF.
+- **[Model loaders](developer/models.md)** - vision (ResNet / ViT / CLIP), sentence
+  encoders and rerankers, GPT-2, and Whisper speech-to-text (both towers on the ANE).
+- **[ONNX import](onnx.md)** - run an existing `.onnx` model on the engine via `af.load_onnx`.
+
 ### Use the engine well
 
 - **[Cross-chip deployment](cross-chip.md)** - compiling and gating for other ANE
@@ -43,6 +51,7 @@ train, target, and extend the frontend.
 | How do I install + run? | [getting-started](getting-started.md) |
 | How do I use the Python frontend? | [aneforge-api](aneforge-api.md) |
 | How do I train a model on the ANE? | [training](training.md) |
+| How do I run an LLM, Whisper, or ONNX model? | [llm](llm.md), [model loaders](developer/models.md), [onnx](onnx.md) |
 | Can I target / deploy to another chip (M1-M5)? | [cross-chip](cross-chip.md) |
 | How do I estimate latency without the hardware? | [aneforge-api: cost estimation](aneforge-api.md#cost-estimation-measurement-free), [cross-chip](cross-chip.md) |
 | How do I shrink weights (int4 / sparse)? | [aneforge-api: weight compression](aneforge-api.md#weight-compression) |

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -13,13 +13,13 @@ works, but the energy advantage is in prefill.
 ```python
 import aneforge as af
 
-model = af.load_llm("Qwen/Qwen3-0.6B")            # any Llama/Qwen-class HF model
+model = af.load_llm("Qwen/Qwen3-0.6B")            # Llama/Qwen/Mistral/Gemma/GPT-2/MoE HF decoder
 text_ids = model.generate(prompt_ids, max_new_tokens=24)
 logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 ```
 
-- `af.load_llm(name, compress=None)` - load an HF Llama/Qwen model for ANE inference.
-  `compress="int8"`/`"int4"` quantizes the weights (see below).
+- `af.load_llm(name, compress=None)` - load an HF decoder LLM (Llama/Qwen/Mistral/Gemma/GPT-2/MoE)
+  for ANE inference. `compress="int8"`/`"int4"` quantizes the weights (see below).
 - `model.generate(ids, max_new_tokens, eos_id)` - greedy generation on the ANE.
 - `model.prefill(ids)` - prefill only; returns next-token logits.
 - `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` - build from numpy weights directly.
@@ -153,7 +153,8 @@ before RoPE), and a large vocab - the layers run on the ANE; the lm_head project
 ## Scope
 
 Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), **Mistral**
-(GQA + sliding window), **Gemma** (scaled embeddings + GeGLU + `(1+w)` RMSNorm), sparse **Mixture-of-Experts**
+(GQA + sliding window), **Gemma** (scaled embeddings + GeGLU + `(1+w)` RMSNorm), **GPT-2** (pre-norm
+LayerNorm decoder, learned positions, tiled tied lm_head), sparse **Mixture-of-Experts**
 (Qwen3-MoE, Qwen2-MoE), and **hybrid** DeltaNet+attention (Qwen3.5). Runtime features: prefill + resident
 KV-cache decode, automatic segmentation past the ~2 GB program ceiling, int8/int4 weights, and exact
 speculative decoding. Static prompt length per compiled graph; the lm_head projection runs on host.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -14,10 +14,10 @@ CoreML dependency. The capability surface is characterized in
 ## Where things stand
 
 The infrastructure is mature. The frontend compiles whole graphs to one
-ANE program; pretrained vision CNNs (ResNet, ViT), transformer encoders and
+ANE program; pretrained vision CNNs (ResNet, ViT), CLIP, transformer encoders and
 rerankers, decoder LLMs (Llama/Qwen/Mistral/Gemma, MoE, hybrid DeltaNet, GPT-2)
-with prefill and resident-KV-cache decode, and diffusion UNet blocks load and
-run correctly; weights stream at fp16, int8, int4-LUT,
+with prefill and resident-KV-cache decode, Whisper speech-to-text (encoder +
+decoder), and diffusion UNet blocks load and run correctly; weights stream at fp16, int8, int4-LUT,
 sparse, or blockwise; a reverse-mode autograd trains real networks
 forward, backward, and optimizer-step on the engine; a per-chip cost model
 estimates latency for any ANE generation without that hardware in hand; and
@@ -146,8 +146,10 @@ past the ~2 GB program ceiling, int8/int4 weights, and exact speculative decodin
 architecture-agnostic, so a new family is an adapter, not a new code path; an
 unsupported architecture is rejected rather than silently mis-loaded. Alongside
 it, model loaders bring GPT-2 (the first LayerNorm decoder, tiled tied lm_head),
-ViT-B/16, ResNet-18/34/50/101, and BERT/RoBERTa rerankers (`CrossEncoder`) onto
-the engine. Reproducible benchmarking landed too: the roofline suite (per-machine
+ViT-B/16, ResNet-18/34/50/101, CLIP, BERT/RoBERTa/DistilBERT rerankers
+(`CrossEncoder`), and Whisper speech-to-text (audio encoder + autoregressive
+decoder, both on the ANE with resident-KV-cache decode) onto the engine.
+Reproducible benchmarking landed too: the roofline suite (per-machine
 `ROOFLINES.md`, contributor-driven) and the MLPerf ResNet-50 harness that clears
 the MLCommons submission checker at reference accuracy. See
 [llm.md](llm.md) and [developer/models.md](developer/models.md).


### PR DESCRIPTION
An audit of the docs (three passes across ~30 files) found drift from the model-loader wave. Fixes here, no code changes.

Corrections (wrong claims):
- `developer/models.md`: GPT-2 was described as two fused programs / native causal SDPA / "no KV cache yet, recompute per length" / S<512 only. It now loads through the unified LLM runner (`LlamaPrefill`) with prefill + resident-KV-cache decode (~140 tok/s on gpt2-medium, M5 Pro), and `examples/gpt2.py` has a >512-token long-context test. Also: the CrossEncoder line said DistilBERT heads "aren't wired up yet" — they are (`pre_classifier -> ReLU -> classifier`).
- `capabilities.md`: the capability registry is exhaustive over the 166-op MIL sweep, not the op-catalog's 187-op count (the two are different sets; `developer/capabilities-and-targets.md` already says 166).

Completeness (features that had shipped but weren't documented):
- `roadmap.md`, `llm.md`: added Whisper speech-to-text and GPT-2 where missing; corrected `load_llm`'s supported-family wording (Llama/Qwen/Mistral/Gemma/GPT-2/MoE).
- `aneforge-api.md`, `getting-started.md`, `index.md`, `developer/overview.md`, `api/models.md`: these predated the loader wave and documented only `load`/`load_resnet`; now cover `CrossEncoder`, `load_vit`, `load_clip`, `load_gpt2`, `load_llm`, `load_whisper`, `load_onnx`.

mkdocs builds clean; all referenced example paths exist.
