### PR TITLE
models: apply pad_id+1 position offset for RoBERTa-family encoders

### DIFF
--- a/aneforge/models.py
+++ b/aneforge/models.py
@@ -266,10 +266,12 @@ class Encoder:
     self.eln_w, self.eln_b = g("embeddings.LayerNorm.weight"), g("embeddings.LayerNorm.bias")
     self.layers = [{k: g(f"encoder.layer.{i}." + v) for k, v in keys.items()}
                    for i in range(self.L)]
-    # MPNet adds a T5-style relative-position bias to the attention scores and offsets positions by pad_id+1.
+    # MPNet adds a T5-style relative-position bias to the attention scores; MPNet and the RoBERTa family
+    # count positions from pad_id+1 (HF create_position_ids_from_input_ids), unlike BERT's 0-based.
     self.rel_bias = g("encoder.relative_attention_bias.weight") if mpnet else None
     self.n_buckets = int(getattr(cfg, "relative_attention_num_buckets", 32))
-    self.pos_offset = int(cfg.pad_token_id) + 1 if mpnet else 0
+    offset_pos = cfg.model_type in ("mpnet", "roberta", "xlm-roberta", "camembert")
+    self.pos_offset = int(cfg.pad_token_id) + 1 if offset_pos else 0
     self._bias_cache: dict[int, np.ndarray] = {}
     self._cache: dict[int, Model | SegmentedModel] = {}
 

--- a/tests/test_roberta_encoder.py
+++ b/tests/test_roberta_encoder.py
@@ -1,0 +1,25 @@
+"""RoBERTa-family encoders need HF's pad_id+1 position offset; 0-based positions wreck the embeddings."""
+import numpy as np
+
+from _helpers import requires_ane
+
+
+@requires_ane
+def test_distilroberta_dropin_matches_hf():
+  """all-distilroberta-v1 (model_type roberta) through the drop-in matches HF mean-pooled embeddings.
+
+  Without the pad_id+1 offset the positions are wrong and the cosine falls to ~0.65."""
+  import torch
+  from transformers import AutoTokenizer, AutoModel
+  from aneforge.sentence_transformers import SentenceTransformer
+  name = "sentence-transformers/all-distilroberta-v1"
+  sents = ["Hello from the Neural Engine", "A cat sits on the mat", "Quantum computing is fun"]
+  af = np.asarray(SentenceTransformer(name).encode(sents, normalize_embeddings=True))
+  tok = AutoTokenizer.from_pretrained(name); hf = AutoModel.from_pretrained(name).eval()
+  b = tok(sents, padding=True, truncation=True, return_tensors="pt")
+  with torch.no_grad():
+    out = hf(**b).last_hidden_state
+  m = b["attention_mask"].unsqueeze(-1).float()
+  ref = torch.nn.functional.normalize((out * m).sum(1) / m.sum(1), dim=1).numpy()
+  cos = [float(af[i] @ ref[i] / (np.linalg.norm(af[i]) * np.linalg.norm(ref[i]) + 1e-9)) for i in range(len(sents))]
+  assert min(cos) > 0.99, f"RoBERTa drop-in vs HF cosine {min(cos):.4f}"


### PR DESCRIPTION
## Bug (found by auditing the just-published cards)

The sentence-transformers `Encoder` counted positions from 0 for every model except MPNet. But RoBERTa, XLM-R and CamemBERT count from `pad_id+1` (HF `create_position_ids_from_input_ids`). With 0-based positions a RoBERTa embedder reads the wrong rows of the position table, so its output is wrong:

`aneforge/all-distilroberta-v1` (which I published earlier this session) scored **cosine 0.65** vs the HF reference -- not the ~1.0 a duplicate should. It only ever got a "loads, norm 1.0" check, not a correctness check.

## Fix

Extend the data-driven `pos_offset` (added for MPNet) to the RoBERTa family (`roberta`, `xlm-roberta`, `camembert`). One line; BERT (0-based) and MPNet are unchanged.

## Verification

- `all-distilroberta-v1` drop-in vs HF: **0.65 -> 1.0000**
- regression: MPNet and BERT (all-MiniLM-L6) drop-ins re-verified at **1.0000**

Audit of all 10 published embedders: 8 are BERT (0-based correct, control at 0.9999), mpnet already handled, distilroberta was the only broken one. No card change needed -- the fix corrects the model for all users once released.

Test (`tests/test_roberta_encoder.py`): on-device distilroberta-vs-HF cosine.