### PR TITLE
docs: README snippets for loading Hub models on the ANE

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,24 @@ reranker, and LLM on one engine: `python3 examples/rag_chat.py`. For speech,
 towers -- audio encoder and text decoder -- on the ANE, matching Hugging Face's
 greedy transcript.
 
+## Run a Hub model on the Neural Engine
+
+ANEForge loads models straight from the Hugging Face Hub by repo id and compiles them for the ANE --
+no CoreML, no conversion step. The same pattern works across tasks:
+
+```python
+import aneforge as af
+from aneforge.sentence_transformers import SentenceTransformer
+
+emb = SentenceTransformer("sentence-transformers/all-MiniLM-L6-v2").encode(["hello"])  # embeddings
+txt = af.load_gpt2("gpt2").generate_text("The Neural Engine is", 20)                   # text generation
+lab = af.load_vit("google/vit-base-patch16-224").classify(image)                      # image classification
+asr = af.load_whisper("openai/whisper-base.en").transcribe(audio)                     # speech to text
+```
+
+Representative model duplicates tagged for ANEForge live under the
+[`aneforge`](https://huggingface.co/aneforge) org on the Hub.
+
 ## How it compares
 
 |                       | On the ANE        | No CoreML | Trains on it |


### PR DESCRIPTION
Adds a short "Run a Hub model on the Neural Engine" section to the README showing the four low-friction task snippets (embeddings / text-gen / image-classification / speech-to-text) that load straight from a Hub repo id.

Requested by @pcuenca in the review of huggingface/huggingface.js#2347, alongside duplicating representative permissively-licensed models under the aneforge Hub org (all-MiniLM-L6-v2, gpt2, vit-base-patch16-224, whisper-base.en), each tagged library_name: aneforge and verified to load and run on the M5.