### PR TITLE
warn on compress= fallback to wider encoding

### DIFF
--- a/aneforge/__init__.py
+++ b/aneforge/__init__.py
@@ -22,7 +22,7 @@ from .graph import (Tensor, affine, batch_norm, batch_to_space, channel_to_space
                     space_to_channel, space_to_depth, split, sort, stack, topk,
                     upsample_bilinear, where)
 from ._compile import (Model, SegmentedModel, compile, PrecisionWarning,
-                       CrossChipFP16Warning, DispatchFloorWarning)
+                       CrossChipFP16Warning, DispatchFloorWarning, CompressionFallbackWarning)
 from ._paired import Paired, paired
 from ._optimize import tune, tune_precision, tune_attention, attention_tiles
 from ._cost import estimate, estimate_provenance, precision_risk, project_peak
@@ -39,7 +39,7 @@ from . import moe as moe   # registers the "moe" MLP + Qwen3-MoE adapter into th
 
 __all__ = [
     "Tensor", "Model", "SegmentedModel", "PrecisionWarning", "CrossChipFP16Warning",
-    "DispatchFloorWarning",
+    "DispatchFloorWarning", "CompressionFallbackWarning",
     "input", "image_input", "conv", "conv_transpose", "dynamic_conv", "concat",
     "batch_norm", "maximum", "minimum", "mha", "cross_attention", "geglu", "sdpa",
     "pixel_shuffle", "pixel_unshuffle", "topk", "sort", "cross_product",

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -76,6 +76,8 @@ class _Emitter:
     self.blob = BlobWriter()
     self.lines: list[str] = []
     self._split_cache: dict = {}       # (src, num_splits, axis) -> emitted part names, so split is emitted once
+    self._n_weights = 0
+    self._n_rejected: dict[str, int] = {}   # encoding -> count of weights that fell through
 
   def line(self, text: str) -> None:
     self.lines.append("        " + text)
@@ -113,6 +115,7 @@ class _Emitter:
     """Declare a constant weight; precedence sparse -> int4-LUT -> per-channel int8 -> fp16."""
     path = '@model_path/weights.bin'
     W2 = W.reshape(W.shape[0], -1)
+    self._n_weights += 1
     _auto = self.compress == "auto"
     if (self.compress == "sparse" or (_auto and "sparse" in self._auto_streams)) and allow_sparse:
       mask, vals = sparsify(W2)
@@ -128,6 +131,7 @@ class _Emitter:
              f'nonzero_data = {name}_nz, mask = {name}_mask)[name = string("{name}")];')
         return name
       # else: fall through to int8/fp16
+      self._n_rejected["sparse"] = self._n_rejected.get("sparse", 0) + 1
     if (self.compress == "int4" or (_auto and "int4" in self._auto_streams)) \
         and allow_int4 and W2.shape[1] % 2 == 0:
       packed, lut = palettize_lut4(W2)
@@ -146,6 +150,7 @@ class _Emitter:
              f'indices = {name}_idx, lut = {name}_lut)[name = string("{name}")];')
         return name
       # else: fall through to int8/fp16
+      self._n_rejected["int4"] = self._n_rejected.get("int4", 0) + 1
     if self.compress == "blockwise" and allow_int8:
       data, scale, nblocks = quantize_blockwise(W2, self.block_size)
       if self._blockwise_rel_error(W2, data, scale, nblocks) <= self.compress_atol:
@@ -162,6 +167,7 @@ class _Emitter:
         self.line(f'{self.ty(W.shape)} {name} = add(x = {name}_bw, y = {name}_bz)[name = string("{name}")];')
         return name
       # else: fall through to int8/fp16
+      self._n_rejected["blockwise"] = self._n_rejected.get("blockwise", 0) + 1
     use_int8 = int8 if int8 is not None else (
       self.int8 or self.compress == "int4" or (_auto and "int8" in self._auto_streams))
     if use_int8 and allow_int8:
@@ -996,6 +1002,7 @@ def compile_multi(outs, build_dir=None, int8: bool = False, compress: str | None
   em = _Emitter(int8, compress=compress, compress_atol=compress_atol, block_size=block_size)
   for t in order:
     if t.op != "input": _EMIT[t.op](em, t, t._name, [src._name for src in t.srcs])
+  _compression_fallback_signal(em)
 
   out_vars = ", ".join(o._name for o in outs)
   d = _emit_program_dir(em, inputs, out_vars, None, build_dir)
@@ -1037,6 +1044,25 @@ def _dispatch_floor_signal(out: Tensor) -> None:
      "toward the compute rate) or chain more ops into one program (share_buffer keeps state "
      "resident). Silence: filter aneforge.DispatchFloorWarning.")
   warnings.warn(msg, DispatchFloorWarning, stacklevel=3)
+
+
+class CompressionFallbackWarning(UserWarning):
+  """Emitted by `compile` when `compress=` rejects weights and falls back to a wider encoding."""
+
+
+def _compression_fallback_signal(em: _Emitter) -> None:
+  """Warn if any requested-compression weights were rejected and fell through."""
+  if not em._n_rejected: return
+  import warnings
+  requested = em.compress
+  total_rejected = sum(em._n_rejected.values())
+  detail = ", ".join(f"{enc}: {n}" for enc, n in sorted(em._n_rejected.items()))
+  applied = "int8" if em.int8 or requested == "int4" else "fp16"
+  msg = (f"aneforge.compile: compress={requested!r} rejected {total_rejected}/{em._n_weights} "
+     f"weights ({detail}); applied {applied}. "
+     f"To widen the tolerance, raise compress_atol (currently {em.compress_atol}). "
+     "Silence: filter aneforge.CompressionFallbackWarning.")
+  warnings.warn(msg, CompressionFallbackWarning, stacklevel=3)
 
 
 def _precision_signal(out: Tensor, strict: bool) -> None:
@@ -1340,6 +1366,7 @@ def compile(out: Tensor, int8: bool = False, build_dir=None, opt: "str | int | N
   em = _Emitter(int8, compress=compress, compress_atol=compress_atol, block_size=block_size, family=family)
   for t in order:
     if t.op != "input": _EMIT[t.op](em, t, t._name, [src._name for src in t.srcs])
+  _compression_fallback_signal(em)
 
   prog = _assemble_and_compile(em, inputs, out._name, out.shape, build_dir)
   n_ops = sum(1 for t in order if t.op != "input")
@@ -1650,6 +1677,7 @@ def _compile_segmented(out: Tensor, int8: bool, build_dir,
     emit_order, inputs_r = _subgraph(target, source_ids)
     em = _Emitter(int8, compress=compress, compress_atol=compress_atol, block_size=block_size, family=family)
     for t in emit_order: _EMIT[t.op](em, t, t._name, [s._name for s in t.srcs])
+    _compression_fallback_signal(em)
     out_var = target._name  # captured post-emit (bias-adding emitters rename in place)
     prog = _assemble_and_compile(em, inputs_r, out_var, target.shape, None)
     stages.append({"kind": "region", "prog": prog, "tid": id(target), "out_var": out_var,

--- a/aneforge/_compile.py
+++ b/aneforge/_compile.py
@@ -1051,13 +1051,18 @@ class CompressionFallbackWarning(UserWarning):
 
 
 def _compression_fallback_signal(em: _Emitter) -> None:
-  """Warn if any requested-compression weights were rejected and fell through."""
-  if not em._n_rejected: return
+  """Warn if an explicit compress= rejected weights and fell through to a wider encoding.
+
+  Only fires for a single requested encoding. compress="auto" falls through by design
+  (it picks the best encoding per weight), and its multi-stream fallthrough would double-
+  count one weight across buckets -- so it is not a rejection worth reporting.
+  """
+  if not em._n_rejected or em.compress not in ("sparse", "int4", "blockwise"): return
   import warnings
   requested = em.compress
   total_rejected = sum(em._n_rejected.values())
   detail = ", ".join(f"{enc}: {n}" for enc, n in sorted(em._n_rejected.items()))
-  applied = "int8" if em.int8 or requested == "int4" else "fp16"
+  applied = "int8" if em.int8 or requested == "int4" else "fp16"   # summary; weights with allow_int8=False land on fp16
   msg = (f"aneforge.compile: compress={requested!r} rejected {total_rejected}/{em._n_weights} "
      f"weights ({detail}); applied {applied}. "
      f"To widen the tolerance, raise compress_atol (currently {em.compress_atol}). "

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -499,3 +499,85 @@ def test_blockwise_compress_none_unaffected(mkdir):
   af.compile(af.input((1, 128)) @ W, compress=None, build_dir=db).release()
   assert Path(da, "weights.bin").read_bytes() == Path(db, "weights.bin").read_bytes()
   assert Path(da, "model.mil").read_text() == Path(db, "model.mil").read_text()
+
+
+# CompressionFallbackWarning
+
+import warnings
+import aneforge as af
+
+
+def test_compress_int4_fallback_warns():
+  """compress='int4' that rejects weights emits CompressionFallbackWarning."""
+  rng = np.random.default_rng(42)
+  # random weights are hard to compress to 16 LUT levels: high rel error -> rejected
+  W = (rng.standard_normal((128, 128)) * 0.5).astype(np.float32)
+  em = _compile._Emitter(int8=False, compress="int4", compress_atol=1e-6)
+  em.weight("w", W.astype(np.float16), allow_int8=True, allow_int4=True)
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    _compile._compression_fallback_signal(em)
+    hits = [x for x in w if issubclass(x.category, af.CompressionFallbackWarning)]
+    assert len(hits) == 1
+    msg = str(hits[0].message)
+    assert "compress='int4'" in msg
+    assert "1/1" in msg
+    assert "int4: 1" in msg
+    assert "applied int8" in msg
+
+
+def test_compress_int4_accepted_no_warning():
+  """compress='int4' that accepts all weights emits no warning."""
+  # constant weights compress perfectly to LUT
+  W = np.full((64, 64), 0.5, dtype=np.float16)
+  em = _compile._Emitter(int8=False, compress="int4", compress_atol=0.05)
+  em.weight("w", W, allow_int8=True, allow_int4=True)
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    _compile._compression_fallback_signal(em)
+    assert not any(issubclass(x.category, af.CompressionFallbackWarning) for x in w)
+
+
+def test_compress_none_no_warning():
+  """compress=None emits no CompressionFallbackWarning."""
+  rng = np.random.default_rng(44)
+  W = (rng.standard_normal((64, 64)) * 0.5).astype(np.float16)
+  em = _compile._Emitter(int8=False, compress=None)
+  em.weight("w", W, allow_int8=True)
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    _compile._compression_fallback_signal(em)
+    assert not any(issubclass(x.category, af.CompressionFallbackWarning) for x in w)
+
+
+def test_compress_warning_is_filterable():
+  """CompressionFallbackWarning can be silenced with filterwarnings."""
+  rng = np.random.default_rng(45)
+  W = (rng.standard_normal((128, 128)) * 0.5).astype(np.float32)
+  em = _compile._Emitter(int8=False, compress="int4", compress_atol=1e-6)
+  em.weight("w", W.astype(np.float16), allow_int8=True, allow_int4=True)
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    warnings.filterwarnings("ignore", category=af.CompressionFallbackWarning)
+    _compile._compression_fallback_signal(em)
+    assert not any(issubclass(x.category, af.CompressionFallbackWarning) for x in w)
+
+
+def test_compress_mixed_accept_reject_counts():
+  """Warning reports correct counts when some weights accept and some reject int4."""
+  rng = np.random.default_rng(46)
+  # constant weight -> accepted by int4
+  W_good = np.full((64, 64), 0.5, dtype=np.float16)
+  # random weight -> rejected by int4
+  W_bad = (rng.standard_normal((64, 64)) * 0.5).astype(np.float32).astype(np.float16)
+  em = _compile._Emitter(int8=False, compress="int4", compress_atol=1e-6)
+  em.weight("good", W_good, allow_int8=True, allow_int4=True)
+  em.weight("bad", W_bad, allow_int8=True, allow_int4=True)
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    _compile._compression_fallback_signal(em)
+    hits = [x for x in w if issubclass(x.category, af.CompressionFallbackWarning)]
+    assert len(hits) == 1
+    msg = str(hits[0].message)
+    assert "1/2" in msg
+    assert "int4: 1" in msg

--- a/tests/test_compress.py
+++ b/tests/test_compress.py
@@ -581,3 +581,15 @@ def test_compress_mixed_accept_reject_counts():
     msg = str(hits[0].message)
     assert "1/2" in msg
     assert "int4: 1" in msg
+
+
+def test_compress_auto_no_warning():
+  """compress='auto' falls through by design, so it never warns (and never double-counts)."""
+  rng = np.random.default_rng(47)
+  W = (rng.standard_normal((128, 128)) * 0.5).astype(np.float32)   # neither sparse nor int4-clean
+  em = _compile._Emitter(int8=False, compress="auto", compress_atol=1e-6)
+  em.weight("w", W.astype(np.float16), allow_int8=True, allow_int4=True, allow_sparse=True)
+  with warnings.catch_warnings(record=True) as w:
+    warnings.simplefilter("always")
+    _compile._compression_fallback_signal(em)
+    assert not any(issubclass(x.category, af.CompressionFallbackWarning) for x in w)


### PR DESCRIPTION
Closes #222.

When `compress='int4'` (or `'sparse'`/`'blockwise'`) rejects a weight because its relative error exceeds `compress_atol`, the weight silently falls through to int8 or fp16. A caller who asked for int4 and got int8 has no runtime signal at all.

## What this does

Adds `CompressionFallbackWarning`, emitted after the emit loop when any requested-compression weight was rejected. The message reports:

- How many weights were rejected (e.g. `47/48`)
- Which encoding was requested and which was applied
- How to widen the tolerance (`compress_atol`)

Follows the existing `DispatchFloorWarning` precedent. Filterable with `warnings.filterwarnings`.

## Changes

- `_Emitter`: tracks `_n_weights` and `_n_rejected` dict; each fallthrough point (sparse, int4, blockwise) increments its counter
- `CompressionFallbackWarning` class + `_compression_fallback_signal()` called from `compile()`, `compile_multi()`, `_compile_segmented()`
- 5 tests: warn on reject, no warn on accept, no warn on `compress=None`, filterability, mixed accept/reject counts

## Checks

- `ruff check` clean
- `pyright aneforge` 0 errors
- `pylint` 10.00/10
- `pytest -m 'not requires_ane'` 383 passed, 2 skipped