### PR TITLE
llm: cap decode-program layers so deep small-dim models don't hit the ANE op ceiling

### DIFF
--- a/aneforge/llm.py
+++ b/aneforge/llm.py
@@ -269,6 +269,8 @@ class LlamaPrefill:
     self.cfg = cfg; self.w = weights; self._net = None; self._seq = 0; self._dec = None; self._pre = None
     self.compress = compress       # None=fp16, or "int8"/"int4"/"blockwise" to quantize the ANE weights
     self._chunk_bytes = 1.6e9      # max fp16 weight bytes per decode program (under the ~2GB ANE ceiling)
+    self._chunk_max_layers = 24    # max layers per decode program: deep small-dim models stay under the byte
+                                   # cap but hit an op-count ceiling (~31 layers, e.g. SmolLM2's 32) -> rc=-1
     self._lmT = None               # cached contiguous fp32 lm_head^T (host matmul); built on first use
     self.ane_lm_head = ane_lm_head  # run lm_head on the ANE (tiled compile_multi) instead of host matmul
     self._lmh: dict | None = None  # cached ANE lm_head program (built once, shape-independent of max_len)
@@ -421,12 +423,13 @@ class LlamaPrefill:
     return self._logits(self._hidden(token_ids)[-1])[None]
 
   def _layer_chunks(self):
-    """Group layers into contiguous chunks whose baked weights stay under the ANE single-program ceiling
-    (~2GB; measured ~1.5GB OK, ~3.4GB fails). int8/int4 weights are smaller, so more layers fit per chunk."""
+    """Group layers into contiguous chunks under two ANE single-program ceilings: baked weight bytes
+    (~2GB; measured ~1.5GB OK, ~3.4GB fails; int8/int4 are smaller, so more layers fit) and an op-count
+    ceiling that a deep small-dim model hits well under the byte cap (`_chunk_max_layers`)."""
     per = sum(int(np.asarray(v).size) for v in self.w["layers"][0].values() if isinstance(v, (np.ndarray, list, tuple))) * 2   # fp16 bytes / layer
     if self.compress in ("int8", "blockwise"): per //= 2
     elif self.compress == "int4": per //= 4
-    n = max(1, min(self.cfg.n_layers, int(self._chunk_bytes // max(per, 1))))
+    n = max(1, min(self.cfg.n_layers, self._chunk_max_layers, int(self._chunk_bytes // max(per, 1))))
     return [range(i, min(i + n, self.cfg.n_layers)) for i in range(0, self.cfg.n_layers, n)]
 
   def _decoder(self, M):

--- a/tests/test_decode_chunking.py
+++ b/tests/test_decode_chunking.py
@@ -1,0 +1,46 @@
+"""Deep small-dim models: the decode program must chunk by layer count, not just weight bytes.
+
+A model like SmolLM2-360M (32 small layers) stays under the per-program weight ceiling but hits an
+op-count ceiling (~31 layers) and the ANE fails the execute with rc=-1. `_layer_chunks` caps layers
+per chunk so these segment and decode correctly."""
+from aneforge.llm import LlamaConfig
+from _helpers import requires_ane, make_random_llama_model as _random_model
+
+
+def _deep_cfg(n_layers):
+  return LlamaConfig(dim=128, n_heads=4, n_kv_heads=2, ffn_dim=256, vocab=64, n_layers=n_layers, head_dim=32)
+
+
+def test_layer_chunks_caps_layer_count():
+  """A deep, small-dim model that fits the byte budget must still split on the layer-count cap."""
+  m = _random_model(_deep_cfg(32))                 # 32 small layers: well under _chunk_bytes
+  chunks = m._layer_chunks()
+  assert max(len(c) for c in chunks) <= m._chunk_max_layers
+  assert sum(len(c) for c in chunks) == 32         # every layer is covered exactly once
+  assert [i for c in chunks for i in c] == list(range(32))
+
+
+def test_layer_chunks_single_when_shallow():
+  """A shallow model stays a single chunk (no needless segmentation / dispatch overhead)."""
+  m = _random_model(_deep_cfg(8))
+  assert m._layer_chunks() == [range(0, 8)]
+
+
+@requires_ane
+def test_deep_model_decodes_without_rc_error():
+  """32 layers used to fail decode with `execute failed rc=-1`; with the layer cap it generates."""
+  out = _random_model(_deep_cfg(32)).generate([1, 2, 3], max_new_tokens=3)
+  assert len(out) == 3
+
+
+@requires_ane
+def test_segmented_decode_matches_single_program():
+  """A model split into >1 decode chunk must produce the same greedy tokens as one that fits in a chunk."""
+  cfg = _deep_cfg(28)
+  m = _random_model(cfg)
+  assert len(m._layer_chunks()) > 1                # 28 > cap -> segmented
+  ref = _random_model(cfg)
+  ref._chunk_max_layers = 999                      # force a single chunk on an identical model
+  assert len(ref._layer_chunks()) == 1
+  prompt = [1, 2, 3, 4]
+  assert list(m.generate(prompt, max_new_tokens=5)) == list(ref.generate(prompt, max_new_tokens=5))


### PR DESCRIPTION
## Problem

`af.load_llm("HuggingFaceTB/SmolLM2-360M-Instruct")` decoded with `RuntimeError: execute failed rc=-1`. Prefill worked; the failure was the resident-state **decode step program** (`llm.py:601`), not the lm_head.

Root cause: `_layer_chunks` splits the decode program into chunks by **baked weight bytes** only (`_chunk_bytes ~1.6GB`). SmolLM2 is deep but narrow (32 layers, dim 960), so all 32 layers stay under the byte cap and compile into one program -- which exceeds an **op-count** ANE ceiling and fails execute.

I isolated the ceiling with synthetic random models: it trips at ~31 layers **regardless of dim** (L30 OK / L32 fails at both dim 128 and dim 960), which is why TinyLlama (22 layers) and Qwen2.5-0.5B (24) work while SmolLM2 (32) did not.

## Fix

Add `_chunk_max_layers = 24` and cap layers-per-chunk by it as well as by bytes. Deep models now segment across decode programs (the machinery already exists; it just wasn't triggered by byte size). 24 sits safely below the measured ~31 ceiling with margin for heavier mixers.

## Verification

- Real `SmolLM2-360M-Instruct` now decodes coherently: *"a powerful tool that can help you analyze and visualize complex data..."* (was `rc=-1`).
- Synthetic 32-layer model generates.
- Segmented decode produces the **same greedy tokens** as a forced single-program run.

Tests (`tests/test_decode_chunking.py`):
- off-device: `_layer_chunks` caps at `_chunk_max_layers` and covers every layer; shallow models stay single-chunk
- on-device (`requires_ane`): 32-layer model decodes without rc-error; segmented vs single-program greedy match

`test_llm.py` + new tests: 19 passed, no regressions.