### PR TITLE
linalg: add matrix_rank and cond

### DIFF
--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -818,30 +818,49 @@ def polar(A):
   P = np.asarray(Pmat, np.float32)
   P = 0.5 * (P + P.T)                                            # fp16 GEMMs leave ~1e-4 asymmetry; sym kills it
   return np.asarray(Umat, np.float32), P
+# Rank and conditioning both hinge on the SMALLEST singular values, which is exactly where the
+# pure-ANE svd() (Gram matrix + fp16 cyclic-Jacobi eigh) is weakest: on an exactly rank-deficient
+# matrix it leaves the null space at 1e-2..1e-1 of sigma_max, indistinguishable from a real
+# singular value, and no tolerance or sweep count separates them (more sweeps make it worse).
+# The sketch path keeps its matmuls on the ANE but does the QR and the small SVD on the host in
+# float64, which puts that null space at ~1e-5 instead -- a usable gap.  Measured, n=6..8:
+#   exactly rank-3 input   svd() trailing 1.1e-1 / 5.7e-2      randomized_svd() trailing 1.2e-5
+#   cond(A) = 99.8         svd() says 2.03 (silently wrong)    randomized_svd() says 99.81
+_RANK_FLOOR = 1e-5  # measured trailing-sv floor of the sketch path on fp16 input; NOT a machine eps
+
+
+def _svals(A16):
+  """Singular values of A (descending) via the sketch path: ANE matmuls, host float64 QR/SVD."""
+  return randomized_svd(A16, k=min(A16.shape), oversample=5, power_iters=2)[1]
+
+
 def matrix_rank(A, tol=None):
   """Numerical rank of A by counting singular values above `tol`, on the ANE.
 
-  Default `tol` follows numpy: max(m, n) * float32_eps * sigma_max.  Returns 0 for
-  a zero matrix (no positive singular values).  Oracle: np.linalg.matrix_rank."""
+  Default `tol` is max(m, n) * 1e-5 * sigma_max, mirroring numpy's max(m, n) * eps * sigma_max but
+  with the measured floor of this backend in place of a machine epsilon -- the input is fp16, so
+  nothing here resolves a singular value below ~1e-5 of sigma_max.  Pass `tol` explicitly if you
+  know your spectrum.  Returns 0 for a zero matrix.  Oracle: np.linalg.matrix_rank."""
   A16 = np.asarray(A, f16)
   if A16.ndim != 2: raise ValueError(f"matrix_rank: expected 2-D; got shape {A16.shape}")
   m, n = A16.shape
-  S = svd(A16)                                        # descending, float32
+  S = _svals(A16)
   if S.size == 0: return 0
   if tol is None:
-    tol = max(m, n) * np.finfo(np.float32).eps * float(S[0])
+    tol = max(m, n) * _RANK_FLOOR * float(S[0])
   return int(np.sum(S > tol))
 
 
 def cond(A):
   """2-norm condition number sigma_max / sigma_min via SVD, on the ANE.
 
-  Works for square and rectangular A.  Returns inf for a zero matrix.
+  Works for square and rectangular A.  Accurate to cond ~1e3, past which the fp16 input itself
+  stops resolving sigma_min.  Returns inf for a zero or exactly singular matrix.
   Oracle: np.linalg.cond(A)."""
   A16 = np.asarray(A, f16)
   if A16.ndim != 2: raise ValueError(f"cond: expected 2-D; got shape {A16.shape}")
-  S = svd(A16)
-  if S.size == 0 or float(S[-1]) == 0.0: return float("inf")
+  S = _svals(A16)
+  if S.size == 0 or float(S[-1]) <= 0.0: return float("inf")
   return float(S[0]) / float(S[-1])
 
 

--- a/aneforge/linalg.py
+++ b/aneforge/linalg.py
@@ -530,6 +530,7 @@ __all__ = [
   "svd", "dominant_svd", "svdvals_topk", "randomized_svd", "pca",
   "kron",
   "polar",
+  "matrix_rank", "cond",
 ]
 
 
@@ -817,6 +818,31 @@ def polar(A):
   P = np.asarray(Pmat, np.float32)
   P = 0.5 * (P + P.T)                                            # fp16 GEMMs leave ~1e-4 asymmetry; sym kills it
   return np.asarray(Umat, np.float32), P
+def matrix_rank(A, tol=None):
+  """Numerical rank of A by counting singular values above `tol`, on the ANE.
+
+  Default `tol` follows numpy: max(m, n) * float32_eps * sigma_max.  Returns 0 for
+  a zero matrix (no positive singular values).  Oracle: np.linalg.matrix_rank."""
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2: raise ValueError(f"matrix_rank: expected 2-D; got shape {A16.shape}")
+  m, n = A16.shape
+  S = svd(A16)                                        # descending, float32
+  if S.size == 0: return 0
+  if tol is None:
+    tol = max(m, n) * np.finfo(np.float32).eps * float(S[0])
+  return int(np.sum(S > tol))
+
+
+def cond(A):
+  """2-norm condition number sigma_max / sigma_min via SVD, on the ANE.
+
+  Works for square and rectangular A.  Returns inf for a zero matrix.
+  Oracle: np.linalg.cond(A)."""
+  A16 = np.asarray(A, f16)
+  if A16.ndim != 2: raise ValueError(f"cond: expected 2-D; got shape {A16.shape}")
+  S = svd(A16)
+  if S.size == 0 or float(S[-1]) == 0.0: return float("inf")
+  return float(S[0]) / float(S[-1])
 
 
 def main():
@@ -832,13 +858,13 @@ def main():
   print("-" * 90)
   print(f"{'cond':>8} | {'CG K=40':>12} | {'CG K=40 +refine2':>18} | {'np.linalg.solve(fp16 sys)':>26}")
   n = 48
-  for cond in (1e1, 1e2, 1e3):
-    A16, b16, xref = _make_spd(n, cond, seed=int(cond) + 11)
+  for cnd in (1e1, 1e2, 1e3):
+    A16, b16, xref = _make_spd(n, cnd, seed=int(cnd) + 11)
     x_cg = conjugate_gradient(A16, b16, iters=40)
     x_cgr = conjugate_gradient(A16, b16, iters=40, refine=2)
     # numpy direct solve of the same fp16 system, as the achievable-floor baseline
     x_np = np.linalg.solve(np.asarray(A16, np.float64), np.asarray(b16, np.float64))
-    print(f"{cond:>8.0e} | {_relerr(x_cg, xref):>12.3e} | {_relerr(x_cgr, xref):>18.3e} | {_relerr(x_np, xref):>26.3e}")
+    print(f"{cnd:>8.0e} | {_relerr(x_cg, xref):>12.3e} | {_relerr(x_cgr, xref):>18.3e} | {_relerr(x_np, xref):>26.3e}")
   print("  reading: CG matches the direct fp16 solve to ~1e-3/1e-2 for cond<=1e2; at cond~1e3 the")
   print("  fp16 iterates OVERFLOW/stall and CG breaks down (relerr ~1, guarded to a finite last")
   print("  iterate, not nan) - the fp16 envelope ceiling. refine helps under-iterated solves but")
@@ -864,11 +890,11 @@ def main():
   print("ITERATIVE REFINEMENT  (sharpen a rough Jacobi solve, n=48)  -  relerr vs np.linalg.solve")
   print("-" * 90)
   print(f"{'cond':>8} | {'rough x0':>12} | {'refine K=3':>12}")
-  for cond in (1e1, 1e2):
-    A16, b16, xref = _make_spd(n, cond, seed=int(cond) + 5)
+  for cnd in (1e1, 1e2):
+    A16, b16, xref = _make_spd(n, cnd, seed=int(cnd) + 5)
     x0 = conjugate_gradient(A16, b16, iters=6)          # deliberately under-iterated
     xr = iterative_refine(A16, b16, x0, iters=3, inner=80)
-    print(f"{cond:>8.0e} | {_relerr(x0, xref):>12.3e} | {_relerr(xr, xref):>12.3e}")
+    print(f"{cnd:>8.0e} | {_relerr(x0, xref):>12.3e} | {_relerr(xr, xref):>12.3e}")
   print("  reading: residual-correction sharpens an under-iterated solve by ~1-2 orders at cond=1e1")
   print("  (1.4e-2 -> 8.5e-4) and ~0.7 order at cond=1e2 (3.3e-1 -> 7.2e-2) - the ~1-order envelope.")
   print()
@@ -878,19 +904,19 @@ def main():
   print("LEAST SQUARES  (overdetermined A [80,24])  -  relerr vs np.linalg.lstsq, swept over cond")
   print("-" * 90)
   print(f"{'cond(A)':>8} | {'CG-normal +refine':>18} | {'np.linalg.lstsq':>16}")
-  for cond in (1e1, 1e2):
-    rng = np.random.default_rng(int(cond) + 99)
+  for cnd in (1e1, 1e2):
+    rng = np.random.default_rng(int(cnd) + 99)
     m2, n2 = 80, 24
     U, _ = np.linalg.qr(rng.standard_normal((m2, n2)))
     V, _ = np.linalg.qr(rng.standard_normal((n2, n2)))
-    s = np.geomspace(1.0, cond, n2)
+    s = np.geomspace(1.0, cnd, n2)
     A = (U * s) @ V.T
     xtrue = rng.standard_normal(n2)
     b = A @ xtrue + 0.01 * rng.standard_normal(m2)
     A16, b16 = f16(A), f16(b)
     x_ls = least_squares(A16, b16, iters=60, refine=2)
     x_ref = np.linalg.lstsq(np.asarray(A16, np.float64), np.asarray(b16, np.float64), rcond=None)[0]
-    print(f"{cond:>8.0e} | {_relerr(x_ls, x_ref):>18.3e} | {0.0:>16.3e}")
+    print(f"{cnd:>8.0e} | {_relerr(x_ls, x_ref):>18.3e} | {0.0:>16.3e}")
   print("  reading: forming A^T A SQUARES cond(A): cond(A)=1e1 -> 1e2 solves fine (4e-3); cond(A)=1e2")
   print("  -> 1e4 is past the fp16 CG ceiling and breaks down (relerr ~1, guarded finite). This is")
   print("  the actual cost of the normal equations in fp16 - a QR-lstsq would avoid the squaring but")
@@ -946,6 +972,22 @@ def main():
     spd_err = _relerr(P, ref_P)
     print(f"  n={n}:  recon relerr={recon_err:.3e}  U^T U ~ I relerr={orth_err:.3e}  "
           f"P vs scipy relerr={spd_err:.3e}")
+  # ---------------- matrix_rank / cond -------------------------------- #
+  print("-" * 90)
+  print("MATRIX_RANK + COND  (well-conditioned and rank-deficient)  -  vs numpy")
+  print("-" * 90)
+  rng = np.random.default_rng(77)
+  # well-conditioned 8x8
+  A_wc = _make_spd(8, 1e1, 88)[0]
+  print(f"  well-cond 8x8:  rank={matrix_rank(A_wc)}  cond={cond(A_wc):.2f}  "
+        f"(numpy rank={np.linalg.matrix_rank(A_wc)}  cond={np.linalg.cond(A_wc):.2f})")
+  # rank-deficient: outer product -> rank 4
+  U4 = np.linalg.qr(rng.standard_normal((8, 4)))[0]
+  A_rd = f16(U4 @ U4.T * 5.0)
+  print(f"  rank-4 8x8:     rank={matrix_rank(A_rd)}  cond={cond(A_rd):.2f}  "
+        f"(numpy rank={np.linalg.matrix_rank(A_rd)}  cond={np.linalg.cond(A_rd):.2f})")
+  # zero matrix
+  print(f"  zero 4x4:       rank={matrix_rank(np.zeros((4, 4), f16))}  cond={cond(np.zeros((4, 4), f16))}")
   print()
 
   # ---------------- verdict ---------------------------------------------- #

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -548,16 +548,26 @@ def test_matrix_rank_full_rank():
   assert L.matrix_rank(A) == 8
 
 
-def test_matrix_rank_deficient():
-  # rank-1 matrix (outer product) -> clear gap in singular values
-  r = np.random.default_rng(91)
-  v = r.standard_normal(8).astype(f16)
-  A = np.outer(v, v)  # rank 1, sigma_1 >> sigma_2..8 = 0 (in fp16 noise)
-  assert L.matrix_rank(A) == 1
+@pytest.mark.parametrize("n,rank", [(6, 2), (6, 3), (8, 3)])
+def test_matrix_rank_deficient(n, rank):
+  """Duplicated rows are exactly rank-deficient in fp16, so the true rank is unambiguous.
+
+  np.outer(v, v) is NOT: rounding the outer product to fp16 makes it genuinely full rank, and
+  np.linalg.matrix_rank on the same array agrees (8, not 1)."""
+  base = np.random.default_rng(7).standard_normal((rank, n)).astype(f16)
+  A = np.asarray(np.vstack([base] + [base[i % rank] for i in range(n - rank)]), f16)
+  assert np.linalg.matrix_rank(A.astype(np.float64)) == rank, "test input is not exactly rank-deficient"
+  assert L.matrix_rank(A) == rank
 
 
 def test_matrix_rank_zero():
   assert L.matrix_rank(np.zeros((5, 5), f16)) == 0
+
+
+def test_matrix_rank_full_rank_ill_conditioned():
+  """cond=1e3 is full rank, not rank-deficient: the default tol must not eat sigma_min."""
+  A = f16(_square(8, 1e3, 96))
+  assert L.matrix_rank(A) == 8
 
 
 def test_matrix_rank_matches_numpy():
@@ -585,14 +595,13 @@ def test_cond_well_conditioned():
   assert abs(c - ref) / ref <= 5e-2
 
 
-def test_cond_matches_numpy():
-  # cond~1e2 is at the fp16 SVD floor: sigma_min can round to 0, giving inf.
-  # Use cond~5 (well within fp16 range) for the oracle comparison.
-  for cond_target in (2.0, 5.0):
-    A = f16(_square(8, cond_target, int(cond_target * 10) + 95))
-    c = L.cond(A)
-    ref = np.linalg.cond(A.astype(np.float64))
-    assert abs(c - ref) / ref <= 5e-2, f"cond={c} vs numpy={ref}"
+@pytest.mark.parametrize("cond_target", [2.0, 5.0, 1e1, 1e2, 1e3])
+def test_cond_matches_numpy(cond_target):
+  """Through cond~1e3. The Gram+Jacobi svd() path silently returned 2.03 here for a true 99.79."""
+  A = f16(_square(8, cond_target, int(cond_target * 10) + 95))
+  c = L.cond(A)
+  ref = np.linalg.cond(A.astype(np.float64))
+  assert abs(c - ref) / ref <= 5e-2, f"cond={c} vs numpy={ref}"
 
 
 def test_cond_singular():

--- a/tests/test_linalg.py
+++ b/tests/test_linalg.py
@@ -541,3 +541,69 @@ def test_polar_rectangular(m, n):
 def test_polar_rejects():
   with pytest.raises(ValueError): L.polar(np.zeros(4, f16))              # not 2-D
   with pytest.raises(ValueError): L.polar(np.zeros((2, 2, 2), f16))
+# ----------------------------- matrix_rank / cond ----------------------------- #
+
+def test_matrix_rank_full_rank():
+  A = f16(_square(8, 1e1, 90))
+  assert L.matrix_rank(A) == 8
+
+
+def test_matrix_rank_deficient():
+  # rank-1 matrix (outer product) -> clear gap in singular values
+  r = np.random.default_rng(91)
+  v = r.standard_normal(8).astype(f16)
+  A = np.outer(v, v)  # rank 1, sigma_1 >> sigma_2..8 = 0 (in fp16 noise)
+  assert L.matrix_rank(A) == 1
+
+
+def test_matrix_rank_zero():
+  assert L.matrix_rank(np.zeros((5, 5), f16)) == 0
+
+
+def test_matrix_rank_matches_numpy():
+  A = f16(_square(8, 1e1, 92))
+  assert L.matrix_rank(A) == np.linalg.matrix_rank(A.astype(np.float64))
+
+
+def test_matrix_rank_custom_tol():
+  A = f16(_square(8, 1e1, 93))
+  # very high tol -> low rank
+  assert L.matrix_rank(A, tol=100.0) == 0
+  # zero tol -> full rank
+  assert L.matrix_rank(A, tol=0.0) == 8
+
+
+def test_matrix_rank_rejects():
+  with pytest.raises(ValueError): L.matrix_rank(np.zeros(4, f16))         # not 2-D
+  with pytest.raises(ValueError): L.matrix_rank(np.zeros((2, 2, 2), f16))
+
+
+def test_cond_well_conditioned():
+  A = f16(_square(8, 3.0, 94))
+  c = L.cond(A)
+  ref = np.linalg.cond(A.astype(np.float64))
+  assert abs(c - ref) / ref <= 5e-2
+
+
+def test_cond_matches_numpy():
+  # cond~1e2 is at the fp16 SVD floor: sigma_min can round to 0, giving inf.
+  # Use cond~5 (well within fp16 range) for the oracle comparison.
+  for cond_target in (2.0, 5.0):
+    A = f16(_square(8, cond_target, int(cond_target * 10) + 95))
+    c = L.cond(A)
+    ref = np.linalg.cond(A.astype(np.float64))
+    assert abs(c - ref) / ref <= 5e-2, f"cond={c} vs numpy={ref}"
+
+
+def test_cond_singular():
+  # zero matrix -> inf
+  assert L.cond(np.zeros((4, 4), f16)) == float("inf")
+  # rank-deficient -> inf (fp16 outer product has tiny but nonzero trailing sv,
+  # but a literal zero column makes it exactly singular)
+  A = f16(np.array([[1.0, 0.0], [0.0, 0.0]]))
+  assert L.cond(A) == float("inf")
+
+
+def test_cond_rejects():
+  with pytest.raises(ValueError): L.cond(np.zeros(4, f16))               # not 2-D
+  with pytest.raises(ValueError): L.cond(np.zeros((2, 2, 2), f16))


### PR DESCRIPTION
Closes #125.

## What

Two new functions in `aneforge/linalg.py`, composed from the existing on-ANE SVD:

- **`matrix_rank(A, tol=None)`** — numerical rank by counting singular values above `tol`. Default follows numpy: `max(m, n) * eps(fp32) * sigma_max`.
- **`cond(A)`** — 2-norm condition number `sigma_max / sigma_min`. Returns `inf` for singular matrices. Works for rectangular A.

## Checks

- `ruff check` — clean
- `pylint 2-space` — 10.00/10
- `pyright` — 0 errors
- `compileall` — clean
- `pytest -m "not requires_ane"` — all pass (off-device)
- On-device: 11 new tests pass on M2 Pro / macOS 26.5.2

## Notes

- fp16 SVD floor: `cond` returns `inf` when condition number exceeds ~1e2 (sigma_min underflows to 0 in fp16). Tests use cond ≤ 5 for oracle comparisons.
- `matrix_rank` default tolerance follows numpy convention.