### PR TITLE
cleanup: remove dead code and dedup two helpers

### DIFF
--- a/aneforge/_optimize.py
+++ b/aneforge/_optimize.py
@@ -559,34 +559,6 @@ def tune(out, budget: int = 8, inputs=None, prune_factor: float = 1.5,
   return build_variant(out, best_cfg)
 
 
-def tune_report(out, budget: int = 8, inputs=None, reps: int = 20):
-  """Like tune() but returns a structured report dict instead of a Model (always measures, never caches)."""
-  input_shapes = _input_shapes(out)
-  if inputs is None: inputs = _gen_inputs(input_shapes)
-  configs = _variants(out)
-  ranked = ([c for c in configs if not c.get("lossy")] +
-            [c for c in configs if c.get("lossy")])
-
-  baseline_out = None
-  rows = []
-  for cfg in ranked:
-    est = _estimate_variant(out, cfg)
-    us, out_arr = measure(out, inputs, cfg, baseline_out=baseline_out, reps=reps)
-    if baseline_out is None and out_arr is not None: baseline_out = out_arr
-    rows.append({"config": cfg, "label": _config_label(cfg), "est_us": est,
-                 "meas_us": us, "correct": us != float("inf")})
-
-  correct = [r for r in rows if r["correct"]]
-  baseline = next((r for r in rows if not r["config"].get("lossy")), None)
-  winner = min(correct, key=lambda r: r["meas_us"]) if correct else baseline
-  speedup = None
-  if baseline and winner and baseline["meas_us"] not in (None, float("inf")) and \
-      winner["meas_us"] not in (None, float("inf")):
-    speedup = baseline["meas_us"] / winner["meas_us"]
-  return {"rows": rows, "n_variants": len(rows), "baseline": baseline,
-          "winner": winner, "speedup": speedup, "baseline_out": baseline_out}
-
-
 # precision-aware tune: given an explicit error budget, select the numerics-aware #
 # rewrite set that meets it at minimum cost (accuracy vs an fp32 reference).
 def _f16(x):  # fp16 rounding of operands/products, wide accum

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -17,16 +17,10 @@ f16 = np.float16
 def _ane_gemm(A16: np.ndarray, B16: np.ndarray, transpose_a: bool = False) -> np.ndarray:
   """C = A @ B (or A^T @ B) on the ANE; B folds in as a weight."""
   A16 = A16.astype(f16); B16 = B16.astype(f16)
-  if transpose_a:
-    m, n = A16.shape
-    At = af.input((m, n))
-    net = af.compile(At.transpose([1, 0]) @ B16)   # [n,m] @ [m,k]
-    C = net(A16)
-  else:
-    m, n = A16.shape
-    At = af.input((m, n))
-    net = af.compile(At @ B16)                     # [m,n] @ [n,k]
-    C = net(A16)
+  m, n = A16.shape
+  At = af.input((m, n))
+  net = af.compile(At.transpose([1, 0]) @ B16 if transpose_a else At @ B16)   # [n,m]@[m,k] or [m,n]@[n,k]
+  C = net(A16)
   net.release()
   return np.asarray(C, f16)
 

--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -180,9 +180,7 @@ def _gelu_mlp(h: Tensor, w: dict, cfg: LlamaConfig, ls: LayerSpec) -> Tensor:
   hn = (h.layer_norm(w["mlp_norm_w"], w["mlp_norm_b"], cfg.norm_eps)
         if cfg.norm_type == "layer" else h.rms_norm(w["mlp_norm"], cfg.norm_eps))
   g = hn.linear(w["wfc"], w.get("fc_bias"))
-  inner = (g + g.pow(3.0) * 0.044715) * np.sqrt(2.0 / np.pi)
-  act = (g * 0.5) * inner.tanh().adds(1.0)
-  return h + act.linear(w["wproj"], w.get("proj_bias"))
+  return h + _gelu_tanh(g).linear(w["wproj"], w.get("proj_bias"))
 
 def _gelu_tanh(x: Tensor) -> Tensor:
   """PyTorch 'tanh' GELU (Gemma's `gelu_pytorch_tanh`), built out of primitive math ops rather than the

--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -8,7 +8,7 @@ import numpy as np
 
 from .graph import Tensor, concat, conv, input, mha, space_to_depth, _const
 from .autograd import conv2d, conv_param, parameter
-from ._compile import Model, SegmentedModel, MultiModel, compile, compile_multi
+from ._compile import Model, SegmentedModel, compile, compile_multi
 from . import _targets
 
 _NORM_CACHE: dict[int, Model | SegmentedModel] = {}
@@ -479,28 +479,6 @@ def load_gpt2(name: str, int8: bool = False, max_layers: int | None = None) -> "
   return GPT2(name, int8=int8, max_layers=max_layers)
 
 
-def _gpt2_layers(sd: dict, L: int, D: int, Dff: int) -> list[dict]:
-  """Per-layer weight maps from a HF GPT-2 state dict. GPT-2 projections are Conv1D
-  (`[in, out]`): transpose each so `.linear()` (x @ W.T with W `[out, in]`) consumes it,
-  and split the c_attn rows into q/k/v. LayerNorm and embedding tensors are NOT transposed."""
-  layers = []
-  for i in range(L):
-    p = f"transformer.h.{i}."
-    Wqkv = sd[p + "attn.c_attn.weight"].T                # [3D, D]
-    bqkv = sd[p + "attn.c_attn.bias"]
-    layers.append({
-      "ln1w": sd[p + "ln_1.weight"], "ln1b": sd[p + "ln_1.bias"],
-      "Wq": Wqkv[:D], "bq": bqkv[:D],
-      "Wk": Wqkv[D:2 * D], "bk": bqkv[D:2 * D],
-      "Wv": Wqkv[2 * D:3 * D], "bv": bqkv[2 * D:3 * D],
-      "Wo": sd[p + "attn.c_proj.weight"].T, "bo": sd[p + "attn.c_proj.bias"],
-      "ln2w": sd[p + "ln_2.weight"], "ln2b": sd[p + "ln_2.bias"],
-      "Wi": sd[p + "mlp.c_fc.weight"].T, "bi": sd[p + "mlp.c_fc.bias"],          # [Dff, D]
-      "Wd": sd[p + "mlp.c_proj.weight"].T, "bd": sd[p + "mlp.c_proj.bias"],      # [D, Dff]
-    })
-  return layers
-
-
 def _whisper_layers(sd: dict, prefix: str, n: int) -> list[dict]:
   """Per-layer numpy weights for the Whisper encoder/decoder graphs. HF linear weights are [out, in]
   and used as-is by `.linear()`. Whisper's k_proj carries no bias, so bk/Cbk are omitted. A decoder
@@ -526,31 +504,16 @@ def _whisper_layers(sd: dict, prefix: str, n: int) -> list[dict]:
   return out
 
 
-def _gelu_new(x: Tensor) -> Tensor:
-  """GPT-2's tanh-approximated GELU, composed from native ops (mirrors the ONNX
-  `approximate="tanh"` handler, aneforge/onnx.py:352-360)."""
-  inner = (x + x.pow(3.0) * 0.044715) * np.sqrt(2.0 / np.pi)
-  return (x * 0.5) * inner.tanh().adds(1.0)
-
-
 def _lm_head_tiles(h: Tensor, wte: np.ndarray) -> list[Tensor]:
   """Tied lm_head logits = h @ wte.T, tiled along vocab so no matmul output dim exceeds the
   target family's max tensor dimension. Returns a LIST of tiles, never a concatenated [S, vocab]
   tensor: the concat itself exceeds the family-3 cap (the #183 lesson). The tiles are the head's
-  output ports; stitching is host-side via `_logits_from`."""
+  output ports; callers concatenate them host-side."""
   V = wte.shape[0]
   tile = _targets.limit("max_tensor_dim", _targets.detect_family())
   if V <= tile:
     return [h.linear(wte)]
   return [h.linear(wte[i:i + tile]) for i in range(0, V, tile)]
-
-
-def _logits_from(net: MultiModel | Model, out) -> np.ndarray:
-  """Reassemble a tiled lm_head result into [S, vocab] host-side (the tiles are what the
-  ANE produced; concatenating here does not change the numerics)."""
-  if not isinstance(net, MultiModel):
-    return np.asarray(out, np.float32)
-  return np.concatenate([np.asarray(out[name], np.float32) for _, name in net.output_ports], axis=1)
 
 
 class GPT2:

--- a/tests/test_gpt2.py
+++ b/tests/test_gpt2.py
@@ -9,7 +9,7 @@ import pytest
 import aneforge as af
 import aneforge.models as models
 from aneforge._compile import _lower_fused_to_dir
-from aneforge.models import _gpt2_layers, _gelu_new, _lm_head_tiles, GPT2
+from aneforge.models import _lm_head_tiles, GPT2
 from aneforge.llm import _gpt2_adapter, LlamaConfig, LlamaPrefill, ModelType
 from _helpers import requires_ane
 
@@ -36,30 +36,6 @@ def _synthetic_sd(D=16, H=4, L=2, V=100):
     sd[p + "mlp.c_proj.weight"] = np.arange(Dff * D, dtype=np.float32).reshape(Dff, D)
     sd[p + "mlp.c_proj.bias"] = np.zeros(D, np.float32)
   return sd
-
-
-def test_gpt2_conv1d_mapping_orientation():
-  """Conv1D weights are `[in, out]`; the loader transposes to `[out, in]` for `.linear()` and
-  splits c_attn rows into q/k/v -- so Wq[0] must equal c_attn.weight[:, 0]."""
-  D = 16
-  layers = _gpt2_layers(_synthetic_sd(), L=2, D=D, Dff=64)
-  assert len(layers) == 2
-  w = layers[1]
-  c = _synthetic_sd()
-  i = 1
-  p = f"transformer.h.{i}."
-  # rows of the transposed c_attn weight, one [D, D] block per of q/k/v
-  assert w["Wq"].shape == (D, D) and w["Wk"].shape == (D, D) and w["Wv"].shape == (D, D)
-  assert np.array_equal(w["Wq"], c[p + "attn.c_attn.weight"].T[:D])
-  assert np.array_equal(w["Wk"], c[p + "attn.c_attn.weight"].T[D:2 * D])
-  assert np.array_equal(w["Wv"], c[p + "attn.c_attn.weight"].T[2 * D:3 * D])
-  assert np.array_equal(w["Wo"], c[p + "attn.c_proj.weight"].T)
-  assert w["Wi"].shape == (64, D) and np.array_equal(w["Wi"], c[p + "mlp.c_fc.weight"].T)
-  assert w["Wd"].shape == (D, 64) and np.array_equal(w["Wd"], c[p + "mlp.c_proj.weight"].T)
-  # biases are split, not transposed
-  assert np.array_equal(w["bq"], c[p + "attn.c_attn.bias"][:D])
-  assert np.array_equal(w["bk"], c[p + "attn.c_attn.bias"][D:2 * D])
-  assert np.array_equal(w["bv"], c[p + "attn.c_attn.bias"][2 * D:3 * D])
 
 
 def test_gpt2_lm_head_tiles_shapes(monkeypatch):
@@ -118,12 +94,6 @@ def test_gpt2_generate_text_decodes_generated_tokens():
   assert g.generate_text("prompt", max_new_tokens=2) == " generated text"
   g.generate.assert_called_once_with("prompt", 2)
   g.tok.decode.assert_called_once_with([17, 42])
-
-
-def test_gpt2_gelu_new_lowers():
-  """The gelu_new composition (mirror of the ONNX tanh handler) lowers with only native ops."""
-  x = af.input((4, 64))
-  _lower_fused_to_dir(_gelu_new(x), None)
 
 
 def test_gpt2_tiled_head_lowers():


### PR DESCRIPTION
Removes verified-dead code and two small duplications found in the LOC audit. Net -73 library lines, no functional or readability loss.

Dead code (zero callers, checked across aneforge/, tests/, examples/, and the registries):
- `models.py`: `_logits_from` (no callers), `_gpt2_layers` and `_gelu_new` (reachable only from their own tests; the production GPT-2 path is `llm._gpt2_adapter`, and `_gelu_new`'s tanh-GELU formula already lives in `onnx._gelu`, `llm._gelu_mlp`, and `llm._gelu_tanh`). The two dead tests are dropped with them. Also drops the now-unused `MultiModel` import.
- `_optimize.py`: `tune_report` (never imported, exported, tested, or dispatched).

Behavior-neutral dedups (verified on-device):
- `llm._gelu_mlp` calls the existing `_gelu_tanh` instead of re-inlining the identical formula.
- `linalg._ane_gemm` folds its two branches into one `af.compile` of the same per-branch expression (checked both paths, cosine ~1.0).

Not touched (audit flagged as risky or low-value): the `onnx._pad_hw` pairwise-concat form (deliberate, avoids a lowering failure when axes stack), and the per-layer weight-mapping helpers (shapes diverge too much for a clean shared helper).

Off-device suite 379 passed (381 minus the 2 dead tests); ruff and pyright clean.