### PR TITLE
llm: greedy tie-margin host fallback for the ANE lm_head (#241)

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -263,9 +263,9 @@ class LlamaPrefill:
   a dict of numpy arrays (see `from_pretrained`). The host `lm_head` keeps a cached fp32 transpose
   (`_lmT`): for large vocabularies this is the runner's biggest host allocation (GPT-2 ~206 MB, a
   151936x4096 head ~2.5 GB), freed by `release()`. With `ane_lm_head=True`, the head runs on the ANE
-  as a tiled `compile_multi` instead: `_lmT` is never built, at the cost of fp16 (not fp32) matmul
-  numerics, and - when the head is TIED to `embed`, as in GPT-2 - of baking a second copy of those
-  weights into the ANE program while `embed` stays on the host for the token gather."""
+  as a tiled `compile_multi`; greedy stays exact via the `lmhead_tie_margin` host fallback (so `_lmT`
+  is built only if a near-tie fires), and a head tied to `embed` (GPT-2) bakes a second copy into the
+  program while `embed` stays on the host for the token gather."""
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None,
                ane_lm_head: bool = False):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
@@ -278,6 +278,7 @@ class LlamaPrefill:
     self._lmhead_bytes = 1.2e9     # budget: heads above this fall back to host (safety under ~2GB ANE ceiling)
     self._lmhead_compress: str | None = None  # head always fp16; quantizing it degrades logits more than
                                               # an intermediate layer (no residual to absorb the error)
+    self.lmhead_tie_margin = 3e-3  # greedy near-tie (top-2 gap < margin*max|logit|) recomputes on host fp32
 
   def release(self) -> None:
     """Release every compiled program (prefill, decode chunks, batched-prefill chunks, ANE lm_head),
@@ -386,6 +387,17 @@ class LlamaPrefill:
     pr.set_input(lmh["x"], hidden_row.astype(np.float16)[None])
     pr.execute()
     return np.concatenate([np.asarray(pr.read_output(o), np.float32) for o in lmh["outs"]], axis=1)[0]
+
+  def _decode_logits(self, hidden_row, use_ane, greedy):
+    """Step logits with the greedy tie-margin fallback: an ANE-head near-tie recomputes on the host fp32
+    head, so greedy matches the host exactly (see `lmhead_tie_margin`). Sampling stays on the ANE."""
+    use_ane = self.ane_lm_head if use_ane is None else bool(use_ane)
+    logits = self._logits(hidden_row, use_ane)
+    if greedy and use_ane and self._lmh is not None:      # only when the ANE head, not a host fallback, ran
+      p = np.partition(logits, -2)
+      if p[-1] - p[-2] < self.lmhead_tie_margin * (float(np.abs(logits).max()) + 1e-9):
+        logits = self._logits(hidden_row, ane=False)      # host fp32 recompute for this near-tie step
+    return logits
 
   @staticmethod
   def _sample(logits, temperature, top_p, top_k):
@@ -501,7 +513,7 @@ class LlamaPrefill:
     self._pre = {"seq": seq, "chunks": chunks}
     return self._pre
 
-  def _prefill_seed(self, token_ids, pad_to=None, ane: bool | None = None):
+  def _prefill_seed(self, token_ids, pad_to=None, ane: bool | None = None, greedy: bool = True):
     """Batched prefill via the cached chunked prefiller: run the whole prompt in one pass per chunk (full causal
     attention -- the compute-bound matmuls the engine likes) instead of stepping the decode program per token.
     `pad_to` right-pads the prompt to a fixed bucket length so ONE prefiller compile is reused across prompts of
@@ -524,7 +536,7 @@ class LlamaPrefill:
       for li, kport, vport in p["kv"]:                                        # keep only the real positions
         kv_by_layer[li] = (np.asarray(pr.read_output(kport)).astype(f16)[:, :real, :],
                            np.asarray(pr.read_output(vport)).astype(f16)[:, :real, :])
-    return self._logits(h[real - 1].astype(np.float32), ane)[None], kv_by_layer
+    return self._decode_logits(h[real - 1].astype(np.float32), ane, greedy)[None], kv_by_layer
 
   def _seed_cache(self, d, kv_by_layer, seq):
     """Write a batched prefill's per-layer K/V into the resident decode cache buffers (positions [0:seq]), the
@@ -592,7 +604,7 @@ class LlamaPrefill:
                    and all(self._spec(i).mixer == "attention" for i in range(cfg.n_layers)))
     out = []
     if use_batched:                                            # one-pass prefill, then seed the resident cache
-      logits0, kv = self._prefill_seed(prompt, prefill_pad, use_ane)
+      logits0, kv = self._prefill_seed(prompt, prefill_pad, use_ane, temperature <= 0)
       self._seed_cache(d, kv, len(prompt))
       cur = self._sample(logits0[0], temperature, top_p, top_k); out.append(cur)
       if cur in eos: return out
@@ -605,7 +617,7 @@ class LlamaPrefill:
       if pos >= M - 1: break                                   # cache full
       t0 = time.perf_counter() if profiling else 0.0; hidden = step(cur, pos)
       if on_stage is not None: on_stage("step", time.perf_counter() - t0)
-      t0 = time.perf_counter() if profiling else 0.0; logits = self._logits(hidden, use_ane)
+      t0 = time.perf_counter() if profiling else 0.0; logits = self._decode_logits(hidden, use_ane, temperature <= 0)
       if on_stage is not None: on_stage("lm_head", time.perf_counter() - t0)
       t0 = time.perf_counter() if profiling else 0.0; nxt = self._sample(logits, temperature, top_p, top_k)
       if on_stage is not None: on_stage("sample", time.perf_counter() - t0)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -36,11 +36,15 @@ as `generate(..., ane_lm_head=True)`. Measured on an M2 Pro (macOS 26.5.2, fp16)
 | gpt2-medium (vocab 50257, 4 tiles) | 10.8 ms/tok | 3.4 ms/tok | 39.6 tok/s | 59.4 tok/s |
 | Qwen3-0.6B (vocab 151936, 10 tiles) | 30.1 ms/tok | 8.2 ms/tok | 17.8 tok/s | 29.3 tok/s |
 
-It also drops the `_lmT` host allocation (GPT-2: 206 MB, Qwen3-0.6B: 622 MB). The trade-off is fp16
-matmul numerics instead of fp32, so greedy argmax can differ on close ties (it did not on either
-model above, 64/64 tokens); and when the head is tied to `embed`, the ANE program bakes a second
-copy of those weights. The default stays `False` for that reason. `warmup(max_len)` compiles the
-head too when the flag is set on the model, keeping the compile out of the first token.
+It also drops the `_lmT` host allocation (GPT-2: 206 MB, Qwen3-0.6B: 622 MB). The head runs fp16, so a
+greedy argmax could flip against the host fp32 on a close tie; a tie-margin fallback keeps greedy exact
+by recomputing a step on the host fp32 head when the top-2 gap is under `lmhead_tie_margin` (default
+`3e-3`) times the max logit magnitude -- about 6x the measured fp16-head error, firing on ~2-3% of
+tokens. So greedy matches the host (and Hugging Face) exactly while the rest keep ANE speed; the
+recompute builds `_lmT` only if a tie fires, and sampling stays on the ANE. When the head is tied to
+`embed` (GPT-2), the ANE program bakes a second copy of those weights. The default stays `False`,
+mainly because the head compiles on first use (0.4 s GPT-2, 1.8 s Qwen3-0.6B); `warmup(max_len)` moves
+that off the first token.
 
 ## Prefill and decode
 
@@ -174,4 +178,5 @@ Decoder LLMs that run today: dense Llama/Qwen (RMSNorm + RoPE + GQA + SwiGLU), *
 LayerNorm decoder, learned positions, tiled tied lm_head), sparse **Mixture-of-Experts**
 (Qwen3-MoE, Qwen2-MoE), and **hybrid** DeltaNet+attention (Qwen3.5). Runtime features: prefill + resident
 KV-cache decode, automatic segmentation past the ~2 GB program ceiling, int8/int4 weights, and exact
-speculative decoding. Static prompt length per compiled graph; the lm_head projection runs on host.
+speculative decoding. Static prompt length per compiled graph; the lm_head projection runs on host by
+default, or on the ANE with `ane_lm_head` (above).

--- a/tests/test_lm_head.py
+++ b/tests/test_lm_head.py
@@ -162,6 +162,38 @@ def test_lm_head_compile_failure_falls_back():
   np.testing.assert_array_equal(m._logits(h), _host_logits(m, h))
 
 
+def test_decode_logits_tie_margin_fallback():
+  """_decode_logits recomputes a greedy step on the host fp32 head only when the ANE top-2 gap is under
+  lmhead_tie_margin * max|logit| -- so greedy matches the host on ties, keeps ANE speed otherwise, and
+  never falls back while sampling."""
+  m = _random_model(_cfg(100), seed=1)
+  m.ane_lm_head = True
+  m._lmh = object()                                  # pretend the ANE head is live
+  m.lmhead_tie_margin = 3e-3
+  near_tie = np.zeros(100, np.float32); near_tie[0] = 10.0; near_tie[1] = 10.0 - 0.001   # gap 0.001 < 0.03
+  clear = np.zeros(100, np.float32); clear[0] = 10.0                                       # gap 10 >> margin
+  host = np.zeros(100, np.float32); host[1] = 10.0; host[0] = 9.99                         # host prefers idx 1
+  calls = []
+
+  def fake(which):
+    def _f(h, ane=None):
+      calls.append(ane)
+      return which if ane else host
+    return _f
+
+  m._logits = fake(near_tie)                          # near-tie -> ANE then host recompute
+  out = m._decode_logits(np.zeros(m.cfg.dim, np.float32), True, greedy=True)
+  assert calls == [True, False] and int(out.argmax()) == 1     # host's pick wins the tie
+
+  calls.clear(); m._logits = fake(clear)              # clear winner -> ANE only, no host recompute
+  out = m._decode_logits(np.zeros(m.cfg.dim, np.float32), True, greedy=True)
+  assert calls == [True] and int(out.argmax()) == 0
+
+  calls.clear(); m._logits = fake(near_tie)           # sampling -> never falls back, even on a tie
+  m._decode_logits(np.zeros(m.cfg.dim, np.float32), True, greedy=False)
+  assert calls == [True]
+
+
 def test_lm_head_program_dim_mismatch_falls_back():
   """A lm_head whose in-dim disagrees with cfg.dim declines with a clear reason (a raise, not an
   assert, so `python -O` keeps the check) and leaves the host path serving logits."""


### PR DESCRIPTION
Closes #241.

The ANE lm_head added in #240 runs fp16, so its greedy argmax can flip against the host fp32 head only when the top-2 logits sit within fp16-head noise. This adds a tie-margin host fallback so greedy stays exact.

`_decode_logits` computes the ANE logits, and if the greedy top-2 gap is under `lmhead_tie_margin` (default `3e-3`) times the max logit magnitude, recomputes that step on the host fp32 head. The margin is set from measured error: `|ANE - host|` is ~5e-4 of the max logit magnitude across gpt2 (logits ~157) and Qwen3-0.6B (logits ~21), so `3e-3` is about 6x that, with headroom.

Measured on an M5 Pro:

- Qwen3-0.6B and gpt2 greedy now match the host head exactly. Both diverged before this (a genuine near-tie flip, top-2 gap ~0.005 vs fp16 error ~0.005).
- The fallback fires on ~2-3% of tokens, so the rest keep ANE speed. `_lmT` is built only if a tie ever fires; runs with no ties keep the memory win from #240.
- Sampling tolerates the fp16 perturbation and stays on the ANE.

Tests: an off-device unit test for the tie logic (recompute on a near-tie, ANE-only on a clear winner, never during sampling); the existing `requires_ane` greedy-match tests still pass.

The default stays `ane_lm_head=False`. Greedy is now exact, so the remaining reason not to default it on is the first-token compile cost (0.4 s gpt2, 1.8 s Qwen3-0.6B) that every un-warmed `generate` would pay; flipping the default is a follow-up once that is handled (lazy/background compile).
