### PR TITLE
models: load_resnet accepts a Hugging Face repo id (microsoft/resnet-50)

### DIFF
--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -38,8 +38,9 @@ _RESNETS: dict[int, tuple[str, tuple[int, int, int, int]]] = {
 def load_resnet(name_or_depth: int | str = 18, int8: bool = False, compress: str | None = None,
                 compress_atol: float = 0.05, build_dir: str | None = None,
                 weights: str = "IMAGENET1K_V1") -> "Vision":
-  """Load a torchvision ResNet (18/34/50/101, ImageNet) as a fused ANE classifier; BatchNorm folded
-  into the preceding conv at load. `name_or_depth` takes 50, "50" or "resnet50"."""
+  """Load a ResNet as a fused ANE classifier; BatchNorm folded into the preceding conv at load.
+  `name_or_depth` takes a torchvision depth (50, "50", "resnet50" -> 18/34/50/101 ImageNet weights)
+  or a Hugging Face ResNet repo id (contains "/", e.g. "microsoft/resnet-50")."""
   return Vision(name_or_depth, int8=int8, compress=compress, compress_atol=compress_atol,
                 build_dir=build_dir, weights=weights)
 
@@ -59,15 +60,60 @@ def _resnet_depth(name_or_depth: int | str) -> int:
   return int(s)
 
 
+def _hf_resnet_to_tv(hf: dict, layer_type: str, depths) -> tuple[dict, str, list[int]]:
+  """Remap a HF ResNet state_dict (numpy arrays) into torchvision key names -- a pure rename.
+
+  HF's ResNet is architecturally identical to torchvision's, so only the names differ: the stem is
+  `embedder.embedder`, each block is `encoder.stages.{s}.layers.{l}` with conv+BN sub-layers under
+  `layer.{0..}` (and a `shortcut` projection), and the head is `classifier.1`. Rewriting these to
+  conv1/bn1, layerX.i.conv{1,2,3}/bn{1,2,3}, downsample.0/1 and fc lets `Vision._build` run unchanged."""
+  block = "bottleneck" if layer_type == "bottleneck" else "basic"
+  convs = (("conv1", "bn1"), ("conv2", "bn2"), ("conv3", "bn3")) if block == "bottleneck" else (("conv1", "bn1"), ("conv2", "bn2"))
+  sd: dict = {}
+
+  def bn(dst: str, src: str) -> None:
+    for s in ("weight", "bias", "running_mean", "running_var"):
+      sd[f"{dst}.{s}"] = hf[f"{src}.{s}"]
+
+  sd["conv1.weight"] = hf["resnet.embedder.embedder.convolution.weight"]
+  bn("bn1", "resnet.embedder.embedder.normalization")
+  for s, n in enumerate(depths):
+    for li in range(n):
+      hp, tp = f"resnet.encoder.stages.{s}.layers.{li}", f"layer{s + 1}.{li}"
+      for hi, (tc, tb) in enumerate(convs):
+        sd[f"{tp}.{tc}.weight"] = hf[f"{hp}.layer.{hi}.convolution.weight"]
+        bn(f"{tp}.{tb}", f"{hp}.layer.{hi}.normalization")
+      if f"{hp}.shortcut.convolution.weight" in hf:
+        sd[f"{tp}.downsample.0.weight"] = hf[f"{hp}.shortcut.convolution.weight"]
+        bn(f"{tp}.downsample.1", f"{hp}.shortcut.normalization")
+  sd["fc.weight"], sd["fc.bias"] = hf["classifier.1.weight"], hf["classifier.1.bias"]
+  return sd, block, list(depths)
+
+
+def _load_hf_resnet(name: str) -> tuple[dict, str, list[int]]:
+  """Load a Hugging Face ResNet checkpoint (e.g. microsoft/resnet-50) as a torchvision-named state_dict."""
+  from transformers import AutoConfig, AutoModelForImageClassification  # lazy
+  cfg = AutoConfig.from_pretrained(name)
+  if getattr(cfg, "model_type", None) != "resnet":
+    raise ValueError(f"load_resnet: {name!r} is not a ResNet (model_type={getattr(cfg, 'model_type', None)!r})")
+  hf = {k: v.detach().numpy().astype(np.float32)
+        for k, v in AutoModelForImageClassification.from_pretrained(name).state_dict().items()}
+  return _hf_resnet_to_tv(hf, cfg.layer_type, cfg.depths)
+
+
 class Vision:
   def __init__(self, name_or_depth: int | str = 18, int8: bool = False, compress: str | None = None,
                compress_atol: float = 0.05, build_dir: str | None = None,
                weights: str = "IMAGENET1K_V1") -> None:
-    import torchvision  # lazy
-    self.depth = _resnet_depth(name_or_depth)
-    self.block, self.stages = _RESNETS[self.depth]
-    m = getattr(torchvision.models, f"resnet{self.depth}")(weights=weights).eval()
-    self.sd = {k: v.detach().numpy().astype(np.float32) for k, v in m.state_dict().items()}
+    if isinstance(name_or_depth, str) and "/" in name_or_depth:   # a Hugging Face repo id, not a depth
+      self.depth = None
+      self.sd, self.block, self.stages = _load_hf_resnet(name_or_depth)
+    else:
+      import torchvision  # lazy
+      self.depth = _resnet_depth(name_or_depth)
+      self.block, self.stages = _RESNETS[self.depth]
+      m = getattr(torchvision.models, f"resnet{self.depth}")(weights=weights).eval()
+      self.sd = {k: v.detach().numpy().astype(np.float32) for k, v in m.state_dict().items()}
     self.int8 = int8
     self.compress = compress
     self.compress_atol = compress_atol

--- a/tests/test_hf_resnet.py
+++ b/tests/test_hf_resnet.py
@@ -1,0 +1,65 @@
+"""load_resnet from a Hugging Face repo id (e.g. microsoft/resnet-50): key remap + HF-logit match."""
+import numpy as np
+
+from aneforge.models import _hf_resnet_to_tv
+from _helpers import requires_ane
+
+
+def _fake_hf(depths, layer_type="bottleneck"):
+  """A minimal HF-named ResNet state_dict (zeros) for testing the pure key remap without a download."""
+  hf: dict = {}
+
+  def bn(p):
+    for s in ("weight", "bias", "running_mean", "running_var"):
+      hf[f"{p}.{s}"] = np.zeros(4, np.float32)
+
+  hf["resnet.embedder.embedder.convolution.weight"] = np.zeros((4, 3, 7, 7), np.float32)
+  bn("resnet.embedder.embedder.normalization")
+  nconv = 3 if layer_type == "bottleneck" else 2
+  for s, n in enumerate(depths):
+    for li in range(n):
+      hp = f"resnet.encoder.stages.{s}.layers.{li}"
+      for hi in range(nconv):
+        hf[f"{hp}.layer.{hi}.convolution.weight"] = np.zeros((4, 4, 1, 1), np.float32)
+        bn(f"{hp}.layer.{hi}.normalization")
+      if li == 0:                                    # first block of each stage projects the residual
+        hf[f"{hp}.shortcut.convolution.weight"] = np.zeros((4, 4, 1, 1), np.float32)
+        bn(f"{hp}.shortcut.normalization")
+  hf["classifier.1.weight"] = np.zeros((1000, 4), np.float32)
+  hf["classifier.1.bias"] = np.zeros(1000, np.float32)
+  return hf
+
+
+def test_hf_resnet_remap_produces_torchvision_keys():
+  """A bottleneck HF checkpoint must remap to the exact torchvision names Vision._build reads."""
+  sd, block, stages = _hf_resnet_to_tv(_fake_hf([2, 1]), "bottleneck", [2, 1])
+  assert block == "bottleneck" and stages == [2, 1]
+  expected = {"conv1.weight", "bn1.running_var",
+              "layer1.0.conv1.weight", "layer1.0.conv2.weight", "layer1.0.conv3.weight",
+              "layer1.0.bn3.weight", "layer1.0.downsample.0.weight", "layer1.0.downsample.1.running_mean",
+              "layer1.1.conv1.weight", "layer2.0.conv3.weight", "fc.weight", "fc.bias"}
+  assert expected <= set(sd), expected - set(sd)
+  assert "layer1.1.downsample.0.weight" not in sd    # non-first blocks have no projection
+  assert sd["fc.weight"].shape == (1000, 4)
+
+
+def test_hf_resnet_remap_basic_has_two_convs():
+  """A basic-block checkpoint maps to conv1/conv2 only (no conv3)."""
+  sd, block, _ = _hf_resnet_to_tv(_fake_hf([1], "basic"), "basic", [1])
+  assert block == "basic"
+  assert "layer1.0.conv2.weight" in sd and "layer1.0.conv3.weight" not in sd
+
+
+@requires_ane
+def test_hf_resnet50_matches_hf():
+  """load_resnet('microsoft/resnet-50') logits match HF on the same preprocessed image."""
+  import torch
+  from transformers import AutoModelForImageClassification
+  import aneforge as af
+  x = (np.random.default_rng(0).standard_normal((1, 3, 224, 224)) * 0.5).astype(np.float32)
+  ane = np.asarray(af.load_resnet("microsoft/resnet-50")(x)).ravel()
+  hf = AutoModelForImageClassification.from_pretrained("microsoft/resnet-50").eval()
+  with torch.no_grad():
+    ref = hf(torch.tensor(x)).logits[0].numpy()
+  cos = float(ane @ ref / (np.linalg.norm(ane) * np.linalg.norm(ref) + 1e-9))
+  assert cos > 0.99 and int(ane.argmax()) == int(ref.argmax()), f"cosine {cos:.4f}"


### PR DESCRIPTION
## What

`load_resnet` was torchvision-only (a depth: 50, \"resnet50\"). It now also accepts a Hugging Face ResNet repo id (detected by a \"/\"), e.g. `af.load_resnet(\"microsoft/resnet-50\")`.

## How

HF's ResNet is architecturally identical to torchvision's -- only the weight names differ (stem `embedder.embedder`, blocks `encoder.stages.{s}.layers.{l}.layer.{0,1,2}`, `shortcut`, head `classifier.1`). `_hf_resnet_to_tv` is a pure rename into torchvision keys (conv1/bn1, layerX.i.conv{1,2,3}/bn{1,2,3}, downsample.0/1, fc), after which `Vision._build` runs unchanged -- BN fold, V1.5 stride-on-3x3, and residual-projection detection all as-is.

## Verification

`microsoft/resnet-50` matches HF logits at **cosine 1.0000** (argmax match) on a preprocessed image.

Tests (`tests/test_hf_resnet.py`):
- off-device: the remap produces the exact torchvision key names for bottleneck and basic blocks, and omits projections on non-first blocks
- on-device (`requires_ane`): resnet-50 vs HF logit cosine + argmax

torchvision depth path unchanged: `test_resnet_depths.py` 16 passed.