### PR TITLE
llm: default the ANE lm_head on, with an execute-path host fallback

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -262,12 +262,12 @@ class LlamaPrefill:
   `prefill(token_ids)` returns next-token logits; `generate(...)` does resident-KV-cache decode. Weights are
   a dict of numpy arrays (see `from_pretrained`). The host `lm_head` keeps a cached fp32 transpose
   (`_lmT`): for large vocabularies this is the runner's biggest host allocation (GPT-2 ~206 MB, a
-  151936x4096 head ~2.5 GB), freed by `release()`. With `ane_lm_head=True`, the head runs on the ANE
-  as a tiled `compile_multi`; greedy stays exact via the `lmhead_tie_margin` host fallback (so `_lmT`
-  is built only if a near-tie fires), and a head tied to `embed` (GPT-2) bakes a second copy into the
-  program while `embed` stays on the host for the token gather."""
+  151936x4096 head ~2.5 GB), freed by `release()`. By default (`ane_lm_head`) the head runs on the ANE
+  as a tiled `compile_multi` instead; greedy stays exact via the `lmhead_tie_margin` host fallback (so
+  `_lmT` is built only if a near-tie fires), and a head tied to `embed` (GPT-2) bakes a second copy into
+  the program while `embed` stays on the host for the token gather. `ane_lm_head=False` forces the host."""
   def __init__(self, cfg: LlamaConfig, weights: dict, compress: str | None = None,
-               ane_lm_head: bool = False):
+               ane_lm_head: bool = True):
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
     self._chunk_bytes = 1.6e9      # max fp16 weight bytes per decode program (under the ~2GB ANE ceiling)
@@ -341,7 +341,11 @@ class LlamaPrefill:
     if self.ane_lm_head if ane is None else ane:      # per-call override wins, attribute otherwise
       lmh = self._lm_head_program()
       if lmh is not None:
-        return self._ane_logits(lmh, hidden_row)
+        try:
+          return self._ane_logits(lmh, hidden_row)
+        except Exception as e:                        # execute failed -> decline to host, never break generate
+          self._lmh_off = True; lmh["net"].release(); self._lmh = None
+          warnings.warn(f"ANE lm_head execute failed, using the host matmul: {e}")
     lm = self._lmT
     if lm is None:
       # Build once: NumPy has no fp16 BLAS, and a live `.T` view is strided, so a per-call
@@ -780,11 +784,11 @@ def _assert_dense_compatible(c) -> None:
       f"(model_type 'gemma'), and MoE. See docs/llm.md.")
 
 
-def from_pretrained(name: str, compress: str | None = None, ane_lm_head: bool = False) -> LlamaPrefill:
+def from_pretrained(name: str, compress: str | None = None, ane_lm_head: bool = True) -> LlamaPrefill:
   """Load a decoder LM from Hugging Face for ANE inference: dense Llama/Qwen/Mistral, Gemma, and MoE
   (an unsupported arch is rejected, not silently mis-loaded). `compress` ("int8"/"int4"/"blockwise")
-  quantizes the ANE weights. `ane_lm_head` runs the head on the ANE instead of the host (see
-  `LlamaPrefill`)."""
+  quantizes the ANE weights. `ane_lm_head` (default True) runs the head on the ANE; `False` forces the
+  host matmul (see `LlamaPrefill`)."""
   import torch
   from transformers import AutoModelForCausalLM
   hf = AutoModelForCausalLM.from_pretrained(name)

--- a/docs/llm.md
+++ b/docs/llm.md
@@ -27,9 +27,10 @@ logits = model.prefill(prompt_ids)                # next-token logits [1, vocab]
 
 ### lm_head on the ANE
 
-`ane_lm_head=True` (default `False`) runs the lm_head on the ANE as a `compile_multi` tiled along
-vocab, instead of the host fp32 matmul. Pass it to `af.load_llm` or `af.LlamaPrefill`, or per call
-as `generate(..., ane_lm_head=True)`. Measured on an M2 Pro (macOS 26.5.2, fp16), median of 3 runs:
+`ane_lm_head` (default `True`) runs the lm_head on the ANE as a `compile_multi` tiled along vocab,
+instead of the host fp32 matmul. Pass `ane_lm_head=False` to `af.load_llm` or `af.LlamaPrefill`, or per
+call as `generate(..., ane_lm_head=False)`, to force the host matmul. Measured on an M2 Pro (macOS
+26.5.2, fp16), median of 3 runs:
 
 | model | lm_head host | lm_head ANE | decode host | decode ANE |
 |---|---|---|---|---|
@@ -41,10 +42,12 @@ greedy argmax could flip against the host fp32 on a close tie; a tie-margin fall
 by recomputing a step on the host fp32 head when the top-2 gap is under `lmhead_tie_margin` (default
 `3e-3`) times the max logit magnitude -- about 6x the measured fp16-head error, firing on ~2-3% of
 tokens. So greedy matches the host (and Hugging Face) exactly while the rest keep ANE speed; the
-recompute builds `_lmT` only if a tie fires, and sampling stays on the ANE. When the head is tied to
-`embed` (GPT-2), the ANE program bakes a second copy of those weights. The default stays `False`,
-mainly because the head compiles on first use (0.4 s GPT-2, 1.8 s Qwen3-0.6B); `warmup(max_len)` moves
-that off the first token.
+recompute builds `_lmT` only if a tie fires, and sampling stays on the ANE (softmax shifts by ~2e-3, so
+sampling is unaffected). If the head compiles but fails to execute -- e.g. `ANEFORGE_TARGET` set above
+the host family -- it declines to the host matmul rather than breaking `generate`. When the head is tied
+to `embed` (GPT-2), the ANE program bakes a second copy of those weights. The head compiles on first use
+(0.4 s GPT-2, 1.8 s Qwen3-0.6B, ~15% of the decode-program compile that first token already pays);
+`warmup(max_len)` moves it off the first token.
 
 ## Prefill and decode
 

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -38,7 +38,8 @@ def make_random_llama_model(cfg, compress=None, seed=0):
                    ("mlp.gate_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.up_proj", (cfg.ffn_dim, cfg.dim)), ("mlp.down_proj", (cfg.dim, cfg.ffn_dim))]:
       sd[p + nm + ".weight"] = R(*sh)
     sd[p + "input_layernorm.weight"] = np.ones(cfg.dim, np.float32); sd[p + "post_attention_layernorm.weight"] = np.ones(cfg.dim, np.float32)
-  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), compress=compress)
+  # host lm_head for a deterministic fp32 baseline; ANE-head tests opt in with m.ane_lm_head = True
+  return LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), compress=compress, ane_lm_head=False)
 
 
 def ane_available() -> bool:

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -99,7 +99,7 @@ def test_logits_caches_contiguous_fp32():
   rng = np.random.default_rng(0)
   cfg = LlamaConfig(dim=16, n_layers=2, n_heads=4, n_kv_heads=4, ffn_dim=64, vocab=100)
   w = {"lm_head": rng.standard_normal((100, 16)).astype(np.float16), "layers": []}
-  model = LlamaPrefill(cfg, w)
+  model = LlamaPrefill(cfg, w, ane_lm_head=False)    # this test is about the host fp32 transpose cache
   h = rng.standard_normal(16).astype(np.float32)
   expected = h @ np.asarray(w["lm_head"]).T          # the pre-cache matmul, unchanged numerics
   assert np.array_equal(model._logits(h), expected)

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -111,7 +111,7 @@ def test_prefill_matches_huggingface_llama():  # the definitive check: ANE prefi
   toks = np.random.default_rng(0).integers(0, 64, 10)
   with torch.no_grad(): ref = m(torch.tensor(toks)[None]).logits[0, -1].numpy()
   cfg = _cfg_from_hf(m.config); sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
-  ane = np.asarray(LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg)).prefill(toks)).ravel().astype(np.float32)
+  ane = np.asarray(LlamaPrefill(cfg, _weights_from_state_dict(sd, cfg), ane_lm_head=False).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"
 
@@ -129,7 +129,7 @@ def test_prefill_matches_huggingface_gemma():  # the Gemma adapter: embed scale,
   with torch.no_grad(): ref = m(torch.tensor(toks)[None]).logits[0, -1].numpy()
   sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
   cfg, w = _gemma_adapter(m.config, sd)
-  ane = np.asarray(LlamaPrefill(cfg, w).prefill(toks)).ravel().astype(np.float32)
+  ane = np.asarray(LlamaPrefill(cfg, w, ane_lm_head=False).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE Gemma prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"
 
@@ -147,7 +147,7 @@ def test_prefill_matches_huggingface_mistral():  # the Mistral adapter: GQA + sl
   sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
   cfg, w = _mistral_adapter(m.config, sd)
   assert cfg.extra["sliding_window"] == 32, "sliding window must be surfaced in cfg.extra"
-  ane = np.asarray(LlamaPrefill(cfg, w).prefill(toks)).ravel().astype(np.float32)
+  ane = np.asarray(LlamaPrefill(cfg, w, ane_lm_head=False).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE Mistral prefill vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"
 

--- a/tests/test_lm_head.py
+++ b/tests/test_lm_head.py
@@ -111,6 +111,27 @@ def test_lm_head_program_is_built_once():
     assert cm.call_count == 1
 
 
+def test_ane_lm_head_defaults_on():
+  """load_llm / LlamaPrefill default to the ANE head."""
+  from aneforge.llm import LlamaPrefill
+  assert LlamaPrefill(_cfg(100), {}).ane_lm_head is True
+
+
+def test_ane_lm_head_execute_failure_falls_back():
+  """If the ANE head compiles but execute raises, _logits declines to host and never breaks generate."""
+  m = _random_model(_cfg(100), seed=42)
+  m.ane_lm_head = True
+  h = np.random.default_rng(3).standard_normal(m.cfg.dim).astype(np.float32)
+  with patch("aneforge._compile.compile_multi", side_effect=_make_mock_net), \
+       patch.object(type(m), "_ane_logits", side_effect=RuntimeError("execute boom")):
+    with warnings.catch_warnings(record=True) as w:
+      warnings.simplefilter("always")
+      out = m._logits(h, ane=True)
+    assert len([x for x in w if "execute failed" in str(x.message)]) == 1
+  np.testing.assert_array_equal(out, _host_logits(m, h))
+  assert m._lmh_off is True and m._lmh is None
+
+
 def test_logits_host_path_unchanged_when_flag_off():
   """With ane_lm_head=False, _logits never builds _lmh and returns h @ lm_head.T fp32 bit-identical."""
   m = _random_model(_cfg(100, dim=16), seed=0)

--- a/tests/test_moe.py
+++ b/tests/test_moe.py
@@ -86,6 +86,6 @@ def test_moe_prefill_matches_huggingface():  # definitive: ANE MoE model (adapte
   sd = {k: v.detach().float().numpy() for k, v in m.state_dict().items()}
   cfg, weights = _moe_adapter(m.config, sd)
   assert [ls.mlp for ls in cfg.layers] == ["moe", "moe"]      # both layers routed (decoder_sparse_step=1)
-  ane = np.asarray(LlamaPrefill(cfg, weights).prefill(toks)).ravel().astype(np.float32)
+  ane = np.asarray(LlamaPrefill(cfg, weights, ane_lm_head=False).prefill(toks)).ravel().astype(np.float32)
   cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
   assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"ANE MoE vs HF cosine={cos}, argmax {ane.argmax()} vs {ref.argmax()}"


### PR DESCRIPTION
Defaults `ane_lm_head` to True and closes the execute-path fallback gap, following the audit of what stood between the tie-margin fallback (#243) and defaulting the ANE head on.

The audit found two of the three concerns didn't hold up. The first-token compile cost is only ~15% of the decode-program compile every first `generate` already pays (0.28s vs 1.69s on gpt2, 0.73s vs 6.36s on Qwen3-0.6B). The sampling perturbation is max |softmax(host) - softmax(ANE)| = 1.9e-3 at temperature 1.0, far below what temperature or top-p do. With greedy already exact from #243, neither justifies keeping the default off.

The one real gap was the execute path: the #240 fallback caught compile failures but not execute failures, so a head that compiles but fails to execute (the `ANEFORGE_TARGET`-above-host misconfig) would crash `generate`. `_logits` now wraps the ANE execute and declines to the host matmul on failure, releasing the program and warning once, matching the compile-fail path.

Changes:
- Execute-path host fallback in `_logits`.
- `ane_lm_head` defaults to True in `LlamaPrefill` and `from_pretrained`.
- Tests default to the host head where they want a deterministic fp32 baseline (`make_random_llama_model`, the prefill-vs-HF checks, the MoE check, the `_lmT`-cache test). Added off-device tests for the new default and the execute fallback.

Validated on an M5 Pro: `load_llm` greedy matches the host head exactly on gpt2 and Qwen3-0.6B; off-device suite 381 passed; on-device test_llm/moe/qwen35/speculative/resident/streaming all pass.
