### PR TITLE
cleanup: tighten Whisper docstrings and README bullet slop

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,14 +30,14 @@ CPU or GPU, and it gives you no way to train there. ANEForge skips it: it compil
 a tensor graph into one ANE program and dispatches that program through the same
 private `aned` stack CoreML, MPSGraph, and Espresso use internally. From there:
 
-- **Training runs on the engine.** The forward pass, the backward pass, and the Adam update all compile to ANE programs.
+- Training runs on the engine. The forward pass, the backward pass, and the Adam update all compile to ANE programs.
 - A CNN trains from scratch on CIFAR-10 to 71%, on a chip Apple ships for inference only.
-- **Hardware layers CoreML can't reach.** `af.sdpa` drives the engine's fused-attention layer directly, the one Apple's compiler decomposes and never emits; 18 other native layers (`argmax`, `topk`, `sort`, geometry) come the same way.
-- **The engine, never a fallback.** A pretrained ResNet-18 runs end-to-end in 0.33 ms, matching the reference to cosine 1.0000, at a fraction of the GPU's energy (table below).
-- **MLPerf, on the engine.** The MLPerf reference ResNet-50 runs pure-ANE and passes the upstream MLCommons `submission_checker` (v5.1, all three edge scenarios VALID) at the reference accuracy (fp16 76.44%, equal to fp32); [one command reproduces it](bench/mlperf).
-- **LLMs run on the engine.** Prefill and KV-cache decode for Llama/Qwen, exact speculative decoding, Mixture-of-Experts from GGUF, and the hybrid Qwen3.5-27B (DeltaNet + attention), decoding end to end on a pure ANE.
-- **Speech-to-text on the engine.** Whisper's audio encoder and its autoregressive text decoder both run on the ANE with resident-KV-cache decode, matching Hugging Face's greedy transcript.
-- **Cross-compilation for chips you don't own.** Lower and gate a graph for any of 28 ANE targets (M1-M5) from one machine, and estimate its latency without running it.
+- Hardware layers CoreML can't reach. `af.sdpa` drives the engine's fused-attention layer directly, the one Apple's compiler decomposes and never emits; 18 other native layers (`argmax`, `topk`, `sort`, geometry) come the same way.
+- The engine, never a fallback. A pretrained ResNet-18 runs end-to-end in 0.33 ms, matching the reference to cosine 1.0000, at a fraction of the GPU's energy (table below).
+- MLPerf, on the engine. The MLPerf reference ResNet-50 runs pure-ANE and passes the upstream MLCommons `submission_checker` (v5.1, all three edge scenarios VALID) at the reference accuracy (fp16 76.44%, equal to fp32); [one command reproduces it](bench/mlperf).
+- LLMs run on the engine. Prefill and KV-cache decode for Llama/Qwen, exact speculative decoding, Mixture-of-Experts from GGUF, and the hybrid Qwen3.5-27B (DeltaNet + attention), decoding end to end on a pure ANE.
+- Speech-to-text on the engine. Whisper's audio encoder and its autoregressive text decoder both run on the ANE with resident-KV-cache decode, matching Hugging Face's greedy transcript.
+- Cross-compilation for chips you don't own. Lower and gate a graph for any of 28 ANE targets (M1-M5) from one machine, and estimate its latency without running it.
 
 ```python
 import aneforge as af
@@ -188,12 +188,12 @@ Reproduce with [`python examples/train_neural_ca.py`](examples/train_neural_ca.p
 
 ## What it does
 
-- **Graph -> compile -> run.** 58 fused operators (conv/pool, `matmul`/`bmm`/`einsum`, activations, reductions, norms, softmax, attention, shape/geometry) into one program with int8/int4/fp16 weights, plus a bridge route for 19 native ops the public toolchain never emits.
-- **Streaming weight compression.** int8, int4-LUT, or sparse weights streamed from the engine's dequant path (~4x smaller for int4), accuracy-gated.
-- **On-device uint8 image input,** dequantized in-graph, so raw camera or video bytes feed the model directly.
-- **Resident state.** KV-cache and optimizer state kept on the engine across steps via buffer aliasing (`share_buffer`).
-- **Accuracy-preserving optimizer.** `af.tune` measures equivalent lowerings on the engine and returns the lossless pick.
-- **Linear algebra and spectral methods.** `aneforge.linalg` and `aneforge.fft` as static-dataflow graphs.
+- Graph -> compile -> run. 58 fused operators (conv/pool, `matmul`/`bmm`/`einsum`, activations, reductions, norms, softmax, attention, shape/geometry) into one program with int8/int4/fp16 weights, plus a bridge route for 19 native ops the public toolchain never emits.
+- Streaming weight compression. int8, int4-LUT, or sparse weights streamed from the engine's dequant path (~4x smaller for int4), accuracy-gated.
+- On-device uint8 image input, dequantized in-graph, so raw camera or video bytes feed the model directly.
+- Resident state. KV-cache and optimizer state kept on the engine across steps via buffer aliasing (`share_buffer`).
+- Accuracy-preserving optimizer. `af.tune` measures equivalent lowerings on the engine and returns the lossless pick.
+- Linear algebra and spectral methods. `aneforge.linalg` and `aneforge.fft` as static-dataflow graphs.
 
 ## What runs
 

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -784,11 +784,9 @@ def load_whisper(name: str = "openai/whisper-base.en") -> "Whisper":
 
 
 class Whisper:
-  """OpenAI Whisper (encoder-decoder ASR) on the ANE. The audio encoder is one fused program run once per
-  clip; the text decoder is one fused single-token program run per greedy step against a resident KV cache
-  (self-attention caches grow on the ANE; each layer's cross-attention K/V over the audio is computed once per
-  clip and held resident). Greedy decoding replicates Hugging Face's forced-prompt and logit-suppression rules,
-  so it matches `generate`. Host-side log-mel and tokenization only. Default `whisper-base.en`.
+  """OpenAI Whisper (encoder-decoder ASR) on the ANE: one fused encoder program per clip, and a single-token
+  decoder program per greedy step against a resident KV cache. Greedy matches HF `generate`. Host-side log-mel
+  and tokenization only. Default `whisper-base.en`. See docs/developer/models.md.
   `.transcribe(audio)` -> str; `.encode(audio)` -> audio features [1500, 512]."""
 
   def __init__(self, name: str = "openai/whisper-base.en") -> None:
@@ -804,8 +802,7 @@ class Whisper:
     self.dec_heads = cfg.decoder_attention_heads
     self.n_mels, self.vocab = cfg.num_mel_bins, cfg.vocab_size
     self.max_dec = cfg.max_target_positions                   # resident KV-cache length (== HF's max decode length)
-    # The decode prompt and logit rules come from the checkpoint's generation config, so a non-.en Whisper gets
-    # the right start tokens and suppressions rather than hardcoded English ids.
+    # decode prompt + logit rules from the generation config, so a non-.en checkpoint gets the right ids
     forced = getattr(gen, "forced_decoder_ids", None) or []
     self.sot = [cfg.decoder_start_token_id] + [int(t) for _, t in sorted(forced)]      # e.g. [sot, notimestamps]
     self.suppress = np.asarray(gen.suppress_tokens or [], dtype=np.int64)              # forced to -inf every step
@@ -851,10 +848,8 @@ class Whisper:
     return np.asarray(self._encoder(mel), np.float32)
 
   def _build_decode_step(self) -> dict:
-    """One fused single-token decode program with a resident KV cache (built once, cached). Self-attention
-    reads/writes a resident `[H, M, dh]` cache via a one-hot positional write (`Kout = Kin*inv + k*oh`, the
-    `_attn_decode` pattern); cross-attention reads resident audio K/V set once per clip; each cache output is
-    aliased back to its input with `share_buffer` so it stays on the ANE across steps. Returns the port map."""
+    """Single-token decode program with a resident KV cache (built once): self-attn one-hot cache write
+    (`Kout = Kin*inv + k*oh`), cross-attn to per-clip audio K/V, caches aliased resident via `share_buffer`."""
     M, D, H, dh = self.max_dec, self.D, self.dec_heads, self.D // self.dec_heads
     scale = 1.0 / dh ** 0.5
     x = input((1, D))                                          # this step's token+position embedding
@@ -895,10 +890,7 @@ class Whisper:
             "cross": [(inm[id(ck)], inm[id(cv)]) for ck, cv in cross]}
 
   def transcribe(self, audio: np.ndarray) -> str:
-    """Greedy transcript of a 16 kHz mono clip, both towers on the ANE. The decoder runs one token per step
-    against a resident KV cache: self-attention caches grow on the ANE, and each layer's cross-attention K/V
-    over the audio is computed once per clip and held resident. Greedy selection applies Hugging Face's forced
-    prompt and logit suppressions, so the transcript matches `generate` (up to `max_dec` tokens)."""
+    """Greedy transcript of a 16 kHz mono clip, both towers on the ANE. Matches HF `generate` up to `max_dec` tokens."""
     if self._decoder is None:
       self._decoder = self._build_decode_step()
     d = self._decoder; prog = d["net"].prog


### PR DESCRIPTION
Two small cleanups.

- models.py: the Whisper class/method docstrings repeated the same resident-cache / cross-attn / suppression explanation three times; trimmed to one-liners that point at docs/developer/models.md, and shortened a two-line config comment. No code change.
- README.md: dropped the bold lead-ins from the two feature-bullet lists (intro highlights and "What it does"), so they read as plain sentences. Kept the tagline, the Status/roofline callouts, and the comparison table's row highlighting, which are structural rather than emphasis.