### PR TITLE
readme: add a lines-of-code badge

### DIFF
--- a/.github/badges/loc.json
+++ b/.github/badges/loc.json
@@ -1,0 +1,1 @@
+{"schemaVersion":1,"label":"lines of code","message":"38.5k","color":"2e6b69"}

--- a/.github/badges/loc.json
+++ b/.github/badges/loc.json
@@ -1,1 +1,1 @@
-{"schemaVersion":1,"label":"lines of code","message":"38.5k","color":"2e6b69"}
+{"schemaVersion":1,"label":"lines of code","message":"16.8k","color":"2e6b69"}

--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -1,0 +1,35 @@
+# Refresh the lines-of-code badge (.github/badges/loc.json, a shields.io endpoint).
+# Recounts with cloc on each push to main and commits the JSON only when the rounded
+# number changes. Best-effort: if the push is blocked, the badge stays at its last value.
+name: LOC badge
+
+on:
+  push:
+    branches: [main]
+    paths-ignore: [".github/badges/loc.json"]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  loc:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Count and write the badge JSON
+        run: |
+          sudo apt-get update -qq && sudo apt-get install -y -qq cloc
+          code=$(cloc --quiet --json --include-lang=Python,"C/C++ Header","C++",Objective-C,"Objective-C++" \
+                   aneforge tests examples bench | python3 -c "import sys,json; print(json.load(sys.stdin)['SUM']['code'])")
+          msg=$(awk "BEGIN{printf \"%.1fk\", $code/1000}")
+          printf '{"schemaVersion":1,"label":"lines of code","message":"%s","color":"2e6b69"}\n' "$msg" \
+            > .github/badges/loc.json
+          echo "lines of code: $code -> $msg"
+      - name: Commit if changed
+        continue-on-error: true
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add .github/badges/loc.json
+          git diff --cached --quiet || { git commit -m "chore: update lines-of-code badge [skip ci]"; git push; }

--- a/.github/workflows/loc.yml
+++ b/.github/workflows/loc.yml
@@ -21,7 +21,7 @@ jobs:
         run: |
           sudo apt-get update -qq && sudo apt-get install -y -qq cloc
           code=$(cloc --quiet --json --include-lang=Python,"C/C++ Header","C++",Objective-C,"Objective-C++" \
-                   aneforge tests examples bench | python3 -c "import sys,json; print(json.load(sys.stdin)['SUM']['code'])")
+                   aneforge | python3 -c "import sys,json; print(json.load(sys.stdin)['SUM']['code'])")
           msg=$(awk "BEGIN{printf \"%.1fk\", $code/1000}")
           printf '{"schemaVersion":1,"label":"lines of code","message":"%s","color":"2e6b69"}\n' "$msg" \
             > .github/badges/loc.json

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Website](https://img.shields.io/badge/web-aneforge.com-2e6b69.svg)](https://aneforge.com)
 [![CI](https://github.com/sbryngelson/ANEForge/actions/workflows/ci.yml/badge.svg)](https://github.com/sbryngelson/ANEForge/actions/workflows/ci.yml)
 [![PyPI](https://img.shields.io/pypi/v/aneforge?color=2e6b69)](https://pypi.org/project/aneforge/)
+[![Lines of code](https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fsbryngelson%2FANEForge%2Fmain%2F.github%2Fbadges%2Floc.json)](#)
 [![Docs](https://readthedocs.org/projects/aneforge/badge/?version=latest)](https://aneforge.readthedocs.io)
 [![arXiv](https://img.shields.io/badge/arXiv-2606.17090-b31b1b.svg)](https://arxiv.org/abs/2606.17090)
 [![ANE guide](https://img.shields.io/badge/ANE%20guide-arXiv%202606.22283-b31b1b.svg)](https://arxiv.org/abs/2606.22283)


### PR DESCRIPTION
Adds a lines-of-code badge to the README badge row, counting the `aneforge` package source only.

The live LOC badge services are all unreliable right now (shields' tokei endpoint 404s, tokei.rs is unreachable, codetabs returns 522), so a third-party badge would render "inaccessible". Instead this is self-hosted: cloc counts the source into a shields endpoint JSON at .github/badges/loc.json, and .github/workflows/loc.yml recounts on each push to main and commits the JSON only when the rounded number changes. It renders in the repo's badge color and degrades to static if the refresh push is ever blocked.

Currently 16.8k lines of code (Python + Objective-C++ in aneforge/). The badge only shows once this is on main (the endpoint reads the raw file from main).