### PR TITLE
perf: tiled ANE lm_head for LlamaPrefill decode (#227)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -6,6 +6,7 @@ The runner is model-agnostic: a `LlamaConfig` carries a per-layer plan (`LayerSp
 and an MLP from the builder registries below, so supporting a new architecture is an *adapter* that emits
 the plan + canonical weights - not new branches in the hot path."""
 from __future__ import annotations
+import warnings
 from dataclasses import dataclass, field
 from enum import Enum
 import time
@@ -246,29 +247,47 @@ DECODE_MLPS = {"swiglu": _swiglu, "geglu": _geglu, "gelu_new": _gelu_mlp}
 _DECODE_CTX = ("oh", "inv", "mask", "cosp", "sinp")
 
 
+def _lm_head_tile_size() -> int:
+  """Vocab-axis tile for the ANE lm_head: the target family's max tensor dim (A13-A15 16384,
+  A16+ 65536). compile_multi does not run the oversize gate, so this is the only guard."""
+  from . import _targets
+  return _targets.limit("max_tensor_dim", _targets.detect_family())
+
+
 class LlamaPrefill:
   """A decoder compiled for the ANE. `compile(seq)` builds the prefill graph for a fixed prompt length;
   `prefill(token_ids)` returns next-token logits; `generate(...)` does resident-KV-cache decode. Weights are
   a dict of numpy arrays (see `from_pretrained`). The host `lm_head` keeps a cached fp32 transpose
   (`_lmT`): for large vocabularies this is the runner's biggest host allocation (GPT-2 ~206 MB, a
-  151936x4096 head ~2.5 GB), freed by `release()`."""
-  def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None):
+  151936x4096 head ~2.5 GB), freed by `release()`. With `ane_lm_head=True`, the head runs on the ANE
+  as a tiled `compile_multi` instead, saving host memory but changing numerics (fp16 vs fp32 matmul)."""
+  def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None,
+               ane_lm_head: bool = False):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
     self._chunk_bytes = 1.6e9      # max fp16 weight bytes per decode program (under the ~2GB ANE ceiling)
     self._lmT = None               # cached contiguous fp32 lm_head^T (host matmul); built on first use
+    self.ane_lm_head = ane_lm_head  # run lm_head on the ANE (tiled compile_multi) instead of host matmul
+    self._lmh: dict | None = None  # cached ANE lm_head program (built once, shape-independent of max_len)
+    self._lmh_off = False          # True if ANE lm_head was attempted and failed or declined
+    self._lmhead_bytes = 1.2e9     # budget: heads above this fall back to host (safety under ~2GB ANE ceiling)
+    self._lmhead_compress: str | None = None  # head always fp16; quantizing the head degrades logits more
+                                               # than quantizing an intermediate layer (no residual to absorb)
 
   def release(self) -> None:
-    """Release every compiled program (prefill, decode chunks, batched-prefill chunks), the cached host
-    `_lmT` transpose, and the cached state, so a subsequent call transparently recompiles instead of
-    replaying a freed program or stale buffers."""
+    """Release every compiled program (prefill, decode chunks, batched-prefill chunks, ANE lm_head),
+    the cached host `_lmT` transpose, and the cached state, so a subsequent call transparently
+    recompiles instead of replaying a freed program or stale buffers."""
     if self._net is not None:
       self._net.release()
     if self._dec is not None:
       for c in self._dec["chunks"]: c["net"].release()
     if self._pre is not None:
       for c in self._pre["chunks"]: c["net"].release()
+    if self._lmh is not None:
+      self._lmh["net"].release()
     self._net, self._seq, self._dec, self._pre, self._lmT = None, 0, None, None, None
+    self._lmh = None; self._lmh_off = False
 
   def _check_positions(self, n: int) -> None:
     """Raise a clear error instead of an out-of-bounds `wpe` index/broadcast failure when `n` exceeds a
@@ -311,6 +330,10 @@ class LlamaPrefill:
     return np.asarray(net(emb.astype(np.float16))).astype(np.float32)
 
   def _logits(self, hidden_row):
+    if self.ane_lm_head:
+      lmh = self._lm_head_program()
+      if lmh is not None:
+        return self._ane_logits(lmh, hidden_row)
     lm = self._lmT
     if lm is None:
       # Build once: NumPy has no fp16 BLAS, and a live `.T` view is strided, so a per-call
@@ -318,6 +341,43 @@ class LlamaPrefill:
       # 50k vocab). A contiguous fp32 copy of the transpose is converted once and is ~10x faster.
       lm = self._lmT = np.ascontiguousarray(np.asarray(self.w["lm_head"]).T, np.float32)
     return hidden_row @ lm
+
+  def _lm_head_program(self):
+    """Build (once, cached) the tiled ANE lm_head: [1, dim] -> N vocab tiles, each <= the family
+    max tensor dim. Returns None when the head stays on the host (opt-out, oversize, or a failed
+    compile). Shape-independent of max_len, so a decoder rebuild does not invalidate it."""
+    if self._lmh is not None:
+      return self._lmh
+    if self._lmh_off:
+      return None
+    try:
+      W = np.asarray(self.w["lm_head"])
+      V, D = W.shape
+      assert D == self.cfg.dim, f"lm_head dim {D} != model dim {self.cfg.dim}"
+      if V * D * 2 > self._lmhead_bytes:
+        warnings.warn(f"ANE lm_head skipped: {V}x{D} head = {V * D * 2 / 1e9:.2f} GB exceeds budget")
+        self._lmh_off = True
+        return None
+      tile = _lm_head_tile_size()
+      x = _input((1, D))
+      from ._compile import compile_multi
+      tiles = [x.linear(W[i:i + tile]) for i in range(0, V, tile)]
+      assert all(t.shape[-1] <= tile for t in tiles)
+      net = compile_multi(tiles, compress=self._lmhead_compress)
+      inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
+      self._lmh = {"net": net, "x": inm[id(x)], "outs": [om[t] for t in tiles], "V": V}
+      return self._lmh
+    except Exception as e:
+      warnings.warn(f"ANE lm_head compile failed, falling back to host: {e}")
+      self._lmh_off = True
+      return None
+
+  def _ane_logits(self, lmh, hidden_row):
+    """Execute the tiled ANE lm_head and return [vocab] fp32 logits."""
+    pr = lmh["net"].prog
+    pr.set_input(lmh["x"], hidden_row.astype(np.float16)[None])
+    pr.execute()
+    return np.concatenate([np.asarray(pr.read_output(o), np.float32) for o in lmh["outs"]], axis=1)[0]
 
   @staticmethod
   def _sample(logits, temperature, top_p, top_k):
@@ -394,8 +454,12 @@ class LlamaPrefill:
 
   def warmup(self, max_len):
     """Compile and cache the decode program for context length `max_len` (the one-time cost) so the next
-    `generate` streams immediately. Returns self."""
-    self._decoder(int(max_len)); return self
+    `generate` streams immediately. If `ane_lm_head` is active, compile the ANE lm_head too, so the first
+    token does not pay the compilation cost. Returns self."""
+    self._decoder(int(max_len))
+    if self.ane_lm_head:
+      self._lm_head_program()
+    return self
 
   def _prefiller(self, seq):
     """Build (once, cached) the CHUNKED batched-prefill program(s) for prompt length `seq`: layers split under
@@ -469,7 +533,8 @@ class LlamaPrefill:
         c["net"].prog.set_input(port, buf)
 
   def generate(self, token_ids, max_new_tokens=40, eos_id=None, max_len=None, on_token=None,
-               temperature=0.0, top_p=1.0, top_k=0, batched_prefill=True, prefill_pad=None, on_stage=None):
+               temperature=0.0, top_p=1.0, top_k=0, batched_prefill=True, prefill_pad=None, on_stage=None,
+               ane_lm_head=None):
     """Autoregressive generation with a resident KV-cache. The decode program (compiled once and cached) runs
     all layers for one token attending to caches that stay on the ANE across steps, so each step feeds only the
     token embedding + a position one-hot. `on_token(id)` is called per token (streaming). Greedy by default
@@ -477,9 +542,14 @@ class LlamaPrefill:
 
     `on_stage(name, elapsed)` receives per-token timing (seconds) when profiling: `embedding` and `layers`
     are the two halves of one decode step (the `step` stage times the whole call, so summing all stages
-    double-counts `step`), then `lm_head` and `sample`. Only emitted while profiling is on."""
+    double-counts `step`), then `lm_head` and `sample`. Only emitted while profiling is on.
+
+    `ane_lm_head` overrides `self.ane_lm_head` for this call (None keeps the attribute)."""
     cfg = self.cfg; f16 = np.float16
     profiling = on_stage is not None
+    saved = self.ane_lm_head
+    if ane_lm_head is not None:
+      self.ane_lm_head = ane_lm_head
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
     eos = {int(eos_id)} if isinstance(eos_id, int) else {int(e) for e in (eos_id or ())}   # any-of stop set
     d = self._decoder(M); chunks = d["chunks"]
@@ -535,6 +605,8 @@ class LlamaPrefill:
       if nxt in eos: break
       if on_token is not None: on_token(nxt)                   # stream the token
       cur, pos = nxt, pos + 1
+    if ane_lm_head is not None:
+      self.ane_lm_head = saved
     return out
 
 

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -249,7 +249,10 @@ _DECODE_CTX = ("oh", "inv", "mask", "cosp", "sinp")
 
 def _lm_head_tile_size() -> int:
   """Vocab-axis tile for the ANE lm_head: the target family's max tensor dim (A13-A15 16384,
-  A16+ 65536). compile_multi does not run the oversize gate, so this is the only guard."""
+  A16+ 65536). `compile_multi` never runs `_retarget_for`, so nothing downstream re-checks the tile;
+  an oversize one fails inside e5rt instead. `detect_family()` honours `ANEFORGE_TARGET`, which is how
+  the A16 single-tile branch is exercised from an M2 - and equally how pointing it above the host
+  family tiles for a cap the host cannot run."""
   from . import _targets
   return _targets.limit("max_tensor_dim", _targets.detect_family())
 
@@ -260,7 +263,9 @@ class LlamaPrefill:
   a dict of numpy arrays (see `from_pretrained`). The host `lm_head` keeps a cached fp32 transpose
   (`_lmT`): for large vocabularies this is the runner's biggest host allocation (GPT-2 ~206 MB, a
   151936x4096 head ~2.5 GB), freed by `release()`. With `ane_lm_head=True`, the head runs on the ANE
-  as a tiled `compile_multi` instead, saving host memory but changing numerics (fp16 vs fp32 matmul)."""
+  as a tiled `compile_multi` instead: `_lmT` is never built, at the cost of fp16 (not fp32) matmul
+  numerics, and - when the head is TIED to `embed`, as in GPT-2 - of baking a second copy of those
+  weights into the ANE program while `embed` stays on the host for the token gather."""
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None,
                ane_lm_head: bool = False):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
@@ -271,8 +276,8 @@ class LlamaPrefill:
     self._lmh: dict | None = None  # cached ANE lm_head program (built once, shape-independent of max_len)
     self._lmh_off = False          # True if ANE lm_head was attempted and failed or declined
     self._lmhead_bytes = 1.2e9     # budget: heads above this fall back to host (safety under ~2GB ANE ceiling)
-    self._lmhead_compress: str | None = None  # head always fp16; quantizing the head degrades logits more
-                                               # than quantizing an intermediate layer (no residual to absorb)
+    self._lmhead_compress: str | None = None  # head always fp16; quantizing it degrades logits more than
+                                              # an intermediate layer (no residual to absorb the error)
 
   def release(self) -> None:
     """Release every compiled program (prefill, decode chunks, batched-prefill chunks, ANE lm_head),
@@ -329,8 +334,10 @@ class LlamaPrefill:
       emb = emb + self.w["wpe"][:len(ids)]
     return np.asarray(net(emb.astype(np.float16))).astype(np.float32)
 
-  def _logits(self, hidden_row):
-    if self.ane_lm_head:
+  def _logits(self, hidden_row, ane: bool | None = None):
+    """Next-token logits for one hidden row. `ane` overrides `self.ane_lm_head` for this call only
+    (passed down by `generate`), so nothing mutates instance state for a per-call override."""
+    if self.ane_lm_head if ane is None else ane:      # per-call override wins, attribute otherwise
       lmh = self._lm_head_program()
       if lmh is not None:
         return self._ane_logits(lmh, hidden_row)
@@ -353,27 +360,28 @@ class LlamaPrefill:
     try:
       W = np.asarray(self.w["lm_head"])
       V, D = W.shape
-      assert D == self.cfg.dim, f"lm_head dim {D} != model dim {self.cfg.dim}"
+      if D != self.cfg.dim:                  # raise, not assert: -O must not strip the check
+        raise ValueError(f"lm_head dim {D} != model dim {self.cfg.dim}")
       if V * D * 2 > self._lmhead_bytes:
-        warnings.warn(f"ANE lm_head skipped: {V}x{D} head = {V * D * 2 / 1e9:.2f} GB exceeds budget")
-        self._lmh_off = True
-        return None
-      tile = _lm_head_tile_size()
-      x = _input((1, D))
-      from ._compile import compile_multi
-      tiles = [x.linear(W[i:i + tile]) for i in range(0, V, tile)]
-      assert all(t.shape[-1] <= tile for t in tiles)
-      net = compile_multi(tiles, compress=self._lmhead_compress)
-      inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
-      self._lmh = {"net": net, "x": inm[id(x)], "outs": [om[t] for t in tiles], "V": V}
-      return self._lmh
-    except Exception as e:
-      warnings.warn(f"ANE lm_head compile failed, falling back to host: {e}")
-      self._lmh_off = True
-      return None
+        reason = f"{V}x{D} head is {V * D * 2 / 1e9:.2f} GB, over the {self._lmhead_bytes / 1e9:.2f} GB budget"
+      else:
+        tile = _lm_head_tile_size()
+        x = _input((1, D))
+        from ._compile import compile_multi
+        tiles = [x.linear(W[i:i + tile]) for i in range(0, V, tile)]
+        net = compile_multi(tiles, compress=self._lmhead_compress)
+        inm = {id(t): n for t, n in net.input_ports}; om = dict(net.output_ports)
+        self._lmh = {"net": net, "x": inm[id(x)], "outs": [om[t] for t in tiles], "V": V}
+        return self._lmh
+    except Exception as e:                   # an optimization must never break `generate`
+      reason = f"compile failed ({e})"
+    self._lmh_off = True                     # warn once, outside the try, so the reason stays accurate
+    warnings.warn(f"ANE lm_head unavailable, using the host matmul: {reason}")
+    return None
 
   def _ane_logits(self, lmh, hidden_row):
-    """Execute the tiled ANE lm_head and return [vocab] fp32 logits."""
+    """Execute the tiled ANE lm_head on a single row `hidden_row` [dim] and return [vocab] fp32
+    logits. Row-only, unlike the host path: `generate`, `prefill` and `_prefill_seed` all pass one row."""
     pr = lmh["net"].prog
     pr.set_input(lmh["x"], hidden_row.astype(np.float16)[None])
     pr.execute()
@@ -493,7 +501,7 @@ class LlamaPrefill:
     self._pre = {"seq": seq, "chunks": chunks}
     return self._pre
 
-  def _prefill_seed(self, token_ids, pad_to=None):
+  def _prefill_seed(self, token_ids, pad_to=None, ane: bool | None = None):
     """Batched prefill via the cached chunked prefiller: run the whole prompt in one pass per chunk (full causal
     attention -- the compute-bound matmuls the engine likes) instead of stepping the decode program per token.
     `pad_to` right-pads the prompt to a fixed bucket length so ONE prefiller compile is reused across prompts of
@@ -516,7 +524,7 @@ class LlamaPrefill:
       for li, kport, vport in p["kv"]:                                        # keep only the real positions
         kv_by_layer[li] = (np.asarray(pr.read_output(kport)).astype(f16)[:, :real, :],
                            np.asarray(pr.read_output(vport)).astype(f16)[:, :real, :])
-    return self._logits(h[real - 1].astype(np.float32))[None], kv_by_layer
+    return self._logits(h[real - 1].astype(np.float32), ane)[None], kv_by_layer
 
   def _seed_cache(self, d, kv_by_layer, seq):
     """Write a batched prefill's per-layer K/V into the resident decode cache buffers (positions [0:seq]), the
@@ -544,12 +552,12 @@ class LlamaPrefill:
     are the two halves of one decode step (the `step` stage times the whole call, so summing all stages
     double-counts `step`), then `lm_head` and `sample`. Only emitted while profiling is on.
 
-    `ane_lm_head` overrides `self.ane_lm_head` for this call (None keeps the attribute)."""
+    `ane_lm_head` overrides `self.ane_lm_head` for this call (None keeps the attribute); it is threaded
+    into `_logits`, not written back to the instance. An override does NOT pre-compile the head, so the
+    first token pays that compile - call `warmup` with the attribute set to keep it out of the timings."""
     cfg = self.cfg; f16 = np.float16
     profiling = on_stage is not None
-    saved = self.ane_lm_head
-    if ane_lm_head is not None:
-      self.ane_lm_head = ane_lm_head
+    use_ane = self.ane_lm_head if ane_lm_head is None else bool(ane_lm_head)
     prompt = [int(t) for t in token_ids]; M = int(max_len or len(prompt) + max_new_tokens)
     eos = {int(eos_id)} if isinstance(eos_id, int) else {int(e) for e in (eos_id or ())}   # any-of stop set
     d = self._decoder(M); chunks = d["chunks"]
@@ -584,7 +592,7 @@ class LlamaPrefill:
                    and all(self._spec(i).mixer == "attention" for i in range(cfg.n_layers)))
     out = []
     if use_batched:                                            # one-pass prefill, then seed the resident cache
-      logits0, kv = self._prefill_seed(prompt, prefill_pad)
+      logits0, kv = self._prefill_seed(prompt, prefill_pad, use_ane)
       self._seed_cache(d, kv, len(prompt))
       cur = self._sample(logits0[0], temperature, top_p, top_k); out.append(cur)
       if cur in eos: return out
@@ -597,7 +605,7 @@ class LlamaPrefill:
       if pos >= M - 1: break                                   # cache full
       t0 = time.perf_counter() if profiling else 0.0; hidden = step(cur, pos)
       if on_stage is not None: on_stage("step", time.perf_counter() - t0)
-      t0 = time.perf_counter() if profiling else 0.0; logits = self._logits(hidden)
+      t0 = time.perf_counter() if profiling else 0.0; logits = self._logits(hidden, use_ane)
       if on_stage is not None: on_stage("lm_head", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0; nxt = self._sample(logits, temperature, top_p, top_k)
       if on_stage is not None: on_stage("sample", time.perf_counter() - t0)
@@ -605,8 +613,6 @@ class LlamaPrefill:
       if nxt in eos: break
       if on_token is not None: on_token(nxt)                   # stream the token
       cur, pos = nxt, pos + 1
-    if ane_lm_head is not None:
-      self.ane_lm_head = saved
     return out
 
 
@@ -762,10 +768,11 @@ def _assert_dense_compatible(c) -> None:
       f"(model_type 'gemma'), and MoE. See docs/llm.md.")
 
 
-def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
+def from_pretrained(name: str, compress: str | None = None, ane_lm_head: bool = False) -> LlamaPrefill:
   """Load a decoder LM from Hugging Face for ANE inference: dense Llama/Qwen/Mistral, Gemma, and MoE
   (an unsupported arch is rejected, not silently mis-loaded). `compress` ("int8"/"int4"/"blockwise")
-  quantizes the ANE weights."""
+  quantizes the ANE weights. `ane_lm_head` runs the head on the ANE instead of the host (see
+  `LlamaPrefill`)."""
   import torch
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)
@@ -776,4 +783,4 @@ def from_pretrained(name: str, compress: str | None = None) -> LlamaPrefill:
   # wastes memory (~28 GB for a 7B, enough to OOM a 32 GB Mac). Same rounding the bake does, so unchanged.
   sd = {k: v.detach().to(torch.float16).numpy() for k, v in hf.state_dict().items()}
   cfg, weights = adapt(hf.config, sd)
-  return LlamaPrefill(cfg, weights, compress=compress)
+  return LlamaPrefill(cfg, weights, compress=compress, ane_lm_head=ane_lm_head)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -25,10 +25,22 @@ logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 - `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` - build from numpy weights directly.
   `af.rope` / `af.prefill_block` are the building blocks.
 
-`LlamaPrefill` accepts `ane_lm_head=False` (default). When `True`, the lm_head runs on the ANE as
-a tiled `compile_multi` instead of a host fp32 matmul. This saves host memory (GPT-2: ~206 MB)
-but changes numerics (fp16 vs fp32 matmul), so greedy argmax may differ on close ties. Pass
-`ane_lm_head=True` to `__init__` or as a per-call override in `generate(..., ane_lm_head=True)`.
+### lm_head on the ANE
+
+`ane_lm_head=True` (default `False`) runs the lm_head on the ANE as a `compile_multi` tiled along
+vocab, instead of the host fp32 matmul. Pass it to `af.load_llm` or `af.LlamaPrefill`, or per call
+as `generate(..., ane_lm_head=True)`. Measured on an M2 Pro (macOS 26.5.2, fp16), median of 3 runs:
+
+| model | lm_head host | lm_head ANE | decode host | decode ANE |
+|---|---|---|---|---|
+| gpt2-medium (vocab 50257, 4 tiles) | 10.8 ms/tok | 3.4 ms/tok | 39.6 tok/s | 59.4 tok/s |
+| Qwen3-0.6B (vocab 151936, 10 tiles) | 30.1 ms/tok | 8.2 ms/tok | 17.8 tok/s | 29.3 tok/s |
+
+It also drops the `_lmT` host allocation (GPT-2: 206 MB, Qwen3-0.6B: 622 MB). The trade-off is fp16
+matmul numerics instead of fp32, so greedy argmax can differ on close ties (it did not on either
+model above, 64/64 tokens); and when the head is tied to `embed`, the ANE program bakes a second
+copy of those weights. The default stays `False` for that reason. `warmup(max_len)` compiles the
+head too when the flag is set on the model, keeping the compile out of the first token.
 
 ## Prefill and decode
 

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -25,6 +25,11 @@ logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 - `af.LlamaPrefill(cfg, weights)` / `af.LlamaConfig` - build from numpy weights directly.
   `af.rope` / `af.prefill_block` are the building blocks.
 
+`LlamaPrefill` accepts `ane_lm_head=False` (default). When `True`, the lm_head runs on the ANE as
+a tiled `compile_multi` instead of a host fp32 matmul. This saves host memory (GPT-2: ~206 MB)
+but changes numerics (fp16 vs fp32 matmul), so greedy argmax may differ on close ties. Pass
+`ane_lm_head=True` to `__init__` or as a per-call override in `generate(..., ane_lm_head=True)`.
+
 ## Prefill and decode
 
 `generate()` prefills the prompt, then runs a greedy decode loop with a resident KV-cache: each

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -150,3 +150,39 @@ def test_prefill_matches_huggingface_mistral():  # the Mistral adapter: GQA + sl
   ane = np.asarray(LlamaPrefill(cfg, w).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE Mistral prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"
+
+
+@requires_ane
+def test_ane_lm_head_matches_host_logits(monkeypatch):
+  """The tiled ANE head must agree with the host fp32 matmul on the argmax and stay within fp16
+  tolerance elementwise. The tile cap is monkeypatched low so a >1-tile head is exercised on an M2."""
+  import aneforge.llm as llm_mod
+  monkeypatch.setattr(llm_mod, "_lm_head_tile_size", lambda: 96)
+  cfg = LlamaConfig(dim=32, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=64, vocab=200)
+  m = _random_model(cfg, seed=3)
+  m.ane_lm_head = True
+  lmh = m._lm_head_program()
+  assert lmh is not None and len(lmh["outs"]) == 3, "expected a 3-tile head (200 vocab / cap 96)"
+  h = (np.random.default_rng(11).standard_normal(cfg.dim) * 0.5).astype(np.float32)
+  ane = m._ane_logits(lmh, h)
+  host = m._logits(h, ane=False)
+  assert ane.shape == host.shape == (cfg.vocab,)
+  assert int(ane.argmax()) == int(host.argmax()), f"argmax {ane.argmax()} vs host {host.argmax()}"
+  rel = np.abs(ane - host).max() / (np.abs(host).max() + 1e-9)
+  assert rel < 5e-3, f"ANE lm_head vs host relerr {rel}"
+
+
+@requires_ane
+def test_generate_ane_lm_head_matches_host():
+  """Greedy decode with the ANE head must produce the same tokens as the host head, same prompt and
+  max_len, and must not build the host `_lmT` transpose on the ANE path."""
+  cfg = LlamaConfig(dim=32, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=64, vocab=200)
+  m = _random_model(cfg, seed=3)
+  prompt = [3, 17, 42, 8]
+  host = m.generate(prompt, max_new_tokens=12, max_len=32, eos_id=None)
+  assert m._lmT is not None and m._lmh is None
+  m2 = _random_model(cfg, seed=3)
+  m2.ane_lm_head = True
+  ane = m2.generate(prompt, max_new_tokens=12, max_len=32, eos_id=None)
+  assert m2._lmT is None, "the ANE path must never build the host transpose"
+  assert ane == host, f"ANE head greedy {ane} != host greedy {host}"

--- a/tests/test_lm_head.py
+++ b/tests/test_lm_head.py
@@ -8,6 +8,26 @@ from aneforge.llm import LlamaConfig, LlamaPrefill, _lm_head_tile_size, _weights
 from _helpers import make_random_llama_model as _random_model
 
 
+def _make_mock_net(outs, **kw):
+  """Build a mock MultiModel with proper input/output ports by traversing the graph."""
+  visited = set(); inputs = []
+  def _walk(t):
+    if id(t) in visited: return
+    visited.add(id(t))
+    if t.op == "input": inputs.append(t)
+    for s in t.srcs: _walk(s)
+  for o in outs: _walk(o)
+  inputs.sort(key=lambda t: t.attrs.get("idx", 0))
+  for i, t in enumerate(inputs): t._name = f"in{i}"
+  for i, t in enumerate(outs): t._name = f"out{i}"
+  m = Mock()
+  m.input_ports = [(t, t._name) for t in inputs]
+  m.output_ports = [(t, t._name) for t in outs]
+  m.prog = Mock()
+  m.release = Mock()
+  return m
+
+
 def test_lm_head_tiles_follow_target_family(monkeypatch):
   """Tile shapes match the target family: A13-A15 (cap 16384) -> 4 tiles for 50257 vocab;
   A16+ (cap 65536) -> 1 tile. Small vocab is always one tile."""
@@ -27,39 +47,37 @@ def test_lm_head_tiles_follow_target_family(monkeypatch):
   sd["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
   m = LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), ane_lm_head=True)
 
-  monkeypatch.setattr(_targets, "detect_family", lambda: 3)   # A14 (M2)
-  pr = m._lm_head_program()
-  assert pr is not None
-  assert pr["V"] == 50257
-  tile = _lm_head_tile_size()
-  assert tile == 16384
-  # 50257 / 16384 = 3 full tiles + 1 short = 4 outputs
-  assert len(pr["outs"]) == 4
+  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
+    monkeypatch.setattr(_targets, "detect_family", lambda: 3)   # A14 (M2)
+    pr = m._lm_head_program()
+    assert pr is not None
+    assert pr["V"] == 50257
+    tile = _lm_head_tile_size()
+    assert tile == 16384
+    assert len(pr["outs"]) == 4
 
-  # Reset for A16 test
-  m._lmh = None; m._lmh_off = False
-  monkeypatch.setattr(_targets, "detect_family", lambda: 5)   # A16 (M4/M5)
-  pr16 = m._lm_head_program()
-  assert pr16 is not None
-  assert len(pr16["outs"]) == 1   # 50257 fits in one tile at 65536 cap
+    m._lmh = None; m._lmh_off = False
+    monkeypatch.setattr(_targets, "detect_family", lambda: 5)   # A16 (M4/M5)
+    pr16 = m._lm_head_program()
+    assert pr16 is not None
+    assert len(pr16["outs"]) == 1
 
-  # Small vocab: always one tile regardless of family
-  cfg2 = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-  sd2 = {"model.embed_tokens.weight": R(100, 64), "model.norm.weight": np.ones(64, np.float32),
-         "lm_head.weight": R(100, 64)}
-  sd2["model.layers.0.self_attn.q_proj.weight"] = R(64, 64)
-  sd2["model.layers.0.self_attn.k_proj.weight"] = R(32, 64)
-  sd2["model.layers.0.self_attn.v_proj.weight"] = R(32, 64)
-  sd2["model.layers.0.self_attn.o_proj.weight"] = R(64, 64)
-  sd2["model.layers.0.mlp.gate_proj.weight"] = R(128, 64)
-  sd2["model.layers.0.mlp.up_proj.weight"] = R(128, 64)
-  sd2["model.layers.0.mlp.down_proj.weight"] = R(64, 128)
-  sd2["model.layers.0.input_layernorm.weight"] = np.ones(64, np.float32)
-  sd2["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
-  m2 = LlamaPrefill(cfg2, _weights_from_state_dict(sd2, cfg2), ane_lm_head=True)
-  pr_small = m2._lm_head_program()
-  assert pr_small is not None
-  assert len(pr_small["outs"]) == 1
+    cfg2 = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+    sd2 = {"model.embed_tokens.weight": R(100, 64), "model.norm.weight": np.ones(64, np.float32),
+           "lm_head.weight": R(100, 64)}
+    sd2["model.layers.0.self_attn.q_proj.weight"] = R(64, 64)
+    sd2["model.layers.0.self_attn.k_proj.weight"] = R(32, 64)
+    sd2["model.layers.0.self_attn.v_proj.weight"] = R(32, 64)
+    sd2["model.layers.0.self_attn.o_proj.weight"] = R(64, 64)
+    sd2["model.layers.0.mlp.gate_proj.weight"] = R(128, 64)
+    sd2["model.layers.0.mlp.up_proj.weight"] = R(128, 64)
+    sd2["model.layers.0.mlp.down_proj.weight"] = R(64, 128)
+    sd2["model.layers.0.input_layernorm.weight"] = np.ones(64, np.float32)
+    sd2["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
+    m2 = LlamaPrefill(cfg2, _weights_from_state_dict(sd2, cfg2), ane_lm_head=True)
+    pr_small = m2._lm_head_program()
+    assert pr_small is not None
+    assert len(pr_small["outs"]) == 1
 
 
 def test_lm_head_program_declines_when_oversized():
@@ -67,18 +85,16 @@ def test_lm_head_program_declines_when_oversized():
   cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
   m = _random_model(cfg, seed=42)
   m.ane_lm_head = True
-  m._lmhead_bytes = 1   # 1 byte budget: will always exceed
+  m._lmhead_bytes = 1
   with warnings.catch_warnings(record=True) as w:
     warnings.simplefilter("always")
     pr = m._lm_head_program()
     assert pr is None
     assert len(w) == 1 and "skipped" in str(w[0].message)
-  # _logits still returns the host result
   rng = np.random.default_rng(99)
   h = rng.standard_normal(cfg.dim).astype(np.float32)
   host_logits = h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
-  ane_logits = m._logits(h)
-  np.testing.assert_array_equal(ane_logits, host_logits)
+  np.testing.assert_array_equal(m._logits(h), host_logits)
 
 
 def test_release_drops_lm_head_program():
@@ -86,10 +102,8 @@ def test_release_drops_lm_head_program():
   cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
   m = _random_model(cfg, seed=42)
   m.ane_lm_head = True
-  pr = m._lm_head_program()
-  assert pr is not None
   mock_net = Mock(); m._lmh = {"net": mock_net, "x": 0, "outs": [1], "V": 100}
-  m._lmh_off = True   # simulate a declined head to test both resets
+  m._lmh_off = True
   m.release()
   assert m._lmh is None
   assert m._lmh_off is False
@@ -103,9 +117,11 @@ def test_lm_head_program_survives_decoder_rebuild():
   m.ane_lm_head = True
   sentinel = object()
   m._lmh = sentinel
-  m._decoder(16)
+  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
+    m._decoder(16)
   assert m._lmh is sentinel, "decoder rebuild must not overwrite _lmh"
-  m._decoder(32)
+  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
+    m._decoder(32)
   assert m._lmh is sentinel, "second decoder rebuild must not overwrite _lmh"
 
 
@@ -134,8 +150,8 @@ def test_lm_head_compile_failure_falls_back():
       pr = m._lm_head_program()
       assert pr is None
       assert m._lmh_off is True
-      assert len(w) == 1 and "failed" in str(w[0].message)
-  # _logits returns host fallback
+      fallback = [x for x in w if "failed" in str(x.message)]
+      assert len(fallback) == 1
   rng = np.random.default_rng(88)
   h = rng.standard_normal(cfg.dim).astype(np.float32)
   host_logits = h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
@@ -147,10 +163,11 @@ def test_lm_head_program_dim_mismatch_asserts():
   cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
   m = _random_model(cfg, seed=42)
   m.ane_lm_head = True
-  m.w["lm_head"] = np.zeros((100, 32), np.float16)   # dim 32 != model dim 64
+  m.w["lm_head"] = np.zeros((100, 32), np.float16)
   with warnings.catch_warnings(record=True) as w:
     warnings.simplefilter("always")
     pr = m._lm_head_program()
     assert pr is None
     assert m._lmh_off is True
-    assert len(w) == 1 and "failed" in str(w[0].message)
+    fallback = [x for x in w if "failed" in str(x.message)]
+    assert len(fallback) == 1

--- a/tests/test_lm_head.py
+++ b/tests/test_lm_head.py
@@ -1,0 +1,156 @@
+"""Off-device tests for the ANE lm_head: tiled compile_multi path (CI-safe, no ANE dispatch)."""
+import warnings
+from unittest.mock import Mock, patch
+
+import numpy as np
+
+from aneforge.llm import LlamaConfig, LlamaPrefill, _lm_head_tile_size, _weights_from_state_dict
+from _helpers import make_random_llama_model as _random_model
+
+
+def test_lm_head_tiles_follow_target_family(monkeypatch):
+  """Tile shapes match the target family: A13-A15 (cap 16384) -> 4 tiles for 50257 vocab;
+  A16+ (cap 65536) -> 1 tile. Small vocab is always one tile."""
+  from aneforge import _targets
+  rng = np.random.default_rng(0); R = lambda *s: (rng.standard_normal(s) * 0.1).astype(np.float32)
+  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=50257)
+  sd = {"model.embed_tokens.weight": R(50257, 64), "model.norm.weight": np.ones(64, np.float32),
+        "lm_head.weight": R(50257, 64)}
+  sd["model.layers.0.self_attn.q_proj.weight"] = R(64, 64)
+  sd["model.layers.0.self_attn.k_proj.weight"] = R(32, 64)
+  sd["model.layers.0.self_attn.v_proj.weight"] = R(32, 64)
+  sd["model.layers.0.self_attn.o_proj.weight"] = R(64, 64)
+  sd["model.layers.0.mlp.gate_proj.weight"] = R(128, 64)
+  sd["model.layers.0.mlp.up_proj.weight"] = R(128, 64)
+  sd["model.layers.0.mlp.down_proj.weight"] = R(64, 128)
+  sd["model.layers.0.input_layernorm.weight"] = np.ones(64, np.float32)
+  sd["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
+  m = LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), ane_lm_head=True)
+
+  monkeypatch.setattr(_targets, "detect_family", lambda: 3)   # A14 (M2)
+  pr = m._lm_head_program()
+  assert pr is not None
+  assert pr["V"] == 50257
+  tile = _lm_head_tile_size()
+  assert tile == 16384
+  # 50257 / 16384 = 3 full tiles + 1 short = 4 outputs
+  assert len(pr["outs"]) == 4
+
+  # Reset for A16 test
+  m._lmh = None; m._lmh_off = False
+  monkeypatch.setattr(_targets, "detect_family", lambda: 5)   # A16 (M4/M5)
+  pr16 = m._lm_head_program()
+  assert pr16 is not None
+  assert len(pr16["outs"]) == 1   # 50257 fits in one tile at 65536 cap
+
+  # Small vocab: always one tile regardless of family
+  cfg2 = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+  sd2 = {"model.embed_tokens.weight": R(100, 64), "model.norm.weight": np.ones(64, np.float32),
+         "lm_head.weight": R(100, 64)}
+  sd2["model.layers.0.self_attn.q_proj.weight"] = R(64, 64)
+  sd2["model.layers.0.self_attn.k_proj.weight"] = R(32, 64)
+  sd2["model.layers.0.self_attn.v_proj.weight"] = R(32, 64)
+  sd2["model.layers.0.self_attn.o_proj.weight"] = R(64, 64)
+  sd2["model.layers.0.mlp.gate_proj.weight"] = R(128, 64)
+  sd2["model.layers.0.mlp.up_proj.weight"] = R(128, 64)
+  sd2["model.layers.0.mlp.down_proj.weight"] = R(64, 128)
+  sd2["model.layers.0.input_layernorm.weight"] = np.ones(64, np.float32)
+  sd2["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
+  m2 = LlamaPrefill(cfg2, _weights_from_state_dict(sd2, cfg2), ane_lm_head=True)
+  pr_small = m2._lm_head_program()
+  assert pr_small is not None
+  assert len(pr_small["outs"]) == 1
+
+
+def test_lm_head_program_declines_when_oversized():
+  """When _lmhead_bytes is too low, _lm_head_program returns None and _logits falls back to host."""
+  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+  m = _random_model(cfg, seed=42)
+  m.ane_lm_head = True
+  m._lmhead_bytes = 1   # 1 byte budget: will always exceed
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    pr = m._lm_head_program()
+    assert pr is None
+    assert len(w) == 1 and "skipped" in str(w[0].message)
+  # _logits still returns the host result
+  rng = np.random.default_rng(99)
+  h = rng.standard_normal(cfg.dim).astype(np.float32)
+  host_logits = h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
+  ane_logits = m._logits(h)
+  np.testing.assert_array_equal(ane_logits, host_logits)
+
+
+def test_release_drops_lm_head_program():
+  """release() frees the ANE lm_head and resets _lmh/_lmh_off so the model recompiles cleanly."""
+  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+  m = _random_model(cfg, seed=42)
+  m.ane_lm_head = True
+  pr = m._lm_head_program()
+  assert pr is not None
+  mock_net = Mock(); m._lmh = {"net": mock_net, "x": 0, "outs": [1], "V": 100}
+  m._lmh_off = True   # simulate a declined head to test both resets
+  m.release()
+  assert m._lmh is None
+  assert m._lmh_off is False
+  mock_net.release.assert_called_once()
+
+
+def test_lm_head_program_survives_decoder_rebuild():
+  """_lmh is shape-independent of max_len; a new _decoder(M) does not invalidate it."""
+  cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+  m = _random_model(cfg, seed=42)
+  m.ane_lm_head = True
+  sentinel = object()
+  m._lmh = sentinel
+  m._decoder(16)
+  assert m._lmh is sentinel, "decoder rebuild must not overwrite _lmh"
+  m._decoder(32)
+  assert m._lmh is sentinel, "second decoder rebuild must not overwrite _lmh"
+
+
+def test_logits_host_path_unchanged_when_flag_off():
+  """With ane_lm_head=False, _logits never builds _lmh and returns h @ lm_head.T fp32 bit-identical."""
+  cfg = LlamaConfig(dim=16, n_layers=2, n_heads=4, n_kv_heads=4, ffn_dim=64, vocab=100)
+  m = _random_model(cfg, seed=0)
+  assert m.ane_lm_head is False
+  rng = np.random.default_rng(7)
+  h = rng.standard_normal(cfg.dim).astype(np.float32)
+  lm = np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
+  ref = h @ lm
+  got = m._logits(h)
+  np.testing.assert_array_equal(got, ref)
+  assert m._lmh is None, "_lmh must not be built when flag is off"
+
+
+def test_lm_head_compile_failure_falls_back():
+  """If compile_multi raises, _lm_head_program declines and _logits returns host result."""
+  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+  m = _random_model(cfg, seed=42)
+  m.ane_lm_head = True
+  with patch("aneforge._compile.compile_multi", side_effect=RuntimeError("ANE error")):
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      pr = m._lm_head_program()
+      assert pr is None
+      assert m._lmh_off is True
+      assert len(w) == 1 and "failed" in str(w[0].message)
+  # _logits returns host fallback
+  rng = np.random.default_rng(88)
+  h = rng.standard_normal(cfg.dim).astype(np.float32)
+  host_logits = h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
+  np.testing.assert_array_equal(m._logits(h), host_logits)
+
+
+def test_lm_head_program_dim_mismatch_asserts():
+  """If lm_head dim != model dim, _lm_head_program catches the assertion and falls back to host."""
+  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
+  m = _random_model(cfg, seed=42)
+  m.ane_lm_head = True
+  m.w["lm_head"] = np.zeros((100, 32), np.float16)   # dim 32 != model dim 64
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    pr = m._lm_head_program()
+    assert pr is None
+    assert m._lmh_off is True
+    assert len(w) == 1 and "failed" in str(w[0].message)

--- a/tests/test_lm_head.py
+++ b/tests/test_lm_head.py
@@ -4,12 +4,17 @@ from unittest.mock import Mock, patch
 
 import numpy as np
 
-from aneforge.llm import LlamaConfig, LlamaPrefill, _lm_head_tile_size, _weights_from_state_dict
+from aneforge.llm import LlamaConfig, _lm_head_tile_size
 from _helpers import make_random_llama_model as _random_model
 
 
+def _cfg(vocab, dim=64, n_layers=1):
+  return LlamaConfig(dim=dim, n_layers=n_layers, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=vocab)
+
+
 def _make_mock_net(outs, **kw):
-  """Build a mock MultiModel with proper input/output ports by traversing the graph."""
+  """Mock a MultiModel: name the graph's input/output tensors as ports, and keep the output tensors
+  on `.tiles` so a test can assert the tiling the caller actually built."""
   visited = set(); inputs = []
   def _walk(t):
     if id(t) in visited: return
@@ -23,84 +28,58 @@ def _make_mock_net(outs, **kw):
   m = Mock()
   m.input_ports = [(t, t._name) for t in inputs]
   m.output_ports = [(t, t._name) for t in outs]
+  m.tiles = list(outs)
   m.prog = Mock()
+  shapes = {t._name: t.shape for t in outs}   # so `_ane_logits` can run without a device
+  m.prog.read_output = Mock(side_effect=lambda name: np.zeros(shapes[name], np.float16))
   m.release = Mock()
   return m
 
 
+def _host_logits(m, h):
+  return h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
+
+
 def test_lm_head_tiles_follow_target_family(monkeypatch):
-  """Tile shapes match the target family: A13-A15 (cap 16384) -> 4 tiles for 50257 vocab;
-  A16+ (cap 65536) -> 1 tile. Small vocab is always one tile."""
+  """Tile widths, not just the tile count, follow the target family's max tensor dim: cap 16384 splits
+  50257 into 16384/16384/16384/1105; cap 65536 emits one tile. A small vocab is always one tile."""
   from aneforge import _targets
-  rng = np.random.default_rng(0); R = lambda *s: (rng.standard_normal(s) * 0.1).astype(np.float32)
-  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=50257)
-  sd = {"model.embed_tokens.weight": R(50257, 64), "model.norm.weight": np.ones(64, np.float32),
-        "lm_head.weight": R(50257, 64)}
-  sd["model.layers.0.self_attn.q_proj.weight"] = R(64, 64)
-  sd["model.layers.0.self_attn.k_proj.weight"] = R(32, 64)
-  sd["model.layers.0.self_attn.v_proj.weight"] = R(32, 64)
-  sd["model.layers.0.self_attn.o_proj.weight"] = R(64, 64)
-  sd["model.layers.0.mlp.gate_proj.weight"] = R(128, 64)
-  sd["model.layers.0.mlp.up_proj.weight"] = R(128, 64)
-  sd["model.layers.0.mlp.down_proj.weight"] = R(64, 128)
-  sd["model.layers.0.input_layernorm.weight"] = np.ones(64, np.float32)
-  sd["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
-  m = LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), ane_lm_head=True)
+  m = _random_model(_cfg(50257), seed=0); m.ane_lm_head = True
 
   with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
-    monkeypatch.setattr(_targets, "detect_family", lambda: 3)   # A14 (M2)
+    monkeypatch.setattr(_targets, "detect_family", lambda: 3)      # A14 (M2)
+    assert _lm_head_tile_size() == 16384
     pr = m._lm_head_program()
-    assert pr is not None
-    assert pr["V"] == 50257
-    tile = _lm_head_tile_size()
-    assert tile == 16384
-    assert len(pr["outs"]) == 4
+    assert pr is not None and pr["V"] == 50257
+    assert [t.shape for t in pr["net"].tiles] == [(1, 16384), (1, 16384), (1, 16384), (1, 1105)]
 
     m._lmh = None; m._lmh_off = False
-    monkeypatch.setattr(_targets, "detect_family", lambda: 5)   # A16 (M4/M5)
+    monkeypatch.setattr(_targets, "detect_family", lambda: 5)      # A16 (M4/M5)
+    assert _lm_head_tile_size() == 65536
     pr16 = m._lm_head_program()
     assert pr16 is not None
-    assert len(pr16["outs"]) == 1
+    assert [t.shape for t in pr16["net"].tiles] == [(1, 50257)]
 
-    cfg2 = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-    sd2 = {"model.embed_tokens.weight": R(100, 64), "model.norm.weight": np.ones(64, np.float32),
-           "lm_head.weight": R(100, 64)}
-    sd2["model.layers.0.self_attn.q_proj.weight"] = R(64, 64)
-    sd2["model.layers.0.self_attn.k_proj.weight"] = R(32, 64)
-    sd2["model.layers.0.self_attn.v_proj.weight"] = R(32, 64)
-    sd2["model.layers.0.self_attn.o_proj.weight"] = R(64, 64)
-    sd2["model.layers.0.mlp.gate_proj.weight"] = R(128, 64)
-    sd2["model.layers.0.mlp.up_proj.weight"] = R(128, 64)
-    sd2["model.layers.0.mlp.down_proj.weight"] = R(64, 128)
-    sd2["model.layers.0.input_layernorm.weight"] = np.ones(64, np.float32)
-    sd2["model.layers.0.post_attention_layernorm.weight"] = np.ones(64, np.float32)
-    m2 = LlamaPrefill(cfg2, _weights_from_state_dict(sd2, cfg2), ane_lm_head=True)
-    pr_small = m2._lm_head_program()
-    assert pr_small is not None
-    assert len(pr_small["outs"]) == 1
+    small = _random_model(_cfg(100), seed=0); small.ane_lm_head = True
+    assert [t.shape for t in small._lm_head_program()["net"].tiles] == [(1, 100)]
 
 
 def test_lm_head_program_declines_when_oversized():
   """When _lmhead_bytes is too low, _lm_head_program returns None and _logits falls back to host."""
-  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-  m = _random_model(cfg, seed=42)
+  m = _random_model(_cfg(100), seed=42)
   m.ane_lm_head = True
   m._lmhead_bytes = 1
   with warnings.catch_warnings(record=True) as w:
     warnings.simplefilter("always")
-    pr = m._lm_head_program()
-    assert pr is None
-    assert len(w) == 1 and "skipped" in str(w[0].message)
-  rng = np.random.default_rng(99)
-  h = rng.standard_normal(cfg.dim).astype(np.float32)
-  host_logits = h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
-  np.testing.assert_array_equal(m._logits(h), host_logits)
+    assert m._lm_head_program() is None
+    assert len(w) == 1 and "over the" in str(w[0].message)
+  h = np.random.default_rng(99).standard_normal(m.cfg.dim).astype(np.float32)
+  np.testing.assert_array_equal(m._logits(h), _host_logits(m, h))
 
 
 def test_release_drops_lm_head_program():
   """release() frees the ANE lm_head and resets _lmh/_lmh_off so the model recompiles cleanly."""
-  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-  m = _random_model(cfg, seed=42)
+  m = _random_model(_cfg(100), seed=42)
   m.ane_lm_head = True
   mock_net = Mock(); m._lmh = {"net": mock_net, "x": 0, "outs": [1], "V": 100}
   m._lmh_off = True
@@ -112,62 +91,85 @@ def test_release_drops_lm_head_program():
 
 def test_lm_head_program_survives_decoder_rebuild():
   """_lmh is shape-independent of max_len; a new _decoder(M) does not invalidate it."""
-  cfg = LlamaConfig(dim=64, n_layers=2, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-  m = _random_model(cfg, seed=42)
+  m = _random_model(_cfg(100, n_layers=2), seed=42)
   m.ane_lm_head = True
   sentinel = object()
   m._lmh = sentinel
-  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
-    m._decoder(16)
-  assert m._lmh is sentinel, "decoder rebuild must not overwrite _lmh"
-  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
-    m._decoder(32)
-  assert m._lmh is sentinel, "second decoder rebuild must not overwrite _lmh"
+  for M in (16, 32):
+    with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
+      m._decoder(M)
+    assert m._lmh is sentinel, f"_decoder({M}) must not overwrite _lmh"
+
+
+def test_lm_head_program_is_built_once():
+  """Repeated calls reuse the same compiled program instead of recompiling per token."""
+  m = _random_model(_cfg(100), seed=42)
+  m.ane_lm_head = True
+  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net) as cm:
+    first = m._lm_head_program()
+    assert m._lm_head_program() is first
+    assert cm.call_count == 1
 
 
 def test_logits_host_path_unchanged_when_flag_off():
   """With ane_lm_head=False, _logits never builds _lmh and returns h @ lm_head.T fp32 bit-identical."""
-  cfg = LlamaConfig(dim=16, n_layers=2, n_heads=4, n_kv_heads=4, ffn_dim=64, vocab=100)
-  m = _random_model(cfg, seed=0)
+  m = _random_model(_cfg(100, dim=16), seed=0)
   assert m.ane_lm_head is False
-  rng = np.random.default_rng(7)
-  h = rng.standard_normal(cfg.dim).astype(np.float32)
-  lm = np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
-  ref = h @ lm
-  got = m._logits(h)
-  np.testing.assert_array_equal(got, ref)
+  h = np.random.default_rng(7).standard_normal(m.cfg.dim).astype(np.float32)
+  np.testing.assert_array_equal(m._logits(h), _host_logits(m, h))
   assert m._lmh is None, "_lmh must not be built when flag is off"
+
+
+def test_logits_per_call_override_does_not_touch_the_instance():
+  """`_logits(h, ane=...)` is the per-call override `generate` threads down: it must not write back
+  to `self.ane_lm_head`, and `ane=False` must keep the host path on an ANE-head model."""
+  m = _random_model(_cfg(100), seed=42)
+  m.ane_lm_head = True
+  h = np.random.default_rng(5).standard_normal(m.cfg.dim).astype(np.float32)
+  np.testing.assert_array_equal(m._logits(h, ane=False), _host_logits(m, h))
+  assert m._lmh is None and m.ane_lm_head is True
+
+  m.ane_lm_head = False
+  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net):
+    got = m._logits(h, ane=True)
+  assert got.shape == (m.cfg.vocab,)          # tiles concatenated back to one row of logits
+  assert m._lmh is not None and m.ane_lm_head is False
+
+
+def test_generate_override_never_leaks_into_the_instance():
+  """An `ane_lm_head=` override on generate() must not survive the call, including when generate
+  raises or returns early -- it is threaded through _logits, not written to the instance."""
+  m = _random_model(_cfg(100), seed=42)
+  m._decoder = lambda M: (_ for _ in ()).throw(RuntimeError("boom"))
+  try:
+    m.generate([1, 2, 3], max_new_tokens=2, max_len=8, ane_lm_head=True)
+  except RuntimeError:
+    pass
+  assert m.ane_lm_head is False
 
 
 def test_lm_head_compile_failure_falls_back():
   """If compile_multi raises, _lm_head_program declines and _logits returns host result."""
-  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-  m = _random_model(cfg, seed=42)
+  m = _random_model(_cfg(100), seed=42)
   m.ane_lm_head = True
   with patch("aneforge._compile.compile_multi", side_effect=RuntimeError("ANE error")):
     with warnings.catch_warnings(record=True) as w:
       warnings.simplefilter("always")
-      pr = m._lm_head_program()
-      assert pr is None
+      assert m._lm_head_program() is None
       assert m._lmh_off is True
-      fallback = [x for x in w if "failed" in str(x.message)]
-      assert len(fallback) == 1
-  rng = np.random.default_rng(88)
-  h = rng.standard_normal(cfg.dim).astype(np.float32)
-  host_logits = h @ np.ascontiguousarray(np.asarray(m.w["lm_head"]).T, np.float32)
-  np.testing.assert_array_equal(m._logits(h), host_logits)
+      assert len([x for x in w if "compile failed" in str(x.message)]) == 1
+  h = np.random.default_rng(88).standard_normal(m.cfg.dim).astype(np.float32)
+  np.testing.assert_array_equal(m._logits(h), _host_logits(m, h))
 
 
-def test_lm_head_program_dim_mismatch_asserts():
-  """If lm_head dim != model dim, _lm_head_program catches the assertion and falls back to host."""
-  cfg = LlamaConfig(dim=64, n_layers=1, n_heads=4, n_kv_heads=2, ffn_dim=128, vocab=100)
-  m = _random_model(cfg, seed=42)
+def test_lm_head_program_dim_mismatch_falls_back():
+  """A lm_head whose in-dim disagrees with cfg.dim declines with a clear reason (a raise, not an
+  assert, so `python -O` keeps the check) and leaves the host path serving logits."""
+  m = _random_model(_cfg(100), seed=42)
   m.ane_lm_head = True
   m.w["lm_head"] = np.zeros((100, 32), np.float16)
   with warnings.catch_warnings(record=True) as w:
     warnings.simplefilter("always")
-    pr = m._lm_head_program()
-    assert pr is None
+    assert m._lm_head_program() is None
     assert m._lmh_off is True
-    fallback = [x for x in w if "failed" in str(x.message)]
-    assert len(fallback) == 1
+    assert len([x for x in w if "lm_head dim 32 != model dim 64" in str(x.message)]) == 1


### PR DESCRIPTION
## What's in this PR

Opt-in tiled lm_head on the ANE for `LlamaPrefill`, replacing the host fp32 matmul. `compile_multi`
tiles the vocab axis to the target family's `max_tensor_dim` (16384 on A13-A15, 65536 on A16+), so
every tile ships in one program and costs one dispatch per token.

- `_lm_head_tile_size()`, `_lm_head_program()` (built once, cached, independent of `max_len`), `_ane_logits()`
- `_logits(hidden_row, ane=None)` routes to the ANE head; `ane` is the per-call override, threaded down from `generate`
- `release()` frees the program, `warmup()` compiles it, `af.load_llm(..., ane_lm_head=True)` enables it
- Declines to the host path on opt-out, a head over `_lmhead_bytes` (1.2 GB), or a failed compile: warn once, never break `generate`

Default is `False`.

## Measurements

M2 Pro, macOS 26.5.2, fp16, family 3 (cap 16384). Interleaved host/ANE rounds in one process, both
paths pre-warmed, median of 3 runs, first token dropped.

| model | tiles | lm_head host | lm_head ANE | decode host | decode ANE |
|---|---|---|---|---|---|
| gpt2-medium (vocab 50257) | 4 | 10.8 ms/tok | 3.4 ms/tok | 39.6 tok/s | 59.4 tok/s |
| Qwen3-0.6B (vocab 151936) | 10 | 30.1 ms/tok | 8.2 ms/tok | 17.8 tok/s | 29.3 tok/s |

`layers` is unchanged (13.9 vs 13.5, and 25.9 vs 25.9 ms/tok), so the whole delta is the head. Ten
output ports do not eat the gain: one program, one dispatch, so the cost tracks bytes and not tiles.
Greedy output identical host vs ANE, 64/64 tokens, both models. `_lmT` is never allocated on the ANE
path: 206 MB of host memory on GPT-2, 622 MB on Qwen3-0.6B. Head compile is 0.4 s and 1.8 s, paid by
`warmup`.

GPT-2 medium vs Hugging Face with the ANE head serving prefill, seed and decode: prefill cosine
1.00000, argmax match, 16/16 greedy tokens.

## Honest accounting

- Not bit-exact. The hidden row casts to fp16 and the matmul runs in fp16. Greedy matched on both
  models measured, but argmax can flip on a close tie, so the default stays `False`.
- The head compiles fp16 even when `compress="int8"`: quantizing the head has no residual to absorb
  the error. Conservative choice, not measured.
- Tied heads pay twice. In GPT-2 `lm_head is embed`, so the ANE program bakes 103 MB while `embed`
  stays on the host for the token gather. The `_lmT` saving is real, the device cost is not free.
- The A16 single-tile branch is covered off-device only (monkeypatched family). Not run on hardware.
- `compile_multi` never calls `_retarget_for`, so the multi-output path has no oversize gate. The
  tile size is the only thing keeping tiles legal, and pointing `ANEFORGE_TARGET` above the host
  family will tile for a cap the host cannot run.
- `mkdocs build --strict` not run: mkdocs is not installed locally. `docs/llm.md` only adds prose and
  a table, and `tables` is already enabled in `mkdocs.yml`.

## Validation

Off-device: `ruff check` clean, pylint (W0311/C0303) 10.00, `pyright aneforge` no new errors vs
`main` (the 22 it reports are missing optional imports, identical on both), `compileall`,
`pytest -m "not requires_ane"` 356 passed / 6 skipped.

On-device (M2 Pro): corpus `GATE: GREEN` 90/90. `pytest tests/` 1045 passed, 13 skipped, 4 failed;
the 4 are missing optional deps in my environment (`torchvision` for the ONNX ResNet-18 and CIFAR
tests, `scipy` for the two `erf` tests), unrelated to this change.

Ten off-device tests: per-family tile widths (not just the count), oversize decline,
compile-failure fallback, dim-mismatch fallback, `release()`, decoder rebuild not invalidating the
program, program built once, host path bit-identical when off, per-call override not touching
instance state, and the override not leaking out of `generate`.

Two on-device tests: ANE vs host logits over a 3-tile head (argmax plus fp16 tolerance), and greedy
`generate` parity host vs ANE with `_lmT` never built.

## Follow-ups

Found while working on this, not touched here:

1. `speculative._build_lm_head` hardcodes 65536 (`speculative.py:72`). The real cap is 16384 on
   A13-A15 and `compile_multi` has no gate, so `spec_generate` with a large vocab on an M1/M2/M3
   fails without a clear error. Current tests use vocab 48 and miss it.
2. `LlamaPrefill.release()` does not free `_verifier`, its chunks, or its lm_head. Preexisting leak
   from speculative decoding.
3. Four implementations of a tiled lm_head now: `models._lm_head_tiles` (no call site),
   `speculative._build_lm_head`, `bench/decode_measurement._lm_head` (16384 fixed), and this one.
4. `moe.load_gguf` keeps `lm_head` fp32 on the host for exactly the reason this PR addresses, so it
   could drop that allocation too.
